### PR TITLE
chore: pin current Rust security tools

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,7 +61,7 @@ jobs:
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Run clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
   test:
     name: Test Suite
@@ -86,4 +86,4 @@ jobs:
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       - name: Run tests
-        run: cargo test --all-features
+        run: cargo test --locked --all-features

--- a/flake.lock
+++ b/flake.lock
@@ -78,7 +78,8 @@
         "flake-utils": "flake-utils",
         "nitro-util": "nitro-util",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": "rust-overlay",
+        "security-tools-nixpkgs": "security-tools-nixpkgs"
       }
     },
     "rust-overlay": {
@@ -98,6 +99,22 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "security-tools-nixpkgs": {
+      "locked": {
+        "lastModified": 1785067121,
+        "narHash": "sha256-rdJdWxAcg5fnntU4DjPivPdVEN4F+VJavw+UWpEMeUI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "329c3d2af6d1b618705150ea39f72c15eb4e613e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-26.05-darwin",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -8,17 +8,20 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     nixpkgs.url = "nixpkgs/nixos-unstable";
+    # Keep dev security tools current without moving the application or Nitro build pin.
+    security-tools-nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
     nitro-util = {
       url = "github:monzo/aws-nitro-util/7d755578b0b0b9850c0d7c4738a6c8daf3ff55c0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay, nitro-util }:
+  outputs = { self, nixpkgs, security-tools-nixpkgs, flake-utils, rust-overlay, nitro-util }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         overlays = [ rust-overlay.overlays.default ];
         pkgs = import nixpkgs { inherit system overlays; };
+        securityToolsPkgs = import security-tools-nixpkgs { inherit system; };
         rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
         nitro = nitro-util.lib.${system};
 
@@ -56,7 +59,13 @@
           pkgs.libiconv
           pkgs.apple-sdk
         ];
+        securityToolInputs = [
+          securityToolsPkgs.cargo-audit
+          securityToolsPkgs.cargo-deny
+          securityToolsPkgs.cargo-machete
+        ];
         inputs = commonInputs
+          ++ securityToolInputs
           ++ pkgs.lib.optionals pkgs.stdenv.isLinux linuxOnlyInputs
           ++ pkgs.lib.optionals pkgs.stdenv.isDarwin darwinOnlyInputs;
 


### PR DESCRIPTION
## Summary

- add a separately pinned `nixpkgs-26.05-darwin` input for `cargo-audit`, `cargo-deny`, and `cargo-machete` in the development shell
- preserve all four existing dev-shell systems, including `x86_64-darwin`
- keep the application, Nitro, kernel, and primary nixpkgs build inputs unchanged
- run CI clippy and tests with `--locked` so `Cargo.lock` cannot drift silently

## Why

The primary reproducibility-sensitive nixpkgs pin provides cargo-audit 0.21.2, which cannot parse current RustSec advisories containing CVSS 4 data. The original PR used current `nixos-unstable`, but that package set now rejects `x86_64-darwin` because Nixpkgs 26.11 dropped Intel Darwin support.

The secondary input is therefore pinned to the final supported Darwin channel, `nixpkgs-26.05-darwin` at `329c3d2af6d1b618705150ea39f72c15eb4e613e`. It supplies current-enough security tools without moving any production build input.

## Validation

- rebased onto current `master` (`5eb95f9`) with no merge commit
- `git diff --check`
- workflow YAML parse
- evaluated `devShell.<system>.drvPath` successfully for:
  - `x86_64-linux`
  - `aarch64-linux`
  - `x86_64-darwin`
  - `aarch64-darwin`
- `nix flake check --no-build --all-systems`
- host development shell exposes:
  - cargo-audit 0.22.1
  - cargo-deny 0.19.6
  - cargo-machete 0.9.2
- `cargo audit --no-fetch` loaded 1,186 current RustSec advisories, including CVSS 4.0 records, and scanned all 519 locked dependencies successfully; it then exited 1 for three existing dependency advisories, rather than a database/parser error
- verified every pre-existing `flake.lock` node is unchanged; only the `security-tools-nixpkgs` node and root input edge were added
- live verification confirmed the original `nixos-unstable` revision fails `x86_64-darwin` with Nixpkgs' explicit 26.11 removal error

## Scope

This does not add an audit CI job or cargo-deny policy, remediate existing dependency advisories, or update the primary nixpkgs/Nitro inputs.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/opensecret/pull/231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
