### PR TITLE
Harden attestation session key handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3057,6 +3057,7 @@ dependencies = [
  "x25519-dalek",
  "x509-parser",
  "yasna",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ validator = { version = "0.20.0", features = ["derive"] }
 regex = "1.9.0"
 lazy_static = "1.4.0"
 subtle = "2.6.1"
+zeroize = { version = "1.8", features = ["derive"] }
 tiktoken-rs = "0.5"
 once_cell = "1.19"
 pulldown-cmark = { version = "0.13.0", default-features = false }

--- a/src/web/attestation_routes.rs
+++ b/src/web/attestation_routes.rs
@@ -20,7 +20,9 @@ use tracing::{error, trace};
 use uuid::Uuid;
 use yasna::models::ObjectIdentifier;
 use yasna::{construct_der, Tag};
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
+#[derive(Zeroize, ZeroizeOnDrop)]
 pub struct SessionState {
     session_key: [u8; 32],
 }
@@ -30,13 +32,12 @@ impl SessionState {
         Self { session_key }
     }
 
-    pub fn get_session_key(&self) -> [u8; 32] {
-        self.session_key
+    pub fn get_session_key(&self) -> &[u8; 32] {
+        &self.session_key
     }
 
     pub fn decrypt(&self, encrypted_data: &[u8], nonce: &[u8; 12]) -> Result<Vec<u8>, ApiError> {
         tracing::trace!("decrypting encrypted data");
-        tracing::trace!("session key: {:?}", self.session_key);
         tracing::trace!("nonce: {:?}", nonce);
         tracing::trace!("encrypted data length: {}", encrypted_data.len());
 
@@ -402,7 +403,7 @@ async fn key_exchange(
     let shared_secret = ephemeral_secret.diffie_hellman(&client_public_key);
 
     // Generate a random session key using your secure random function
-    let session_key: [u8; 32] = crate::encrypt::generate_random();
+    let session_state = SessionState::new(crate::encrypt::generate_random());
 
     // Encrypt the session key using the shared secret
     let nonce_bytes: [u8; 12] = crate::encrypt::generate_random();
@@ -411,26 +412,36 @@ async fn key_exchange(
     let mut encrypted_session_key = nonce_bytes.to_vec();
     encrypted_session_key.extend_from_slice(
         &cipher
-            .encrypt(nonce, session_key.as_ref())
+            .encrypt(nonce, session_state.get_session_key().as_ref())
             .map_err(|_| ApiError::InternalServerError)?,
     );
 
     // Generate a new UUID for the session
     let session_id = Uuid::new_v4();
 
-    trace!(
-        "Generated session key {:?} for nonce {:?}",
-        session_key,
-        nonce
-    );
-
     // Store the session state
     data.session_states
         .write()
         .await
-        .insert(session_id, SessionState::new(session_key));
+        .insert(session_id, session_state);
     Ok(Json(KeyExchangeResponse {
         session_id,
         encrypted_session_key: general_purpose::STANDARD.encode(&encrypted_session_key),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_state_zeroizes_key_material() {
+        fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
+
+        assert_zeroize_on_drop::<SessionState>();
+
+        let mut state = SessionState::new([0xA5; 32]);
+        state.zeroize();
+        assert_eq!(state.get_session_key(), &[0; 32]);
+    }
 }


### PR DESCRIPTION
## Summary

- remove plaintext encryption-session key material from TRACE logging
- zeroize each session key when its final `SessionState` reference is dropped
- avoid unnecessary key copies by returning a fixed-size reference and constructing the canonical session state before encrypting the key-exchange response

## Compatibility

This is stack layer 1 of 5 and is based directly on `master`. It does not change routes, request or response schemas, status codes, session lifetimes, or capacity behavior. No client change is required.

## Validation

- full Rust test suite
- strict all-target/all-feature Clippy
- formatting and Nix flake checks
- independent security and compatibility review

The cache limits and eviction policies are intentionally isolated in later PRs.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
