### PR TITLE
Add agent feature flag key

### DIFF
--- a/src/os_flags.rs
+++ b/src/os_flags.rs
@@ -11,6 +11,9 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 const USER_FLAGS_CACHE_TTL: Duration = Duration::from_secs(10 * 60);
 
+#[allow(dead_code)]
+pub const AGENT_FEATURE_FLAG_KEY: &str = "agent";
+
 #[derive(Debug, thiserror::Error)]
 pub enum OsFlagsError {
     #[error("Invalid base URL: {0}")]


### PR DESCRIPTION
## Summary
- add the inert `agent` feature flag key constant
- mark it with `#[allow(dead_code)]` because this PR intentionally does not wire behavior to the flag yet

## Verification
- `nix develop -c cargo check`

## Notes
- PCR update intentionally omitted for this review PR; deployment PCRs will be regenerated separately before deploy.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret/pull/210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new public feature flag key, `agent`, for external use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->