### PR TITLE
Handle malformed KMS command output without panicking

### DIFF
--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -25,8 +25,10 @@ pub enum EncryptError {
     FailedToDecrypt,
     #[error("Bad data")]
     BadData,
-    #[error("KMS encryption failed: {0}")]
+    #[error("KMS operation failed: {0}")]
     KmsError(String),
+    #[error("Random generation failed: {0}")]
+    RandomGenerationFailed(String),
     #[error("No content to decrypt")]
     NoContent,
     #[error("Deserialization failed: {0}")]
@@ -352,30 +354,18 @@ pub fn decrypt_with_kms(
         .arg(ciphertext)
         .output()
         .map_err(|e| {
-            tracing::error!(
-                "Failed to execute kmstool_enclave_cli for decryption: {}",
-                e
-            );
-            EncryptError::KmsError(e.to_string())
+            let error = kms_execution_error("decrypt", &e);
+            tracing::error!("{error}");
+            error
         })?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        tracing::error!("kmstool_enclave_cli decryption failed: {}", stderr);
-        return Err(EncryptError::KmsError(stderr.to_string()));
+        let error = kms_command_error("decrypt", &output.stderr);
+        tracing::error!("{error}");
+        return Err(error);
     }
 
-    let output_str =
-        String::from_utf8(output.stdout).map_err(|e| EncryptError::KmsError(e.to_string()))?;
-
-    let plaintext_b64 = output_str
-        .strip_prefix("PLAINTEXT: ")
-        .ok_or_else(|| EncryptError::KmsError("Failed to parse plaintext".to_string()))?
-        .trim();
-
-    STANDARD
-        .decode(plaintext_b64)
-        .map_err(|e| EncryptError::KmsError(format!("Failed to decode base64: {}", e)))
+    parse_kms_plaintext_output(&output.stdout, "decrypt")
 }
 
 #[derive(Debug)]
@@ -411,40 +401,127 @@ pub fn create_new_encryption_key(
         .arg("AES-256")
         .output()
         .map_err(|e| {
-            tracing::error!("Failed to execute kmstool_enclave_cli: {}", e);
-            EncryptError::KmsError(e.to_string())
+            let error = kms_execution_error("genkey", &e);
+            tracing::error!("{error}");
+            error
         })?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        tracing::error!("kmstool_enclave_cli failed: {}", stderr);
-        return Err(EncryptError::KmsError(stderr.to_string()));
+        let error = kms_command_error("genkey", &output.stderr);
+        tracing::error!("{error}");
+        return Err(error);
     }
 
-    let output_str =
-        String::from_utf8(output.stdout).map_err(|e| EncryptError::KmsError(e.to_string()))?;
-    let lines: Vec<&str> = output_str.lines().collect();
+    parse_kms_genkey_output(&output.stdout)
+}
 
-    let encrypted_key_b64 = lines[0]
-        .split(": ")
-        .nth(1)
-        .ok_or_else(|| EncryptError::KmsError("Failed to parse encrypted key".to_string()))?;
-    let plaintext_key_b64 = lines[1]
-        .split(": ")
-        .nth(1)
-        .ok_or_else(|| EncryptError::KmsError("Failed to parse plaintext key".to_string()))?;
+fn kms_execution_error(operation: &str, error: &std::io::Error) -> EncryptError {
+    EncryptError::KmsError(format!(
+        "kmstool_enclave_cli {operation} could not be executed: {error}"
+    ))
+}
 
-    let encrypted_key = STANDARD
-        .decode(encrypted_key_b64)
-        .map_err(|e| EncryptError::KmsError(format!("Failed to decode encrypted key: {}", e)))?;
+fn kms_command_error(operation: &str, stderr: &[u8]) -> EncryptError {
+    let stderr = String::from_utf8_lossy(stderr);
+    let stderr = stderr.trim();
+    let detail = if stderr.is_empty() {
+        "no error output".to_string()
+    } else {
+        stderr.to_string()
+    };
 
-    let plaintext_key = STANDARD
-        .decode(plaintext_key_b64)
-        .map_err(|e| EncryptError::KmsError(e.to_string()))?;
+    EncryptError::KmsError(format!(
+        "kmstool_enclave_cli {operation} exited unsuccessfully: {detail}"
+    ))
+}
 
