### PR TITLE
feat: Add Kagi search API integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ tinfoil-proxy/*.spec
 tuf-repo-cdn.sigstore.dev.json
 # Keep the binary
 !tinfoil-proxy/dist/tinfoil-proxy
+
+/thirdparty

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1983,6 +1983,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kagi-api-rust"
+version = "0.1.0"
+source = "git+https://github.com/kagisearch/kagi-api-rust.git?branch=main#0669b190ae9fd17a6bea3df7040280b1488bda82"
+dependencies = [
+ "reqwest 0.12.7",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2092,6 +2104,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -2331,6 +2353,7 @@ dependencies = [
  "hyper-tls 0.5.0",
  "jsonwebtoken",
  "jwt-compact",
+ "kagi-api-rust",
  "lazy_static",
  "oauth2",
  "password-auth",
@@ -2811,6 +2834,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
@@ -3110,6 +3134,17 @@ checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -3603,6 +3638,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,4 @@ validator = { version = "0.20.0", features = ["derive"] }
 regex = "1.9.0"
 lazy_static = "1.4.0"
 subtle = "2.6.1"
+kagi-api-rust = { git = "https://github.com/kagisearch/kagi-api-rust.git", branch = "main" }

--- a/KAGI_SEARCH_API_DOCS.md
+++ b/KAGI_SEARCH_API_DOCS.md
@@ -1,0 +1,328 @@
+# Kagi Search API Documentation for OpenSecret
+
+## Overview
+
+The OpenSecret platform provides a pass-through API to Kagi's search service with end-to-end encryption and JWT authentication. This document describes the API endpoint, request/response formats, and data structures.
+
+## Authentication
+
+All requests require:
+1. A valid JWT token in the `Authorization` header: `Bearer <token>`
+2. A session ID in the `x-session-id` header
+3. Encrypted request body (for POST requests)
+
+## Endpoint
+
+```
+POST /v1/search
+```
+
+## Request Format
+
+### Headers
+```
+Authorization: Bearer <jwt_token>
+x-session-id: <uuid>
+Content-Type: application/json
+```
+
+### Request Body (Before Encryption)
+```json
+{
+  "query": "your search query",
+  "workflow": "search"  // optional, see workflows below
+}
+```
+
+### Encrypted Request Format
+The actual request body sent to the server must be encrypted:
+```json
+{
+  "encrypted": "<base64_encoded_encrypted_data>"
+}
+```
+
+### Available Workflows
+- `"search"` - Standard web search (default)
+- `"images"` - Image search
+- `"videos"` - Video search
+- `"news"` - News search
+- `"podcasts"` - Podcast search
+
+## Response Format
+
+### Response Body (After Decryption)
+```json
+{
+  "success": true,
+  "data": {
+    // Kagi API response data (see below)
+  },
+  "error": null
+}
+```
+
+### Error Response
+```json
+{
+  "success": false,
+  "data": null,
+  "error": "Error message"
+}
+```
+
+### Encrypted Response Format
+The actual response from the server will be encrypted:
+```json
+{
+  "encrypted": "<base64_encoded_encrypted_response>"
+}
+```
+
+## Kagi API Data Format
+
+The `data` field in a successful response contains the Kagi search results:
+
+### Top-Level Structure
+```json
+{
+  "meta": {
+    "trace": "trace-id-for-debugging",
+    "id": "request-id",
+    "node": "server-hostname",
+    "ms": 123  // processing time in milliseconds
+  },
+  "data": {
+    // Search results organized by type (see below)
+  }
+}
+```
+
+### Search Results Data Structure
+
+The `data` object contains different arrays based on the result types. Each workflow may populate different fields:
+
+```json
+{
+  "data": {
+    "search": [...],           // Web search results
+    "image": [...],            // Image results
+    "video": [...],            // Video results
+    "podcast": [...],          // Podcast results
+    "podcast_creator": [...],  // Podcast creator results
+    "news": [...],             // News article results
+    "adjacent_question": [...],// Related questions
+    "direct_answer": [...],    // Quick answers (calculations, conversions)
+    "interesting_news": [...], // Kagi's curated news
+    "interesting_finds": [...],// Small web discoveries
+    "infobox": [...],          // Structured info about entities
+    "code": [...],             // Code repositories and resources
+    "package_tracking": [...], // Package tracking links
+    "public_records": [...],   // Government/court documents
+    "weather": [...],          // Weather information
+    "related_search": [...],   // Related search suggestions
+    "listicle": [...],         // List-based articles
+    "web_archive": [...]       // Archived websites
+  }
+}
+```
+
+### Individual Search Result Structure
+
+Each result in the arrays above follows this structure:
+
+```json
+{
+  "url": "https://example.com/page",
+  "title": "Page Title",
+  "snippet": "A brief excerpt or description of the content...",
+  "time": "2024-01-15T10:30:00Z",  // Optional: publication/update time
+  "image": {                       // Optional: thumbnail/preview image
+    "url": "https://example.com/image.jpg",
+    "width": 200,
+    "height": 150
+  },
+  "props": {                       // Optional: additional metadata
+    // Varies by result type, examples:
+    "author": "John Doe",
+    "duration": "5:32",           // For videos/podcasts
+    "question": "Related query?", // For adjacent_questions
+    "price": "$19.99",            // For products
+    // ... other type-specific properties
+  }
+}
+```
+
+## Example Usage
+
+### Search Request Example
+
+```javascript
+// 1. Prepare the request data
+const searchRequest = {
+  query: "best programming languages 2024",
+  workflow: "search"
+};
+
+// 2. Encrypt the request using your session key
+const encryptedRequest = await encryptWithSessionKey(searchRequest, sessionId);
+
+// 3. Send the request
+const response = await fetch('https://api.opensecret.cloud/v1/search', {
+  method: 'POST',
+  headers: {
+    'Authorization': `Bearer ${jwtToken}`,
+    'x-session-id': sessionId,
+    'Content-Type': 'application/json'
+  },
+  body: JSON.stringify({
+    encrypted: btoa(encryptedRequest)
+  })
+});
+
+// 4. Decrypt the response
+const encryptedResponse = await response.json();
+const decryptedData = await decryptWithSessionKey(
+  atob(encryptedResponse.encrypted),
+  sessionId
+);
+```
+
+### Image Search Example
+
+```javascript
+const imageSearchRequest = {
+  query: "mountain landscape photography",
+  workflow: "images"
+};
+```
+
+### Response Example (Web Search)
+
+```json
+{
+  "success": true,
+  "data": {
+    "meta": {
+      "trace": "abc123",
+      "id": "req_456",
+      "node": "search-node-1",
+      "ms": 89
+    },
+    "data": {
+      "search": [
+        {
+          "url": "https://stackoverflow.com/questions/programming-languages-2024",
+          "title": "What are the best programming languages to learn in 2024?",
+          "snippet": "Based on industry trends and job market data, here are the top programming languages...",
+          "time": "2024-01-10T15:20:00Z"
+        },
+        {
+          "url": "https://github.com/trending",
+          "title": "Trending Programming Languages on GitHub",
+          "snippet": "See what the GitHub community is most excited about today...",
+          "props": {
+            "stars": "15.2k",
+            "language": "Multiple"
+          }
+        }
+      ],
+      "related_search": [
+        {
+          "url": "#",
+          "title": "programming languages for beginners 2024",
+          "props": {
+            "query": "programming languages for beginners 2024"
+          }
+        },
+        {
+          "url": "#",
+          "title": "highest paying programming languages",
+          "props": {
+            "query": "highest paying programming languages"
+          }
+        }
+      ]
+    }
+  },
+  "error": null
+}
+```
+
+## Error Handling
+
+### Common Error Responses
+
+1. **Missing API Key Configuration**
+```json
+{
+  "success": false,
+  "data": null,
+  "error": "Search service not configured"
+}
+```
+
+2. **Kagi API Error**
+```json
+{
+  "success": false,
+  "data": null,
+  "error": "Search failed: <kagi_error_details>"
+}
+```
+
+3. **Authentication Error** (HTTP 401)
+```json
+{
+  "status": 401,
+  "message": "Invalid JWT"
+}
+```
+
+4. **Bad Request** (HTTP 400)
+```json
+{
+  "status": 400,
+  "message": "Bad Request"
+}
+```
+
+## Rate Limiting
+
+Rate limiting is enforced at multiple levels:
+1. OpenSecret platform rate limits (based on your subscription)
+2. Kagi API rate limits (passed through from Kagi)
+
+## Notes for SDK Implementation
+
+1. **Encryption/Decryption**: You must implement the session-based encryption/decryption using the same algorithm as other OpenSecret protected endpoints.
+
+2. **Session Management**: The `x-session-id` must match an active session established during login.
+
+3. **Error Handling**: Always check the `success` field first. If `false`, display the error message to the user.
+
+4. **Result Type Handling**: Different workflows return results in different fields. For example:
+   - `workflow: "search"` → results in `data.search`
+   - `workflow: "images"` → results in `data.image`
+   - `workflow: "news"` → results in `data.news`
+
+5. **Optional Fields**: Many fields in the Kagi response are optional. Always check for existence before accessing.
+
+6. **Props Field**: The `props` field contains type-specific metadata. Its structure varies based on the result type.
+
+## Testing
+
+To test the endpoint:
+
+1. Authenticate and establish a session
+2. Use the session key to encrypt a test search request
+3. Send the encrypted request to `/v1/search`
+4. Decrypt the response
+5. Verify the structure matches the documentation
+
+## Support
+
+For issues related to:
+- OpenSecret platform: Contact OpenSecret support
+- Kagi search results/API: Refer to [Kagi API documentation](https://help.kagi.com/kagi/api/search.html)
+- This integration: File an issue in the OpenSecret repository

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -7,6 +7,7 @@ mod oauth_routes;
 mod openai;
 pub mod platform;
 pub mod protected_routes;
+mod search_routes;
 
 pub use documents::router as document_routes;
 pub use health_routes::router as health_routes;
@@ -15,5 +16,6 @@ pub use oauth_routes::router as oauth_routes;
 pub use openai::router as openai_routes;
 pub use platform::router as platform_routes;
 pub use protected_routes::router as protected_routes;
+pub use search_routes::router as search_routes;
 
 pub use platform::login_routes as platform_login_routes;

--- a/src/web/search_routes.rs
+++ b/src/web/search_routes.rs
@@ -1,0 +1,136 @@
+use crate::web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse};
+use crate::{ApiError, AppState};
+use axum::middleware::from_fn_with_state;
+use axum::{extract::State, routing::post, Extension, Json, Router};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tracing::{debug, error, info, trace};
+use uuid::Uuid;
+
+use crate::models::users::User;
+
+// Import Kagi SDK types
+use kagi_api_rust::{
+    apis::{
+        configuration::{ApiKey, Configuration},
+        search_api,
+    },
+    models::SearchRequest as KagiSearchRequest,
+};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SearchRequest {
+    pub query: String,
+    pub workflow: Option<String>, // Options: search, images, videos, news, podcasts
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchResponse {
+    pub success: bool,
+    pub data: Option<serde_json::Value>,
+    pub error: Option<String>,
+}
+
+pub fn router(app_state: Arc<AppState>) -> Router<()> {
+    Router::new()
+        .route(
+            "/v1/search",
+            post(search_handler).layer(from_fn_with_state(
+                app_state.clone(),
+                decrypt_request::<SearchRequest>,
+            )),
+        )
+        .with_state(app_state.clone())
+}
+
+async fn search_handler(
+    State(app_state): State<Arc<AppState>>,
+    Extension(user): Extension<User>,
+    Extension(search_request): Extension<SearchRequest>,
+    Extension(session_id): Extension<Uuid>,
+) -> Result<Json<EncryptedResponse<SearchResponse>>, ApiError> {
+    debug!("Entering search_handler function");
+    info!("Search request from user {}", user.uuid);
+    tracing::trace!(
+        "Search query: {:?}, workflow: {:?}",
+        search_request.query,
+        search_request.workflow
+    );
+
+    // Check if Kagi API key is available
+    let kagi_api_key = match &app_state.kagi_api_key {
+        Some(key) => key,
+        None => {
+            error!("Kagi API key not configured");
+            let response = SearchResponse {
+                success: false,
+                data: None,
+                error: Some("Search service not configured".to_string()),
+            };
+            return encrypt_response(&app_state, &session_id, &response).await;
+        }
+    };
+
+    // Configure Kagi API client
+    let configuration = Configuration {
+        base_path: "https://kagi.com/api/v1".to_string(),
+        api_key: Some(ApiKey {
+            prefix: None,
+            key: kagi_api_key.clone(),
+        }),
+        ..Default::default()
+    };
+
+    // Convert workflow string to enum if provided
+    let workflow = search_request
+        .workflow
+        .as_ref()
+        .and_then(|w| match w.as_str() {
+            "search" => Some(kagi_api_rust::models::search_request::Workflow::Search),
+            "images" => Some(kagi_api_rust::models::search_request::Workflow::Images),
+            "videos" => Some(kagi_api_rust::models::search_request::Workflow::Videos),
+            "news" => Some(kagi_api_rust::models::search_request::Workflow::News),
+            "podcasts" => Some(kagi_api_rust::models::search_request::Workflow::Podcasts),
+            _ => None,
+        });
+
+    // Create Kagi search request
+    let kagi_request = KagiSearchRequest {
+        query: search_request.query.clone(),
+        workflow,
+    };
+
+    // Call Kagi API
+    match search_api::search(&configuration, kagi_request).await {
+        Ok(kagi_response) => {
+            info!("Kagi search successful for user {}", user.uuid);
+
+            // Convert Kagi response to JSON value
+            let data = serde_json::to_value(kagi_response).map_err(|e| {
+                error!("Failed to serialize Kagi response: {:?}", e);
+                ApiError::InternalServerError
+            })?;
+
+            let response = SearchResponse {
+                success: true,
+                data: Some(data),
+                error: None,
+            };
+
+            trace!("Search response data: {:?}", response);
+            debug!("Exiting search_handler function - success");
+            encrypt_response(&app_state, &session_id, &response).await
+        }
+        Err(e) => {
+            error!("Kagi API error: {:?}", e);
+            let response = SearchResponse {
+                success: false,
+                data: None,
+                error: Some(format!("Search failed: {:?}", e)),
+            };
+
+            debug!("Exiting search_handler function - error");
+            encrypt_response(&app_state, &session_id, &response).await
+        }
+    }
+}


### PR DESCRIPTION
- Add Kagi search as a pass-through API at /v1/search endpoint
- Implement end-to-end encryption for search requests/responses
- Support all Kagi workflows: search, images, videos, news, podcasts
- Handle API key management for both local and enclave modes
- Follow secure logging practices (sensitive data only in trace logs)
- Add comprehensive API documentation for SDK developers

🤖 Generated with [Claude Code](https://claude.ai/code)