### PR TITLE
Bound buffered provider response bodies

### DIFF
--- a/src/provider_client.rs
+++ b/src/provider_client.rs
@@ -1,7 +1,7 @@
 use crate::provider_routing::ProviderName;
 use crate::proxy_config::ProxyConfig;
 use axum::http::{header, HeaderMap, HeaderName, HeaderValue};
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use futures::{Stream, StreamExt};
 use hyper::client::HttpConnector;
 use hyper::header::{HeaderName as HyperHeaderName, HeaderValue as HyperHeaderValue};
@@ -46,6 +46,15 @@ pub enum ProviderRequestError {
 
     #[error("provider request failed: {0}")]
     Send(String),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProviderBodyReadError {
+    #[error("provider response body exceeded the {limit}-byte limit")]
+    TooLarge { limit: usize },
+
+    #[error("failed to read provider response body: {0}")]
+    Read(String),
 }
 
 pub enum ProviderResponse {
@@ -126,6 +135,46 @@ impl ProviderResponse {
         }
     }
 
+    fn content_length(&self) -> Option<u64> {
+        match self {
+            Self::Tinfoil(response) => response
+                .headers()
+                .get("content-length")
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.parse().ok()),
+            Self::Standard(response) => response
+                .headers()
+                .get("content-length")
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.parse().ok()),
+        }
+    }
+
+    pub async fn bytes_limited(self, limit: usize) -> Result<Bytes, ProviderBodyReadError> {
+        if self
+            .content_length()
+            .is_some_and(|content_length| content_length > limit as u64)
+        {
+            return Err(ProviderBodyReadError::TooLarge { limit });
+        }
+
+        let mut body_stream = self.bytes_stream();
+        let mut collected = BytesMut::new();
+
+        while let Some(chunk) = body_stream.next().await {
+            let chunk = chunk.map_err(ProviderBodyReadError::Read)?;
+            collected
+                .len()
+                .checked_add(chunk.len())
+                .filter(|next_len| *next_len <= limit)
+                .ok_or(ProviderBodyReadError::TooLarge { limit })?;
+            collected.extend_from_slice(&chunk);
+        }
+
+        Ok(collected.freeze())
+    }
+
+    #[cfg(test)]
     pub async fn bytes(self) -> Result<Bytes, String> {
         match self {
             Self::Tinfoil(response) => response.bytes().await.map_err(|error| error.to_string()),
@@ -862,6 +911,13 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
     use tokio::sync::mpsc;
 
+    fn standard_response_from_chunks(chunks: Vec<Bytes>) -> ProviderResponse {
+        let body = HyperBody::wrap_stream(futures::stream::iter(
+            chunks.into_iter().map(Result::<Bytes, std::io::Error>::Ok),
+        ));
+        ProviderResponse::Standard(hyper::Response::new(body))
+    }
+
     fn tinfoil_proxy() -> ProxyConfig {
         ProxyConfig {
             base_url: "http://ignored.invalid".to_string(),
@@ -1220,6 +1276,42 @@ mod tests {
 
         assert!(response.is_success());
         assert_eq!(response.bytes().await.unwrap(), "standard-provider-ok");
+    }
+
+    #[tokio::test]
+    async fn limited_body_reader_accepts_chunked_body_at_limit() {
+        let response = standard_response_from_chunks(vec![
+            Bytes::from_static(b"abcd"),
+            Bytes::from_static(b"efgh"),
+        ]);
+
+        assert_eq!(response.bytes_limited(8).await.unwrap(), "abcdefgh");
+    }
+
+    #[tokio::test]
+    async fn limited_body_reader_rejects_chunked_body_over_limit() {
+        let response = standard_response_from_chunks(vec![
+            Bytes::from_static(b"abcd"),
+            Bytes::from_static(b"efghi"),
+        ]);
+
+        assert!(matches!(
+            response.bytes_limited(8).await,
+            Err(ProviderBodyReadError::TooLarge { limit: 8 })
+        ));
+    }
+
+    #[tokio::test]
+    async fn limited_body_reader_rejects_oversized_content_length_before_reading() {
+        let response = hyper::Response::builder()
+            .header("content-length", "9")
+            .body(HyperBody::empty())
+            .unwrap();
+
+        assert!(matches!(
+            ProviderResponse::Standard(response).bytes_limited(8).await,
+            Err(ProviderBodyReadError::TooLarge { limit: 8 })
+        ));
     }
 
     #[tokio::test]

--- a/src/web/health_routes.rs
+++ b/src/web/health_routes.rs
@@ -1,3 +1,4 @@
+use super::openai::{safe_log_preview, MAX_MODELS_RESPONSE_BYTES, MAX_PROVIDER_ERROR_BODY_BYTES};
 use crate::{
     provider_client::{ProviderClient, ProviderRequest},
     AppState,
@@ -107,12 +108,12 @@ async fn fetch_models_directly(
 
     if !res.is_success() {
         let status = res.status_code();
-        let body_bytes = res.bytes().await?;
-        let body_str = String::from_utf8_lossy(&body_bytes);
-        return Err(format!("HTTP {}: {}", status, body_str).into());
+        let body_bytes = res.bytes_limited(MAX_PROVIDER_ERROR_BODY_BYTES).await?;
+        let body_preview = safe_log_preview(&String::from_utf8_lossy(&body_bytes));
+        return Err(format!("HTTP {}: {}", status, body_preview).into());
     }
 
-    let body_bytes = res.bytes().await?;
+    let body_bytes = res.bytes_limited(MAX_MODELS_RESPONSE_BYTES).await?;
     let models_response: serde_json::Value = serde_json::from_slice(&body_bytes)?;
 
     // Count the models

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -38,6 +38,17 @@ use uuid::Uuid;
 // Maximum audio file size (100MB) - sanity check, CF already limits to 50MB
 const MAX_AUDIO_SIZE: usize = 100 * 1024 * 1024;
 
+// Provider responses cross an untrusted boundary. These limits bound the raw
+// body retained before JSON parsing, base64 encoding, and response encryption.
+const MAX_COMPLETION_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
+pub(super) const MAX_MODELS_RESPONSE_BYTES: usize = 4 * 1024 * 1024;
+const MAX_EMBEDDINGS_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
+const MAX_TRANSCRIPTION_RESPONSE_BYTES: usize = 32 * 1024 * 1024;
+// TTS bytes are base64-encoded into JSON and then encrypted, so keep the raw
+// provider-body ceiling separate from the larger inbound audio-upload limit.
+const MAX_TTS_RESPONSE_BYTES: usize = 32 * 1024 * 1024;
+pub(super) const MAX_PROVIDER_ERROR_BODY_BYTES: usize = 64 * 1024;
+
 // Timeout constants for provider requests
 const REQUEST_TIMEOUT_SECS: u64 = 120; // Request timeout (generous for large non-streaming responses)
 const STREAM_CHUNK_TIMEOUT_SECS: u64 = 120; // Per-chunk timeout for streaming reads
@@ -351,7 +362,7 @@ fn image_part_url(part: &Value) -> Option<&str> {
         .or_else(|| part.get("image").and_then(Value::as_str))
 }
 
-fn safe_log_preview(value: &str) -> String {
+pub(super) fn safe_log_preview(value: &str) -> String {
     let mut chars = value.chars();
     let preview = chars
         .by_ref()
@@ -364,6 +375,14 @@ fn safe_log_preview(value: &str) -> String {
     } else {
         preview
     }
+}
+
+async fn provider_error_preview(response: ProviderResponse) -> Option<String> {
+    response
+        .bytes_limited(MAX_PROVIDER_ERROR_BODY_BYTES)
+        .await
+        .ok()
+        .map(|body| safe_log_preview(&String::from_utf8_lossy(&body)))
 }
 
 /// Parameters for transcription requests
@@ -1063,10 +1082,13 @@ pub async fn get_chat_completion_response(
         debug!("Processing non-streaming response with internal billing");
         // The request's streaming fields are forwarded unchanged, but this
         // encrypted endpoint currently buffers one byte-exact response carrier.
-        let body_bytes = res.bytes().await.map_err(|e| {
-            error!("Failed to read response body: {:?}", e);
-            ApiError::InternalServerError
-        })?;
+        let body_bytes = res
+            .bytes_limited(MAX_COMPLETION_RESPONSE_BYTES)
+            .await
+            .map_err(|e| {
+                error!("Failed to read response body: {:?}", e);
+                ApiError::InternalServerError
+            })?;
 
         let mut response_json: Value = serde_json::from_str(&String::from_utf8_lossy(&body_bytes))
             .map_err(|e| {
@@ -1613,9 +1635,8 @@ async fn fetch_provider_models(
 
     if !res.is_success() {
         let status = res.status_code();
-        let body_bytes = res.bytes().await.ok();
-        let error_msg = body_bytes
-            .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
+        let error_msg = provider_error_preview(res)
+            .await
             .unwrap_or_else(|| status.to_string());
         error!(
             "Provider {} returned non-success status for models: {} - {}",
@@ -1624,10 +1645,13 @@ async fn fetch_provider_models(
         return Err(ApiError::InternalServerError);
     }
 
-    let body_bytes = res.bytes().await.map_err(|e| {
-        error!("Failed to read models response body: {:?}", e);
-        ApiError::InternalServerError
-    })?;
+    let body_bytes = res
+        .bytes_limited(MAX_MODELS_RESPONSE_BYTES)
+        .await
+        .map_err(|e| {
+            error!("Failed to read models response body: {:?}", e);
+            ApiError::InternalServerError
+        })?;
 
     serde_json::from_slice(&body_bytes).map_err(|e| {
         error!("Failed to parse models response: {:?}", e);
@@ -2056,10 +2080,13 @@ async fn send_transcription_request(
     {
         Ok(res) => {
             if res.is_success() {
-                let body_bytes = res.bytes().await.map_err(|e| {
-                    error!("Failed to read transcription response body: {:?}", e);
-                    ApiError::InternalServerError
-                })?;
+                let body_bytes = res
+                    .bytes_limited(MAX_TRANSCRIPTION_RESPONSE_BYTES)
+                    .await
+                    .map_err(|e| {
+                        error!("Failed to read transcription response body: {:?}", e);
+                        ApiError::InternalServerError
+                    })?;
 
                 let response_json: Value = serde_json::from_slice(&body_bytes).map_err(|e| {
                     error!("Failed to parse transcription response: {:?}", e);
@@ -2069,9 +2096,8 @@ async fn send_transcription_request(
                 Ok(response_json)
             } else {
                 let status = res.status_code();
-                let body_bytes = res.bytes().await.ok();
-                let error_msg = body_bytes
-                    .map(|b| String::from_utf8_lossy(&b).to_string())
+                let error_msg = provider_error_preview(res)
+                    .await
                     .unwrap_or_else(|| status.to_string());
 
                 error!(
@@ -2204,10 +2230,13 @@ async fn proxy_tts(
             .content_type()
             .unwrap_or("application/octet-stream")
             .to_string();
-        let body_bytes = res.bytes().await.map_err(|e| {
-            error!("Failed to read TTS response body: {:?}", e);
-            ApiError::InternalServerError
-        })?;
+        let body_bytes = res
+            .bytes_limited(MAX_TTS_RESPONSE_BYTES)
+            .await
+            .map_err(|e| {
+                error!("Failed to read TTS response body: {:?}", e);
+                ApiError::InternalServerError
+            })?;
         Ok((body_bytes, content_type))
     })
     .await
@@ -2318,9 +2347,8 @@ async fn proxy_embeddings(
 
     if !res.is_success() {
         let status = res.status_code();
-        let body_bytes = res.bytes().await.ok();
-        let error_msg = body_bytes
-            .map(|b| String::from_utf8_lossy(&b).to_string())
+        let error_msg = provider_error_preview(res)
+            .await
             .unwrap_or_else(|| status.to_string());
         error!(
             "Embeddings proxy returned non-success status: {} - {}",
@@ -2330,10 +2358,13 @@ async fn proxy_embeddings(
     }
 
     // Parse response
-    let body_bytes = res.bytes().await.map_err(|e| {
-        error!("Failed to read embeddings response body: {:?}", e);
-        ApiError::InternalServerError
-    })?;
+    let body_bytes = res
+        .bytes_limited(MAX_EMBEDDINGS_RESPONSE_BYTES)
+        .await
+        .map_err(|e| {
+            error!("Failed to read embeddings response body: {:?}", e);
+            ApiError::InternalServerError
+        })?;
 
     let response_json: Value = serde_json::from_slice(&body_bytes).map_err(|e| {
         error!("Failed to parse embeddings response: {:?}", e);
@@ -2407,9 +2438,7 @@ async fn try_provider(
                 debug!("Response headers: {}", response.headers_debug());
 
                 // Try to get error body for logging
-                if let Ok(body_bytes) = response.bytes().await {
-                    let body_str = String::from_utf8_lossy(&body_bytes);
-                    let body_preview = safe_log_preview(&body_str);
+                if let Some(body_preview) = provider_error_preview(response).await {
                     error!("Response body preview: {}", body_preview);
                     Err(ProviderRequestError::Send(format!(
                         "Provider {} returned status {}; body_preview={}",


### PR DESCRIPTION
## Summary

- replace unbounded aggregate provider-body reads with a checked cumulative collector shared by standard Hyper and attested Tinfoil transports
- apply response-class-specific raw-body ceilings: 16 MiB completion JSON, 4 MiB model metadata, 64 MiB embeddings, 32 MiB transcription JSON, 32 MiB TTS output, and 64 KiB diagnostic error bodies
- reject an advertised oversized `Content-Length` before reading while still enforcing the cumulative limit for missing, invalid, understated, chunked, or decompressed lengths
- sanitize bounded provider error previews before logging
- keep public request/response schemas and behavior unchanged for responses within the limits

The TTS provider-response cap is intentionally separate from the larger inbound audio-upload limit. TTS bytes are base64-encoded into JSON and then encrypted, so a 32 MiB raw response has a substantially larger in-process peak. These are per-response ceilings, not a global concurrency or Nitro RSS bound.

Streaming response framing and cumulative stream limits are intentionally isolated in stacked follow-ups.

## Stack

1. #223 — bound streamed Responses tool-call indices
2. this PR — bound buffered provider response bodies
3. #248 — bound each streamed upstream provider response
4. #249 — bound cumulative Responses provider output

## Validation

- `nix develop -c cargo fmt --all -- --check`
- `git diff --check`
- `nix develop -c cargo test --locked provider_client::tests` (18 passed; 1 credentialed live-Tinfoil test ignored)
- Tinfoil loopback request/response contract test passed
- `nix develop -c cargo test --locked web::openai::tests::tts_` (10 passed)
- independent exact-head security/correctness review approved
