### PR TITLE
test: add property coverage for crypto invariants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3054,6 +3054,7 @@ dependencies = [
  "once_cell",
  "openssl",
  "password-auth",
+ "proptest",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "rand_core 0.6.4",
@@ -3399,6 +3400,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+dependencies = [
+ "bitflags 2.13.0",
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3522,6 +3539,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4853,6 +4879,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,3 +87,4 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 [dev-dependencies]
 openssl = "0.10.78"
 syn = { version = "2", features = ["full", "visit"] }
+proptest = { version = "=1.6.0", default-features = false, features = ["std"] }

--- a/src/crypto_property_tests.rs
+++ b/src/crypto_property_tests.rs
@@ -1,0 +1,196 @@
+use proptest::{collection::vec, prelude::*, test_runner::Config};
+use uuid::Uuid;
+
+use crate::{
+    encrypt::{decrypt_aead_v1, encrypt_aead_v1, CanonicalBytes},
+    seed_wrapping::{
+        decrypt_seed_v1, encrypt_seed_v1, normalize_email_login_identifier, AuthBinding,
+        CredentialKind,
+    },
+};
+
+const PROPERTY_CASES: u32 = 64;
+
+fn property_config() -> Config {
+    Config {
+        cases: PROPERTY_CASES,
+        max_shrink_iters: 512,
+        ..Config::default()
+    }
+}
+
+fn credential_kind() -> impl Strategy<Value = CredentialKind> {
+    prop_oneof![Just(CredentialKind::Password), Just(CredentialKind::OAuth)]
+}
+
+proptest! {
+    #![proptest_config(property_config())]
+
+    #[test]
+    fn aead_round_trips_arbitrary_plaintext_and_aad(
+        key in any::<[u8; 32]>(),
+        plaintext in vec(any::<u8>(), 0..513),
+        aad in vec(any::<u8>(), 0..129),
+    ) {
+        let encrypted = encrypt_aead_v1(&key, &plaintext, &aad)
+            .expect("bounded plaintext should encrypt");
+        let decrypted = decrypt_aead_v1(&key, &encrypted, &aad)
+            .expect("matching key and AAD should decrypt");
+
+        prop_assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn aead_rejects_any_single_bit_ciphertext_tamper(
+        key in any::<[u8; 32]>(),
+        plaintext in vec(any::<u8>(), 0..513),
+        aad in vec(any::<u8>(), 0..129),
+        offset in any::<usize>(),
+        bit in 0u8..8,
+    ) {
+        let mut encrypted = encrypt_aead_v1(&key, &plaintext, &aad)
+            .expect("bounded plaintext should encrypt");
+        let tampered_offset = offset % encrypted.len();
+        encrypted[tampered_offset] ^= 1 << bit;
+
+        prop_assert!(decrypt_aead_v1(&key, &encrypted, &aad).is_err());
+    }
+
+    #[test]
+    fn aead_rejects_changed_aad(
+        key in any::<[u8; 32]>(),
+        plaintext in vec(any::<u8>(), 0..513),
+        aad in vec(any::<u8>(), 0..129),
+    ) {
+        let encrypted = encrypt_aead_v1(&key, &plaintext, &aad)
+            .expect("bounded plaintext should encrypt");
+        let mut changed_aad = aad.clone();
+        changed_aad.push(0);
+
+        prop_assert!(decrypt_aead_v1(&key, &encrypted, &changed_aad).is_err());
+    }
+
+    #[test]
+    fn canonical_bytes_unambiguously_frame_field_boundaries(
+        prefix in vec(any::<u8>(), 0..65),
+        moved_bytes in vec(any::<u8>(), 1..65),
+        suffix in vec(any::<u8>(), 0..65),
+    ) {
+        let mut left_first_field = prefix.clone();
+        left_first_field.extend_from_slice(&moved_bytes);
+        let mut right_second_field = moved_bytes;
+        right_second_field.extend_from_slice(&suffix);
+
+        let mut left = CanonicalBytes::new("property-test-domain");
+        left.append_bytes(&left_first_field).append_bytes(&suffix);
+
+        let mut right = CanonicalBytes::new("property-test-domain");
+        right.append_bytes(&prefix).append_bytes(&right_second_field);
+
+        // Both logical sequences contain identical concatenated payload bytes;
+        // only their field boundaries differ.
+        prop_assert_ne!(left.into_bytes(), right.into_bytes());
+    }
+
+    #[test]
+    fn seed_wrap_round_trips_and_rejects_changed_context(
+        root_key in any::<[u8; 32]>(),
+        plaintext_seed in vec(any::<u8>(), 0..257),
+        user_id in any::<u128>(),
+        project_id in any::<i32>(),
+        kind in credential_kind(),
+        auth_binding_bytes in any::<[u8; 32]>(),
+    ) {
+        let user_uuid = Uuid::from_u128(user_id);
+        let auth_binding = AuthBinding::from_bytes(auth_binding_bytes);
+        let encrypted = encrypt_seed_v1(
+            &root_key,
+            &plaintext_seed,
+            user_uuid,
+            project_id,
+            kind,
+            &auth_binding,
+        )
+        .expect("bounded seed should encrypt");
+
+        let decrypted = decrypt_seed_v1(
+            &root_key,
+            &encrypted,
+            user_uuid,
+            project_id,
+            kind,
+            &auth_binding,
+        )
+        .expect("matching seed-wrap context should decrypt");
+        prop_assert_eq!(decrypted, plaintext_seed);
+
+        let changed_user_uuid = Uuid::from_u128(user_id ^ 1);
+        prop_assert!(decrypt_seed_v1(
+            &root_key,
+            &encrypted,
+            changed_user_uuid,
+            project_id,
+            kind,
+            &auth_binding,
+        )
+        .is_err());
+
+        prop_assert!(decrypt_seed_v1(
+            &root_key,
+            &encrypted,
+            user_uuid,
+            project_id.wrapping_add(1),
+            kind,
+            &auth_binding,
+        )
+        .is_err());
+
+        let changed_kind = match kind {
+            CredentialKind::Password => CredentialKind::OAuth,
+            CredentialKind::OAuth => CredentialKind::Password,
+        };
+        prop_assert!(decrypt_seed_v1(
+            &root_key,
+            &encrypted,
+            user_uuid,
+            project_id,
+            changed_kind,
+            &auth_binding,
+        )
+        .is_err());
+
+        let mut changed_auth_binding_bytes = auth_binding_bytes;
+        changed_auth_binding_bytes[0] ^= 1;
+        let changed_auth_binding = AuthBinding::from_bytes(changed_auth_binding_bytes);
+        prop_assert!(decrypt_seed_v1(
+            &root_key,
+            &encrypted,
+            user_uuid,
+            project_id,
+            kind,
+            &changed_auth_binding,
+        )
+        .is_err());
+
+        let mut changed_root_key = root_key;
+        changed_root_key[0] ^= 1;
+        prop_assert!(decrypt_seed_v1(
+            &changed_root_key,
+            &encrypted,
+            user_uuid,
+            project_id,
+            kind,
+            &auth_binding,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn email_normalization_is_idempotent(
+        email in vec(any::<char>(), 0..129).prop_map(|chars| chars.into_iter().collect::<String>()),
+    ) {
+        let normalized = normalize_email_login_identifier(&email);
+
+        prop_assert_eq!(normalize_email_login_identifier(&normalized), normalized);
+    }
+}

--- a/src/crypto_property_tests.rs
+++ b/src/crypto_property_tests.rs
@@ -95,12 +95,17 @@ proptest! {
     #[test]
     fn seed_wrap_round_trips_and_rejects_changed_context(
         root_key in any::<[u8; 32]>(),
+        alternate_root_key in any::<[u8; 32]>(),
         plaintext_seed in vec(any::<u8>(), 0..257),
         user_id in any::<u128>(),
         project_id in any::<i32>(),
         kind in credential_kind(),
         auth_binding_bytes in any::<[u8; 32]>(),
+        alternate_auth_binding_bytes in any::<[u8; 32]>(),
     ) {
+        prop_assume!(alternate_root_key != root_key);
+        prop_assume!(alternate_auth_binding_bytes != auth_binding_bytes);
+
         let user_uuid = Uuid::from_u128(user_id);
         let auth_binding = AuthBinding::from_bytes(auth_binding_bytes);
         let encrypted = encrypt_seed_v1(
@@ -159,9 +164,7 @@ proptest! {
         )
         .is_err());
 
-        let mut changed_auth_binding_bytes = auth_binding_bytes;
-        changed_auth_binding_bytes[0] ^= 1;
-        let changed_auth_binding = AuthBinding::from_bytes(changed_auth_binding_bytes);
+        let changed_auth_binding = AuthBinding::from_bytes(alternate_auth_binding_bytes);
         prop_assert!(decrypt_seed_v1(
             &root_key,
             &encrypted,
@@ -172,10 +175,8 @@ proptest! {
         )
         .is_err());
 
-        let mut changed_root_key = root_key;
-        changed_root_key[0] ^= 1;
         prop_assert!(decrypt_seed_v1(
-            &changed_root_key,
+            &alternate_root_key,
             &encrypted,
             user_uuid,
             project_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,8 @@ mod aws_credentials;
 mod billing;
 mod bounded_ttl_cache;
 mod brave;
+#[cfg(test)]
+mod crypto_property_tests;
 mod db;
 mod email;
 mod encrypt;


### PR DESCRIPTION
## Summary

- add bounded property tests for AEAD round trips, tamper detection, and AAD authentication
- verify canonical field boundaries and seed-wrap context binding across user, project, credential kind, auth binding, and root key
- verify email normalization idempotence over bounded Unicode input
- keep proptest dev-only with a minimal feature set and preserve production transitive lockfile versions

The generators run 64 bounded cases per property so this remains fast in CI while retaining shrinking and reproducible failure seeds.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features crypto_property_tests` (5 consecutive runs; 6 passed each)
- `cargo test --locked --all-features` (340 passed, 17 ignored)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret/pull/229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->