### PR TITLE
Remove unnecessary trace logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3070,6 +3070,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "subtle",
+ "syn 2.0.106",
  "thiserror 1.0.63",
  "tiktoken-rs",
  "tinfoil",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,3 +86,4 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 
 [dev-dependencies]
 openssl = "0.10.78"
+syn = { version = "2", features = ["full", "visit"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2024,7 +2024,7 @@ impl AppState {
         plaintext_secret: String,
         new_password: String,
     ) -> Result<(), Error> {
-        trace!("Confirm platform password reset for {email} with code {alphanumeric_code}");
+        trace!("Confirm platform password reset for {email}");
 
         let platform_user = match self.db.get_platform_user_by_email(&email) {
             Ok(Some(user)) => user,

--- a/src/security_invariants.rs
+++ b/src/security_invariants.rs
@@ -69,6 +69,39 @@ fn request_time_paths_do_not_use_legacy_seed_decrypt_helpers() {
 }
 
 #[test]
+fn request_time_logs_do_not_include_session_keys_tokens_or_reset_codes() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    for (relative_path, forbidden_patterns) in [
+        (
+            "src/web/attestation_routes.rs",
+            &["session key:", "Generated session key"][..],
+        ),
+        (
+            "src/web/login_routes.rs",
+            &["Logout request for refresh token:"][..],
+        ),
+        (
+            "src/web/platform/login_routes.rs",
+            &["Platform logout request for refresh token:"][..],
+        ),
+        ("src/main.rs", &["with code {alphanumeric_code}"][..]),
+    ] {
+        let source_path = manifest_dir.join(relative_path);
+        let contents = fs::read_to_string(&source_path)
+            .unwrap_or_else(|_| panic!("{} should be readable", source_path.display()));
+
+        for forbidden_pattern in forbidden_patterns {
+            assert!(
+                !contents.contains(forbidden_pattern),
+                "{} must not log sensitive data via `{forbidden_pattern}`",
+                source_path.display()
+            );
+        }
+    }
+}
+
+#[test]
 fn openai_compatible_routes_do_not_request_user_storage_keys() {
     let openai_routes = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/web/openai.rs");
     let contents =

--- a/src/security_invariants.rs
+++ b/src/security_invariants.rs
@@ -1,6 +1,32 @@
 use std::{collections::BTreeSet, fs, path::Path};
+use syn::visit::{self, Visit};
 
 const REQUEST_TIME_SCAN_ROOTS: &[&str] = &["src/main.rs", "src/web"];
+
+const SENSITIVE_LOG_IDENTIFIERS: &[&str] = &["session_key", "refresh_token", "alphanumeric_code"];
+
+const SENSITIVE_LOG_MESSAGES: &[&str] = &[
+    "session key:",
+    "Generated session key",
+    "Logout request for refresh token:",
+    "Platform logout request for refresh token:",
+    "with code {alphanumeric_code}",
+];
+
+const LOG_MACROS: &[&str] = &[
+    "trace",
+    "debug",
+    "info",
+    "warn",
+    "error",
+    "event",
+    "span",
+    "trace_span",
+    "debug_span",
+    "info_span",
+    "warn_span",
+    "error_span",
+];
 
 const LEGACY_SEED_PATTERNS: &[&str] = &[
     "get_seed_encrypted",
@@ -71,34 +97,69 @@ fn request_time_paths_do_not_use_legacy_seed_decrypt_helpers() {
 #[test]
 fn request_time_logs_do_not_include_session_keys_tokens_or_reset_codes() {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut findings = Vec::new();
 
-    for (relative_path, forbidden_patterns) in [
-        (
-            "src/web/attestation_routes.rs",
-            &["session key:", "Generated session key"][..],
-        ),
-        (
-            "src/web/login_routes.rs",
-            &["Logout request for refresh token:"][..],
-        ),
-        (
-            "src/web/platform/login_routes.rs",
-            &["Platform logout request for refresh token:"][..],
-        ),
-        ("src/main.rs", &["with code {alphanumeric_code}"][..]),
-    ] {
-        let source_path = manifest_dir.join(relative_path);
-        let contents = fs::read_to_string(&source_path)
-            .unwrap_or_else(|_| panic!("{} should be readable", source_path.display()));
-
-        for forbidden_pattern in forbidden_patterns {
-            assert!(
-                !contents.contains(forbidden_pattern),
-                "{} must not log sensitive data via `{forbidden_pattern}`",
-                source_path.display()
-            );
-        }
+    for root in REQUEST_TIME_SCAN_ROOTS {
+        collect_sensitive_log_findings_in_path(
+            &manifest_dir.join(root),
+            manifest_dir,
+            &mut findings,
+        );
     }
+
+    assert!(
+        findings.is_empty(),
+        "request-time log macros must not reference session keys, refresh tokens, or reset codes:\n{}",
+        findings.join("\n")
+    );
+}
+
+#[test]
+fn sensitive_log_scanner_detects_multiline_fields_and_formatted_identifiers() {
+    let source = r#"
+fn example(request: Request, session_key: [u8; 32], alphanumeric_code: String) {
+    tracing::warn!(
+        refresh_token = %request.refresh_token,
+        "logout failed"
+    );
+    debug!("generated key: {session_key:?}");
+    tracing::event!(Level::WARN, alphanumeric_code, "reset failed");
+    trace!("Generated session key: redacted");
+}
+"#;
+
+    let findings = collect_sensitive_log_findings("example.rs", source);
+
+    assert_eq!(findings.len(), 4, "unexpected findings: {findings:#?}");
+    for expected in ["refresh_token", "session_key", "alphanumeric_code"] {
+        assert!(
+            findings.iter().any(|finding| finding.contains(expected)),
+            "expected a finding for `{expected}`"
+        );
+    }
+    assert!(
+        findings
+            .iter()
+            .any(|finding| finding.contains("Generated session key")),
+        "expected the legacy exact message to remain forbidden"
+    );
+}
+
+#[test]
+fn sensitive_log_scanner_ignores_identifiers_outside_logging_macros() {
+    let source = r#"
+fn example(refresh_token: String, session_key: [u8; 32], alphanumeric_code: String) {
+    let response = json!({
+        "refresh_token": refresh_token,
+        "session_key": session_key,
+        "alphanumeric_code": alphanumeric_code,
+    });
+    info!(refresh_token_hash = "redacted", "token revoked");
+    consume(response);
+}
+"#;
+
+    assert!(collect_sensitive_log_findings("example.rs", source).is_empty());
 }
 
 #[test]
@@ -770,6 +831,99 @@ fn password_registration_and_login_issue_tokens_only_after_seed_wrap_verificatio
             "password login must contain `{required_pattern}`"
         );
     }
+}
+
+fn collect_sensitive_log_findings(source_path: &str, source: &str) -> Vec<String> {
+    let syntax = syn::parse_file(source)
+        .unwrap_or_else(|error| panic!("{source_path} should parse as Rust source: {error}"));
+    let mut visitor = SensitiveLogVisitor {
+        source_path,
+        findings: Vec::new(),
+    };
+    visitor.visit_file(&syntax);
+    visitor.findings
+}
+
+fn collect_sensitive_log_findings_in_path(
+    path: &Path,
+    manifest_dir: &Path,
+    findings: &mut Vec<String>,
+) {
+    if path.is_dir() {
+        for entry in fs::read_dir(path).expect("source directory should be readable") {
+            let entry = entry.expect("source directory entry should be readable");
+            collect_sensitive_log_findings_in_path(&entry.path(), manifest_dir, findings);
+        }
+        return;
+    }
+
+    if path.extension().and_then(|extension| extension.to_str()) != Some("rs") {
+        return;
+    }
+
+    let contents = fs::read_to_string(path)
+        .unwrap_or_else(|_| panic!("{} should be readable", path.display()));
+    let relative_path = path.strip_prefix(manifest_dir).unwrap_or(path);
+    findings.extend(collect_sensitive_log_findings(
+        &relative_path.display().to_string(),
+        &contents,
+    ));
+}
+
+struct SensitiveLogVisitor<'a> {
+    source_path: &'a str,
+    findings: Vec<String>,
+}
+
+impl<'ast> Visit<'ast> for SensitiveLogVisitor<'_> {
+    fn visit_macro(&mut self, log_macro: &'ast syn::Macro) {
+        let Some(macro_name) = log_macro
+            .path
+            .segments
+            .last()
+            .map(|segment| segment.ident.to_string())
+        else {
+            return;
+        };
+
+        if LOG_MACROS.contains(&macro_name.as_str()) {
+            let body = log_macro.tokens.to_string();
+            let mut sensitive_references = SENSITIVE_LOG_IDENTIFIERS
+                .iter()
+                .filter(|identifier| contains_identifier(&body, identifier))
+                .map(|identifier| format!("identifier `{identifier}`"))
+                .collect::<Vec<_>>();
+            sensitive_references.extend(
+                SENSITIVE_LOG_MESSAGES
+                    .iter()
+                    .filter(|message| body.contains(*message))
+                    .map(|message| format!("message `{message}`")),
+            );
+
+            if !sensitive_references.is_empty() {
+                self.findings.push(format!(
+                    "{}: `{}!` references {}",
+                    self.source_path,
+                    macro_name,
+                    sensitive_references.join(", ")
+                ));
+            }
+        }
+
+        visit::visit_macro(self, log_macro);
+    }
+}
+
+fn contains_identifier(source: &str, identifier: &str) -> bool {
+    source.match_indices(identifier).any(|(start, _)| {
+        let before = source[..start].chars().next_back();
+        let after = source[start + identifier.len()..].chars().next();
+        !before.is_some_and(is_identifier_character) && !after.is_some_and(is_identifier_character)
+    })
+}
+
+fn is_identifier_character(character: char) -> bool {
+    character == '_' || character.is_alphanumeric()
 }
 
 fn collect_forbidden_legacy_seed_matches(

--- a/src/web/login_routes.rs
+++ b/src/web/login_routes.rs
@@ -247,10 +247,7 @@ pub async fn logout(
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     info!("Logout request received");
     // TODO actually delete the refresh token
-    tracing::trace!(
-        "Logout request for refresh token: {}",
-        logout_request.refresh_token
-    );
+    drop(logout_request.refresh_token);
     let response = json!({ "message": "Logged out successfully" });
     let result = encrypt_response(&data, &session_id, &response).await;
     result

--- a/src/web/platform/login_routes.rs
+++ b/src/web/platform/login_routes.rs
@@ -438,11 +438,7 @@ pub async fn logout_platform_user(
     info!("Platform logout request received");
 
     // TODO: Implement token invalidation logic here when needed
-    tracing::trace!(
-        "Platform logout request for refresh token: {}",
-        logout_request.refresh_token
-    );
-
+    drop(logout_request.refresh_token);
     let response = json!({ "message": "Logged out successfully" });
     let result = encrypt_response(&data, &session_id, &response).await;
     result


### PR DESCRIPTION
## Summary

- remove user and platform refresh-token values from logout trace output
- retain platform password-reset metadata without including the reset code
- add a recursive source-level invariant over the existing request-time Rust roots for the named session-key, refresh-token, and reset-code identifiers and known legacy log messages

## Context

The attestation session-key traces originally covered by this PR were removed independently by `f5fe470` (`Harden attestation session key handling`), which reached `master` through #247. This rebased PR intentionally leaves `src/web/attestation_routes.rs` unchanged and preserves the bounded, zeroizing session-cache implementation now on `master`.

The source invariant is targeted: it inspects known tracing/log macros for the named identifiers and messages across `src/main.rs` and `src/web` recursively. It is a regression guard, not general secret-flow analysis.

The container image sets `RUST_LOG=info`, and the entrypoint preserves that configured value. This is preventive hardening; there is no evidence of production trace exposure.

Logout, refresh-token revocation, and password-reset behavior are otherwise unchanged.

## Validation

- focused sensitive-log invariant: 1 passed
- focused scanner behavior tests: 2 passed
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`: 337 passed, 17 database/live-network tests ignored as expected
- `git diff --check`

No PCR files are changed by this PR.