### PR TITLE
Bound streamed Responses tool-call indices

### DIFF
--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -340,28 +340,39 @@ fn append_streamed_tool_calls(tool_calls: &mut Vec<StreamedToolCall>, tool_call_
         );
     }
 
+    let mut ignored_nonzero_index = false;
     for tool_call in tool_call_entries {
         let index = tool_call
             .get("index")
             .and_then(|index| index.as_u64())
-            .unwrap_or(0) as usize;
+            .unwrap_or(0);
 
-        while tool_calls.len() <= index {
+        if index != 0 {
+            ignored_nonzero_index = true;
+            continue;
+        }
+
+        if tool_calls.is_empty() {
             tool_calls.push(StreamedToolCall::default());
         }
 
+        let tool_call_state = &mut tool_calls[0];
         if let Some(function) = tool_call.get("function") {
             if let Some(name) = function.get("name").and_then(|name| name.as_str()) {
-                tool_calls[index].name = Some(name.to_string());
+                tool_call_state.name = Some(name.to_string());
             }
 
             if let Some(arguments) = function
                 .get("arguments")
                 .and_then(|arguments| arguments.as_str())
             {
-                tool_calls[index].arguments.push_str(arguments);
+                tool_call_state.arguments.push_str(arguments);
             }
         }
+    }
+
+    if ignored_nonzero_index {
+        warn!("Ignoring streamed tool calls with nonzero indices; only index 0 is supported in v1");
     }
 }
 
@@ -696,6 +707,85 @@ mod tests {
         let tool_call = finalize_first_model_tool_call(&tool_calls).expect("tool call");
         assert_eq!(tool_call.name, "web_search");
         assert_eq!(tool_call.arguments["query"], "Donald Trump birthday");
+    }
+
+    #[test]
+    fn test_append_streamed_tool_calls_ignores_max_index_without_allocating() {
+        let mut tool_calls = Vec::<StreamedToolCall>::new();
+        let initial_capacity = tool_calls.capacity();
+
+        append_streamed_tool_calls(
+            &mut tool_calls,
+            &json!([{
+                "index": u64::MAX,
+                "function": {
+                    "name": "web_search",
+                    "arguments": "{}"
+                }
+            }]),
+        );
+
+        assert!(tool_calls.is_empty());
+        assert_eq!(tool_calls.capacity(), initial_capacity);
+    }
+
+    #[test]
+    fn test_append_streamed_tool_calls_ignores_sparse_nonzero_index() {
+        let mut tool_calls = Vec::<StreamedToolCall>::new();
+
+        append_streamed_tool_calls(
+            &mut tool_calls,
+            &json!([{
+                "index": 42,
+                "function": {
+                    "name": "web_search",
+                    "arguments": "{}"
+                }
+            }]),
+        );
+
+        assert!(tool_calls.is_empty());
+    }
+
+    #[test]
+    fn test_append_streamed_tool_calls_ignores_multiple_unsupported_indices_without_growth() {
+        let mut tool_calls = vec![StreamedToolCall {
+            name: Some("web_search".to_string()),
+            arguments: "{\"query\":\"existing\"}".to_string(),
+        }];
+        let initial_capacity = tool_calls.capacity();
+
+        append_streamed_tool_calls(
+            &mut tool_calls,
+            &json!([
+                {
+                    "index": 1,
+                    "function": {
+                        "name": "ignored_one",
+                        "arguments": "{}"
+                    }
+                },
+                {
+                    "index": 9,
+                    "function": {
+                        "name": "ignored_nine",
+                        "arguments": "{}"
+                    }
+                },
+                {
+                    "index": u64::MAX,
+                    "function": {
+                        "name": "ignored_max",
+                        "arguments": "{}"
+                    }
+                }
+            ]),
+        );
+
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls.capacity(), initial_capacity);
+        assert_eq!(tool_calls[0].name.as_deref(), Some("web_search"));
+        assert_eq!(tool_calls[0].arguments, "{\"query\":\"existing\"}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- enforce the existing Responses v1 single-tool contract by accepting only tool-call index 0
- ignore nonzero provider indices without casting them to `usize` or growing the accumulator vector
- emit one bounded warning per chunk when unsupported indices are present
- preserve index-0 name and argument-fragment reassembly

## Rationale

The provider-controlled streamed index was previously cast from `u64` to `usize` and used to grow a vector up to that index. A sparse or very large index could therefore cause excessive allocation or architecture-dependent truncation even though v1 only executes the first tool call and sends `parallel_tool_calls = false`.

## Tests

- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo clippy --locked --all-targets --all-features -- -D warnings`
- `nix develop -c cargo test --locked --all-features test_append_streamed_tool_calls -- --nocapture` (5 passed, 0 failed)
- `nix develop -c cargo test --locked --all-features` (337 passed, 17 environment-dependent tests ignored, 0 failed)
- regression coverage for `u64::MAX`, sparse/nonzero indices, multiple unsupported indices, no vector growth, and index-0 fragment reassembly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret/pull/223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->