### PR TITLE
Reject malformed parent secret responses without panicking

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,8 @@ mod web;
 
 #[cfg(test)]
 mod aead_db_tamper_tests;
+#[cfg(test)]
+mod parent_secret_response_tests;
 
 use apple_signin::AppleJwtVerifier;
 use oauth::{AppleProvider, GithubProvider, GoogleProvider, OAuthManager};
@@ -2401,7 +2403,7 @@ impl AppState {
     }
 }
 
-async fn get_secret(key_name: &str) -> Result<String, Error> {
+async fn get_secret(key_name: &str, expected_field: &str) -> Result<String, Error> {
     let cid = crate::aws_credentials::PARENT_CID;
     let port = crate::aws_credentials::CREDENTIAL_REQUESTER_PORT;
 
@@ -2421,20 +2423,29 @@ async fn get_secret(key_name: &str) -> Result<String, Error> {
         crate::aws_credentials::MAX_VSOCK_RESPONSE_BYTES,
     )?;
 
-    let parent_response: ParentResponse = serde_json::from_str(&response)?;
-    if parent_response.response_type == "secret" {
-        let secret_json: Value =
-            serde_json::from_str(parent_response.response_value.as_str().unwrap())?;
+    parse_parent_secret_response(&response, expected_field)
+}
 
-        // Assuming the secret is always a JSON object with a single key-value pair
-        if let Some((_, value)) = secret_json.as_object().and_then(|obj| obj.iter().next()) {
-            Ok(value.as_str().unwrap_or_default().to_string())
-        } else {
-            Err(Error::SecretParsingError)
-        }
-    } else {
-        Err(Error::AuthenticationError)
+fn parse_parent_secret_response(response: &str, expected_field: &str) -> Result<String, Error> {
+    let parent_response: ParentResponse = serde_json::from_str(response)?;
+    if parent_response.response_type != "secret" {
+        return Err(Error::AuthenticationError);
     }
+
+    let response_value = parent_response
+        .response_value
+        .as_str()
+        .ok_or(Error::SecretParsingError)?;
+    let secret_json: Value = serde_json::from_str(response_value)?;
+
+    // The parent returns a JSON object containing the requested secret value.
+    let secret_object = secret_json.as_object().ok_or(Error::SecretParsingError)?;
+
+    secret_object
+        .get(expected_field)
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .ok_or(Error::SecretParsingError)
 }
 
 async fn get_or_create_enclave_key(
@@ -3182,7 +3193,7 @@ async fn main() -> Result<(), Error> {
             }
             AppMode::Local => unreachable!("just checked"),
         };
-        match get_secret(secret_name).await {
+        match get_secret(secret_name, "database_url").await {
             Ok(encrypted_url) => {
                 let creds = aws_credential_manager
                     .read()

--- a/src/parent_secret_response_tests.rs
+++ b/src/parent_secret_response_tests.rs
@@ -1,0 +1,103 @@
+use super::{parse_parent_secret_response, Error};
+
+const DATABASE_URL_FIELD: &str = "database_url";
+
+#[test]
+fn parses_valid_parent_secret_response() {
+    let response = r#"{
+        "response_type": "secret",
+        "response_value": "{\"database_url\":\"postgres://localhost/test\"}"
+    }"#;
+
+    let secret = parse_parent_secret_response(response, DATABASE_URL_FIELD)
+        .expect("valid response should parse");
+
+    assert_eq!(secret, "postgres://localhost/test");
+}
+
+#[test]
+fn rejects_non_string_response_value_without_panicking() {
+    let response = r#"{
+        "response_type": "secret",
+        "response_value": {"database_url": "postgres://localhost/test"}
+    }"#;
+
+    assert!(matches!(
+        parse_parent_secret_response(response, DATABASE_URL_FIELD),
+        Err(Error::SecretParsingError)
+    ));
+}
+
+#[test]
+fn rejects_truncated_parent_response() {
+    let response = r#"{"response_type":"secret","response_value":"{}""#;
+
+    assert!(matches!(
+        parse_parent_secret_response(response, DATABASE_URL_FIELD),
+        Err(Error::JsonError(_))
+    ));
+}
+
+#[test]
+fn rejects_unexpected_parent_response_type() {
+    let response = r#"{"response_type":"credentials","response_value":"{}"}"#;
+
+    assert!(matches!(
+        parse_parent_secret_response(response, DATABASE_URL_FIELD),
+        Err(Error::AuthenticationError)
+    ));
+}
+
+#[test]
+fn rejects_malformed_encoded_secret() {
+    let response = r#"{"response_type":"secret","response_value":"not json"}"#;
+
+    assert!(matches!(
+        parse_parent_secret_response(response, DATABASE_URL_FIELD),
+        Err(Error::JsonError(_))
+    ));
+}
+
+#[test]
+fn rejects_invalid_secret_object_shapes() {
+    for response_value in ["{}", r#"{"database_url":42}"#] {
+        let response = serde_json::json!({
+            "response_type": "secret",
+            "response_value": response_value,
+        })
+        .to_string();
+
+        assert!(matches!(
+            parse_parent_secret_response(&response, DATABASE_URL_FIELD),
+            Err(Error::SecretParsingError)
+        ));
+    }
+}
+
+#[test]
+fn rejects_object_with_only_an_unexpected_field() {
+    let response = serde_json::json!({
+        "response_type": "secret",
+        "response_value": r#"{"jwt_secret":"wrong secret"}"#,
+    })
+    .to_string();
+
+    assert!(matches!(
+        parse_parent_secret_response(&response, DATABASE_URL_FIELD),
+        Err(Error::SecretParsingError)
+    ));
+}
+
+#[test]
+fn accepts_expected_field_with_unrelated_metadata() {
+    let response = serde_json::json!({
+        "response_type": "secret",
+        "response_value": r#"{"database_url":"postgres://localhost/test","metadata":{"version":2}}"#,
+    })
+    .to_string();
+
+    let secret = parse_parent_secret_response(&response, DATABASE_URL_FIELD)
+        .expect("expected field should parse when unrelated metadata is present");
+
+    assert_eq!(secret, "postgres://localhost/test");
+}


### PR DESCRIPTION
## Summary

- isolate parsing of secret responses received from the Nitro parent
- return normal errors for malformed JSON, non-string payloads, and invalid secret shapes instead of panicking or silently returning an empty value
- require the requested `database_url` member to be a string while permitting unrelated metadata members
- cover valid, truncated, malformed, unexpected-type, non-string, missing-member, and metadata-bearing responses with deterministic tests

## Security boundary

This parser runs only during non-local startup when retrieving the database secret from the Nitro parent over vsock CID 3 / port 8003. The requested Secrets Manager key is selected from `APP_MODE`; no public or customer-controlled request reaches this path. The parent normally serializes AWS `SecretString` as a string, while the enclave read remains capped at 256 KiB with 30-second read and write timeouts.

This PR is fail-closed defense-in-depth for malformed, buggy, or compromised parent responses and mis-shaped secrets. It does not authenticate the parent, remove the parent's availability control, or change the expected wire format.

## Validation

Rebased onto `master` at `5eb95f9`.

- `nix develop -c cargo test parent_secret_response_tests -- --nocapture` (8 passed)
- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo clippy --all-targets --all-features -- -D warnings`
- `nix develop -c cargo test --all-targets --all-features` (342 passed, 17 existing database or live-network tests ignored)

PCR artifacts were intentionally left unchanged; fresh GitHub checks are pending.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret/pull/227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