-    Ok(GenKeyResult {
-        encrypted_key,
-        key: plaintext_key,
+fn parse_kms_plaintext_output(stdout: &[u8], operation: &str) -> Result<Vec<u8>, EncryptError> {
+    let output = parse_kms_stdout(stdout, operation)?;
+    decode_kms_output_field(output, "PLAINTEXT", operation)
+}
+
+fn parse_kms_genkey_output(stdout: &[u8]) -> Result<GenKeyResult, EncryptError> {
+    const OPERATION: &str = "genkey";
+
+    let output = parse_kms_stdout(stdout, OPERATION)?;
+    let encrypted_key = decode_kms_output_field(output, "CIPHERTEXT", OPERATION)?;
+    let key = validate_enclave_root_key(
+        decode_kms_output_field(output, "PLAINTEXT", OPERATION)?,
+        OPERATION,
+    )?;
+
+    Ok(GenKeyResult { key, encrypted_key })
+}
+
+pub(crate) fn validate_enclave_root_key(
+    key: Vec<u8>,
+    operation: &str,
+) -> Result<Vec<u8>, EncryptError> {
+    const ENCLAVE_ROOT_KEY_LENGTH: usize = 32;
+
+    if key.len() != ENCLAVE_ROOT_KEY_LENGTH {
+        return Err(EncryptError::KmsError(format!(
+            "kmstool_enclave_cli {operation} returned an enclave root key with {} bytes; expected {ENCLAVE_ROOT_KEY_LENGTH}",
+            key.len()
+        )));
+    }
+
+    SecretKey::from_slice(&key).map_err(|error| {
+        EncryptError::KmsError(format!(
+            "kmstool_enclave_cli {operation} returned an invalid secp256k1 enclave root key: {error}"
+        ))
+    })?;
+
+    Ok(key)
+}
+
+fn parse_kms_random_output(stdout: &[u8], expected_length: usize) -> Result<Vec<u8>, EncryptError> {
+    let bytes = parse_kms_plaintext_output(stdout, "genrandom")?;
+    if bytes.len() != expected_length {
+        return Err(EncryptError::KmsError(format!(
+            "kmstool_enclave_cli genrandom returned {} bytes; expected {expected_length}",
+            bytes.len()
+        )));
+    }
+
+    Ok(bytes)
+}
+
+fn parse_kms_stdout<'a>(stdout: &'a [u8], operation: &str) -> Result<&'a str, EncryptError> {
+    std::str::from_utf8(stdout).map_err(|error| {
+        EncryptError::KmsError(format!(
+            "kmstool_enclave_cli {operation} returned non-UTF-8 output: {error}"
+        ))
+    })
+}
+
+fn decode_kms_output_field(
+    output: &str,
+    field: &str,
+    operation: &str,
+) -> Result<Vec<u8>, EncryptError> {
+    let prefix = format!("{field}:");
+    let mut values = output
+        .lines()
+        .filter_map(|line| line.strip_prefix(&prefix).map(str::trim));
+    let encoded = values.next();
+
+    if values.next().is_some() {
+        return Err(EncryptError::KmsError(format!(
+            "kmstool_enclave_cli {operation} output contains duplicate {field} fields"
+        )));
+    }
+
+    let encoded = encoded.filter(|value| !value.is_empty()).ok_or_else(|| {
+        EncryptError::KmsError(format!(
+            "kmstool_enclave_cli {operation} output is missing {field}"
+        ))
+    })?;
+
+    STANDARD.decode(encoded).map_err(|error| {
+        EncryptError::KmsError(format!(
+            "kmstool_enclave_cli {operation} returned invalid base64 for {field}: {error}"
+        ))
     })
 }
 
