### PR TITLE
chore: remediate Rust dependency advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "argon2"
@@ -1340,8 +1340,18 @@ version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.10",
+ "darling_macro 0.20.10",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -1359,12 +1369,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.10",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.106",
 ]
@@ -1459,7 +1494,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.10",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -1477,15 +1512,16 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.2.3"
+version = "2.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e13bab2796f412722112327f3e575601a3e9cdcbe426f0d30dbf43f3f5dc71"
+checksum = "e54d1f576cd3a3460f212a4615fd12ce1b6303c095b79a44449ffbe627753dc1"
 dependencies = [
  "bigdecimal",
  "bitflags 2.13.0",
  "byteorder",
  "chrono",
  "diesel_derives",
+ "downcast-rs",
  "itoa",
  "num-bigint",
  "num-integer",
@@ -1510,9 +1546,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.2.2"
+version = "2.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ff2be1e7312c858b2ef974f5c7089833ae57b5311b334b30923af58e5718d8"
+checksum = "d1817b7f4279b947fc4cafddec12b0e5f8727141706561ce3ac94a60bddd1cf5"
 dependencies = [
  "diesel_table_macro_syntax",
  "dsl_auto_type",
@@ -1523,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_table_macro_syntax"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
+checksum = "fe2444076b48641147115697648dc743c2c00b61adade0f01ce67133c7babe8c"
 dependencies = [
  "syn 2.0.106",
 ]
@@ -1591,12 +1627,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
-name = "dsl_auto_type"
-version = "0.1.2"
+name = "downcast-rs"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d9abe6314103864cc2d8901b7ae224e0ab1a103a0a416661b4097b0779b607"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
+name = "dsl_auto_type"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd122633e4bef06db27737f21d3738fb89c8f6d5360d6d9d7635dda142a7757e"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "either",
  "heck 0.5.0",
  "proc-macro2",
@@ -4296,9 +4338,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spinning_top"
@@ -4967,7 +5009,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
 dependencies = [
- "darling",
+ "darling 0.20.10",
  "once_cell",
  "proc-macro-error2",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "1.0.63"
 async-trait = "0.1.81"
 jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
 jwt-compact = { version = "0.9.0-beta.1", features = ["es256k"] }
-diesel = { version = "=2.2.3", features = [
+diesel = { version = "=2.3.11", features = [
     "postgres",
     "postgres_backend",
     "r2d2",


### PR DESCRIPTION
## Summary

- rebase the remediation onto current `master` (`5eb95f9`)
- bump the exact Diesel dependency from 2.2.3 to 2.3.11 and refresh only its required macro dependencies
- refresh transitive `anyhow` from 1.0.100 to 1.0.104
- move transitive `spin` from yanked 0.9.8 to compatible non-yanked 0.9.9 without changing Axum or Multer

## Security scope

`RUSTSEC-2026-0136` affects Diesel's PostgreSQL `CopyFromQuery` / `CopyToQuery` option handling. OpenSecret does not use either API (or raw `COPY FROM` / `COPY TO`), so the vulnerable path was not reachable; removing the vulnerable Diesel version is defense in depth.

`RUSTSEC-2026-0172` is SQLite-only. OpenSecret enables the PostgreSQL backend, not SQLite. Diesel 2.3.11 removes both affected Diesel ranges from the lockfile and is the current stable compatible patch release.

The current RustSec database also reports `RUSTSEC-2023-0071` (Marvin) for `rsa 0.9.10`. That dependency is `opensecret -> tinfoil v0.1.3 -> sev 8.0.0 -> rsa 0.9.10`; the reachable code constructs an `RsaPublicKey` and RSA-PSS verifier solely to validate AMD's public certificate chain. It does not perform private-key operations, which are the source of the timing leak, and no fixed `rsa` release exists. Validation therefore ignores exactly this advisory on the command line with `--ignore RUSTSEC-2023-0071`; it is not hidden in repository configuration.

This PR does **not** claim a global zero-advisory state. After that single applicability-based ignore, `cargo-audit` still reports six allowed, pre-existing unmaintained-crate warnings: `backoff`, `dotenv`, `instant`, `proc-macro-error2`, `rustls-pemfile`, and `serde_cbor`. Those maintenance migrations remain outside this focused remediation.

## Validation

- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo clippy --all-targets --all-features --locked -- -D warnings`
- `nix develop -c cargo test --all-targets --all-features --locked` (334 passed, 17 ignored)
- fresh isolated workspace Postgres initialized and all 30 repository migrations applied successfully
- all normally ignored database/OAuth/AEAD tests run serially against that migrated database (16 passed)
- pinned Tinfoil v0.1.3 `test_full_hardware_attestation` against the live public router (1 passed), exercising full AMD certificate-chain verification with `rsa 0.9.10`
- `cargo-audit 0.22.2` with a freshly fetched 1,186-entry RustSec database:
  - unfiltered: exactly `RUSTSEC-2023-0071` plus the six maintenance warnings (exit 1)
  - `--ignore RUSTSEC-2023-0071`: no remaining actionable vulnerability, with all six maintenance warnings still reported (exit 0)
- crates.io API independently confirms `spin 0.9.8` is yanked and `spin 0.9.9` is not

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret/pull/230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
