### PR TITLE
Enforce Tinfoil provider configuration

### DIFF
--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -1132,6 +1132,7 @@ async fn build_local_test_app_state(database_url: String) -> AppState {
         .enclave_key([42u8; 32].to_vec())
         .aws_credential_manager(Arc::new(RwLock::new(None)))
         .openai_api_base("http://localhost:9".to_string())
+        .tinfoil_api_base("http://localhost:9".to_string())
         .jwt_secret([24u8; 32].to_vec())
         .build()
         .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -543,8 +543,8 @@ impl AppStateBuilder {
         self
     }
 
-    pub fn tinfoil_api_base(mut self, tinfoil_api_base: Option<String>) -> Self {
-        self.tinfoil_api_base = tinfoil_api_base;
+    pub fn tinfoil_api_base(mut self, tinfoil_api_base: String) -> Self {
+        self.tinfoil_api_base = Some(tinfoil_api_base);
         self
     }
 
@@ -726,10 +726,15 @@ impl AppStateBuilder {
         let apple_jwt_verifier = Arc::new(AppleJwtVerifier::new());
 
         // Initialize the ProxyRouter
+        let tinfoil_api_base = self
+            .tinfoil_api_base
+            .clone()
+            .expect("Tinfoil API base must be configured");
+
         let proxy_router = Arc::new(ProxyRouter::new(
             openai_api_base.clone(),
             self.openai_api_key.clone(),
-            self.tinfoil_api_base.clone(),
+            tinfoil_api_base,
         ));
         let provider_router = Arc::new(ProviderRouter::default());
 
@@ -3017,8 +3022,8 @@ async fn main() -> Result<(), Error> {
         None // No API key needed if not using OpenAI's domain
     };
 
-    // Tinfoil API base is always from environment (like OpenAI API base)
-    let tinfoil_api_base = env::var("TINFOIL_API_BASE").ok();
+    // Tinfoil is a hard runtime requirement for OpenSecret.
+    let tinfoil_api_base = env::var("TINFOIL_API_BASE").expect("TINFOIL_API_BASE must be set");
 
     let jwt_secret = get_or_create_jwt_secret(
         &app_mode,

--- a/src/provider_routing.rs
+++ b/src/provider_routing.rs
@@ -391,7 +391,7 @@ fn stable_account_bucket(account_uuid: Uuid) -> u8 {
 
 fn proxy_for_provider(proxy_router: &ProxyRouter, provider: ProviderName) -> Option<ProxyConfig> {
     match provider {
-        ProviderName::Tinfoil => proxy_router.get_tinfoil_proxy(),
+        ProviderName::Tinfoil => Some(proxy_router.get_tinfoil_proxy()),
         ProviderName::Continuum => {
             let proxy = proxy_router.get_default_proxy();
             (proxy.provider_name == ProviderName::Continuum.as_str()).then_some(proxy)
@@ -407,7 +407,7 @@ mod tests {
         ProxyRouter::new(
             "http://continuum.example.com".to_string(),
             None,
-            Some("http://tinfoil.example.com".to_string()),
+            "http://tinfoil.example.com".to_string(),
         )
     }
 
@@ -555,7 +555,7 @@ mod tests {
         let proxy_router = ProxyRouter::new(
             "http://continuum.example.com".to_string(),
             None,
-            Some("http://tinfoil.example.com".to_string()),
+            "http://tinfoil.example.com".to_string(),
         );
 
         let selected = router
@@ -576,7 +576,7 @@ mod tests {
         let tinfoil_only = ProxyRouter::new(
             "https://api.openai.com".to_string(),
             None,
-            Some("http://tinfoil.example.com".to_string()),
+            "http://tinfoil.example.com".to_string(),
         );
         let selected = router
             .select_completion_route_with_preference(
@@ -593,18 +593,25 @@ mod tests {
     }
 
     #[test]
-    fn test_kimi_uses_only_eligible_provider_when_other_proxy_is_missing() {
+    fn test_kimi_uses_tinfoil_when_continuum_proxy_is_missing() {
         let router = ProviderRouter::default();
-        let proxy_router = ProxyRouter::new("http://continuum.example.com".to_string(), None, None);
+        let proxy_router = ProxyRouter::new(
+            "https://api.openai.com".to_string(),
+            None,
+            "http://tinfoil.example.com".to_string(),
+        );
 
         let selected = router
             .select_completion_route(&proxy_router, uuid_for_bucket(1), "kimi-k2-6")
             .expect("route");
 
-        assert_eq!(selected.proxy.provider_name, "continuum");
-        assert_eq!(selected.provider_model_id, "kimi-k2.6");
-        assert_eq!(selected.bucket, Some(1));
-        assert_eq!(selected.selection_source, ProviderSelectionSource::Fallback);
+        assert_eq!(selected.proxy.provider_name, "tinfoil");
+        assert_eq!(selected.provider_model_id, "kimi-k2-6");
+        assert_eq!(selected.bucket, None);
+        assert_eq!(
+            selected.selection_source,
+            ProviderSelectionSource::DefaultProvider
+        );
     }
 
     #[test]
@@ -624,9 +631,13 @@ mod tests {
     }
 
     #[test]
-    fn test_non_tinfoil_fallback_resolves_known_alias_before_provider_request() {
+    fn test_tinfoil_fallback_resolves_known_alias_before_provider_request() {
         let router = ProviderRouter::default();
-        let proxy_router = ProxyRouter::new("http://continuum.example.com".to_string(), None, None);
+        let proxy_router = ProxyRouter::new(
+            "http://continuum.example.com".to_string(),
+            None,
+            "http://tinfoil.example.com".to_string(),
+        );
 
         let selected = router
             .select_completion_route(
@@ -636,7 +647,7 @@ mod tests {
             )
             .expect("route");
 
-        assert_eq!(selected.proxy.provider_name, "continuum");
+        assert_eq!(selected.proxy.provider_name, "tinfoil");
         assert_eq!(
             selected.public_model_id,
             crate::model_config::QUICK_MODEL_ID
@@ -653,19 +664,22 @@ mod tests {
     }
 
     #[test]
-    fn test_non_tinfoil_fallback_preserves_unknown_model_passthrough() {
+    fn test_tinfoil_fallback_rejects_unknown_model_passthrough() {
         let router = ProviderRouter::default();
-        let proxy_router = ProxyRouter::new("http://continuum.example.com".to_string(), None, None);
+        let proxy_router = ProxyRouter::new(
+            "http://continuum.example.com".to_string(),
+            None,
+            "http://tinfoil.example.com".to_string(),
+        );
 
-        let selected = router
+        let error = router
             .select_completion_route(&proxy_router, uuid_for_bucket(50), "provider-native-model")
-            .expect("route");
+            .expect_err("unsupported model");
 
-        assert_eq!(selected.proxy.provider_name, "continuum");
-        assert_eq!(selected.public_model_id, "provider-native-model");
-        assert_eq!(selected.provider_model_id, "provider-native-model");
-        assert_eq!(selected.response_model_id, "provider-native-model");
-        assert_eq!(selected.bucket, None);
+        assert_eq!(
+            error,
+            ProviderRoutingError::UnsupportedModel("provider-native-model".to_string())
+        );
     }
 
     #[test]
@@ -684,17 +698,23 @@ mod tests {
     }
 
     #[test]
-    fn test_configured_model_errors_when_no_provider_route_is_eligible() {
+    fn test_configured_model_uses_tinfoil_when_continuum_is_missing() {
         let router = ProviderRouter::default();
-        let proxy_router = ProxyRouter::new("https://api.openai.com".to_string(), None, None);
+        let proxy_router = ProxyRouter::new(
+            "https://api.openai.com".to_string(),
+            None,
+            "http://tinfoil.example.com".to_string(),
+        );
 
-        let error = router
+        let selected = router
             .select_completion_route(&proxy_router, uuid_for_bucket(50), "kimi-k2-6")
-            .expect_err("no route");
+            .expect("route");
 
+        assert_eq!(selected.proxy.provider_name, "tinfoil");
+        assert_eq!(selected.provider_model_id, "kimi-k2-6");
         assert_eq!(
-            error,
-            ProviderRoutingError::NoEligibleRoute("kimi-k2-6".to_string())
+            selected.selection_source,
+            ProviderSelectionSource::DefaultProvider
         );
     }
 }

--- a/src/proxy_config.rs
+++ b/src/proxy_config.rs
@@ -8,7 +8,7 @@ pub struct ProxyConfig {
 #[derive(Debug, Clone)]
 pub struct ProxyRouter {
     default_proxy: ProxyConfig,
-    tinfoil_proxy: Option<ProxyConfig>,
+    tinfoil_proxy: ProxyConfig,
 }
 
 pub fn canonicalize_tinfoil_model(model: &str) -> String {
@@ -19,11 +19,12 @@ pub fn canonicalize_tinfoil_model(model: &str) -> String {
 }
 
 impl ProxyRouter {
-    pub fn new(
-        openai_base: String,
-        openai_key: Option<String>,
-        tinfoil_base: Option<String>,
-    ) -> Self {
+    pub fn new(openai_base: String, openai_key: Option<String>, tinfoil_base: String) -> Self {
+        assert!(
+            !tinfoil_base.trim().is_empty(),
+            "Tinfoil API base must be configured"
+        );
+
         let default_proxy = ProxyConfig {
             base_url: openai_base.clone(),
             api_key: if openai_base.contains("api.openai.com") {
@@ -38,13 +39,11 @@ impl ProxyRouter {
             },
         };
 
-        let tinfoil_proxy = tinfoil_base
-            .filter(|base| !base.is_empty())
-            .map(|base_url| ProxyConfig {
-                base_url,
-                api_key: None,
-                provider_name: "tinfoil".to_string(),
-            });
+        let tinfoil_proxy = ProxyConfig {
+            base_url: tinfoil_base,
+            api_key: None,
+            provider_name: "tinfoil".to_string(),
+        };
 
         Self {
             default_proxy,
@@ -57,19 +56,15 @@ impl ProxyRouter {
     }
 
     pub fn get_completion_proxy(&self) -> ProxyConfig {
-        self.tinfoil_proxy
-            .clone()
-            .unwrap_or_else(|| self.default_proxy.clone())
-    }
-
-    pub fn get_tinfoil_proxy(&self) -> Option<ProxyConfig> {
         self.tinfoil_proxy.clone()
     }
 
-    pub fn get_tinfoil_base_url(&self) -> Option<String> {
-        self.tinfoil_proxy
-            .as_ref()
-            .map(|proxy| proxy.base_url.clone())
+    pub fn get_tinfoil_proxy(&self) -> ProxyConfig {
+        self.tinfoil_proxy.clone()
+    }
+
+    pub fn get_tinfoil_base_url(&self) -> String {
+        self.tinfoil_proxy.base_url.clone()
     }
 }
 
@@ -82,7 +77,7 @@ mod tests {
         let router = ProxyRouter::new(
             "https://api.openai.com".to_string(),
             Some("test-key".to_string()),
-            None,
+            "http://tinfoil.example.com".to_string(),
         );
 
         assert_eq!(router.get_default_proxy().provider_name, "openai");
@@ -94,7 +89,7 @@ mod tests {
         let continuum_router = ProxyRouter::new(
             "http://continuum.example.com".to_string(),
             Some("ignored".to_string()),
-            None,
+            "http://tinfoil.example.com".to_string(),
         );
 
         assert_eq!(
@@ -109,22 +104,36 @@ mod tests {
         let router = ProxyRouter::new(
             "http://continuum.example.com".to_string(),
             None,
-            Some("http://tinfoil.example.com".to_string()),
+            "http://tinfoil.example.com".to_string(),
         );
 
         assert_eq!(router.get_completion_proxy().provider_name, "tinfoil");
         assert_eq!(
             router.get_tinfoil_base_url(),
-            Some("http://tinfoil.example.com".to_string())
+            "http://tinfoil.example.com".to_string()
         );
     }
 
     #[test]
-    fn test_completion_proxy_falls_back_to_default_without_tinfoil() {
-        let router = ProxyRouter::new("http://continuum.example.com".to_string(), None, None);
+    #[should_panic(expected = "Tinfoil API base must be configured")]
+    fn test_proxy_router_requires_tinfoil() {
+        let _router = ProxyRouter::new(
+            "http://continuum.example.com".to_string(),
+            None,
+            String::new(),
+        );
+    }
 
-        assert_eq!(router.get_completion_proxy().provider_name, "continuum");
-        assert_eq!(router.get_tinfoil_proxy(), None);
+    #[test]
+    fn test_completion_proxy_uses_tinfoil_even_with_continuum_default() {
+        let router = ProxyRouter::new(
+            "http://continuum.example.com".to_string(),
+            None,
+            "http://tinfoil.example.com".to_string(),
+        );
+
+        assert_eq!(router.get_completion_proxy().provider_name, "tinfoil");
+        assert_eq!(router.get_tinfoil_proxy().provider_name, "tinfoil");
     }
 
     #[test]

--- a/src/web/health_routes.rs
+++ b/src/web/health_routes.rs
@@ -64,10 +64,7 @@ pub async fn health_check_extended(
     // Try to fetch models directly from the tinfoil proxy with a timeout
     let timeout_duration = Duration::from_secs(5);
 
-    let tinfoil_proxy = state.proxy_router.get_tinfoil_proxy().ok_or((
-        StatusCode::SERVICE_UNAVAILABLE,
-        "Tinfoil proxy is not configured".to_string(),
-    ))?;
+    let tinfoil_proxy = state.proxy_router.get_tinfoil_proxy();
 
     let result = timeout(
         timeout_duration,

--- a/src/web/oauth_routes.rs
+++ b/src/web/oauth_routes.rs
@@ -1672,6 +1672,7 @@ mod tests {
             .enclave_key([42u8; 32].to_vec())
             .aws_credential_manager(Arc::new(RwLock::new(None)))
             .openai_api_base("http://localhost:9".to_string())
+            .tinfoil_api_base("http://localhost:9".to_string())
             .jwt_secret([24u8; 32].to_vec())
             .build()
             .await

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -1599,15 +1599,8 @@ async fn proxy_transcription(
                 chunk.index, chunk_size
             );
 
-            let mut primary_provider = match &tinfoil_proxy {
-                Some(proxy) => proxy.clone(),
-                None => default_proxy.clone(),
-            };
-            let mut fallback_provider = if tinfoil_proxy.is_some() {
-                Some(default_proxy.clone())
-            } else {
-                None
-            };
+            let mut primary_provider = tinfoil_proxy.clone();
+            let mut fallback_provider = Some(default_proxy.clone());
 
             if chunk_size > TINFOIL_MAX_SIZE && primary_provider.provider_name == "tinfoil" {
                 info!(
@@ -1921,10 +1914,7 @@ async fn proxy_tts(
 
     // Use the tinfoil proxy configuration
     // For now, we'll hardcode to use tinfoil proxy - in future could route based on model
-    let base_url = state.proxy_router.get_tinfoil_base_url().ok_or_else(|| {
-        error!("Tinfoil proxy not configured for TTS");
-        ApiError::InternalServerError
-    })?;
+    let base_url = state.proxy_router.get_tinfoil_base_url();
 
     let proxy_config = ProxyConfig {
         base_url,
@@ -2046,10 +2036,7 @@ async fn proxy_embeddings(
         return Err(ApiError::BadRequest);
     }
 
-    let proxy_config = state
-        .proxy_router
-        .get_tinfoil_proxy()
-        .unwrap_or_else(|| state.proxy_router.get_default_proxy());
+    let proxy_config = state.proxy_router.get_tinfoil_proxy();
 
     // Create a new hyper client
     let https = HttpsConnector::new();


### PR DESCRIPTION
## Summary
- require Tinfoil provider configuration at app-state/startup boundaries
- store Tinfoil as a required proxy in `ProxyRouter` instead of an optional fallback
- route embeddings and Tinfoil-only health/TTS paths through the required Tinfoil proxy directly
- keep Continuum optional for configured Kimi routing via the default proxy

## Validation
- `nix develop -c cargo fmt`
- `nix develop -c cargo test proxy_config`
- `nix develop -c cargo test provider_routing`
- `nix develop -c cargo check`
- `nix develop -c cargo clippy --all-features -- -D warnings`
- `nix develop -c cargo test --all-features`

## Rollout note
This should be a deployed-environment no-op because Tinfoil is already configured everywhere. Missing `TINFOIL_API_BASE` now fails loudly instead of silently falling back.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret/pull/218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routing reliability so requests consistently use the configured Tinfoil service when available.
  * Tightened startup validation to catch missing or empty Tinfoil settings earlier.
  * Updated health and proxy behavior to avoid unexpected fallback paths during transcription, speech, and embeddings handling.
  * Refreshed test coverage to reflect the new routing and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->