### PR TITLE
Add macOS local proxy setup

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,6 @@
 DATABASE_URL=postgres://localhost/opensecret
+APP_MODE=local
 OPENAI_API_KEY=
 ENCLAVE_SECRET_MOCK=
+JWT_SECRET=
 RESEND_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /target
 /build
 /result
+/.local/
 /*.tar
 /*/*.tar
 

--- a/docs/local-macos-stack.md
+++ b/docs/local-macos-stack.md
@@ -1,0 +1,114 @@
+# Local macOS Stack
+
+This runbook is for developing OpenSecret locally on macOS with native macOS proxy binaries. It is intentionally separate from the Linux/Nitro enclave deployment path.
+
+## Shape
+
+Run these processes from the OpenSecret checkout:
+
+```text
+Continuum proxy   http://127.0.0.1:8092
+Tinfoil proxy     http://127.0.0.1:8093
+OpenSecret API    http://127.0.0.1:3000
+Maple frontend    VITE_OPEN_SECRET_API_URL=http://127.0.0.1:3000
+```
+
+In local mode, OpenSecret reads `.env` through `dotenv`.
+
+When `OPENAI_API_BASE` is not `api.openai.com`, OpenSecret treats it as the default Continuum-compatible proxy and does not require `OPENAI_API_KEY` for that route.
+
+When `TINFOIL_API_BASE` is set, OpenSecret uses it for the Tinfoil route.
+
+## One-Time Setup
+
+Initialize submodules:
+
+```sh
+git submodule update --init --recursive
+```
+
+Build macOS-native proxy binaries:
+
+```sh
+nix develop -c just build-local-proxies-macos
+```
+
+This writes generated binaries under `.local/bin/`, which is gitignored:
+
+```text
+.local/bin/continuum-proxy-darwin
+.local/bin/tinfoil-proxy-darwin
+```
+
+The checked-in Linux proxy binaries are not replaced.
+
+## Secrets
+
+For local development, store proxy keys in gitignored files:
+
+```text
+.local/secrets/continuum_api_key
+.local/secrets/tinfoil_api_key
+```
+
+The run recipes also accept environment variables:
+
+```sh
+CONTINUUM_API_KEY=...
+TINFOIL_API_KEY=...
+```
+
+Prefer the gitignored files for day-to-day use so keys do not land in shell history.
+
+## Environment
+
+The usual path is to enter the dev shell once and let its shell hook create
+`.env`:
+
+```sh
+nix develop
+```
+
+When `.env` does not already exist, `nix develop` starts from `.env.sample`,
+fills in the local Postgres URL, and generates local-only secret values.
+
+The `run-local-backend-macos` recipe injects the local proxy URLs when it starts
+the backend. If creating `.env` by hand and running `cargo run` directly,
+generate local-only secrets with OpenSSL and set the proxy settings yourself:
+
+```dotenv
+APP_MODE=local
+OPENAI_API_BASE=http://127.0.0.1:8092
+TINFOIL_API_BASE=http://127.0.0.1:8093
+ENCLAVE_SECRET_MOCK=<openssl rand -hex 32>
+JWT_SECRET=<openssl rand -hex 32>
+```
+
+## Running
+
+Use separate terminals:
+
+```sh
+nix develop -c just run-continuum-proxy-macos
+nix develop -c just run-tinfoil-proxy-macos
+nix develop -c just diesel-migration-run-local
+nix develop -c just run-local-backend-macos
+```
+
+Then point Maple at the local backend from the Maple checkout:
+
+```dotenv
+VITE_OPEN_SECRET_API_URL=http://127.0.0.1:3000
+```
+
+and run:
+
+```sh
+nix develop -c just dev
+```
+
+## Notes
+
+- Production Linux/Nitro entrypoint behavior is unchanged.
+- The macOS proxy binaries are generated local artifacts only.
+- Device builds, TestFlight, notarization, and production app signing still need Apple developer credentials configured separately.

--- a/flake.nix
+++ b/flake.nix
@@ -54,8 +54,7 @@
         ];
         darwinOnlyInputs = [
           pkgs.libiconv
-          pkgs.darwin.apple_sdk.frameworks.Security
-          pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
+          pkgs.apple-sdk
         ];
         inputs = commonInputs
           ++ pkgs.lib.optionals pkgs.stdenv.isLinux linuxOnlyInputs
