### PR TITLE
fix: allow non-URL audience values in third-party tokens

### DIFF
--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -136,11 +136,19 @@ impl TokenType {
             return Err(ApiError::BadRequest);
         }
 
-        // 5. Parse the URL to ensure it's valid
-        let _url = Url::parse(aud).map_err(|e| {
-            tracing::error!("Invalid audience URL format: {}, error: {:?}", aud, e);
-            ApiError::BadRequest
-        })?;
+        // 5. Reject empty audience values
+        if aud.is_empty() {
+            tracing::error!("Audience value cannot be empty");
+            return Err(ApiError::BadRequest);
+        }
+
+        // 6. Parse as URI to ensure it's valid if it contains ':'
+        if aud.contains(':') {
+            Url::parse(aud).map_err(|e| {
+                tracing::error!("Invalid audience URI format: {}, error: {:?}", aud, e);
+                ApiError::BadRequest
+            })?;
+        }
 
         Ok(())
     }

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -1230,15 +1230,15 @@ pub async fn generate_third_party_token(
         user.uuid, request.audience
     );
 
-    // Validate the audience URL
+    // Validate the audience
     if let Some(audience) = request.audience.as_ref() {
-        if url::Url::parse(audience).is_err() {
-            error!("Invalid audience URL provided: {}", audience);
+        if audience.is_empty() || (audience.contains(':') && url::Url::parse(audience).is_err()) {
+            error!("Invalid audience provided: {}", audience);
             return Err(ApiError::BadRequest);
         }
     }
 
-    debug!("Audience URL validation successful");
+    debug!("Audience validation successful");
 
     let project = data.db.get_org_project_by_id(user.project_id)?;
 


### PR DESCRIPTION
Per [RFC 7519 Section 2](https://datatracker.ietf.org/doc/html/rfc7519#section-2), the `aud` claim is a `StringOrURI`. That means arbitrary strings are valid, and only values containing a `:` need to be valid URIs. The current code runs `Url::parse` on all audience values, which rejects things like `"agicash-mint"` or `"authenticated"` with a 400.

This fixes both validation sites to only require URI parsing when the value contains a colon. 

Closes #142
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret/pull/160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Audience validation for third-party tokens now rejects empty audience values and provides clearer error handling.
  * URL parsing is now conditional, allowing broader identifier formats (non-URL audiences) while preserving existing rejection rules and error responses.
  * Validation messaging clarified to better reflect accepted audience formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->