### PR TITLE
Make local dev shell Postgres configurable

### DIFF
--- a/docs/dev-shell.md
+++ b/docs/dev-shell.md
@@ -1,0 +1,56 @@
+# Development Shell
+
+The default `nix develop` behavior starts a local Postgres instance under
+`.pgdata`, creates a local `.env` if one does not exist, and keeps the historical
+port `5432` default.
+
+For multi-workspace local development, the shell hook can be configured without
+changing the default path for existing developers.
+
+## Postgres Controls
+
+Skip shell-hook Postgres management:
+
+```sh
+OPENSECRET_DEV_POSTGRES=0 nix develop
+```
+
+Override the local Postgres state directory and port:
+
+```sh
+PGDATA=/tmp/opensecret-feature-a/pgdata \
+PGPORT=32417 \
+nix develop
+```
+
+The shell hook also respects `PGSOCKETS` when set. If not set, it defaults to
+`$PGDATA/sockets`.
+
+## Environment Controls
+
+Skip shell-hook `.env` generation:
+
+```sh
+OPENSECRET_DEV_ENV=0 nix develop
+```
+
+When `.env` does not exist and generation is enabled, the generated
+`DATABASE_URL` is based on `OPENSECRET_DEV_DATABASE_URL` if set, otherwise on
+the configured `PGPORT`:
+
+```sh
+OPENSECRET_DEV_DATABASE_URL=postgres://opensecret_user:password@localhost:32417/opensecret \
+nix develop
+```
+
+These controls are intended for tools such as `opensecret-workspaces`, where
+each feature workspace owns its own runtime state and ports.
+
+## Backend Bind Address
+
+The local backend listens on `127.0.0.1:3000` by default. Override it when
+running multiple local backends at once:
+
+```sh
+OPENSECRET_BIND_ADDR=127.0.0.1:31417 cargo run
+```

--- a/flake.nix
+++ b/flake.nix
@@ -61,9 +61,15 @@
           ++ pkgs.lib.optionals pkgs.stdenv.isDarwin darwinOnlyInputs;
 
         setupPostgresScript = pkgs.writeShellScript "setup-postgres" ''
-          export PGDATA="$PWD/.pgdata"
-          export PGPORT=5432
-          export PGSOCKETS="$PWD/.pgdata/sockets"
+          case "''${OPENSECRET_DEV_POSTGRES:-1}" in
+            0|false|False|FALSE|no|No|NO|skip|Skip|SKIP)
+              exit 0
+              ;;
+          esac
+
+          export PGDATA="''${PGDATA:-$PWD/.pgdata}"
+          export PGPORT="''${PGPORT:-5432}"
+          export PGSOCKETS="''${PGSOCKETS:-$PGDATA/sockets}"
 
           # Skip if Postgres is already running
           if ${pkgs.postgresql}/bin/pg_isready -h localhost -p $PGPORT >/dev/null 2>&1; then
@@ -92,6 +98,12 @@
         '';
 
         setupEnvScript = pkgs.writeShellScript "setup-env" ''
+          case "''${OPENSECRET_DEV_ENV:-1}" in
+            0|false|False|FALSE|no|No|NO|skip|Skip|SKIP)
+              exit 0
+              ;;
+          esac
+
           if [ ! -f .env ]; then
             cp .env.sample .env
 
@@ -104,7 +116,9 @@
               mv "$tmp" .env
             }
 
-            replace_env 'DATABASE_URL=postgres://localhost/opensecret' 'DATABASE_URL=postgres://opensecret_user:password@localhost:5432/opensecret'
+            export PGPORT="''${PGPORT:-5432}"
+            export OPENSECRET_DEV_DATABASE_URL="''${OPENSECRET_DEV_DATABASE_URL:-postgres://opensecret_user:password@localhost:$PGPORT/opensecret}"
+            replace_env 'DATABASE_URL=postgres://localhost/opensecret' "DATABASE_URL=$OPENSECRET_DEV_DATABASE_URL"
 
             # Get a new ENCLAVE_SECRET_MOCK value using openssl
             export enclaveSecret=$(openssl rand -hex 32)
@@ -453,6 +467,11 @@
         devShell = pkgs.mkShell {
           packages = inputs;
           shellHook = ''
+            export PGDATA="''${PGDATA:-$PWD/.pgdata}"
+            export PGPORT="''${PGPORT:-5432}"
+            export PGSOCKETS="''${PGSOCKETS:-$PGDATA/sockets}"
+            export OPENSECRET_DEV_DATABASE_URL="''${OPENSECRET_DEV_DATABASE_URL:-postgres://opensecret_user:password@localhost:$PGPORT/opensecret}"
+
             export LIBCLANG_PATH=${pkgs.libclang.lib}/lib/
             export LD_LIBRARY_PATH=${pkgs.openssl}/lib:$LD_LIBRARY_PATH
             export CC_wasm32_unknown_unknown=${pkgs.llvmPackages_14.clang-unwrapped}/bin/clang-14

--- a/src/main.rs
+++ b/src/main.rs
@@ -2716,11 +2716,11 @@ async fn main() -> Result<(), Error> {
         )
         .layer(cors);
 
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000")
-        .await
-        .unwrap();
+    let bind_addr =
+        std::env::var("OPENSECRET_BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
+    let listener = tokio::net::TcpListener::bind(&bind_addr).await.unwrap();
 
-    tracing::info!("Listening on http://localhost:3000");
+    tracing::info!("Listening on http://{}", bind_addr);
 
     Ok(axum::serve(listener, app.into_make_service()).await?)
 }


### PR DESCRIPTION
## Summary
- Add `OPENSECRET_DEV_POSTGRES` and `OPENSECRET_DEV_ENV` skips for tooling-managed dev shells.
- Allow `PGDATA`, `PGPORT`, `PGSOCKETS`, and `OPENSECRET_DEV_DATABASE_URL` to configure local Postgres/env generation without changing existing defaults.
- Add `OPENSECRET_BIND_ADDR` so multiple local backends can run on separate ports.
- Document the dev-shell controls in `docs/dev-shell.md`.

## Validation
- `OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 nix develop -c cargo fmt --check`
- `OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 nix develop -c cargo check`
- Real `opensecret-workspaces` smoke passed against this branch with isolated Postgres/proxy/backend ports.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret/pull/197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added guidance for the local development shell, including default Postgres setup, `.env` generation, and how to customize Postgres data directory and port.

* **New Features**
  * Development shell now supports optional skipping of Postgres and `.env` generation via environment controls.
  * Server bind address is configurable via an environment variable (defaulting to `127.0.0.1:3000`), and the startup log reflects the selected address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->