### PR TITLE
Restrict OpenAI API keys to the exact API origin

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,7 @@ mod aead_db_tamper_tests;
 use apple_signin::AppleJwtVerifier;
 use oauth::{AppleProvider, GithubProvider, GoogleProvider, OAuthManager};
 use provider_routing::{ProviderName, ProviderPreference, ProviderRouter};
-use proxy_config::ProxyRouter;
+use proxy_config::{is_openai_api_origin, ProxyRouter};
 
 const ENCLAVE_KEY_NAME: &str = "enclave_key";
 const OPENAI_API_KEY_NAME: &str = "openai_api_key";
@@ -2390,10 +2390,6 @@ fn get_kms_key_id(app_mode: &AppMode) -> String {
     }
 }
 
-fn is_default_openai_domain(domain: &str) -> bool {
-    domain.contains("openai.com")
-}
-
 fn default_os_flags_base_url(app_mode: &AppMode) -> String {
     match app_mode {
         AppMode::Prod => "https://flags.opensecret.cloud".to_string(),
@@ -3005,7 +3001,7 @@ async fn main() -> Result<(), Error> {
     let openai_api_base =
         env::var("OPENAI_API_BASE").unwrap_or_else(|_| "https://api.openai.com".to_string());
 
-    let openai_api_key = if is_default_openai_domain(&openai_api_base) {
+    let openai_api_key = if is_openai_api_origin(&openai_api_base) {
         if app_mode != AppMode::Local {
             Some(
                 retrieve_openai_api_key(aws_credential_manager.clone(), db.clone())

--- a/src/proxy_config.rs
+++ b/src/proxy_config.rs
@@ -1,3 +1,5 @@
+use url::Url;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProxyConfig {
     pub base_url: String,
@@ -18,6 +20,18 @@ pub fn canonicalize_tinfoil_model(model: &str) -> String {
     }
 }
 
+pub(crate) fn is_openai_api_origin(base_url: &str) -> bool {
+    let Ok(url) = Url::parse(base_url) else {
+        return false;
+    };
+
+    url.scheme() == "https"
+        && url.host_str() == Some("api.openai.com")
+        && url.port_or_known_default() == Some(443)
+        && url.username().is_empty()
+        && url.password().is_none()
+}
+
 impl ProxyRouter {
     pub fn new(openai_base: String, openai_key: Option<String>, tinfoil_base: String) -> Self {
         assert!(
@@ -25,14 +39,11 @@ impl ProxyRouter {
             "Tinfoil API base must be configured"
         );
 
+        let is_openai = is_openai_api_origin(&openai_base);
         let default_proxy = ProxyConfig {
             base_url: openai_base.clone(),
-            api_key: if openai_base.contains("api.openai.com") {
-                openai_key
-            } else {
-                None
-            },
-            provider_name: if openai_base.contains("api.openai.com") {
+            api_key: if is_openai { openai_key } else { None },
+            provider_name: if is_openai {
                 "openai".to_string()
             } else {
                 "continuum".to_string()
@@ -73,30 +84,71 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_proxy_router_uses_openai_api_key_only_for_openai() {
-        let router = ProxyRouter::new(
-            "https://api.openai.com".to_string(),
-            Some("test-key".to_string()),
-            "http://tinfoil.example.com".to_string(),
-        );
+    fn recognizes_only_the_openai_api_https_origin() {
+        for base_url in [
+            "https://api.openai.com",
+            "https://api.openai.com/",
+            "https://api.openai.com/v1",
+            "https://api.openai.com:443/v1/",
+            "https://API.OPENAI.COM/v1",
+            "https://api.openai.com/v1/users/@me?email=user@example.com#@profile",
+        ] {
+            assert!(
+                is_openai_api_origin(base_url),
+                "expected OpenAI origin: {base_url}"
+            );
+        }
 
-        assert_eq!(router.get_default_proxy().provider_name, "openai");
-        assert_eq!(
-            router.get_default_proxy().api_key,
-            Some("test-key".to_string())
-        );
+        for base_url in [
+            "http://api.openai.com",
+            "https://api.openai.com:8443",
+            "https://api.openai.com.attacker.example",
+            "https://notapi.openai.com",
+            "https://attacker.example/api.openai.com",
+            "https://api.openai.com@attacker.example",
+            "https://attacker@api.openai.com",
+            "https://attacker:password@api.openai.com",
+            "https://api.openai.com.",
+            "api.openai.com",
+            "not a url containing api.openai.com",
+        ] {
+            assert!(
+                !is_openai_api_origin(base_url),
+                "expected non-OpenAI origin: {base_url}"
+            );
+        }
+    }
 
-        let continuum_router = ProxyRouter::new(
-            "http://continuum.example.com".to_string(),
-            Some("ignored".to_string()),
-            "http://tinfoil.example.com".to_string(),
-        );
+    #[test]
+    fn proxy_router_attaches_openai_api_key_only_to_openai_origin() {
+        for base_url in ["https://api.openai.com", "https://api.openai.com:443/v1/"] {
+            let router = ProxyRouter::new(
+                base_url.to_string(),
+                Some("test-key".to_string()),
+                "http://tinfoil.example.com".to_string(),
+            );
+            let default_proxy = router.get_default_proxy();
 
-        assert_eq!(
-            continuum_router.get_default_proxy().provider_name,
-            "continuum"
-        );
-        assert_eq!(continuum_router.get_default_proxy().api_key, None);
+            assert_eq!(default_proxy.provider_name, "openai");
+            assert_eq!(default_proxy.api_key.as_deref(), Some("test-key"));
+        }
+
+        for base_url in [
+            "http://continuum.example.com",
+            "https://api.openai.com.attacker.example",
+            "https://api.openai.com@attacker.example",
+            "https://attacker.example/api.openai.com",
+        ] {
+            let router = ProxyRouter::new(
+                base_url.to_string(),
+                Some("must-not-be-forwarded".to_string()),
+                "http://tinfoil.example.com".to_string(),
+            );
+            let default_proxy = router.get_default_proxy();
+
+            assert_eq!(default_proxy.provider_name, "continuum");
+            assert_eq!(default_proxy.api_key, None);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- classify the OpenAI API base with the existing URL parser instead of substring matching
- require the exact HTTPS `api.openai.com` origin on the default port before loading or forwarding the OpenAI API key
- preserve Continuum and Tinfoil routing while covering lookalike hosts, userinfo, schemes, ports, invalid URLs, and path-only matches

## Testing

- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo test proxy_config::tests:: -- --nocapture`
- `nix develop -c cargo clippy --all-targets --all-features -- -D warnings`
- `nix develop -c cargo test --all-features` (214 passed, 16 database-dependent tests ignored)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret/pull/225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->