@@ -95,15 +94,25 @@
         setupEnvScript = pkgs.writeShellScript "setup-env" ''
           if [ ! -f .env ]; then
             cp .env.sample .env
-            sed -i 's|DATABASE_URL=postgres://localhost/opensecret|DATABASE_URL=postgres://opensecret_user:password@localhost:5432/opensecret|g' .env
+
+            replace_env() {
+              local pattern="$1"
+              local replacement="$2"
+              local tmp
+              tmp="$(mktemp)"
+              sed "s|$pattern|$replacement|g" .env > "$tmp"
+              mv "$tmp" .env
+            }
+
+            replace_env 'DATABASE_URL=postgres://localhost/opensecret' 'DATABASE_URL=postgres://opensecret_user:password@localhost:5432/opensecret'
 
             # Get a new ENCLAVE_SECRET_MOCK value using openssl
             export enclaveSecret=$(openssl rand -hex 32)
-            sed -i "s|ENCLAVE_SECRET_MOCK=|ENCLAVE_SECRET_MOCK=$enclaveSecret|g" .env
+            replace_env 'ENCLAVE_SECRET_MOCK=' "ENCLAVE_SECRET_MOCK=$enclaveSecret"
 
             # Get a new JWT_SECRET value using openssl
             export jwtSecret=$(openssl rand -base64 32)
-            sed -i "s|JWT_SECRET=|JWT_SECRET=$jwtSecret|g" .env
+            replace_env 'JWT_SECRET=' "JWT_SECRET=$jwtSecret"
           fi
         '';
 
@@ -449,6 +458,11 @@
             export CC_wasm32_unknown_unknown=${pkgs.llvmPackages_14.clang-unwrapped}/bin/clang-14
             export CFLAGS_wasm32_unknown_unknown="-I ${pkgs.llvmPackages_14.libclang.lib}/lib/clang/14.0.6/include/"
             export PKG_CONFIG_PATH=${pkgs.openssl.dev}/lib/pkgconfig