@@ -456,29 +533,39 @@ pub fn generate_random<const LENGTH: usize>() -> [u8; LENGTH] {
 
 pub async fn generate_random_enclave<const LENGTH: usize>(
     aws_credential_manager: Arc<tokio::sync::RwLock<Option<AwsCredentialManager>>>,
-) -> [u8; LENGTH] {
-    let nonce = if let Some(cred_manager) = aws_credential_manager.read().await.as_ref().cloned() {
-        let aws_creds = cred_manager
-            .get_credentials()
-            .await
-            .expect("should have creds");
+) -> Result<[u8; LENGTH], EncryptError> {
+    if let Some(cred_manager) = aws_credential_manager.read().await.as_ref().cloned() {
+        let aws_creds = cred_manager.get_credentials().await.ok_or_else(|| {
+            EncryptError::KmsError(
+                "AWS credentials are unavailable for kmstool_enclave_cli genrandom".to_string(),
+            )
+        })?;
 
-        generate_random_bytes_from_enclave(
+        let bytes = generate_random_bytes_from_enclave(
             &aws_creds.region,
             &aws_creds.access_key_id,
             &aws_creds.secret_access_key,
             &aws_creds.token,
             LENGTH,
         )
-        .await
-        .expect("should generate random bytes")
+        .await?;
+
+        bytes.try_into().map_err(|bytes: Vec<u8>| {
+            EncryptError::KmsError(format!(
+                "kmstool_enclave_cli genrandom returned {} bytes; expected {LENGTH}",
+                bytes.len()
+            ))
+        })
     } else {
         // Use OS random if aws_credential_manager is None
         let mut nonce = [0u8; LENGTH];
-        OsRng.fill_bytes(&mut nonce);
-        nonce.to_vec()
-    };
-    nonce.try_into().expect("Length mismatch")
+        OsRng.try_fill_bytes(&mut nonce).map_err(|error| {
+            EncryptError::RandomGenerationFailed(format!(
+                "OS entropy source could not fill {LENGTH} bytes: {error}"
+            ))
+        })?;
+        Ok(nonce)
+    }
 }
 
 pub async fn generate_random_bytes_from_enclave(
@@ -505,33 +592,18 @@ pub async fn generate_random_bytes_from_enclave(
         .arg(length.to_string())
         .output()
         .map_err(|e| {
-            tracing::error!(
-                "Failed to execute kmstool_enclave_cli for random byte generation: {}",
-                e
-            );
-            EncryptError::KmsError(e.to_string())
+            let error = kms_execution_error("genrandom", &e);
+            tracing::error!("{error}");
+            error
         })?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        tracing::error!(
-            "kmstool_enclave_cli random byte generation failed: {}",
-            stderr
-        );
-        return Err(EncryptError::KmsError(stderr.to_string()));
+        let error = kms_command_error("genrandom", &output.stderr);
+        tracing::error!("{error}");
+        return Err(error);
     }
 
-    let output_str =
-        String::from_utf8(output.stdout).map_err(|e| EncryptError::KmsError(e.to_string()))?;
-
-    let plaintext_b64 = output_str
-        .strip_prefix("PLAINTEXT: ")
-        .ok_or_else(|| EncryptError::KmsError("Failed to parse plaintext".to_string()))?
-        .trim();
-
-    STANDARD
-        .decode(plaintext_b64)
-        .map_err(|e| EncryptError::KmsError(format!("Failed to decode base64: {}", e)))
+    parse_kms_random_output(&output.stdout, length)
 }
 
 pub struct CustomRng {
@@ -644,5 +716,201 @@ mod tests {
         let encrypted = encrypt_key_deterministic(&key, content);
         let decrypted = decrypt_key_deterministic(&key, &encrypted).unwrap();
         assert_eq!(content.to_vec(), decrypted);
+    }
+
+    #[test]
+    fn parses_labeled_genkey_output_without_assuming_line_order() {
+        let key = [1_u8; 32];
+        let output = format!(
+            "PLAINTEXT: {}\nCIPHERTEXT: {}\n",
+            STANDARD.encode(key),
+            STANDARD.encode(b"ciphertext")
+        );
+
+        let result = parse_kms_genkey_output(output.as_bytes()).unwrap();
+
+        assert_eq!(result.key, key);
+        assert_eq!(result.encrypted_key, b"ciphertext");
+    }
+
+    #[test]
+    fn truncated_genkey_output_returns_contextual_errors() {
+        let missing_ciphertext_output = format!("PLAINTEXT: {}\n", STANDARD.encode([1_u8; 32]));
+        let missing_ciphertext = parse_kms_genkey_output(missing_ciphertext_output.as_bytes())
+            .unwrap_err()
+            .to_string();
+        assert!(missing_ciphertext.contains("genkey output is missing CIPHERTEXT"));
+
+        let missing_plaintext = parse_kms_genkey_output(b"CIPHERTEXT: Y2lwaGVydGV4dA==\n")
+            .unwrap_err()
+            .to_string();
+        assert!(missing_plaintext.contains("genkey output is missing PLAINTEXT"));
+    }
+
+    #[test]
+    fn malformed_genkey_fields_return_contextual_errors() {
+        let malformed_ciphertext = parse_kms_genkey_output(
+            format!(
+                "CIPHERTEXT: not-base64!\nPLAINTEXT: {}\n",
+                STANDARD.encode([1_u8; 32])
+            )
+            .as_bytes(),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(malformed_ciphertext.contains("genkey returned invalid base64 for CIPHERTEXT"));
+
+        let malformed_plaintext =
+            parse_kms_genkey_output(b"CIPHERTEXT: Y2lwaGVydGV4dA==\nPLAINTEXT: not-base64!\n")
+                .unwrap_err()
+                .to_string();
+        assert!(malformed_plaintext.contains("genkey returned invalid base64 for PLAINTEXT"));
+    }
+
+    #[test]
+    fn duplicate_genkey_fields_are_rejected() {
+        let encoded_key = STANDARD.encode([1_u8; 32]);
+        let duplicate_ciphertext =
+            format!("CIPHERTEXT: YQ==\nCIPHERTEXT: Yg==\nPLAINTEXT: {encoded_key}\n");
+        let error = parse_kms_genkey_output(duplicate_ciphertext.as_bytes())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("genkey output contains duplicate CIPHERTEXT fields"));
+
+        let duplicate_plaintext =
+            format!("CIPHERTEXT: YQ==\nPLAINTEXT: {encoded_key}\nPLAINTEXT: {encoded_key}\n");
+        let error = parse_kms_genkey_output(duplicate_plaintext.as_bytes())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("genkey output contains duplicate PLAINTEXT fields"));
+    }
+
+    #[test]
+    fn genkey_rejects_wrong_length_enclave_root_keys() {
+        for key in [vec![1_u8; 31], vec![1_u8; 33]] {
+            let output = format!(
+                "CIPHERTEXT: {}\nPLAINTEXT: {}\n",
+                STANDARD.encode(b"ciphertext"),
+                STANDARD.encode(&key)
+            );
+
+            let error = parse_kms_genkey_output(output.as_bytes())
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains(&format!(
+                "enclave root key with {} bytes; expected 32",
+                key.len()
+            )));
+        }
+    }
+
+    #[test]
+    fn genkey_rejects_invalid_secp256k1_scalars() {
+        for key in [[0_u8; 32], [0xff_u8; 32]] {
+            let output = format!(
+                "CIPHERTEXT: {}\nPLAINTEXT: {}\n",
+                STANDARD.encode(b"ciphertext"),
+                STANDARD.encode(key)
+            );
+
+            let error = parse_kms_genkey_output(output.as_bytes())
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("genkey returned an invalid secp256k1 enclave root key"));
+        }
+    }
+
+    #[test]
+    fn decrypted_enclave_root_key_requires_exact_valid_scalar() {
+        let valid = validate_enclave_root_key(vec![1_u8; 32], "decrypt").unwrap();
+        assert_eq!(valid, vec![1_u8; 32]);
+
+        let wrong_length = validate_enclave_root_key(vec![1_u8; 31], "decrypt")
+            .unwrap_err()
+            .to_string();
+        assert!(wrong_length.contains("decrypt returned an enclave root key with 31 bytes"));
+
+        let invalid_scalar = validate_enclave_root_key(vec![0_u8; 32], "decrypt")
+            .unwrap_err()
+            .to_string();
+        assert!(invalid_scalar.contains("decrypt returned an invalid secp256k1 enclave root key"));
+    }
+
+    #[test]
+    fn non_utf8_kms_output_returns_contextual_error() {
+        let error = parse_kms_plaintext_output(&[0xff], "decrypt")
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("kmstool_enclave_cli decrypt returned non-UTF-8 output"));
+    }
+
+    #[test]
+    fn generic_kms_decrypt_preserves_variable_length_plaintext() {
+        let plaintext =
+            parse_kms_plaintext_output(b"PLAINTEXT: cGxhaW50ZXh0\n", "decrypt").unwrap();
+
+        assert_eq!(plaintext, b"plaintext");
+    }
+
+    #[test]
+    fn malformed_base64_returns_field_and_operation_context() {
+        let error = parse_kms_plaintext_output(b"PLAINTEXT: not-base64!\n", "genrandom")
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("genrandom returned invalid base64 for PLAINTEXT"));
+    }
+
+    #[test]
+    fn unexpected_random_output_length_returns_contextual_error() {
+        let error = parse_kms_random_output(b"PLAINTEXT: AQI=\n", 16)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("genrandom returned 2 bytes; expected 16"));
+    }
+
+    #[tokio::test]
+    async fn missing_aws_credentials_are_propagated() {
+        let credential_manager =
+            Arc::new(tokio::sync::RwLock::new(Some(AwsCredentialManager::new())));
+
+        let error = generate_random_enclave::<16>(credential_manager)
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("AWS credentials are unavailable"));
+        assert!(error.contains("genrandom"));
+    }
+
+    #[tokio::test]
+    async fn local_random_fallback_returns_requested_length() {
+        let no_credential_manager = Arc::new(tokio::sync::RwLock::new(None));
+
+        let random = generate_random_enclave::<16>(no_credential_manager)
+            .await
+            .unwrap();
+
+        assert_eq!(random.len(), 16);
+    }
+
+    #[test]
+    fn unsuccessful_command_errors_include_operation_and_lossy_stderr() {
+        let execution_error = kms_execution_error(
+            "genrandom",
+            &std::io::Error::new(std::io::ErrorKind::NotFound, "missing executable"),
+        )
+        .to_string();
+        assert!(execution_error.contains("genrandom could not be executed"));
+        assert!(execution_error.contains("missing executable"));
+
+        let error = kms_command_error("genkey", &[b'f', 0x80]).to_string();
+        assert!(error.contains("kmstool_enclave_cli genkey exited unsuccessfully"));
+        assert!(error.contains('f'));
+
+        let empty_error = kms_command_error("decrypt", b" \n").to_string();
+        assert!(empty_error.contains("decrypt exited unsuccessfully: no error output"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,8 @@ use crate::email::{
 use crate::encrypt::encrypt_key_deterministic;
 use crate::encrypt::generate_random;
 use crate::encrypt::{
-    decrypt_with_key, decrypt_with_kms, encrypt_with_key, CustomRng, GenKeyResult,
+    decrypt_with_key, decrypt_with_kms, encrypt_with_key, validate_enclave_root_key, CustomRng,
+    GenKeyResult,
 };
 use crate::jwt::validate_platform_jwt;
 use crate::login_routes::RegisterCredentials;
@@ -2461,12 +2462,16 @@ async fn get_or_create_enclave_key(
         let base64_encrypted_key = general_purpose::STANDARD.encode(&encrypted_key.value);
 
         // Decrypt the existing key
-        let decrypted_key = decrypt_with_kms(
-            &creds.region,
-            &creds.access_key_id,
-            &creds.secret_access_key,
-            &creds.token,
-            &base64_encrypted_key,
+        let decrypted_key = validate_enclave_root_key(
+            decrypt_with_kms(
+                &creds.region,
+                &creds.access_key_id,
+                &creds.secret_access_key,
+                &creds.token,
+                &base64_encrypted_key,
+            )
+            .map_err(|e| Error::EncryptionError(e.to_string()))?,
+            "decrypt",
         )
         .map_err(|e| Error::EncryptionError(e.to_string()))?;
 

--- a/src/private_key.rs
+++ b/src/private_key.rs
@@ -24,7 +24,9 @@ pub async fn generate_twelve_word_seed(
 ) -> Result<Mnemonic, Error> {
     // the bip39 library supports 12. 15, 18, 21, and 24 word mnemonics
     // we only support 12 words, which is 16 bytes of entropy
-    let random_bytes: [u8; 16] = generate_random_enclave::<16>(aws_credential_manager).await;
+    let random_bytes: [u8; 16] = generate_random_enclave::<16>(aws_credential_manager)
+        .await
+        .map_err(|error| Error::EncryptionError(error.to_string()))?;
 
     let mnemonic =
         Mnemonic::from_entropy(&random_bytes).map_err(|_| Error::PrivateKeyGenerationFailure)?;

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -1293,7 +1293,12 @@ pub async fn create_api_key(
 
     // Generate a random UUID for the API key
     let random_bytes: [u8; 16] =
-        crate::encrypt::generate_random_enclave::<16>(data.aws_credential_manager.clone()).await;
+        crate::encrypt::generate_random_enclave::<16>(data.aws_credential_manager.clone())
+            .await
+            .map_err(|error| {
+                tracing::error!("Failed to generate API key randomness: {error}");
+                ApiError::InternalServerError
+            })?;
     let api_key_uuid = Uuid::from_bytes(random_bytes);
 
     // Hash the UUID string (with dashes) using SHA-256


### PR DESCRIPTION
## Summary

- parse `kmstool_enclave_cli` output by its `CIPHERTEXT` and `PLAINTEXT` labels instead of indexing assumed lines, and reject missing, duplicate, non-UTF-8, or malformed fields
- require generated and decrypted enclave root keys to be exactly 32 bytes and accepted by `secp256k1::SecretKey::from_slice` before a new KMS ciphertext is persisted or key material is used
- preserve variable-length plaintext for generic KMS decryptions while enforcing exact output sizes for `genrandom`
- propagate command execution, nonzero exit, missing-credential, enclave randomness, and OS randomness failures instead of panicking

Invalid existing root-key material now fails closed without replacement. Invalid newly generated material is rejected before its encrypted form can be stored.

## Testing

All commands ran in the repository Nix development shell after rebasing onto current `master`:

- `cargo fmt --all -- --check`
- `cargo test encrypt::tests --locked` (19 passed)
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-targets --all-features --locked` (348 passed, 17 database/live-service tests ignored, 0 failed)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret/pull/228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->