### PR TITLE
Preserve reasoning history for Kimi and GLM

### DIFF
--- a/src/model_config.rs
+++ b/src/model_config.rs
@@ -21,6 +21,12 @@ pub struct SamplingConfig {
     pub top_p: f32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReasoningHistoryStrategy {
+    KimiPreserveThinking,
+    GlmClearThinking,
+}
+
 impl SamplingConfig {
     pub fn with_overrides(self, temperature: Option<f32>, top_p: Option<f32>) -> Self {
         Self {
@@ -471,17 +477,23 @@ pub fn model_context_window(model: &str) -> usize {
     model_config(model).context_window
 }
 
-pub fn model_supports_reasoning_history(model: &str) -> bool {
+pub fn model_reasoning_history_strategy(model: &str) -> Option<ReasoningHistoryStrategy> {
     let canonical = alias_target(model).unwrap_or(model);
-    let normalized = canonical
+    let normalized = canonical.to_ascii_lowercase();
+    let normalized = normalized
         .strip_prefix("openai/")
-        .unwrap_or(canonical)
-        .to_ascii_lowercase();
+        .or_else(|| normalized.strip_prefix("tinfoil/"))
+        .unwrap_or(&normalized);
 
-    matches!(
-        normalized.as_str(),
-        "gpt-oss-120b" | "kimi-k2-6" | "kimi-k2.6"
-    )
+    match normalized {
+        "kimi-k2-6" | "kimi-k2.6" => Some(ReasoningHistoryStrategy::KimiPreserveThinking),
+        "glm-5-2" | "glm-5.2" => Some(ReasoningHistoryStrategy::GlmClearThinking),
+        _ => None,
+    }
+}
+
+pub fn model_supports_reasoning_history(model: &str) -> bool {
+    model_reasoning_history_strategy(model).is_some()
 }
 
 pub fn model_catalog_response() -> Value {
@@ -613,17 +625,37 @@ mod tests {
 
     #[test]
     fn test_model_supports_reasoning_history_only_for_validated_models() {
-        assert!(model_supports_reasoning_history("gpt-oss-120b"));
-        assert!(model_supports_reasoning_history("openai/gpt-oss-120b"));
         assert!(model_supports_reasoning_history("kimi-k2-6"));
         assert!(model_supports_reasoning_history("kimi-k2.6"));
-        assert!(model_supports_reasoning_history(AUTO_QUICK_MODEL_ID));
+        assert!(model_supports_reasoning_history("glm-5-2"));
+        assert!(model_supports_reasoning_history("glm-5.2"));
         assert!(model_supports_reasoning_history(AUTO_POWERFUL_MODEL_ID));
 
+        assert!(!model_supports_reasoning_history("gpt-oss-120b"));
+        assert!(!model_supports_reasoning_history("openai/gpt-oss-120b"));
+        assert!(!model_supports_reasoning_history(AUTO_QUICK_MODEL_ID));
+        assert!(!model_supports_reasoning_history("gpt-oss-safeguard-120b"));
         assert!(!model_supports_reasoning_history("gemma4-31b"));
-        assert!(!model_supports_reasoning_history("glm-5-2"));
+        assert!(!model_supports_reasoning_history("deepseek-v4-pro"));
         assert!(!model_supports_reasoning_history("llama3-3-70b"));
         assert!(!model_supports_reasoning_history("unknown-model"));
+    }
+
+    #[test]
+    fn test_model_reasoning_history_strategy_by_model_family() {
+        assert_eq!(
+            model_reasoning_history_strategy("kimi-k2-6"),
+            Some(ReasoningHistoryStrategy::KimiPreserveThinking)
+        );
+        assert_eq!(
+            model_reasoning_history_strategy("kimi-k2.6"),
+            Some(ReasoningHistoryStrategy::KimiPreserveThinking)
+        );
+        assert_eq!(
+            model_reasoning_history_strategy("glm-5-2"),
+            Some(ReasoningHistoryStrategy::GlmClearThinking)
+        );
+        assert_eq!(model_reasoning_history_strategy("gemma4-31b"), None);
     }
 
     #[test]

--- a/src/web/responses/context_builder.rs
+++ b/src/web/responses/context_builder.rs
@@ -1466,7 +1466,7 @@ mod tests {
         ];
 
         let (messages, total_tokens) =
-            build_prompt_from_chat_messages(msgs, "gpt-oss-120b").expect("build prompt");
+            build_prompt_from_chat_messages(msgs, "glm-5-2").expect("build prompt");
 
         assert_eq!(messages[1]["role"], ROLE_ASSISTANT);
         assert_eq!(messages[1]["content"], "The answer is 42.");

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -6,7 +6,10 @@ use crate::{
     db::DBError,
     encrypt::{decrypt_content, decrypt_string, encrypt_with_key},
     jwt::AuthContext,
-    model_config::{model_config, resolve_public_model_id, ResponsesModelConfig, SamplingConfig},
+    model_config::{
+        model_config, model_reasoning_history_strategy, resolve_public_model_id,
+        ReasoningHistoryStrategy, ResponsesModelConfig, SamplingConfig,
+    },
     models::responses::{NewUserMessage, ResponseStatus, ResponsesError},
     models::users::User,
     tokens::{count_tokens, model_max_ctx},
@@ -55,8 +58,46 @@ fn default_stream() -> bool {
     true
 }
 
-fn apply_responses_model_defaults(chat_request: &mut Value, config: ResponsesModelConfig) {
-    if !config.include_reasoning && !config.enable_thinking {
+fn set_chat_template_kwarg(chat_request: &mut Value, key: &str, value: Value) {
+    let Some(obj) = chat_request.as_object_mut() else {
+        return;
+    };
+
+    let chat_template_kwargs = obj
+        .entry("chat_template_kwargs".to_string())
+        .or_insert_with(|| json!({}));
+
+    if let Some(kwargs) = chat_template_kwargs.as_object_mut() {
+        kwargs.insert(key.to_string(), value);
+    } else {
+        *chat_template_kwargs = json!({});
+        if let Some(kwargs) = chat_template_kwargs.as_object_mut() {
+            kwargs.insert(key.to_string(), value);
+        }
+    }
+}
+
+fn apply_reasoning_history_strategy(chat_request: &mut Value, model: &str) {
+    match model_reasoning_history_strategy(model) {
+        Some(ReasoningHistoryStrategy::KimiPreserveThinking) => {
+            set_chat_template_kwarg(chat_request, "preserve_thinking", json!(true));
+        }
+        Some(ReasoningHistoryStrategy::GlmClearThinking) => {
+            set_chat_template_kwarg(chat_request, "clear_thinking", json!(false));
+        }
+        None => {}
+    }
+}
+
+fn apply_responses_model_defaults(
+    chat_request: &mut Value,
+    config: ResponsesModelConfig,
+    model: &str,
+) {
+    if !config.include_reasoning
+        && !config.enable_thinking
+        && model_reasoning_history_strategy(model).is_none()
+    {
         return;
     }
 
@@ -68,21 +109,11 @@ fn apply_responses_model_defaults(chat_request: &mut Value, config: ResponsesMod
         obj.insert("include_reasoning".to_string(), json!(true));
     }
 
-    if !config.enable_thinking {
-        return;
+    if config.enable_thinking {
+        set_chat_template_kwarg(chat_request, "enable_thinking", json!(true));
     }
 
-    let chat_template_kwargs = obj
-        .entry("chat_template_kwargs".to_string())
-        .or_insert_with(|| json!({}));
-
-    if let Some(kwargs) = chat_template_kwargs.as_object_mut() {
-        kwargs.insert("enable_thinking".to_string(), json!(true));
-    } else {
-        *chat_template_kwargs = json!({
-            "enable_thinking": true
-        });
-    }
+    apply_reasoning_history_strategy(chat_request, model);
 }
 
 fn resolve_responses_sampling(body: &ResponsesCreateRequest) -> SamplingConfig {
@@ -196,7 +227,7 @@ fn build_model_turn_request(
         }
     }
 
-    apply_responses_model_defaults(&mut chat_request, responses_config);
+    apply_responses_model_defaults(&mut chat_request, responses_config, config_model);
     chat_request
 }
 
@@ -307,6 +338,7 @@ mod tests {
         apply_responses_model_defaults(
             &mut chat_request,
             crate::model_config::model_config("gemma4-31b").responses,
+            "gemma4-31b",
         );
 
         assert_eq!(chat_request["include_reasoning"], true);
@@ -326,10 +358,53 @@ mod tests {
         apply_responses_model_defaults(
             &mut chat_request,
             crate::model_config::model_config("gpt-oss-120b").responses,
+            "gpt-oss-120b",
         );
 
         assert!(chat_request.get("include_reasoning").is_none());
         assert!(chat_request.get("chat_template_kwargs").is_none());
+    }
+
+    #[test]
+    fn test_apply_responses_model_defaults_preserves_kimi_reasoning_history() {
+        let mut chat_request = json!({
+            "model": "kimi-k2-6",
+            "chat_template_kwargs": {
+                "foo": "bar"
+            }
+        });
+
+        apply_responses_model_defaults(
+            &mut chat_request,
+            crate::model_config::model_config("kimi-k2-6").responses,
+            "kimi-k2-6",
+        );
+
+        assert_eq!(
+            chat_request["chat_template_kwargs"]["preserve_thinking"],
+            true
+        );
+        assert_eq!(chat_request["chat_template_kwargs"]["foo"], "bar");
+        assert!(chat_request.get("include_reasoning").is_none());
+    }
+
+    #[test]
+    fn test_apply_responses_model_defaults_preserves_glm_reasoning_history() {
+        let mut chat_request = json!({
+            "model": "glm-5-2"
+        });
+
+        apply_responses_model_defaults(
+            &mut chat_request,
+            crate::model_config::model_config("glm-5-2").responses,
+            "glm-5-2",
+        );
+
+        assert_eq!(
+            chat_request["chat_template_kwargs"]["clear_thinking"],
+            false
+        );
+        assert!(chat_request.get("include_reasoning").is_none());
     }
 
     fn responses_request_for_model(model: &str) -> ResponsesCreateRequest {
@@ -429,6 +504,34 @@ mod tests {
         assert_eq!(
             chat_request["model"],
             crate::model_config::AUTO_QUICK_MODEL_ID
+        );
+    }
+
+    #[test]
+    fn test_build_model_turn_request_applies_reasoning_history_template_kwargs() {
+        let kimi = responses_request_for_model("kimi-k2-6");
+        let kimi_request =
+            build_model_turn_request(&kimi, &[json!({"role": "user", "content": "hello"})], false);
+        assert_eq!(
+            kimi_request["chat_template_kwargs"]["preserve_thinking"],
+            true
+        );
+
+        let glm = responses_request_for_model("glm-5-2");
+        let glm_request =
+            build_model_turn_request(&glm, &[json!({"role": "user", "content": "hello"})], false);
+        assert_eq!(glm_request["chat_template_kwargs"]["clear_thinking"], false);
+
+        let auto_powerful =
+            responses_request_for_model(crate::model_config::AUTO_POWERFUL_MODEL_ID);
+        let auto_request = build_model_turn_request(
+            &auto_powerful,
+            &[json!({"role": "user", "content": "hello"})],
+            false,
+        );
+        assert_eq!(
+            auto_request["chat_template_kwargs"]["preserve_thinking"],
+            true
         );
     }
 


### PR DESCRIPTION
## Summary
- add a validated reasoning-history strategy for Kimi K2.6 and GLM 5.2
- attach provider-specific chat template kwargs in Responses API chat-completions requests
- stop treating GPT-OSS as prior-reasoning-history capable in the completions-backed path after provider probes showed no preservation

## Provider behavior verified
- Kimi K2.6: `chat_template_kwargs.preserve_thinking = true`
- GLM 5.2: `chat_template_kwargs.clear_thinking = false`
- Gemma 4, DeepSeek V4 Pro, and GPT-OSS emit or can emit current-turn reasoning, but did not preserve prior assistant `reasoning` in direct Tinfoil chat-completions probes

## Tests
- `nix develop -c cargo fmt`
- `nix develop -c cargo test`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret/pull/216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader support for model-specific reasoning history behavior, including automatic handling for certain model families and aliases.
  * Improved request generation so reasoning/thinking settings are applied more consistently for supported models.

* **Bug Fixes**
  * Fixed model detection to use normalized model names, reducing missed matches from casing or alias variations.
  * Updated prompt/request behavior so supported models preserve or clear thinking context as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->