### PR TITLE
Extend invite expiration time to 7 days

### DIFF
--- a/src/models/invite_codes.rs
+++ b/src/models/invite_codes.rs
@@ -144,9 +144,7 @@ pub struct NewInviteCode {
 }
 
 impl NewInviteCode {
-    pub fn new(org_id: i32, email: String, role: String, expiry_hours: Option<i64>) -> Self {
-        // Default expiration time is 7 days (168 hours)
-        let expiry_hours = expiry_hours.unwrap_or(168);
+    pub fn new(org_id: i32, email: String, role: String, expiry_hours: i64) -> Self {
         NewInviteCode {
             code: Uuid::new_v4(),
             org_id,

--- a/src/models/invite_codes.rs
+++ b/src/models/invite_codes.rs
@@ -144,7 +144,9 @@ pub struct NewInviteCode {
 }
 
 impl NewInviteCode {
-    pub fn new(org_id: i32, email: String, role: String, expiry_hours: i64) -> Self {
+    pub fn new(org_id: i32, email: String, role: String, expiry_hours: Option<i64>) -> Self {
+        // Default expiration time is 7 days (168 hours)
+        let expiry_hours = expiry_hours.unwrap_or(168);
         NewInviteCode {
             code: Uuid::new_v4(),
             org_id,

--- a/src/web/platform/invite_routes.rs
+++ b/src/web/platform/invite_routes.rs
@@ -87,7 +87,7 @@ async fn create_invite(
         org.id,
         create_request.email.clone(),
         role.as_str().to_string(),
-        24, // 24 hour expiry
+        168, // 7 days expiry (168 hours)
     );
 
     let invite = data.db.create_invite_code(new_invite).map_err(|e| {


### PR DESCRIPTION
This PR extends the invite expiration time from 24 hours to 7 days (168 hours).

Changes:
- Updated the expiry time in `create_invite` function from 24 hours to 168 hours (7 days)
- No changes to the method signature or behavior, just updated the expiration duration

Fixes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Invite codes now remain valid for 7 days instead of 24 hours, offering users an extended period to utilize their invite links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->