+
+            ${pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+              export CC=clang
+              export CXX=clang++
+            ''}
 
             ${pkgs.lib.optionalString pkgs.stdenv.isLinux ''
               alias docker='podman'

--- a/justfile
+++ b/justfile
@@ -195,6 +195,90 @@ update-continuum-proxy version="v1.39.1":
     just update-continuum-proxy-version {{version}}
     just build-continuum-proxy
 
+### Local macOS Proxy Commands ###
+
+# Build macOS-native Continuum and Tinfoil proxy binaries under .local/bin.
+# Run from a Nix dev shell, for example: nix develop -c just build-local-proxies-macos
+build-local-proxies-macos: build-continuum-proxy-macos build-tinfoil-proxy-macos
+
+# Build a macOS-native Continuum proxy without replacing the checked-in Linux binary.
+build-continuum-proxy-macos:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p .local/bin
+    version="$(sed -n 's/.*version = "\([^"]*\)".*/\1/p' privatemode-public/version.nix)"
+    if [ -z "$version" ]; then
+        echo "Could not read Continuum version from privatemode-public/version.nix" >&2
+        exit 1
+    fi
+    cd privatemode-public
+    CGO_ENABLED=0 go build \
+        -tags contrast_unstable_api \
+        -ldflags "-X github.com/edgelesssys/continuum/internal/oss/constants.version=$version" \
+        -o ../.local/bin/continuum-proxy-darwin \
+        ./privatemode-proxy
+    ../.local/bin/continuum-proxy-darwin --version
+
+# Build a macOS-native Tinfoil proxy without replacing the checked-in Linux binary.
+build-tinfoil-proxy-macos:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p .local/bin
+    cd tinfoil-proxy
+    CGO_ENABLED=0 go build -o ../.local/bin/tinfoil-proxy-darwin .
+    file ../.local/bin/tinfoil-proxy-darwin
+
+# Run the macOS-native Continuum proxy on CONTINUUM_PROXY_PORT, default 8092.
+# The API key is read from CONTINUUM_API_KEY or .local/secrets/continuum_api_key.
+run-continuum-proxy-macos:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    bin=".local/bin/continuum-proxy-darwin"
+    key_file=".local/secrets/continuum_api_key"
+    port="${CONTINUUM_PROXY_PORT:-8092}"
+    workspace="${CONTINUUM_PROXY_WORKSPACE:-.local/continuum}"
+    if [ ! -x "$bin" ]; then
+        echo "$bin is missing. Run: nix develop -c just build-continuum-proxy-macos" >&2
+        exit 1
+    fi
+    api_key="${CONTINUUM_API_KEY:-}"
+    if [ -z "$api_key" ] && [ -f "$key_file" ]; then
+        api_key="$(tr -d '\r\n' < "$key_file")"
+    fi
+    if [ -z "$api_key" ]; then
+        echo "Set CONTINUUM_API_KEY or write the key to $key_file" >&2
+        exit 1
+    fi
+    mkdir -p "$workspace"
+    exec "$bin" --port "$port" --workspace "$workspace" --apiKey "$api_key"
+
+# Run the macOS-native Tinfoil proxy on TINFOIL_PROXY_PORT, default 8093.
+# The API key is read from TINFOIL_API_KEY or .local/secrets/tinfoil_api_key.
+run-tinfoil-proxy-macos:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    bin=".local/bin/tinfoil-proxy-darwin"
+    key_file=".local/secrets/tinfoil_api_key"
+    port="${TINFOIL_PROXY_PORT:-8093}"
+    if [ ! -x "$bin" ]; then
+        echo "$bin is missing. Run: nix develop -c just build-tinfoil-proxy-macos" >&2
+        exit 1
+    fi
+    api_key="${TINFOIL_API_KEY:-}"
+    if [ -z "$api_key" ] && [ -f "$key_file" ]; then
+        api_key="$(tr -d '\r\n' < "$key_file")"
+    fi
+    if [ -z "$api_key" ]; then
+        echo "Set TINFOIL_API_KEY or write the key to $key_file" >&2
+        exit 1
+    fi
+    TINFOIL_API_KEY="$api_key" TINFOIL_PROXY_PORT="$port" exec "$bin"
+
+# Run the local OpenSecret backend pointed at the macOS proxy ports.
+# Requires Postgres from nix develop and a populated .env.
+run-local-backend-macos:
+    APP_MODE="${APP_MODE:-local}" OPENAI_API_BASE="${OPENAI_API_BASE:-http://127.0.0.1:8092}" TINFOIL_API_BASE="${TINFOIL_API_BASE:-http://127.0.0.1:8093}" cargo run
+
 ### Enclave Management ###
 
 # Terminate the running application enclave (dev)


### PR DESCRIPTION
## Summary
- add macOS-native build/run recipes for Continuum and Tinfoil proxies under `.local/bin`
- add local proxy defaults to `.env.sample` and ignore `.local/` generated artifacts
- document the local macOS OpenSecret + proxy + Maple workflow
- update the Darwin dev shell to use the current Apple SDK package and clang for local Rust builds

## Verification
- `nix develop -c just build-local-proxies-macos`
- `nix develop -c cargo check`
- `nix develop -c just run-local-backend-macos`, then `curl http://127.0.0.1:3000/health-check` returned `200`
- `nix develop -c just run-tinfoil-proxy-macos`, then `curl http://127.0.0.1:8093/v1/models` returned `200`
- `nix develop -c just run-continuum-proxy-macos` starts the macOS Continuum proxy and fetches the coordinator manifest; with a placeholder UUID key it exits at upstream attestation with `invalid API key`, as expected

## Notes
- Linux/Nitro production entrypoints and checked-in Linux proxy binaries are unchanged.
- Generated local binaries, Postgres data, and secret files remain gitignored.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret/pull/196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS-native local proxy build/run commands for Continuum and Tinfoil, plus a helper to run the local backend against the proxy endpoints.

* **Documentation**
  * Added a macOS local development runbook covering setup, configuration, and local secret handling.

* **Chores**
  * Updated the sample environment to include `APP_MODE` and a `JWT_SECRET` placeholder.
  * Ignored root `.local` artifacts and improved local `.env` generation behavior in the dev environment setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->