### PR TITLE
Log successful os-flags bool evaluations

### DIFF
--- a/src/os_flags.rs
+++ b/src/os_flags.rs
@@ -194,7 +194,14 @@ impl OsFlagsClient {
     ) -> Result<Option<bool>, OsFlagsError> {
         let keys = [key];
         let resp = self.get_user_flags(user_uuid, Some(&keys)).await?;
-        Ok(resp.flags.get(key).copied())
+        let value = resp.flags.get(key).copied();
+        tracing::debug!(
+            user_uuid = %user_uuid,
+            flag_key = %key,
+            enabled = ?value,
+            "os-flags bool flag evaluated"
+        );
+        Ok(value)
     }
 }
 


### PR DESCRIPTION
## Summary
- add generic debug logging for successful os-flags boolean evaluations
- include user UUID, flag key, and evaluated Option<bool> so missing keys are visible too
- keep the logging in the shared os-flags client path, including cached evaluations

## Verification
- nix develop -c cargo test os_flags --quiet
- nix develop -c rustfmt --edition 2021 --check src/os_flags.rs
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret/pull/201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal logging for feature flag lookups to improve system observability and debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->