### PR TITLE
Temporarily disable nix flake cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,9 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
 
-      - name: Enable Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v8
+      # Temporarily disabled - waiting for hosted solution account
+      # - name: Enable Magic Nix Cache
+      #   uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - name: Check flake.lock health
         uses: DeterminateSystems/flake-checker-action@v9
@@ -93,8 +94,9 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
 
-      - name: Enable Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v8
+      # Temporarily disabled - waiting for hosted solution account
+      # - name: Enable Magic Nix Cache
+      #   uses: DeterminateSystems/magic-nix-cache-action@v8
 
       - name: Check flake.lock health
         uses: DeterminateSystems/flake-checker-action@v9


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Temporarily disabled the "Magic Nix Cache" action in build workflows for both development and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->