### PR TITLE
Trim noisy application logs

### DIFF
--- a/src/aws_credentials.rs
+++ b/src/aws_credentials.rs
@@ -98,12 +98,8 @@ impl AwsCredentialManager {
     }
 
     pub async fn fetch_credentials(&self) -> Result<AwsCredentials, AwsCredentialError> {
-        tracing::debug!("Entering fetch_credentials");
-
         let creds = Self::fetch_credentials_from_vsock().await?;
         self.set_credentials(creds.clone()).await;
-
-        tracing::debug!("Exiting fetch_credentials");
         Ok(creds)
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -736,7 +736,6 @@ pub(crate) struct PostgresConnection {
 
 impl DBConnection for PostgresConnection {
     fn create_user(&self, new_user: NewUser) -> Result<User, DBError> {
-        debug!("Creating new user");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_user.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -746,7 +745,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_user_by_uuid(&self, uuid: Uuid) -> Result<User, DBError> {
-        debug!("Getting user by UUID");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = User::get_by_uuid(conn, uuid)?.ok_or(DBError::UserNotFound);
         if let Err(ref e) = result {
@@ -756,7 +754,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_user_by_email(&self, email: String, project_id: i32) -> Result<User, DBError> {
-        debug!("Getting user by email and project");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = User::get_by_email(conn, email, project_id)?.ok_or(DBError::UserNotFound);
         if let Err(ref e) = result {
@@ -919,7 +916,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn verify_email(&self, verification: &mut EmailVerification) -> Result<(), DBError> {
-        debug!("Verifying email");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = verification.verify(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -932,7 +928,6 @@ impl DBConnection for PostgresConnection {
         &self,
         new_request: NewPasswordResetRequest,
     ) -> Result<PasswordResetRequest, DBError> {
-        debug!("Creating new password reset request");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_request.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -946,7 +941,6 @@ impl DBConnection for PostgresConnection {
         user_id: Uuid,
         encrypted_code: Vec<u8>,
     ) -> Result<Option<PasswordResetRequest>, DBError> {
-        debug!("Getting password reset request by user_id and encrypted code");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = PasswordResetRequest::get_by_user_id_and_code(conn, user_id, &encrypted_code)
             .map_err(DBError::from);
@@ -963,7 +957,6 @@ impl DBConnection for PostgresConnection {
         new_password_enc: Vec<u8>,
         new_wrapping: NewUserSeedWrapping,
     ) -> Result<(), DBError> {
-        debug!("Updating user password and password seed wrap");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         conn.transaction::<_, DBError, _>(|conn| {
             let updated_user_count = diesel::update(
@@ -994,7 +987,6 @@ impl DBConnection for PostgresConnection {
         &self,
         request: &PasswordResetRequest,
     ) -> Result<(), DBError> {
-        debug!("Marking password reset request as complete");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = request.mark_as_reset(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1218,7 +1210,6 @@ impl DBConnection for PostgresConnection {
 
     // Org implementations
     fn create_org(&self, new_org: NewOrg) -> Result<Org, DBError> {
-        debug!("Creating new org");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_org.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1228,7 +1219,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_org_by_id(&self, id: i32) -> Result<Org, DBError> {
-        debug!("Getting org by ID");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = Org::get_by_id(conn, id)?.ok_or(DBError::OrgNotFound);
         if let Err(ref e) = result {
@@ -1238,7 +1228,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_org_by_uuid(&self, uuid: Uuid) -> Result<Org, DBError> {
-        debug!("Getting org by UUID");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = Org::get_by_uuid(conn, uuid)?.ok_or(DBError::OrgNotFound);
         if let Err(ref e) = result {
@@ -1248,7 +1237,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_org_by_name(&self, name: &str) -> Result<Option<Org>, DBError> {
-        debug!("Getting org by name");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = Org::get_by_name(conn, name).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1258,7 +1246,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_all_orgs(&self) -> Result<Vec<Org>, DBError> {
-        debug!("Getting all orgs");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = Org::get_all(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1268,7 +1255,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn update_org(&self, org: &Org) -> Result<(), DBError> {
-        debug!("Updating org");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = org.update(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1278,7 +1264,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn delete_org(&self, org: &Org) -> Result<(), DBError> {
-        debug!("Deleting org");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = org.delete(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1289,7 +1274,6 @@ impl DBConnection for PostgresConnection {
 
     // Org project implementations
     fn create_org_project(&self, new_project: NewOrgProject) -> Result<OrgProject, DBError> {
-        debug!("Creating new org project");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_project.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1299,7 +1283,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_org_project_by_id(&self, id: i32) -> Result<OrgProject, DBError> {
-        debug!("Getting org project by ID");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = OrgProject::get_by_id(conn, id)?.ok_or(DBError::OrgProjectNotFound);
         if let Err(ref e) = result {
@@ -1309,7 +1292,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_org_project_by_uuid(&self, uuid: Uuid) -> Result<OrgProject, DBError> {
-        debug!("Getting org project by UUID");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = OrgProject::get_by_uuid(conn, uuid)?.ok_or(DBError::OrgProjectNotFound);
         if let Err(ref e) = result {
@@ -1319,7 +1301,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_org_project_by_client_id(&self, client_id: Uuid) -> Result<OrgProject, DBError> {
-        debug!("Getting org project by client ID");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result =
             OrgProject::get_by_client_id(conn, client_id)?.ok_or(DBError::OrgProjectNotFound);
@@ -1334,7 +1315,6 @@ impl DBConnection for PostgresConnection {
         name: &str,
         org_id: i32,
     ) -> Result<Option<OrgProject>, DBError> {
-        debug!("Getting org project by name and org");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = OrgProject::get_by_name_and_org(conn, name, org_id).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1344,7 +1324,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_all_org_projects_for_org(&self, org_id: i32) -> Result<Vec<OrgProject>, DBError> {
-        debug!("Getting all org projects for org");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = OrgProject::get_all_for_org(conn, org_id).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1354,7 +1333,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_active_org_projects_for_org(&self, org_id: i32) -> Result<Vec<OrgProject>, DBError> {
-        debug!("Getting active org projects for org");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = OrgProject::get_active_for_org(conn, org_id).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1364,7 +1342,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn update_org_project(&self, project: &OrgProject) -> Result<(), DBError> {
-        debug!("Updating org project");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = project.update(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1374,7 +1351,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn delete_org_project(&self, project: &OrgProject) -> Result<(), DBError> {
-        debug!("Deleting org project");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = project.delete(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1388,7 +1364,6 @@ impl DBConnection for PostgresConnection {
         &self,
         new_secret: NewOrgProjectSecret,
     ) -> Result<OrgProjectSecret, DBError> {
-        debug!("Creating new org project secret");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_secret.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1398,7 +1373,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_org_project_secret_by_id(&self, id: i32) -> Result<OrgProjectSecret, DBError> {
-        debug!("Getting org project secret by ID");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result =
             OrgProjectSecret::get_by_id(conn, id)?.ok_or(DBError::OrgProjectSecretNotFound);
@@ -1413,7 +1387,6 @@ impl DBConnection for PostgresConnection {
         key_name: &str,
         project_id: i32,
     ) -> Result<Option<OrgProjectSecret>, DBError> {
-        debug!("Getting org project secret by key name and project");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = OrgProjectSecret::get_by_key_name_and_project(conn, key_name, project_id)
             .map_err(DBError::from);
@@ -1430,7 +1403,6 @@ impl DBConnection for PostgresConnection {
         &self,
         project_id: i32,
     ) -> Result<Vec<OrgProjectSecret>, DBError> {
-        debug!("Getting all org project secrets for project");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = OrgProjectSecret::get_all_for_project(conn, project_id).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1440,7 +1412,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn update_org_project_secret(&self, secret: &OrgProjectSecret) -> Result<(), DBError> {
-        debug!("Updating org project secret");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = secret.update(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1450,7 +1421,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn delete_org_project_secret(&self, secret: &OrgProjectSecret) -> Result<(), DBError> {
-        debug!("Deleting org project secret");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = secret.delete(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1461,7 +1431,6 @@ impl DBConnection for PostgresConnection {
 
     // Invite code implementations
     fn create_invite_code(&self, new_invite: NewInviteCode) -> Result<InviteCode, DBError> {
-        debug!("Creating new invite code");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_invite.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1471,7 +1440,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_invite_code_by_id(&self, id: i32) -> Result<InviteCode, DBError> {
-        debug!("Getting invite code by ID");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = InviteCode::get_by_id(conn, id)?.ok_or(DBError::InviteCodeNotFound);
         if let Err(ref e) = result {
@@ -1481,7 +1449,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_invite_code_by_code(&self, code: Uuid) -> Result<InviteCode, DBError> {
-        debug!("Getting invite code by code");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = InviteCode::get_by_code(conn, code)?.ok_or(DBError::InviteCodeNotFound);
         if let Err(ref e) = result {
@@ -1495,7 +1462,6 @@ impl DBConnection for PostgresConnection {
         email: &str,
         org_id: i32,
     ) -> Result<Option<InviteCode>, DBError> {
-        debug!("Getting invite code by email and org");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = InviteCode::get_by_email_and_org(conn, email, org_id).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1505,7 +1471,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_all_invite_codes_for_org(&self, org_id: i32) -> Result<Vec<InviteCode>, DBError> {
-        debug!("Getting all invite codes for org");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = InviteCode::get_all_for_org(conn, org_id).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1515,7 +1480,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn mark_invite_code_as_used(&self, invite: &InviteCode) -> Result<(), DBError> {
-        debug!("Marking invite code as used");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = invite.mark_as_used(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1525,7 +1489,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn update_invite_code(&self, invite: &InviteCode) -> Result<(), DBError> {
-        debug!("Updating invite code");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = invite.update(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1535,7 +1498,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn delete_invite_code(&self, invite: &InviteCode) -> Result<(), DBError> {
-        debug!("Deleting invite code");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = invite.delete(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1546,7 +1508,6 @@ impl DBConnection for PostgresConnection {
 
     // Platform user methods
     fn create_platform_user(&self, new_user: NewPlatformUser) -> Result<PlatformUser, DBError> {
-        debug!("Creating new platform user");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_user.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1556,7 +1517,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_platform_user_by_id(&self, id: i32) -> Result<PlatformUser, DBError> {
-        debug!("Getting platform user by ID");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = PlatformUser::get_by_id(conn, id)?.ok_or(DBError::PlatformUserNotFound);
         if let Err(ref e) = result {
@@ -1566,7 +1526,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_platform_user_by_uuid(&self, uuid: Uuid) -> Result<PlatformUser, DBError> {
-        debug!("Getting platform user by UUID");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = PlatformUser::get_by_uuid(conn, uuid)?.ok_or(DBError::PlatformUserNotFound);
         if let Err(ref e) = result {
@@ -1576,7 +1535,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_platform_user_by_email(&self, email: &str) -> Result<Option<PlatformUser>, DBError> {
-        debug!("Getting platform user by email");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = PlatformUser::get_by_email(conn, email).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1586,7 +1544,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn update_platform_user(&self, user: &PlatformUser) -> Result<(), DBError> {
-        debug!("Updating platform user");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = user.update(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1600,7 +1557,6 @@ impl DBConnection for PostgresConnection {
         user: &PlatformUser,
         new_password_enc: Vec<u8>,
     ) -> Result<(), DBError> {
-        debug!("Updating platform user password");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = user
             .update_password(conn, new_password_enc)
@@ -1616,7 +1572,6 @@ impl DBConnection for PostgresConnection {
         &self,
         new_membership: NewOrgMembership,
     ) -> Result<OrgMembership, DBError> {
-        debug!("Creating new org membership");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_membership
             .insert(conn)
@@ -1632,7 +1587,6 @@ impl DBConnection for PostgresConnection {
         platform_user_id: Uuid,
         org_id: i32,
     ) -> Result<OrgMembership, DBError> {
-        debug!("Getting org membership by platform user and org");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = OrgMembership::get_by_platform_user_and_org(conn, platform_user_id, org_id)
             .map_err(DBError::from);
@@ -1650,7 +1604,6 @@ impl DBConnection for PostgresConnection {
         platform_user_id: Uuid,
         org_id: i32,
     ) -> Result<OrgMembershipWithUser, DBError> {
-        debug!("Getting org membership with user info by platform user and org");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result =
             OrgMembership::get_by_platform_user_and_org_with_user(conn, platform_user_id, org_id)
@@ -1668,7 +1621,6 @@ impl DBConnection for PostgresConnection {
         &self,
         platform_user_id: Uuid,
     ) -> Result<Vec<OrgMembership>, DBError> {
-        debug!("Getting all org memberships for platform user");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result =
             OrgMembership::get_all_for_platform_user(conn, platform_user_id).map_err(DBError::from);
@@ -1682,7 +1634,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_all_org_memberships_for_org(&self, org_id: i32) -> Result<Vec<OrgMembership>, DBError> {
-        debug!("Getting all org memberships for org");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = OrgMembership::get_all_for_org(conn, org_id).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1695,7 +1646,6 @@ impl DBConnection for PostgresConnection {
         &self,
         org_id: i32,
     ) -> Result<Vec<OrgMembershipWithUser>, DBError> {
-        debug!("Getting all org memberships with users for org");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = OrgMembership::get_all_with_users_for_org(conn, org_id).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1708,7 +1658,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn update_org_membership(&self, membership: &OrgMembership) -> Result<(), DBError> {
-        debug!("Updating org membership");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = membership.update(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1718,7 +1667,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn delete_org_membership(&self, membership: &OrgMembership) -> Result<(), DBError> {
-        debug!("Deleting org membership");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = membership.delete(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1732,7 +1680,6 @@ impl DBConnection for PostgresConnection {
         membership: &mut OrgMembership,
         new_role: OrgRole,
     ) -> Result<(), DBError> {
-        debug!("Updating org membership role with owner check");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = OrgMembership::update_role_with_owner_check(conn, membership, new_role)
             .map_err(|e| match e {
@@ -1753,7 +1700,6 @@ impl DBConnection for PostgresConnection {
         &self,
         membership: &OrgMembership,
     ) -> Result<(), DBError> {
-        debug!("Deleting org membership with owner check");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result =
             OrgMembership::delete_with_owner_check(conn, membership).map_err(|e| match e {
@@ -1777,7 +1723,6 @@ impl DBConnection for PostgresConnection {
         page: Option<i64>,
         per_page: Option<i64>,
     ) -> Result<(Vec<User>, i64), DBError> {
-        debug!("Getting all users for project");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
 
         // Get total count first
@@ -1793,7 +1738,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn create_org_with_owner(&self, new_org: NewOrg, owner_id: Uuid) -> Result<Org, DBError> {
-        debug!("Creating new organization with owner");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
 
         conn.transaction(|conn| {
@@ -1813,7 +1757,6 @@ impl DBConnection for PostgresConnection {
         invite: &InviteCode,
         new_membership: NewOrgMembership,
     ) -> Result<OrgMembership, DBError> {
-        debug!("Starting invite acceptance transaction");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
 
         conn.transaction(|conn| {
@@ -1833,7 +1776,6 @@ impl DBConnection for PostgresConnection {
         project_id: i32,
         category: SettingCategory,
     ) -> Result<Option<ProjectSetting>, DBError> {
-        debug!("Getting project settings");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         ProjectSetting::get_by_project_and_category(conn, project_id, category)
             .map_err(DBError::from)
@@ -1845,7 +1787,6 @@ impl DBConnection for PostgresConnection {
         category: SettingCategory,
         settings: serde_json::Value,
     ) -> Result<ProjectSetting, DBError> {
-        debug!("Updating project settings");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
 
         // Check if settings exist
@@ -1870,7 +1811,6 @@ impl DBConnection for PostgresConnection {
         &self,
         project_id: i32,
     ) -> Result<Option<EmailSettings>, DBError> {
-        debug!("Getting project email settings");
         let settings = self.get_project_settings(project_id, SettingCategory::Email)?;
 
         match settings {
@@ -1884,7 +1824,6 @@ impl DBConnection for PostgresConnection {
         project_id: i32,
         settings: EmailSettings,
     ) -> Result<ProjectSetting, DBError> {
-        debug!("Updating project email settings");
         let new_settings = NewProjectSetting::new_email_settings(project_id, settings)?;
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
 
@@ -1905,7 +1844,6 @@ impl DBConnection for PostgresConnection {
         &self,
         project_id: i32,
     ) -> Result<Option<OAuthSettings>, DBError> {
-        debug!("Getting project OAuth settings");
         let settings = self.get_project_settings(project_id, SettingCategory::OAuth)?;
 
         match settings {
@@ -1919,7 +1857,6 @@ impl DBConnection for PostgresConnection {
         project_id: i32,
         settings: OAuthSettings,
     ) -> Result<ProjectSetting, DBError> {
-        debug!("Updating project OAuth settings");
         let new_settings = NewProjectSetting::new_oauth_settings(project_id, settings)?;
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
 
@@ -1941,7 +1878,6 @@ impl DBConnection for PostgresConnection {
         &self,
         new_verification: NewPlatformEmailVerification,
     ) -> Result<PlatformEmailVerification, DBError> {
-        debug!("Creating new platform email verification");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_verification.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -1954,7 +1890,6 @@ impl DBConnection for PostgresConnection {
         &self,
         id: i32,
     ) -> Result<PlatformEmailVerification, DBError> {
-        debug!("Getting platform email verification by ID");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = PlatformEmailVerification::get_by_id(conn, id)?
             .ok_or(DBError::PlatformEmailVerificationNotFound);
@@ -1968,7 +1903,6 @@ impl DBConnection for PostgresConnection {
         &self,
         platform_user_id: Uuid,
     ) -> Result<PlatformEmailVerification, DBError> {
-        debug!("Getting platform email verification by platform user ID");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = PlatformEmailVerification::get_by_platform_user_id(conn, platform_user_id)?
             .ok_or(DBError::PlatformEmailVerificationNotFound);
@@ -1985,7 +1919,6 @@ impl DBConnection for PostgresConnection {
         &self,
         code: Uuid,
     ) -> Result<PlatformEmailVerification, DBError> {
-        debug!("Getting platform email verification by code");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = PlatformEmailVerification::get_by_verification_code(conn, code)?
             .ok_or(DBError::PlatformEmailVerificationNotFound);
@@ -1999,7 +1932,6 @@ impl DBConnection for PostgresConnection {
         &self,
         verification: &PlatformEmailVerification,
     ) -> Result<(), DBError> {
-        debug!("Updating platform email verification");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = verification.update(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -2012,7 +1944,6 @@ impl DBConnection for PostgresConnection {
         &self,
         verification: &PlatformEmailVerification,
     ) -> Result<(), DBError> {
-        debug!("Deleting platform email verification");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = verification.delete(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -2025,7 +1956,6 @@ impl DBConnection for PostgresConnection {
         &self,
         verification: &mut PlatformEmailVerification,
     ) -> Result<(), DBError> {
-        debug!("Verifying platform email");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = verification.verify(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -2039,7 +1969,6 @@ impl DBConnection for PostgresConnection {
         &self,
         new_request: NewPlatformPasswordResetRequest,
     ) -> Result<PlatformPasswordResetRequest, DBError> {
-        debug!("Creating new platform password reset request");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_request.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -2053,7 +1982,6 @@ impl DBConnection for PostgresConnection {
         user_id: Uuid,
         encrypted_code: Vec<u8>,
     ) -> Result<Option<PlatformPasswordResetRequest>, DBError> {
-        debug!("Getting platform password reset request by user_id and encrypted code");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result =
             PlatformPasswordResetRequest::get_by_user_id_and_code(conn, user_id, &encrypted_code)
@@ -2068,7 +1996,6 @@ impl DBConnection for PostgresConnection {
         &self,
         request: &PlatformPasswordResetRequest,
     ) -> Result<(), DBError> {
-        debug!("Marking platform password reset request as complete");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = request.mark_as_reset(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -2096,7 +2023,6 @@ impl DBConnection for PostgresConnection {
 
     // User API key implementations
     fn create_user_api_key(&self, new_key: NewUserApiKey) -> Result<UserApiKey, DBError> {
-        debug!("Creating new user API key");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         new_key.insert(conn).map_err(DBError::from)
     }
@@ -2128,13 +2054,11 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_all_user_api_keys_for_user(&self, user_id: Uuid) -> Result<Vec<UserApiKey>, DBError> {
-        debug!("Getting all API keys for user: {}", user_id);
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         UserApiKey::get_all_for_user(conn, user_id).map_err(DBError::from)
     }
 
     fn delete_user_api_key(&self, id: i32, user_id: Uuid) -> Result<(), DBError> {
-        debug!("Deleting API key {} for user {}", id, user_id);
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         // First verify the key belongs to the user
         // Use the same error for both "not found" and "unauthorized" to prevent information disclosure
@@ -2147,7 +2071,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn delete_user_api_key_by_name(&self, name: &str, user_id: Uuid) -> Result<(), DBError> {
-        debug!("Deleting API key '{}' for user {}", name, user_id);
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         // First find the key by name and user_id, then delete it
         // Use the same error for both "not found" and "unauthorized" to prevent information disclosure
@@ -2162,7 +2085,6 @@ impl DBConnection for PostgresConnection {
         &self,
         new_request: NewAccountDeletionRequest,
     ) -> Result<AccountDeletionRequest, DBError> {
-        debug!("Creating new account deletion request");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_request.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -2176,7 +2098,6 @@ impl DBConnection for PostgresConnection {
         user_id: Uuid,
         encrypted_code: Vec<u8>,
     ) -> Result<Option<AccountDeletionRequest>, DBError> {
-        debug!("Getting account deletion request by user_id and encrypted code");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result =
             AccountDeletionRequest::get_by_user_id_and_code(conn, user_id, &encrypted_code)
@@ -2191,7 +2112,6 @@ impl DBConnection for PostgresConnection {
         &self,
         request: &AccountDeletionRequest,
     ) -> Result<(), DBError> {
-        debug!("Marking account deletion request as complete");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = request.mark_as_deleted(conn).map_err(DBError::from);
         if let Err(ref e) = result {
@@ -2204,7 +2124,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn delete_user(&self, user: &User) -> Result<(), DBError> {
-        debug!("Deleting user with UUID: {}", user.uuid);
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
 
         // Use the User model's delete method
@@ -2243,7 +2162,6 @@ impl DBConnection for PostgresConnection {
         &self,
         new_conversation: NewConversation,
     ) -> Result<Conversation, DBError> {
-        debug!("Creating new conversation");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         new_conversation.insert(conn).map_err(DBError::from)
     }
@@ -2254,8 +2172,6 @@ impl DBConnection for PostgresConnection {
     ) -> Result<ConversationProject, DBError> {
         use crate::models::schema::users;
         use diesel::prelude::*;
-
-        debug!("Creating new conversation project");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
 
         conn.transaction::<ConversationProject, ResponsesError, _>(|tx| {
@@ -2279,7 +2195,6 @@ impl DBConnection for PostgresConnection {
         conversation_id: i64,
         user_id: Uuid,
     ) -> Result<Conversation, DBError> {
-        debug!("Getting conversation by ID and user");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         Conversation::get_by_id_and_user(conn, conversation_id, user_id).map_err(DBError::from)
     }
@@ -2289,7 +2204,6 @@ impl DBConnection for PostgresConnection {
         conversation_uuid: Uuid,
         user_id: Uuid,
     ) -> Result<Conversation, DBError> {
-        debug!("Getting conversation by UUID and user");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         Conversation::get_by_uuid_and_user(conn, conversation_uuid, user_id).map_err(DBError::from)
     }
@@ -2299,7 +2213,6 @@ impl DBConnection for PostgresConnection {
         project_id: i64,
         user_id: Uuid,
     ) -> Result<ConversationProject, DBError> {
-        debug!("Getting conversation project by ID and user");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         ConversationProject::get_by_id_and_user(conn, project_id, user_id).map_err(DBError::from)
     }
@@ -2309,7 +2222,6 @@ impl DBConnection for PostgresConnection {
         project_uuid: Uuid,
         user_id: Uuid,
     ) -> Result<ConversationProject, DBError> {
-        debug!("Getting conversation project by UUID and user");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         ConversationProject::get_by_uuid_and_user(conn, project_uuid, user_id)
             .map_err(DBError::from)
@@ -2321,7 +2233,6 @@ impl DBConnection for PostgresConnection {
         user_id: Uuid,
         metadata_enc: Vec<u8>,
     ) -> Result<Conversation, DBError> {
-        debug!("Updating conversation metadata");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         Conversation::update_metadata(conn, conversation_id, user_id, metadata_enc)
             .map_err(DBError::from)
@@ -2335,7 +2246,6 @@ impl DBConnection for PostgresConnection {
         project_id: Option<Option<i64>>,
         is_pinned: Option<bool>,
     ) -> Result<Conversation, DBError> {
-        debug!("Updating conversation");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         Conversation::update(
             conn,
@@ -2354,7 +2264,6 @@ impl DBConnection for PostgresConnection {
         user_id: Uuid,
         target_project_id: Option<i64>,
     ) -> Result<(), DBError> {
-        debug!("Batch updating conversation projects");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         Conversation::batch_update_project(conn, conversation_uuids, user_id, target_project_id)
             .map_err(DBError::from)
@@ -2369,7 +2278,6 @@ impl DBConnection for PostgresConnection {
         project_filter: ConversationProjectFilter,
         pinned: Option<bool>,
     ) -> Result<Vec<Conversation>, DBError> {
-        debug!("Listing conversations for user");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         Conversation::list_for_user(conn, user_id, limit, after, order, project_filter, pinned)
             .map_err(DBError::from)
@@ -2382,7 +2290,6 @@ impl DBConnection for PostgresConnection {
         after: Option<Uuid>,
         order: &str,
     ) -> Result<Vec<ConversationProject>, DBError> {
-        debug!("Listing conversation projects for user");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         ConversationProject::list_for_user(conn, user_id, limit, after, order)
             .map_err(DBError::from)
@@ -2395,7 +2302,6 @@ impl DBConnection for PostgresConnection {
         name_enc: Option<Vec<u8>>,
         instruction_update: ProjectInstructionUpdate,
     ) -> Result<ConversationProject, DBError> {
-        debug!("Updating conversation project");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
 
         use crate::models::schema::{conversation_projects, user_instructions};
@@ -2492,26 +2398,22 @@ impl DBConnection for PostgresConnection {
     }
 
     fn delete_conversation(&self, conversation_id: i64, user_id: Uuid) -> Result<(), DBError> {
-        debug!("Deleting conversation");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         Conversation::delete_by_id_and_user(conn, conversation_id, user_id).map_err(DBError::from)
     }
 
     fn delete_all_conversations(&self, user_id: Uuid) -> Result<(), DBError> {
-        debug!("Deleting all conversations for user");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         Conversation::delete_all_for_user(conn, user_id).map_err(DBError::from)
     }
 
     fn delete_conversation_project(&self, project_id: i64, user_id: Uuid) -> Result<(), DBError> {
-        debug!("Deleting conversation project");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         ConversationProject::delete_by_id_and_user(conn, project_id, user_id).map_err(DBError::from)
     }
 
     // Responses (job tracker) implementations
     fn create_response(&self, new_response: NewResponse) -> Result<Response, DBError> {
-        debug!("Creating new response");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         new_response.insert(conn).map_err(DBError::from)
     }
@@ -2521,7 +2423,6 @@ impl DBConnection for PostgresConnection {
         uuid: Uuid,
         user_id: Uuid,
     ) -> Result<Response, DBError> {
-        debug!("Getting response by UUID and user");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         Response::get_by_uuid_and_user(conn, uuid, user_id).map_err(DBError::from)
     }
@@ -2532,19 +2433,16 @@ impl DBConnection for PostgresConnection {
         status: ResponseStatus,
         completed_at: Option<DateTime<Utc>>,
     ) -> Result<(), DBError> {
-        debug!("Updating response status");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         Response::update_status(conn, id, status, completed_at).map_err(DBError::from)
     }
 
     fn cancel_response(&self, uuid: Uuid, user_id: Uuid) -> Result<Response, DBError> {
-        debug!("Cancelling response");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         Response::cancel_by_uuid_and_user(conn, uuid, user_id).map_err(DBError::from)
     }
 
     fn delete_response(&self, uuid: Uuid, user_id: Uuid) -> Result<(), DBError> {
-        debug!("Deleting response");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         Response::delete_by_uuid_and_user(conn, uuid, user_id).map_err(DBError::from)
     }
@@ -2560,7 +2458,6 @@ impl DBConnection for PostgresConnection {
         message_uuid: Uuid,
         assistant_message_uuid: Option<Uuid>,
     ) -> Result<(Conversation, Option<Response>, UserMessage), DBError> {
-        debug!("Creating conversation with response and message");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         NewConversation::create_with_response_and_message(
             conn,
@@ -2581,7 +2478,6 @@ impl DBConnection for PostgresConnection {
         &self,
         user_id: Uuid,
     ) -> Result<Option<UserInstruction>, DBError> {
-        debug!("Getting default user instruction for user");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
 
         use crate::models::schema::user_instructions;
@@ -2601,7 +2497,6 @@ impl DBConnection for PostgresConnection {
         project_id: i64,
         user_id: Uuid,
     ) -> Result<Option<UserInstruction>, DBError> {
-        debug!("Getting project instruction for project");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
 
         use crate::models::schema::user_instructions;
@@ -2620,7 +2515,6 @@ impl DBConnection for PostgresConnection {
         conversation_id: i64,
         user_id: Uuid,
     ) -> Result<Option<UserInstruction>, DBError> {
-        debug!("Getting project instruction for conversation");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
 
         use crate::models::schema::{conversations, user_instructions};
@@ -2653,7 +2547,6 @@ impl DBConnection for PostgresConnection {
         uuid: Uuid,
         user_id: Uuid,
     ) -> Result<UserInstruction, DBError> {
-        debug!("Getting user instruction by UUID for user");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
 
         use crate::models::schema::user_instructions;
@@ -2676,7 +2569,6 @@ impl DBConnection for PostgresConnection {
         &self,
         new_instruction: NewUserInstruction,
     ) -> Result<UserInstruction, DBError> {
-        debug!("Creating new user instruction");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
 
         use crate::models::schema::user_instructions;
@@ -2711,7 +2603,6 @@ impl DBConnection for PostgresConnection {
         prompt_tokens: i32,
         is_default: bool,
     ) -> Result<UserInstruction, DBError> {
-        debug!("Updating user instruction");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
 
         use crate::models::schema::user_instructions;
@@ -2750,7 +2641,6 @@ impl DBConnection for PostgresConnection {
     }
 
     fn delete_user_instruction(&self, id: i64, user_id: Uuid) -> Result<(), DBError> {
-        debug!("Deleting user instruction");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
 
         use crate::models::schema::user_instructions;
@@ -2781,7 +2671,6 @@ impl DBConnection for PostgresConnection {
         after: Option<Uuid>,
         order: &str,
     ) -> Result<Vec<UserInstruction>, DBError> {
-        debug!("Listing user instructions");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
 
         use crate::models::schema::user_instructions;
@@ -2845,7 +2734,6 @@ impl DBConnection for PostgresConnection {
         id: i64,
         user_id: Uuid,
     ) -> Result<UserInstruction, DBError> {
-        debug!("Setting default user instruction");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
 
         use crate::models::schema::user_instructions;
@@ -2880,7 +2768,6 @@ impl DBConnection for PostgresConnection {
 
     // User messages
     fn create_user_message(&self, new_msg: NewUserMessage) -> Result<UserMessage, DBError> {
-        debug!("Creating new user message");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         new_msg.insert(conn).map_err(DBError::from)
     }
@@ -2890,7 +2777,6 @@ impl DBConnection for PostgresConnection {
         id: i64,
         prompt_tokens: i32,
     ) -> Result<(), DBError> {
-        debug!("Updating user message prompt tokens");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         use crate::models::schema::user_messages;
         use diesel::prelude::*;
@@ -2903,13 +2789,11 @@ impl DBConnection for PostgresConnection {
     }
 
     fn get_user_message(&self, id: i64, user_id: Uuid) -> Result<UserMessage, DBError> {
-        debug!("Getting user message by ID and user");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         UserMessage::get_by_id_and_user(conn, id, user_id).map_err(DBError::from)
     }
 
     fn get_user_message_by_uuid(&self, uuid: Uuid, user_id: Uuid) -> Result<UserMessage, DBError> {
-        debug!("Getting user message by UUID and user");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         UserMessage::get_by_uuid_and_user(conn, uuid, user_id).map_err(DBError::from)
     }
@@ -2919,7 +2803,6 @@ impl DBConnection for PostgresConnection {
         &self,
         new_msg: NewAssistantMessage,
     ) -> Result<AssistantMessage, DBError> {
-        debug!("Creating new assistant message");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         new_msg.insert(conn).map_err(DBError::from)
     }
@@ -2930,7 +2813,6 @@ impl DBConnection for PostgresConnection {
     ) -> Result<Option<AssistantMessage>, DBError> {
         use crate::models::schema::assistant_messages::dsl::*;
         use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl};
-        debug!("Getting assistant message by UUID: {}", message_uuid);
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         assistant_messages
             .filter(uuid.eq(message_uuid))
@@ -2947,7 +2829,6 @@ impl DBConnection for PostgresConnection {
         status: String,
         finish_reason: Option<String>,
     ) -> Result<AssistantMessage, DBError> {
-        debug!("Updating assistant message {}", message_uuid);
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         AssistantMessage::update(
             conn,
@@ -2962,7 +2843,6 @@ impl DBConnection for PostgresConnection {
 
     // Reasoning items
     fn create_reasoning_item(&self, new_item: NewReasoningItem) -> Result<ReasoningItem, DBError> {
-        debug!("Creating new reasoning item");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         new_item.insert(conn).map_err(DBError::from)
     }
@@ -2974,7 +2854,6 @@ impl DBConnection for PostgresConnection {
         reasoning_tokens: i32,
         status: String,
     ) -> Result<ReasoningItem, DBError> {
-        debug!("Updating reasoning item {}", item_uuid);
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         ReasoningItem::update(conn, item_uuid, content_enc, reasoning_tokens, status)
             .map_err(DBError::from)
@@ -2982,19 +2861,16 @@ impl DBConnection for PostgresConnection {
 
     // Tool calls / outputs
     fn create_tool_call(&self, new_call: NewToolCall) -> Result<ToolCall, DBError> {
-        debug!("Creating new tool call");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         new_call.insert(conn).map_err(DBError::from)
     }
 
     fn get_tool_call_by_uuid(&self, uuid: Uuid, user_id: Uuid) -> Result<ToolCall, DBError> {
-        debug!("Getting tool call by UUID: {} for user: {}", uuid, user_id);
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         ToolCall::get_by_uuid(conn, uuid, user_id).map_err(DBError::from)
     }
 
     fn create_tool_output(&self, new_output: NewToolOutput) -> Result<ToolOutput, DBError> {
-        debug!("Creating new tool output");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         new_output.insert(conn).map_err(DBError::from)
     }
@@ -3007,7 +2883,6 @@ impl DBConnection for PostgresConnection {
         after: Option<Uuid>,
         order: &str,
     ) -> Result<Vec<RawThreadMessage>, DBError> {
-        debug!("Getting conversation context messages");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         RawThreadMessage::get_conversation_context(conn, conversation_id, limit, after, order)
             .map_err(DBError::from)
@@ -3017,7 +2892,6 @@ impl DBConnection for PostgresConnection {
         &self,
         response_id: i64,
     ) -> Result<Vec<RawThreadMessage>, DBError> {
-        debug!("Getting response context messages");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         RawThreadMessage::get_response_context(conn, response_id).map_err(DBError::from)
     }
@@ -3027,7 +2901,6 @@ impl DBConnection for PostgresConnection {
         &self,
         conversation_id: i64,
     ) -> Result<Vec<RawThreadMessageMetadata>, DBError> {
-        debug!("Getting conversation context metadata (lightweight)");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         RawThreadMessageMetadata::get_conversation_context_metadata(conn, conversation_id)
             .map_err(DBError::from)
@@ -3038,14 +2911,12 @@ impl DBConnection for PostgresConnection {
         conversation_id: i64,
         message_ids: &[(String, i64)],
     ) -> Result<Vec<RawThreadMessage>, DBError> {
-        debug!("Getting {} specific messages by ID", message_ids.len());
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         RawThreadMessage::get_messages_by_ids(conn, conversation_id, message_ids)
             .map_err(DBError::from)
     }
 
     fn delete_user_message(&self, id: Uuid, user_id: Uuid) -> Result<(), DBError> {
-        debug!("Deleting user message");
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         // First get the message by UUID to find its ID
         let msg = UserMessage::get_by_uuid_and_user(conn, id, user_id)?;

--- a/src/email.rs
+++ b/src/email.rs
@@ -343,8 +343,6 @@ pub async fn send_hello_email(
     project_id: i32,
     to_email: String,
 ) -> Result<(), EmailError> {
-    tracing::debug!("Entering send_hello_email");
-
     // Get project name
     let project = app_state
         .db
@@ -380,8 +378,6 @@ pub async fn send_hello_email(
         tracing::error!("Failed to send email: {}", e);
         EmailError::UnknownError
     });
-
-    tracing::debug!("Exiting send_hello_email");
     Ok(())
 }
 
@@ -391,8 +387,6 @@ pub async fn send_verification_email(
     to_email: String,
     verification_code: uuid::Uuid,
 ) -> Result<(), EmailError> {
-    tracing::debug!("Entering send_verification_email");
-
     let (api_key, from_email) = get_project_email_settings(app_state, project_id).await?;
     let resend = Resend::new(&api_key);
 
@@ -472,8 +466,6 @@ pub async fn send_verification_email(
         tracing::error!("Failed to send email: {}", e);
         EmailError::UnknownError
     });
-
-    tracing::debug!("Exiting send_verification_email");
     Ok(())
 }
 
@@ -483,8 +475,6 @@ pub async fn send_password_reset_email(
     to_email: String,
     alphanumeric_code: String,
 ) -> Result<(), EmailError> {
-    tracing::debug!("Entering send_password_reset_email");
-
     let (api_key, from_email) = get_project_email_settings(app_state, project_id).await?;
     let resend = Resend::new(&api_key);
 
@@ -543,8 +533,6 @@ pub async fn send_password_reset_email(
         tracing::error!("Failed to send email: {}", e);
         EmailError::UnknownError
     });
-
-    tracing::debug!("Exiting send_password_reset_email");
     Ok(())
 }
 
@@ -553,8 +541,6 @@ pub async fn send_password_reset_confirmation_email(
     project_id: i32,
     to_email: String,
 ) -> Result<(), EmailError> {
-    tracing::debug!("Entering send_password_reset_confirmation_email");
-
     let (api_key, from_email) = get_project_email_settings(app_state, project_id).await?;
     let resend = Resend::new(&api_key);
 
@@ -615,8 +601,6 @@ pub async fn send_password_reset_confirmation_email(
         tracing::error!("Failed to send email: {}", e);
         EmailError::UnknownError
     });
-
-    tracing::debug!("Exiting send_password_reset_confirmation_email");
     Ok(())
 }
 
@@ -626,8 +610,6 @@ pub async fn send_platform_verification_email(
     to_email: String,
     verification_code: uuid::Uuid,
 ) -> Result<(), EmailError> {
-    tracing::debug!("Entering send_verification_email");
-
     if resend_api_key.is_none() {
         return Err(EmailError::ApiKeyNotFound);
     }
@@ -692,8 +674,6 @@ pub async fn send_platform_verification_email(
         tracing::error!("Failed to send email: {}", e);
         EmailError::UnknownError
     });
-
-    tracing::debug!("Exiting send_verification_email");
     Ok(())
 }
 
@@ -705,7 +685,6 @@ pub async fn send_platform_invite_email(
     invite_code: Uuid,
     org_id: Uuid,
 ) -> Result<(), EmailError> {
-    tracing::debug!("Entering send_platform_invite_email");
     if resend_api_key.is_none() {
         return Err(EmailError::ApiKeyNotFound);
     }
@@ -770,8 +749,6 @@ pub async fn send_platform_invite_email(
         tracing::error!("Failed to send email: {}", e);
         EmailError::UnknownError
     });
-
-    tracing::debug!("Exiting send_platform_invite_email");
     Ok(())
 }
 
@@ -791,8 +768,6 @@ pub async fn send_platform_password_reset_email(
     to_email: String,
     alphanumeric_code: String,
 ) -> Result<(), EmailError> {
-    tracing::debug!("Entering send_platform_password_reset_email");
-
     if resend_api_key.is_none() {
         return Err(EmailError::ApiKeyNotFound);
     }
@@ -858,8 +833,6 @@ pub async fn send_platform_password_reset_email(
         tracing::error!("Failed to send email: {}", e);
         EmailError::UnknownError
     });
-
-    tracing::debug!("Exiting send_platform_password_reset_email");
     Ok(())
 }
 
@@ -868,8 +841,6 @@ pub async fn send_platform_password_reset_confirmation_email(
     resend_api_key: Option<String>,
     to_email: String,
 ) -> Result<(), EmailError> {
-    tracing::debug!("Entering send_platform_password_reset_confirmation_email");
-
     if resend_api_key.is_none() {
         return Err(EmailError::ApiKeyNotFound);
     }
@@ -917,8 +888,6 @@ pub async fn send_platform_password_reset_confirmation_email(
         tracing::error!("Failed to send email: {}", e);
         EmailError::UnknownError
     });
-
-    tracing::debug!("Exiting send_platform_password_reset_confirmation_email");
     Ok(())
 }
 
@@ -928,8 +897,6 @@ pub async fn send_account_deletion_email(
     to_email: String,
     confirmation_code: String,
 ) -> Result<(), EmailError> {
-    tracing::debug!("Entering send_account_deletion_email");
-
     let (api_key, from_email) = get_project_email_settings(app_state, project_id).await?;
     let resend = Resend::new(&api_key);
 
@@ -989,8 +956,6 @@ pub async fn send_account_deletion_email(
         tracing::error!("Failed to send email: {}", e);
         EmailError::UnknownError
     });
-
-    tracing::debug!("Exiting send_account_deletion_email");
     Ok(())
 }
 
@@ -999,8 +964,6 @@ pub async fn send_account_deletion_confirmation_email(
     project_id: i32,
     to_email: String,
 ) -> Result<(), EmailError> {
-    tracing::debug!("Entering send_account_deletion_confirmation_email");
-
     let (api_key, from_email) = get_project_email_settings(app_state, project_id).await?;
     let resend = Resend::new(&api_key);
 
@@ -1056,7 +1019,5 @@ pub async fn send_account_deletion_confirmation_email(
         tracing::error!("Failed to send email: {}", e);
         EmailError::UnknownError
     });
-
-    tracing::debug!("Exiting send_account_deletion_confirmation_email");
     Ok(())
 }

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -36,7 +36,6 @@ pub enum EncryptError {
 }
 
 pub async fn encrypt_with_key(encryption_key: &SecretKey, bytes: &[u8]) -> Vec<u8> {
-    tracing::debug!("Entering encrypt_with_key");
     let cipher = Aes256Gcm::new_from_slice(&encryption_key.secret_bytes()).expect("should convert");
 
     // Generate a random 96-bit nonce
@@ -49,14 +48,10 @@ pub async fn encrypt_with_key(encryption_key: &SecretKey, bytes: &[u8]) -> Vec<u
     // Combine nonce and ciphertext
     let mut encrypted = nonce.to_vec();
     encrypted.extend(ciphertext);
-
-    tracing::debug!("Exiting encrypt_with_key");
     encrypted
 }
 
 pub fn decrypt_with_key(encryption_key: &SecretKey, bytes: &[u8]) -> Result<Vec<u8>, EncryptError> {
-    tracing::trace!("Entering decrypt_with_key");
-
     if bytes.len() < 12 {
         tracing::error!(
             "Decrypt failed: Input too short (length {}), minimum 12 bytes required",
@@ -84,8 +79,6 @@ pub fn decrypt_with_key(encryption_key: &SecretKey, bytes: &[u8]) -> Result<Vec<
         );
         EncryptError::FailedToDecrypt
     })?;
-
-    tracing::trace!("Exiting decrypt_with_key");
     Ok(result)
 }
 

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -584,7 +584,6 @@ pub async fn validate_jwt(
     mut req: Request<Body>,
     next: Next,
 ) -> impl IntoResponse {
-    tracing::debug!("Entering validate_jwt");
     let token = match req
         .headers()
         .get(header::AUTHORIZATION)
@@ -638,7 +637,6 @@ pub async fn validate_jwt(
 
     req.extensions_mut().insert(auth_context);
     req.extensions_mut().insert(user);
-    tracing::debug!("Exiting validate_jwt");
     next.run(req).await
 }
 
@@ -647,7 +645,6 @@ pub async fn validate_platform_jwt(
     mut req: Request<Body>,
     next: Next,
 ) -> impl IntoResponse {
-    tracing::debug!("Entering validate_platform_jwt");
     let token = match req
         .headers()
         .get(header::AUTHORIZATION)
@@ -682,7 +679,6 @@ pub async fn validate_platform_jwt(
     };
 
     req.extensions_mut().insert(platform_user);
-    tracing::debug!("Exiting validate_platform_jwt");
     next.run(req).await
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ use tokio::spawn;
 use tokio::sync::RwLock;
 use tokio::task::{self};
 use tower_http::cors::{Any, CorsLayer};
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, trace, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use url::Url;
 use uuid::Uuid;
@@ -1370,26 +1370,14 @@ impl AppState {
         derivation_path: Option<&str>,
         seed_phrase_derivation_path: Option<&str>,
     ) -> Result<SecretKey, Error> {
-        info!("Getting user key for UUID: {}", user.uuid);
-
-        if let Some(path) = derivation_path {
-            debug!("Using BIP-32 derivation path: {}", path);
-        }
-
-        if let Some(path) = seed_phrase_derivation_path {
-            debug!("Using BIP-85 derivation path: {}", path);
-        }
-
         let plaintext_seed = self.decrypt_seed_for_auth_context(user, auth_context)?;
 
-        debug!("Deriving user key from authenticated seed wrap");
         let user_secret_key = plaintext_user_seed_to_key(
             &plaintext_seed,
             derivation_path,
             seed_phrase_derivation_path,
         )?;
 
-        info!("Successfully derived key for user: {}", user.uuid);
         Ok(user_secret_key)
     }
 
@@ -1403,20 +1391,6 @@ impl AppState {
         derivation_path: Option<&str>,
         seed_phrase_derivation_path: Option<&str>,
     ) -> Result<message_signing::SignMessageResponse, Error> {
-        info!(
-            "Signing message for user: {}, algorithm: {:?}",
-            user.uuid, algorithm
-        );
-
-        if let Some(path) = derivation_path {
-            debug!("Using BIP-32 derivation path: {}", path);
-        }
-
-        if let Some(path) = seed_phrase_derivation_path {
-            debug!("Using BIP-85 derivation path: {}", path);
-        }
-
-        debug!("Getting user key for message signing");
         let user_secret_key = self
             .get_user_key(
                 user,
@@ -1426,12 +1400,9 @@ impl AppState {
             )
             .await?;
 
-        debug!("Signing message with algorithm: {:?}", algorithm);
         let result = message_signing::sign_message(&user_secret_key, message_bytes, algorithm);
 
-        if result.is_ok() {
-            info!("Message signed successfully for user: {}", user.uuid);
-        } else {
+        if result.is_err() {
             error!("Failed to sign message for user: {}", user.uuid);
         }
 

--- a/src/private_key.rs
+++ b/src/private_key.rs
@@ -6,7 +6,7 @@ use bitcoin::{
 };
 use secp256k1::SecretKey;
 use std::{str::FromStr, sync::Arc};
-use tracing::{debug, error, info};
+use tracing::error;
 
 use crate::{
     aws_credentials::AwsCredentialManager, encrypt::generate_random_enclave,
@@ -65,41 +65,28 @@ fn derive_mnemonic_to_key(
     seed_phrase_derivation_path: Option<&str>,
 ) -> Result<SecretKey, Error> {
     // If seed_phrase_derivation_path is provided, derive a child mnemonic using BIP-85
-    let (source_mnemonic, uses_bip85) = if let Some(bip85_path) = seed_phrase_derivation_path {
-        info!("Using BIP-85 derivation with path: {}", bip85_path);
-        (
-            derive_bip85_mnemonic_from_root(root_mnemonic, bip85_path)?,
-            true,
-        )
+    let source_mnemonic = if let Some(bip85_path) = seed_phrase_derivation_path {
+        derive_bip85_mnemonic_from_root(root_mnemonic, bip85_path)?
     } else {
-        debug!("Using root mnemonic (no BIP-85 derivation)");
-        (root_mnemonic, false)
+        root_mnemonic
     };
 
     // Generate seed from the appropriate mnemonic (either the root or the BIP-85 derived one)
-    info!(
-        "Generating seed from {} mnemonic",
-        if uses_bip85 { "BIP-85 derived" } else { "root" }
-    );
     let seed = source_mnemonic.to_seed("");
 
     // Create extended private key from the seed
-    debug!("Creating extended private key from seed");
     let xprivkey = Xpriv::new_master(Network::Bitcoin, &seed)
         .map_err(|e| Error::EncryptionError(e.to_string()))?;
 
     // If a derivation path is provided, derive the child key
     if let Some(path) = derivation_path {
-        info!("Deriving child key with BIP-32 path: {}", path);
         let path = DerivationPath::from_str(path)
             .map_err(|e| Error::InvalidDerivationPath(e.to_string()))?;
         let derived_key = xprivkey
             .derive_priv(&secp256k1::Secp256k1::new(), &path)
             .map_err(|e| Error::KeyDerivationError(e.to_string()))?;
-        debug!("Successfully derived child key using BIP-32 path");
         Ok(derived_key.private_key)
     } else {
-        debug!("Using master key (no BIP-32 derivation)");
         Ok(xprivkey.private_key)
     }
 }
@@ -142,13 +129,7 @@ pub fn decrypt_and_derive_bip85_mnemonic(
     encrypted_seed: Vec<u8>,
     bip85_path: &str,
 ) -> Result<Mnemonic, Error> {
-    info!(
-        "Starting BIP-85 mnemonic derivation with path: {}",
-        bip85_path
-    );
-
     // 1. Validate BIP-85 path format
-    debug!("Validating BIP-85 path format");
     // Convert ApiError to our Error type
     validate_bip85_path(bip85_path).map_err(|_| {
         error!("BIP-85 path validation failed: {}", bip85_path);
@@ -156,7 +137,6 @@ pub fn decrypt_and_derive_bip85_mnemonic(
     })?;
 
     // 2. Decrypt user root mnemonic
-    debug!("Decrypting user root mnemonic");
     let root_mnemonic = decrypt_user_seed_to_mnemonic(enclave_key, encrypted_seed)?;
     derive_bip85_mnemonic_from_root(root_mnemonic, bip85_path)
 }
@@ -165,13 +145,7 @@ pub fn derive_bip85_mnemonic_from_root(
     root_mnemonic: Mnemonic,
     bip85_path: &str,
 ) -> Result<Mnemonic, Error> {
-    info!(
-        "Starting BIP-85 mnemonic derivation with path: {}",
-        bip85_path
-    );
-
     // 1. Validate BIP-85 path format
-    debug!("Validating BIP-85 path format");
     // Convert ApiError to our Error type
     validate_bip85_path(bip85_path).map_err(|_| {
         error!("BIP-85 path validation failed: {}", bip85_path);
@@ -181,7 +155,6 @@ pub fn derive_bip85_mnemonic_from_root(
     let root_seed = root_mnemonic.to_seed("");
 
     // 2. Convert root_seed to Xpriv
-    debug!("Converting root seed to extended private key");
     let secp = Secp256k1::new();
     let xpriv = Xpriv::new_master(Network::Bitcoin, &root_seed).map_err(|e| {
         error!("Failed to create master key from seed: {}", e);
@@ -189,7 +162,6 @@ pub fn derive_bip85_mnemonic_from_root(
     })?;
 
     // 3. Parse the BIP-85 path to extract required parameters
-    debug!("Parsing BIP-85 path to extract parameters");
     // Safe to unwrap these values since we already validated the path
     let segments: Vec<&str> = bip85_path.split('/').collect();
 
@@ -220,22 +192,12 @@ pub fn derive_bip85_mnemonic_from_root(
     })?;
 
     // 4. Use the bip85_extended crate to derive the mnemonic
-    info!(
-        "Deriving BIP-85 mnemonic with {} words at index {}",
-        word_count, index
-    );
     let bip85_mnemonic_result =
         bip85_extended::mnemonic::to_mnemonic(&secp, &xpriv, word_count, index);
 
     // 5. Return the derived mnemonic or convert error
     match bip85_mnemonic_result {
-        Ok(derived_mnemonic) => {
-            info!(
-                "Successfully derived BIP-85 mnemonic with {} words",
-                word_count
-            );
-            Ok(derived_mnemonic)
-        }
+        Ok(derived_mnemonic) => Ok(derived_mnemonic),
         Err(e) => {
             error!("BIP-85 derivation failed: {}, path: {}", e, bip85_path);
             Err(Error::KeyDerivationError(format!(

--- a/src/web/attestation_routes.rs
+++ b/src/web/attestation_routes.rs
@@ -16,7 +16,7 @@ use serde_cbor::Value;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use tracing::{debug, error, trace};
+use tracing::{error, trace};
 use uuid::Uuid;
 use yasna::models::ObjectIdentifier;
 use yasna::{construct_der, Tag};
@@ -79,9 +79,6 @@ async fn get_attestation(
     State(data): State<Arc<AppState>>,
     axum::extract::Path(nonce): axum::extract::Path<String>,
 ) -> Result<(StatusCode, Json<AttestationResponse>), ApiError> {
-    debug!("Entering get_attestation function");
-    trace!("Entering get_attestation");
-
     // Create an ephemeral key pair for this request
     trace!("Creating ephemeral key");
     let enclave_public_key = data.create_ephemeral_key(nonce.clone()).await;
@@ -99,9 +96,6 @@ async fn get_attestation(
         AppMode::Local => generate_mock_attestation(data.clone(), request).await,
         _ => generate_real_attestation(data, request).await,
     };
-
-    trace!("Exiting get_attestation");
-    debug!("Exiting get_attestation function");
     result
 }
 
@@ -109,9 +103,6 @@ async fn generate_mock_attestation(
     data: Arc<AppState>,
     request: Request,
 ) -> Result<(StatusCode, Json<AttestationResponse>), ApiError> {
-    debug!("Entering generate_mock_attestation function");
-    trace!("Entering generate_mock_attestation");
-
     let (user_data, nonce, public_key) = match request {
         Request::Attestation {
             user_data,
@@ -160,9 +151,6 @@ async fn generate_mock_attestation(
     trace!("Converting to base64");
     let attestation_doc_base64 = general_purpose::STANDARD.encode(&final_document);
     trace!("Converted to base64");
-
-    trace!("Exiting generate_mock_attestation");
-    debug!("Exiting generate_mock_attestation function");
     Ok((
         StatusCode::OK,
         Json(AttestationResponse {
@@ -177,8 +165,6 @@ async fn create_mock_attestation_document(
     nonce: Option<ByteBuf>,
     public_key: Option<ByteBuf>,
 ) -> Value {
-    trace!("Entering create_mock_attestation_document");
-
     let mut pcrs = BTreeMap::new();
     for i in 0..3 {
         trace!("Generating random bytes for PCR {}", i);
@@ -233,14 +219,10 @@ async fn create_mock_attestation_document(
         Value::Text("nonce".into()),
         nonce.map_or(Value::Null, |n| Value::Bytes(n.into_vec())),
     );
-
-    trace!("Exiting create_mock_attestation_document");
     Value::Map(document)
 }
 
 async fn create_mock_certificate(_data: Arc<AppState>) -> Vec<u8> {
-    trace!("Entering create_mock_certificate");
-
     trace!("Generating random bytes");
     let random_8_bytes = generate_random::<8>();
     let random_32_bytes = generate_random::<32>();
@@ -327,8 +309,6 @@ async fn create_mock_certificate(_data: Arc<AppState>) -> Vec<u8> {
                 .write_bitvec_bytes(&random_32_bytes, random_32_bytes.len() * 8);
         })
     });
-
-    trace!("Exiting create_mock_certificate");
     result
 }
 
@@ -363,7 +343,6 @@ async fn generate_real_attestation(
     _data: Arc<AppState>,
     request: Request,
 ) -> Result<(StatusCode, Json<AttestationResponse>), ApiError> {
-    debug!("Entering generate_real_attestation function");
     // Initialize the Nitro Secure Module (NSM) driver
     let nsm_fd = nsm_init();
     if nsm_fd < 0 {
@@ -404,7 +383,6 @@ async fn key_exchange(
     State(data): State<Arc<AppState>>,
     Json(payload): Json<KeyExchangeRequest>,
 ) -> Result<Json<KeyExchangeResponse>, ApiError> {
-    debug!("Entering key_exchange function");
     trace!("Starting key exchange");
 
     let client_public_key_bytes = general_purpose::STANDARD
@@ -451,8 +429,6 @@ async fn key_exchange(
         .write()
         .await
         .insert(session_id, SessionState::new(session_key));
-
-    debug!("Exiting key_exchange function");
     Ok(Json(KeyExchangeResponse {
         session_id,
         encrypted_session_key: general_purpose::STANDARD.encode(&encrypted_session_key),

--- a/src/web/encryption_middleware.rs
+++ b/src/web/encryption_middleware.rs
@@ -46,7 +46,6 @@ pub async fn decrypt_request<T>(
 where
     T: DeserializeOwned + Send + Sync + Clone + 'static,
 {
-    tracing::debug!("Entering decrypt_request");
     let session_id = headers
         .get("x-session-id")
         .and_then(|v| v.to_str().ok())
@@ -85,8 +84,6 @@ where
 
     request.extensions_mut().insert(decrypted);
     request.extensions_mut().insert(session_id);
-
-    tracing::debug!("Exiting decrypt_request");
     Ok(next.run(request).await)
 }
 
@@ -95,12 +92,10 @@ pub async fn encrypt_response<T: Serialize>(
     session_id: &Uuid,
     response: &T,
 ) -> Result<Json<EncryptedResponse<T>>, ApiError> {
-    tracing::debug!("Entering encrypt_response");
     let response_json = serde_json::to_vec(response).map_err(|_| ApiError::InternalServerError)?;
     let encrypted_response = state
         .encrypt_session_data(session_id, &response_json)
         .await?;
-    tracing::debug!("Exiting encrypt_response");
     Ok(Json(EncryptedResponse::new(
         base64::engine::general_purpose::STANDARD.encode(encrypted_response),
     )))

--- a/src/web/login_routes.rs
+++ b/src/web/login_routes.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
 use tokio::spawn;
-use tracing::{debug, error, info};
+use tracing::{error, info};
 use uuid::Uuid;
 
 #[derive(Deserialize, Clone)]
@@ -136,12 +136,10 @@ pub async fn login(
     Extension(creds): Extension<Credentials>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<AuthResponse>>, ApiError> {
-    debug!("Entering login function");
     tracing::trace!("call login");
 
     let auth_response = login_internal(data.clone(), creds).await?;
     let result = encrypt_response(&data, &session_id, &auth_response).await;
-    debug!("Exiting login function");
     result
 }
 
@@ -247,7 +245,6 @@ pub async fn logout(
     Extension(logout_request): Extension<LogoutRequest>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    debug!("Entering logout function");
     info!("Logout request received");
     // TODO actually delete the refresh token
     tracing::trace!(
@@ -256,7 +253,6 @@ pub async fn logout(
     );
     let response = json!({ "message": "Logged out successfully" });
     let result = encrypt_response(&data, &session_id, &response).await;
-    debug!("Exiting logout function");
     result
 }
 
@@ -265,7 +261,6 @@ pub async fn register(
     Extension(creds): Extension<RegisterCredentials>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<AuthResponse>>, ApiError> {
-    debug!("Entering register function");
     tracing::trace!("call register");
 
     let user = match data.register_user(creds.clone()).await {
@@ -296,7 +291,6 @@ pub async fn register(
     .await?;
 
     let result = encrypt_response(&data, &session_id, &login_result).await;
-    debug!("Exiting register function");
     result
 }
 
@@ -353,7 +347,6 @@ pub async fn refresh_token(
     Extension(refresh_request): Extension<RefreshRequest>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<RefreshResponse>>, ApiError> {
-    debug!("Entering refresh_token function");
     info!("Refresh token request received");
 
     let claims = validate_token(&refresh_request.refresh_token, &data, USER_REFRESH)?;
@@ -380,7 +373,6 @@ pub async fn refresh_token(
         refresh_token: new_refresh_token.token,
     };
     let result = encrypt_response(&data, &session_id, &response).await;
-    debug!("Exiting refresh_token function");
     result
 }
 
@@ -389,7 +381,6 @@ pub async fn verify_email(
     Path(code): Path<Uuid>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    debug!("Entering verify_email function");
     let verification = match data.db.get_email_verification_by_code(code) {
         Ok(v) => v,
         Err(DBError::EmailVerificationNotFound) => return Err(ApiError::BadRequest),
@@ -416,7 +407,6 @@ pub async fn verify_email(
         "message": "Email verified successfully"
     });
     let result = encrypt_response(&data, &session_id, &response).await;
-    debug!("Exiting verify_email function");
     result
 }
 
@@ -425,8 +415,6 @@ pub async fn password_reset_request(
     Extension(payload): Extension<PasswordResetRequestPayload>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    debug!("Entering password_reset_request function");
-
     // Get project by client_id
     let project = data
         .db
@@ -471,7 +459,6 @@ pub async fn password_reset_request(
         "message": "If an account with that email exists, we have sent a password reset link."
     });
     let result = encrypt_response(&data, &session_id, &response).await;
-    debug!("Exiting password_reset_request function");
     result
 }
 
@@ -480,8 +467,6 @@ pub async fn password_reset_confirm(
     Extension(payload): Extension<PasswordResetConfirmPayload>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    debug!("Entering password_reset_confirm function");
-
     // Get project by client_id
     let project = data
         .db
@@ -526,6 +511,5 @@ pub async fn password_reset_confirm(
         "message": "Password reset successful. You can now log in with your new password."
     });
     let result = encrypt_response(&data, &session_id, &response).await;
-    debug!("Exiting password_reset_confirm function");
     result
 }

--- a/src/web/oauth_routes.rs
+++ b/src/web/oauth_routes.rs
@@ -425,8 +425,6 @@ pub async fn initiate_oauth(
     Extension(session_id): Extension<Uuid>,
     provider_name: &str,
 ) -> Result<Json<EncryptedResponse<OAuthOAuthCallbackResponse>>, ApiError> {
-    debug!("Entering init {} auth function", provider_name);
-
     // Get project
     let project = app_state
         .db
@@ -469,8 +467,6 @@ pub async fn initiate_oauth(
         auth_url,
         state: state_base64,
     };
-
-    debug!("Exiting init {} auth function", provider_name);
     encrypt_response(&app_state, &session_id, &response).await
 }
 
@@ -480,7 +476,6 @@ pub async fn oauth_callback(
     Extension(session_id): Extension<Uuid>,
     provider_name: &str,
 ) -> Result<Json<EncryptedResponse<OAuthCallbackResponse>>, ApiError> {
-    debug!("Entering {} callback function", provider_name);
     debug!(
         "Received code (redacted, len={})",
         callback_request.code.len()
@@ -898,8 +893,6 @@ pub async fn oauth_callback(
     };
 
     let auth_response = oauth_callback_response(&app_state, &authenticated_user)?;
-
-    debug!("Exiting {} callback function", provider_name);
     encrypt_response(&app_state, &session_id, &auth_response).await
 }
 

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -566,8 +566,6 @@ async fn proxy_openai(
     axum::Extension(auth_method): axum::Extension<AuthMethod>,
     axum::Extension(body): axum::Extension<Value>,
 ) -> Result<Response, ApiError> {
-    debug!("Entering proxy_openai function");
-
     // Check if guest user is allowed (paid guests are allowed, free guests are not)
     if user.is_guest() {
         if let Some(billing_client) = &state.billing_client {
@@ -657,7 +655,6 @@ async fn proxy_openai(
             // Billing already happened in get_chat_completion_response!
             // Just encrypt and return
             let encrypted_response = encrypt_response(&state, &session_id, &response_json).await?;
-            debug!("Exiting proxy_openai function (non-streaming)");
             return Ok(encrypted_response.into_response());
         } else {
             error!("Expected FullResponse chunk but got something else");
@@ -705,8 +702,6 @@ async fn proxy_openai(
             }
         }
     };
-
-    debug!("Exiting proxy_openai function (streaming)");
     Ok(Sse::new(stream).into_response())
 }
 
@@ -721,8 +716,6 @@ pub async fn get_chat_completion_response(
     headers: &HeaderMap,
     mut billing_context: BillingContext,
 ) -> Result<CompletionStream, ApiError> {
-    debug!("Entering get_chat_completion_response with billing context");
-
     if body.is_null() || body.as_object().is_none_or(|obj| obj.is_empty()) {
         error!("Request body is empty or invalid");
         return Err(ApiError::BadRequest);
@@ -1267,16 +1260,12 @@ async fn proxy_models(
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(_body): axum::Extension<()>,
 ) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
-    debug!("Entering proxy_models function");
-
     let proxy_config = state.proxy_router.get_completion_proxy();
     let models_response = if proxy_config.provider_name == "tinfoil" {
         openai_models_response()
     } else {
         fetch_provider_models(&proxy_config).await?
     };
-
-    debug!("Exiting proxy_models function");
     encrypt_response(&state, &session_id, &models_response).await
 }
 
@@ -1354,11 +1343,7 @@ async fn proxy_model_catalog(
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(_body): axum::Extension<()>,
 ) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
-    debug!("Entering proxy_model_catalog function");
-
     let catalog_response = model_catalog_response();
-
-    debug!("Exiting proxy_model_catalog function");
     encrypt_response(&state, &session_id, &catalog_response).await
 }
 
@@ -1467,8 +1452,6 @@ async fn proxy_transcription(
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(transcription_request): axum::Extension<TranscriptionRequest>,
 ) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
-    debug!("Entering proxy_transcription function");
-
     // Check if guest user is allowed (paid guests are allowed, free guests are not)
     if user.is_guest() {
         if let Some(billing_client) = &state.billing_client {
@@ -1676,8 +1659,6 @@ async fn proxy_transcription(
         response
     };
 
-    debug!("Exiting proxy_transcription function");
-
     // TODO: Add SQS-based billing events for transcription usage
     // Should track: audio duration/size, model used, user ID, timestamp, provider
 
@@ -1835,8 +1816,6 @@ async fn proxy_tts(
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(tts_request): axum::Extension<TTSRequest>,
 ) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
-    debug!("Entering proxy_tts function");
-
     // Check if guest user is allowed (paid guests are allowed, free guests are not)
     if user.is_guest() {
         if let Some(billing_client) = &state.billing_client {
@@ -1965,8 +1944,6 @@ async fn proxy_tts(
         },
     });
 
-    debug!("Exiting proxy_tts function");
-
     // Encrypt and return the response
     encrypt_response(&state, &session_id, &audio_response).await
 }
@@ -1979,8 +1956,6 @@ async fn proxy_embeddings(
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(embedding_request): axum::Extension<EmbeddingRequest>,
 ) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
-    debug!("Entering proxy_embeddings function");
-
     // Check if guest user is allowed (paid guests are allowed, free guests are not)
     if user.is_guest() {
         if let Some(billing_client) = &state.billing_client {
@@ -2122,8 +2097,6 @@ async fn proxy_embeddings(
             .await;
         }
     }
-
-    debug!("Exiting proxy_embeddings function");
 
     // Encrypt and return the response
     encrypt_response(&state, &session_id, &response_json).await

--- a/src/web/platform/login_routes.rs
+++ b/src/web/platform/login_routes.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
 use tokio::spawn;
-use tracing::{debug, error, info};
+use tracing::{error, info};
 use uuid::Uuid;
 use validator::Validate;
 
@@ -195,8 +195,6 @@ pub async fn login_platform_user(
     Extension(login_request): Extension<PlatformLoginRequest>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<PlatformAuthResponse>>, ApiError> {
-    debug!("Entering login_platform_user function");
-
     // Validate request
     if let Err(errors) = login_request.validate() {
         error!("Validation error: {:?}", errors);
@@ -205,7 +203,6 @@ pub async fn login_platform_user(
 
     let auth_response = login_internal_platform(data.clone(), login_request).await?;
     let result = encrypt_response(&data, &session_id, &auth_response).await;
-    debug!("Exiting login_platform_user function");
     result
 }
 
@@ -250,8 +247,6 @@ pub async fn register_platform_user(
     Extension(register_request): Extension<PlatformRegisterRequest>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<PlatformAuthResponse>>, ApiError> {
-    debug!("Entering register_platform_user function");
-
     // Validate request
     if let Err(errors) = register_request.validate() {
         error!("Validation error: {:?}", errors);
@@ -349,7 +344,6 @@ pub async fn register_platform_user(
     };
 
     let result = encrypt_response(&data, &session_id, &response).await;
-    debug!("Exiting register_platform_user function");
     result
 }
 
@@ -358,8 +352,6 @@ pub async fn refresh_platform_token(
     Extension(refresh_request): Extension<PlatformRefreshRequest>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<PlatformRefreshResponse>>, ApiError> {
-    debug!("Entering refresh_platform_token function");
-
     // Validate request
     if let Err(errors) = refresh_request.validate() {
         error!("Validation error: {:?}", errors);
@@ -385,7 +377,6 @@ pub async fn refresh_platform_token(
     };
 
     let result = encrypt_response(&data, &session_id, &response).await;
-    debug!("Exiting refresh_platform_token function");
     result
 }
 
@@ -394,8 +385,6 @@ pub async fn verify_platform_email(
     Path(code): Path<Uuid>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    debug!("Entering verify_platform_email function");
-
     // Retrieve the verification record using the code
     let verification = match data.db.get_platform_email_verification_by_code(code) {
         Ok(verification) => verification,
@@ -438,7 +427,6 @@ pub async fn verify_platform_email(
     });
 
     let result = encrypt_response(&data, &session_id, &response).await;
-    debug!("Exiting verify_platform_email function");
     result
 }
 
@@ -447,7 +435,6 @@ pub async fn logout_platform_user(
     Extension(logout_request): Extension<PlatformLogoutRequest>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    debug!("Entering logout_platform_user function");
     info!("Platform logout request received");
 
     // TODO: Implement token invalidation logic here when needed
@@ -458,7 +445,6 @@ pub async fn logout_platform_user(
 
     let response = json!({ "message": "Logged out successfully" });
     let result = encrypt_response(&data, &session_id, &response).await;
-    debug!("Exiting logout_platform_user function");
     result
 }
 
@@ -467,8 +453,6 @@ pub async fn platform_password_reset_request(
     Extension(payload): Extension<PlatformPasswordResetRequestPayload>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    debug!("Entering platform_password_reset_request function");
-
     // Validate request
     if let Err(errors) = payload.validate() {
         error!("Validation error: {:?}", errors);
@@ -513,7 +497,6 @@ pub async fn platform_password_reset_request(
         "message": "If an account with that email exists, we have sent a password reset link."
     });
     let result = encrypt_response(&data, &session_id, &response).await;
-    debug!("Exiting platform_password_reset_request function");
     result
 }
 
@@ -522,8 +505,6 @@ pub async fn platform_password_reset_confirm(
     Extension(payload): Extension<PlatformPasswordResetConfirmPayload>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    debug!("Entering platform_password_reset_confirm function");
-
     // Validate request
     if let Err(errors) = payload.validate() {
         error!("Validation error: {:?}", errors);
@@ -568,6 +549,5 @@ pub async fn platform_password_reset_confirm(
     });
 
     let result = encrypt_response(&data, &session_id, &response).await;
-    debug!("Exiting platform_password_reset_confirm function");
     result
 }

--- a/src/web/platform/me_routes.rs
+++ b/src/web/platform/me_routes.rs
@@ -15,7 +15,7 @@ use serde::Deserialize;
 use serde_json::json;
 use std::sync::Arc;
 use tokio::spawn;
-use tracing::{debug, error};
+use tracing::error;
 use uuid::Uuid;
 use validator::Validate;
 
@@ -65,8 +65,6 @@ async fn get_platform_user(
     Extension(platform_user): Extension<PlatformUser>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<MeResponse>>, ApiError> {
-    debug!("Entering get_platform_user function");
-
     // Check if email is verified
     let email_verified = match data
         .db
@@ -126,8 +124,6 @@ async fn get_platform_user(
         user,
         organizations,
     };
-
-    debug!("Exiting get_platform_user function");
     encrypt_response(&data, &session_id, &response).await
 }
 
@@ -136,8 +132,6 @@ async fn request_platform_verification(
     Extension(platform_user): Extension<PlatformUser>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    debug!("Entering request_platform_verification function");
-
     // Check if the user is already verified
     match data
         .db
@@ -199,7 +193,6 @@ async fn request_platform_verification(
     });
 
     let response = json!({ "message": "New verification code sent successfully" });
-    debug!("Exiting request_platform_verification function");
     encrypt_response(&data, &session_id, &response).await
 }
 
@@ -209,8 +202,6 @@ pub async fn platform_change_password(
     Extension(change_request): Extension<PlatformChangePasswordRequest>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    debug!("Entering platform_change_password function");
-
     // Validate request
     if let Err(errors) = change_request.validate() {
         error!("Validation error: {:?}", errors);
@@ -236,7 +227,6 @@ pub async fn platform_change_password(
             {
                 Ok(()) => {
                     let response = json!({ "message": "Password changed successfully" });
-                    debug!("Exiting platform_change_password function");
                     encrypt_response(&data, &session_id, &response).await
                 }
                 Err(e) => {

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -134,24 +134,17 @@ pub struct KeyOptions {
 impl KeyOptions {
     /// Validates both derivation paths if present.
     pub fn validate(&self) -> Result<(), ApiError> {
-        debug!("Validating key options");
-
         // Validate private_key_derivation_path if present
         if let Some(ref path) = self.private_key_derivation_path {
-            debug!("Validating BIP-32 derivation path: {}", path);
             validate_path(path)?;
-            info!("BIP-32 derivation path validation successful: {}", path);
         }
 
         // Validate seed_phrase_derivation_path if present
         if let Some(ref path) = self.seed_phrase_derivation_path {
-            debug!("Validating BIP-85 derivation path: {}", path);
             validate_path(path)?;
             validate_bip85_path(path)?;
-            info!("BIP-85 derivation path validation successful: {}", path);
         }
 
-        debug!("Key options validation completed successfully");
         Ok(())
     }
 }
@@ -164,8 +157,6 @@ impl KeyOptions {
 /// - WORDS' must be one of VALID_BIP39_WORD_COUNTS (12', 18', 24', must be hardened)
 /// - INDEX' is the derivation index (must be hardened)
 pub fn validate_bip85_path(path: &str) -> Result<(), ApiError> {
-    debug!("Validating BIP-85 path: {}", path);
-
     // Split the path into segments
     let segments: Vec<&str> = path.split('/').collect();
 
@@ -215,8 +206,6 @@ pub fn validate_bip85_path(path: &str) -> Result<(), ApiError> {
         return Err(ApiError::BadRequest);
     }
 
-    debug!("BIP-85 path language component valid: {}", segments[3]);
-
     // Check word count is valid (12, 18, 24) and hardened
     let word_count = segments[4];
     let word_count_value = match word_count.trim_end_matches(&['\'', 'h'][..]).parse::<u32>() {
@@ -239,8 +228,6 @@ pub fn validate_bip85_path(path: &str) -> Result<(), ApiError> {
         return Err(ApiError::BadRequest);
     }
 
-    debug!("BIP-85 path word count valid: {} words", word_count_value);
-
     // Check word count is hardened
     if !(word_count.ends_with('\'') || word_count.ends_with('h')) {
         error!(
@@ -261,7 +248,7 @@ pub fn validate_bip85_path(path: &str) -> Result<(), ApiError> {
     }
 
     // Try to parse the index to ensure it's a valid number
-    let index_value = match index.trim_end_matches(&['\'', 'h'][..]).parse::<u32>() {
+    match index.trim_end_matches(&['\'', 'h'][..]).parse::<u32>() {
         Ok(value) => value,
         Err(_) => {
             error!(
@@ -271,9 +258,6 @@ pub fn validate_bip85_path(path: &str) -> Result<(), ApiError> {
             return Err(ApiError::BadRequest);
         }
     };
-
-    debug!("BIP-85 path index valid: {}", index_value);
-    info!("BIP-85 path validation successful: {}", path);
 
     Ok(())
 }
@@ -572,8 +556,6 @@ pub async fn user_protected(
     Extension(user): Extension<User>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<ProtectedUserData>>, ApiError> {
-    debug!("Entering user_protected function");
-    tracing::info!("user_protected request");
     let mut app_user: AppUser = AppUser::from(&user);
 
     // Set email verification status - only if not a guest user
@@ -633,8 +615,6 @@ pub async fn user_protected(
     }
 
     let response = ProtectedUserData { user: app_user };
-
-    debug!("Exiting user_protected function");
     encrypt_response(&data, &session_id, &response).await
 }
 
@@ -645,8 +625,6 @@ pub async fn get_kv(
     Extension(session_id): Extension<Uuid>,
     Path(key): Path<String>,
 ) -> Result<Json<EncryptedResponse<Option<String>>>, ApiError> {
-    debug!("Entering get_kv function");
-
     let value = match data.get(&user, &auth_context, key).await {
         Ok(kv) => kv,
         Err(e) => {
@@ -654,7 +632,6 @@ pub async fn get_kv(
             return Err(ApiError::InternalServerError);
         }
     };
-    debug!("Exiting get_kv function");
     encrypt_response(&data, &session_id, &value).await
 }
 
@@ -666,10 +643,6 @@ pub async fn put_kv(
     Path(key): Path<String>,
     Extension(value): Extension<String>,
 ) -> Result<Json<EncryptedResponse<String>>, ApiError> {
-    debug!("Entering put_kv function");
-    info!("Putting key-value pair for user");
-    tracing::trace!("putting key-value pair: {} = {}", key, value);
-
     match data.put(&user, &auth_context, key, value.clone()).await {
         Ok(kv) => kv,
         Err(e) => {
@@ -677,8 +650,6 @@ pub async fn put_kv(
             return Err(ApiError::InternalServerError);
         }
     };
-
-    debug!("Exiting put_kv function");
     encrypt_response(&data, &session_id, &value).await
 }
 
@@ -689,12 +660,9 @@ pub async fn delete_kv(
     Extension(session_id): Extension<Uuid>,
     Path(key): Path<String>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    debug!("Entering delete_kv function");
-
     match data.delete(&user, &auth_context, key).await {
         Ok(_) => {
             let response = json!({ "message": "Resource deleted successfully" });
-            debug!("Exiting delete_kv function");
             encrypt_response(&data, &session_id, &response).await
         }
         Err(e) => {
@@ -709,15 +677,11 @@ pub async fn delete_all_kv(
     Extension(user): Extension<User>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    debug!("Entering delete_all_kv function");
-    info!("Deleting all key-value pairs for user");
-
     match data.delete_all(user.uuid).await {
         Ok(_) => {
             let response = json!({
                 "message": "All key-value pairs deleted successfully"
             });
-            debug!("Exiting delete_all_kv function");
             encrypt_response(&data, &session_id, &response).await
         }
         Err(e) => {
@@ -733,8 +697,6 @@ pub async fn list_kv(
     Extension(auth_context): Extension<AuthContext>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<Vec<KVPair>>>, ApiError> {
-    debug!("Entering list_kv function");
-
     let kvs = match data.list(&user, &auth_context).await {
         Ok(kvs) => kvs,
         Err(e) => {
@@ -742,7 +704,6 @@ pub async fn list_kv(
             return Err(ApiError::InternalServerError);
         }
     };
-    debug!("Exiting list_kv function");
     encrypt_response(&data, &session_id, &kvs).await
 }
 
@@ -751,8 +712,6 @@ pub async fn request_new_verification_code(
     Extension(user): Extension<User>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    debug!("Entering request_new_verification_code function");
-
     // First check if user has an email
     let email = match user.get_email() {
         Some(email) => email.to_string(),
@@ -808,7 +767,6 @@ pub async fn request_new_verification_code(
     }
 
     let response = json!({ "message": "New verification code sent successfully" });
-    debug!("Exiting request_new_verification_code function");
     encrypt_response(&data, &session_id, &response).await
 }
 
@@ -819,8 +777,6 @@ pub async fn change_password(
     Extension(change_request): Extension<ChangePasswordRequest>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    debug!("Entering change_password function");
-
     // Check if user is an OAuth-only user
     if user.password_enc.is_none() {
         error!("OAuth-only user attempted to change password");
@@ -867,7 +823,6 @@ pub async fn change_password(
                         "access_token": access_token.token,
                         "refresh_token": refresh_token.token
                     });
-                    debug!("Exiting change_password function");
                     encrypt_response(&data, &session_id, &response).await
                 }
                 Err(e) => {
@@ -893,21 +848,9 @@ pub async fn get_private_key(
     Extension(session_id): Extension<Uuid>,
     Query(query): Query<DerivationPathQuery>,
 ) -> Result<Json<EncryptedResponse<PrivateKeyResponse>>, ApiError> {
-    info!("Entering get_private_key function for user: {}", user.uuid);
-
-    // Log received derivation paths for debugging purposes
-    if let Some(path) = &query.key_options.seed_phrase_derivation_path {
-        info!("Received BIP-85 derivation path: {}", path);
-    }
-    if let Some(path) = &query.key_options.private_key_derivation_path {
-        info!("Received BIP-32 derivation path: {}", path);
-    }
-
     // Validate paths if present
-    debug!("Validating derivation paths");
     query.validate()?;
 
-    debug!("Retrieving authenticated seed wrap for user");
     let plaintext_seed = data
         .decrypt_seed_for_auth_context(&user, &auth_context)
         .map_err(|e| {
@@ -921,7 +864,6 @@ pub async fn get_private_key(
 
     // Check if BIP-85 derivation is requested
     if let Some(bip85_path) = &query.key_options.seed_phrase_derivation_path {
-        info!("BIP-85 derivation requested with path: {}", bip85_path);
         // Derive a child mnemonic
         let child_mnemonic =
             derive_bip85_mnemonic_from_root(root_mnemonic, bip85_path).map_err(|e| {
@@ -929,31 +871,17 @@ pub async fn get_private_key(
                 ApiError::BadRequest
             })?;
 
-        let word_count = child_mnemonic.word_count();
-        info!(
-            "Successfully derived BIP-85 mnemonic with {} words",
-            word_count
-        );
-
         let response = PrivateKeyResponse {
             mnemonic: child_mnemonic.to_string(),
         };
 
-        debug!("Encrypting response with derived mnemonic");
-        info!("Exiting get_private_key function with derived BIP-85 mnemonic");
         encrypt_response(&data, &session_id, &response).await
     } else {
         // Return root mnemonic
-        info!("Returning root mnemonic (no BIP-85 derivation)");
-        let word_count = root_mnemonic.word_count();
-        debug!("Root mnemonic has {} words", word_count);
-
         let response = PrivateKeyResponse {
             mnemonic: root_mnemonic.to_string(),
         };
 
-        debug!("Encrypting response with root mnemonic");
-        info!("Exiting get_private_key function with root mnemonic");
         encrypt_response(&data, &session_id, &response).await
     }
 }
@@ -965,25 +893,10 @@ pub async fn get_private_key_bytes(
     Extension(session_id): Extension<Uuid>,
     Query(query): Query<DerivationPathQuery>,
 ) -> Result<Json<EncryptedResponse<PrivateKeyBytesResponse>>, ApiError> {
-    info!(
-        "Entering get_private_key_bytes function for user: {}",
-        user.uuid
-    );
-
-    // Log received derivation paths for debugging purposes
-    if let Some(path) = &query.key_options.seed_phrase_derivation_path {
-        info!("Received BIP-85 derivation path: {}", path);
-    }
-    if let Some(path) = &query.key_options.private_key_derivation_path {
-        info!("Received BIP-32 derivation path: {}", path);
-    }
-
     // Validate derivation path if present
-    debug!("Validating derivation paths");
     query.validate()?;
 
     // Use the method that supports both BIP-85 and BIP-32 derivation
-    debug!("Getting user key with provided derivation paths");
     let secret_key = data
         .get_user_key(
             &user,
@@ -1007,16 +920,11 @@ pub async fn get_private_key_bytes(
             }
         })?;
 
-    info!("Successfully retrieved private key for user: {}", user.uuid);
-
     // Convert key to string
-    debug!("Converting private key to string format");
     let response = PrivateKeyBytesResponse {
         private_key: secret_key.display_secret().to_string(),
     };
 
-    debug!("Encrypting private key response");
-    info!("Exiting get_private_key_bytes function");
     encrypt_response(&data, &session_id, &response).await
 }
 
@@ -1027,11 +935,7 @@ pub async fn sign_message(
     Extension(sign_request): Extension<SignMessageRequest>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<SignMessageResponseJson>>, ApiError> {
-    info!("Entering sign_message function for user: {}", user.uuid);
-    debug!("Sign request algorithm: {:?}", sign_request.algorithm);
-
     // Validate key_options
-    debug!("Validating key options");
     let validation_query = DerivationPathQuery {
         key_options: sign_request.key_options.clone(),
     };
@@ -1047,16 +951,6 @@ pub async fn sign_message(
         .seed_phrase_derivation_path
         .as_deref();
 
-    // Log derivation paths if present
-    if let Some(path) = derivation_path {
-        info!("Using BIP-32 derivation path: {}", path);
-    }
-
-    if let Some(path) = seed_phrase_derivation_path {
-        info!("Using BIP-85 derivation path: {}", path);
-    }
-
-    debug!("Decoding base64 message");
     let message_bytes = general_purpose::STANDARD
         .decode(&sign_request.message_base64)
         .map_err(|e| {
@@ -1064,10 +958,6 @@ pub async fn sign_message(
             ApiError::BadRequest
         })?;
 
-    debug!(
-        "Signing message with algorithm: {:?}",
-        sign_request.algorithm
-    );
     let response = data
         .sign_message(
             &user,
@@ -1083,15 +973,11 @@ pub async fn sign_message(
             ApiError::InternalServerError
         })?;
 
-    info!("Message signed successfully for user: {}", user.uuid);
-    debug!("Creating JSON response");
     let json_response = SignMessageResponseJson {
         signature: response.signature.to_string(),
         message_hash: hex::encode(response.message_hash),
     };
 
-    debug!("Encrypting signed message response");
-    info!("Exiting sign_message function");
     encrypt_response(&data, &session_id, &json_response).await
 }
 
@@ -1102,8 +988,6 @@ pub async fn get_public_key(
     Extension(session_id): Extension<Uuid>,
     Query(query): Query<PublicKeyQuery>,
 ) -> Result<Json<EncryptedResponse<PublicKeyResponseJson>>, ApiError> {
-    debug!("Entering get_public_key function");
-
     // Validate the key_options
     let validation_query = DerivationPathQuery {
         key_options: query.key_options.clone(),
@@ -1146,8 +1030,6 @@ pub async fn get_public_key(
         public_key: public_key_str,
         algorithm: query.algorithm,
     };
-
-    debug!("Exiting get_public_key function");
     encrypt_response(&data, &session_id, &response).await
 }
 
@@ -1157,12 +1039,6 @@ pub async fn generate_third_party_token(
     Extension(request): Extension<ThirdPartyTokenRequest>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<ThirdPartyTokenResponse>>, ApiError> {
-    debug!("Entering generate_third_party_token function");
-    info!(
-        "Generating third party token for user {} with audience {:?}",
-        user.uuid, request.audience
-    );
-
     // Validate the audience
     if let Some(audience) = request.audience.as_ref() {
         if audience.is_empty() || (audience.contains(':') && url::Url::parse(audience).is_err()) {
@@ -1170,8 +1046,6 @@ pub async fn generate_third_party_token(
             return Err(ApiError::BadRequest);
         }
     }
-
-    debug!("Audience validation successful");
 
     let project = data.db.get_org_project_by_id(user.project_id)?;
 
@@ -1183,13 +1057,7 @@ pub async fn generate_third_party_token(
         },
         &data,
     ) {
-        Ok(token) => {
-            info!(
-                "Successfully generated third party token for user {}",
-                user.uuid
-            );
-            token
-        }
+        Ok(token) => token,
         Err(e) => {
             error!("Failed to generate third party token: {:?}", e);
             return Err(e);
@@ -1197,8 +1065,6 @@ pub async fn generate_third_party_token(
     };
 
     let response = ThirdPartyTokenResponse { token: token.token };
-
-    debug!("Exiting generate_third_party_token function");
     encrypt_response(&data, &session_id, &response).await
 }
 
@@ -1209,9 +1075,6 @@ pub async fn encrypt_data(
     Extension(request): Extension<EncryptDataRequest>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<EncryptDataResponse>>, ApiError> {
-    debug!("Entering encrypt_data function");
-    info!("Encrypting data for user {}", user.uuid);
-
     // Validate key_options
     let validation_query = DerivationPathQuery {
         key_options: request.key_options.clone(),
@@ -1256,8 +1119,6 @@ pub async fn encrypt_data(
     let response = EncryptDataResponse {
         encrypted_data: encrypted_data_base64,
     };
-
-    debug!("Exiting encrypt_data function");
     encrypt_response(&data, &session_id, &response).await
 }
 
@@ -1268,18 +1129,11 @@ pub async fn decrypt_data(
     Extension(request): Extension<DecryptDataRequest>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<String>>, ApiError> {
-    debug!("Entering decrypt_data function");
-    info!(
-        "Decrypting data for user {} with key options: {:?}",
-        user.uuid, request.key_options
-    );
-
     // Validate key_options
     let validation_query = DerivationPathQuery {
         key_options: request.key_options.clone(),
     };
     validation_query.validate()?;
-    debug!("Derivation path validation successful");
 
     // Extract derivation paths from key_options
     let derivation_path = request.key_options.private_key_derivation_path.as_deref();
@@ -1308,7 +1162,6 @@ pub async fn decrypt_data(
                 ApiError::InternalServerError
             }
         })?;
-    debug!("Successfully retrieved user key");
 
     // Decode the base64 encrypted data
     let encrypted_data = match general_purpose::STANDARD.decode(&request.encrypted_data) {
@@ -1321,10 +1174,7 @@ pub async fn decrypt_data(
 
     // Decrypt the data
     let decrypted_data = match encrypt::decrypt_with_key(&user_key, &encrypted_data) {
-        Ok(data) => {
-            debug!("Successfully decrypted data");
-            data
-        }
+        Ok(data) => data,
         Err(e) => {
             error!("Decryption failed: {e}");
             return Err(ApiError::BadRequest);
@@ -1339,8 +1189,6 @@ pub async fn decrypt_data(
             return Err(ApiError::BadRequest);
         }
     };
-
-    debug!("Exiting decrypt_data function, preparing encrypted response");
     encrypt_response(&data, &session_id, &decrypted_string).await
 }
 
@@ -1350,7 +1198,6 @@ pub async fn initiate_account_deletion(
     Extension(delete_request): Extension<InitiateAccountDeletionRequest>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    debug!("Entering initiate_account_deletion function");
     info!("User {} is initiating account deletion request", user.uuid);
 
     // Create the account deletion request
@@ -1370,7 +1217,6 @@ pub async fn initiate_account_deletion(
             });
 
             let result = encrypt_response(&data, &session_id, &response).await;
-            debug!("Exiting initiate_account_deletion function");
             result
         }
         Err(e) => {
@@ -1386,7 +1232,6 @@ pub async fn confirm_account_deletion(
     Extension(confirm_request): Extension<ConfirmAccountDeletionRequest>,
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    debug!("Entering confirm_account_deletion function");
     info!("User {} is confirming account deletion", user.uuid);
 
     // Confirm the account deletion
@@ -1404,7 +1249,6 @@ pub async fn confirm_account_deletion(
             });
 
             let result = encrypt_response(&data, &session_id, &response).await;
-            debug!("Exiting confirm_account_deletion function");
             result
         }
         Err(e) => match e {

--- a/src/web/responses/conversations.rs
+++ b/src/web/responses/conversations.rs
@@ -28,7 +28,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::{collections::HashMap, sync::Arc};
-use tracing::{debug, error, trace};
+use tracing::error;
 use uuid::Uuid;
 
 // ============================================================================
@@ -387,8 +387,6 @@ async fn create_conversation(
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<CreateConversationRequest>,
 ) -> Result<Json<EncryptedResponse<ConversationResponse>>, ApiError> {
-    debug!("Creating new conversation for user: {}", user.uuid);
-
     // Reject initial items - not supported in our simplified flow
     // Users must use POST /v1/responses to add messages to conversations
     if let Some(items) = &body.items {
@@ -443,14 +441,10 @@ async fn create_conversation(
         metadata_enc,
     };
 
-    trace!("Creating conversation with: {:?}", new_conversation);
-
     let conversation = state
         .db
         .create_conversation(new_conversation)
         .map_err(error_mapping::map_generic_db_error)?;
-
-    trace!("Created conversation: {:?}", conversation);
 
     let mut project_cache = HashMap::new();
     if let Some(project) = project {
@@ -477,11 +471,6 @@ async fn get_conversation(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<ConversationResponse>>, ApiError> {
-    debug!(
-        "Getting conversation {} for user {}",
-        conversation_id, user.uuid
-    );
-
     let ctx = ConversationContext::load(&state, conversation_id, &user, &auth_context).await?;
     let mut project_cache = HashMap::new();
     let response = build_conversation_response(
@@ -505,11 +494,6 @@ async fn update_conversation(
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<UpdateConversationRequest>,
 ) -> Result<Json<EncryptedResponse<ConversationResponse>>, ApiError> {
-    debug!(
-        "Updating conversation {} for user {}",
-        conversation_id, user.uuid
-    );
-
     if body.metadata.is_none() && body.project_id.is_missing() && body.pinned.is_none() {
         return Err(ApiError::BadRequest);
     }
@@ -572,11 +556,6 @@ async fn delete_conversation(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<DeletedObjectResponse>>, ApiError> {
-    debug!(
-        "Deleting conversation {} for user {}",
-        conversation_id, user.uuid
-    );
-
     let ctx = ConversationContext::load(&state, conversation_id, &user, &auth_context).await?;
 
     // Delete the conversation (cascades will delete all associated responses)
@@ -599,11 +578,6 @@ async fn list_conversation_items(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<ConversationItemListResponse>>, ApiError> {
-    debug!(
-        "Listing items for conversation {} for user {}",
-        conversation_id, user.uuid
-    );
-
     let ctx = ConversationContext::load(&state, conversation_id, &user, &auth_context).await?;
 
     // Validate limit
@@ -625,24 +599,6 @@ async fn list_conversation_items(
         )
         .map_err(error_mapping::map_message_error)?;
 
-    trace!(
-        "Retrieved {} raw messages for conversation {} (limit={}, after={:?}, order={})",
-        raw_messages.len(),
-        conversation_id,
-        limit,
-        params.after,
-        params.order
-    );
-    for (i, msg) in raw_messages.iter().enumerate() {
-        trace!(
-            "Message {}: uuid={}, type={}, created_at={}",
-            i,
-            msg.uuid,
-            msg.message_type,
-            msg.created_at
-        );
-    }
-
     // Check if there are more results
     let has_more = raw_messages.len() > limit as usize;
 
@@ -660,8 +616,6 @@ async fn list_conversation_items(
         0, // Start from beginning since pagination is already applied at DB level
         messages_to_return.len(),
     )?;
-
-    trace!("Final items count: {}, has_more: {}", items.len(), has_more);
 
     // Extract cursor IDs
     let (first_id, last_id) = Paginator::get_cursor_ids(&items, |item| match item {
@@ -690,11 +644,6 @@ async fn get_conversation_item(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<ConversationItem>>, ApiError> {
-    debug!(
-        "Getting item {} from conversation {} for user {}",
-        item_id, conversation_id, user.uuid
-    );
-
     let ctx = ConversationContext::load(&state, conversation_id, &user, &auth_context).await?;
 
     // Get all messages from the conversation
@@ -730,8 +679,6 @@ async fn list_conversations(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<ConversationListResponse>>, ApiError> {
-    debug!("Listing conversations for user: {}", user.uuid);
-
     // Validate limit
     let limit = if params.limit <= 0 {
         DEFAULT_PAGINATION_LIMIT
@@ -755,15 +702,6 @@ async fn list_conversations(
         )
         .map_err(error_mapping::map_generic_db_error)?;
 
-    trace!(
-        "Retrieved {} conversations for user {} (limit={}, after={:?}, order={})",
-        conversations.len(),
-        user.uuid,
-        limit,
-        params.after,
-        params.order
-    );
-
     // Check if there are more results
     let has_more = conversations.len() > limit as usize;
 
@@ -785,8 +723,6 @@ async fn list_conversations(
     // Convert to response format
     let mut data = Vec::with_capacity(conversations_to_return.len());
     for conv in conversations_to_return {
-        trace!("Raw conversation object: {:?}", conv);
-        trace!("Conv metadata_enc present: {}", conv.metadata_enc.is_some());
         data.push(build_conversation_response(
             &state,
             user.uuid,
@@ -808,8 +744,6 @@ async fn list_conversations(
         last_id,
     };
 
-    trace!("Final ConversationListResponse: {:?}", response);
-
     encrypt_response(&state, &session_id, &response).await
 }
 
@@ -819,8 +753,6 @@ async fn delete_all_conversations(
     Extension(session_id): Extension<Uuid>,
     Extension(user): Extension<User>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    debug!("Deleting all conversations for user {}", user.uuid);
-
     state
         .db
         .delete_all_conversations(user.uuid)
@@ -848,12 +780,6 @@ async fn batch_delete_conversations(
     if body.ids.is_empty() || body.ids.len() > MAX_CONVERSATION_BATCH_SIZE {
         return Err(ApiError::BadRequest);
     }
-
-    debug!(
-        "Batch deleting {} conversations for user {}",
-        body.ids.len(),
-        user.uuid
-    );
 
     let mut results = Vec::with_capacity(body.ids.len());
 
@@ -915,7 +841,7 @@ async fn batch_update_conversation_project(
         return Err(ApiError::BadRequest);
     }
 
-    let (target_project_uuid, target_project_id) = match body.project_id {
+    let (_, target_project_id) = match body.project_id {
         NullableField::Value(project_uuid) => (
             Some(project_uuid),
             Some(
@@ -929,12 +855,6 @@ async fn batch_update_conversation_project(
         NullableField::Null => (None, None),
         NullableField::Missing => return Err(ApiError::BadRequest),
     };
-
-    debug!(
-        "Batch updating {} conversations to project {:?}",
-        body.ids.len(),
-        target_project_uuid
-    );
 
     state
         .db


### PR DESCRIPTION
## Summary
- remove generic entering/exiting debug breadcrumbs from hot request, middleware, auth, email, OpenAI proxy, and platform routes
- quiet routine key derivation, private-key, conversation, and DB CRUD success logs while preserving error logs
- drop repeated success-path logs that included user IDs, derivation paths, or request details

## Validation
- OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 nix develop -c cargo fmt --all
- OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 nix develop -c cargo clippy --all-targets --all-features -- -D warnings
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret/pull/204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal operations by reducing logging overhead across authentication and database layers.
  * Enhanced API key security with stricter ownership validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->