### PR TITLE
Bound pending attestation state with FIFO eviction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,6 +1125,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.0",
+]
+
+[[package]]
 name = "cmac"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1770,6 +1785,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,6 +2070,11 @@ name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -3008,6 +3034,7 @@ dependencies = [
  "cbc",
  "chacha20poly1305",
  "chrono",
+ "clru",
  "diesel",
  "diesel-derive-enum",
  "dotenv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,13 @@ uuid = { version = "1.10.0", features = ["v4", "serde"] }
 tokio-stream = "0.1"
 async-stream = "0.3"
 bytes = "1.0"
+clru = "=0.6.3"
 sha2 = { version = "0.10", default-features = false }
 hex = "0.4.3"
 base64 = "0.22.1"
 vsock = "0.5.1"
 resend-rs = "0.9.1"
-x25519-dalek = "2.0.1"
+x25519-dalek = { version = "2.0.1", features = ["zeroize"] }
 rand_core = "0.6"
 serde_cbor = "0.11"
 x509-parser = "0.15"

--- a/src/bounded_ttl_cache.rs
+++ b/src/bounded_ttl_cache.rs
@@ -1,0 +1,351 @@
+use clru::CLruCache;
+use std::collections::hash_map::RandomState;
+use std::hash::Hash;
+use std::num::NonZeroUsize;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InsertOutcome {
+    Inserted,
+    Replaced,
+    ReclaimedExpired,
+    EvictedOldest,
+}
+
+struct TimedEntry<V> {
+    value: V,
+    expires_at: Instant,
+}
+
+/// A private, fixed-capacity TTL cache with oldest-first admission.
+///
+/// The wrapped cache uses `RandomState`, preallocates for its immutable capacity,
+/// and deliberately exposes neither mutable iteration nor resizing. In
+/// particular, do not add a call to `CLruCache::resize`: clru issue #67 tracks a
+/// panic after resizing a cache with holes.
+pub(crate) struct BoundedTtlCache<K, V> {
+    entries: CLruCache<K, TimedEntry<V>, RandomState>,
+    ttl: Duration,
+}
+
+impl<K, V> BoundedTtlCache<K, V>
+where
+    K: Eq + Hash,
+{
+    pub(crate) fn new(capacity: NonZeroUsize, ttl: Duration) -> Self {
+        Self {
+            // `with_memory` uses `RandomState` and reserves both the hash table
+            // and dense entry storage. The capacity remains fixed for life.
+            entries: CLruCache::with_memory(capacity, capacity.get()),
+            ttl,
+        }
+    }
+
+    /// Inserts a new value, always admitting it. At capacity, an expired oldest
+    /// entry is reclaimed first; otherwise the oldest live entry is evicted.
+    /// Duplicate keys retain the historical latest-request-wins behavior.
+    pub(crate) fn insert_evicting(&mut self, key: K, value: V) -> InsertOutcome {
+        self.insert_evicting_at(key, value, Instant::now())
+    }
+
+    fn insert_evicting_at(&mut self, key: K, value: V, now: Instant) -> InsertOutcome {
+        let expires_at = now
+            .checked_add(self.ttl)
+            .expect("bounded cache TTL must fit in Instant");
+
+        if let Some(replaced) = self.entries.pop(&key) {
+            drop(replaced);
+            let previous = self.entries.put(key, TimedEntry { value, expires_at });
+            debug_assert!(previous.is_none());
+            return InsertOutcome::Replaced;
+        }
+
+        let outcome = if self.entries.is_full() {
+            let (_, oldest) = self
+                .entries
+                .pop_back()
+                .expect("a full bounded cache must contain an oldest entry");
+            let outcome = if oldest.expires_at <= now {
+                InsertOutcome::ReclaimedExpired
+            } else {
+                InsertOutcome::EvictedOldest
+            };
+            drop(oldest);
+            outcome
+        } else {
+            InsertOutcome::Inserted
+        };
+
+        let previous = self.entries.put(key, TimedEntry { value, expires_at });
+        debug_assert!(previous.is_none());
+        debug_assert!(self.entries.len() <= self.entries.capacity());
+        outcome
+    }
+
+    /// Removes a value exactly once and returns it only while its TTL is live.
+    pub(crate) fn take_live(&mut self, key: &K) -> Option<V> {
+        self.take_live_at(key, Instant::now())
+    }
+
+    fn take_live_at(&mut self, key: &K, now: Instant) -> Option<V> {
+        let entry = self.entries.pop(key)?;
+        if entry.expires_at <= now {
+            drop(entry);
+            None
+        } else {
+            Some(entry.value)
+        }
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    fn cache<K, V>(capacity: usize, ttl: Duration) -> BoundedTtlCache<K, V>
+    where
+        K: Eq + Hash,
+    {
+        BoundedTtlCache::new(NonZeroUsize::new(capacity).unwrap(), ttl)
+    }
+
+    #[test]
+    fn evicts_exactly_the_oldest_entry_and_always_admits_newest() {
+        let start = Instant::now();
+        let mut cache = cache(3, Duration::from_secs(300));
+
+        assert_eq!(
+            cache.insert_evicting_at(1, "one", start),
+            InsertOutcome::Inserted
+        );
+        cache.insert_evicting_at(2, "two", start + Duration::from_secs(1));
+        cache.insert_evicting_at(3, "three", start + Duration::from_secs(2));
+
+        assert_eq!(
+            cache.insert_evicting_at(4, "four", start + Duration::from_secs(3)),
+            InsertOutcome::EvictedOldest
+        );
+        assert_eq!(cache.len(), 3);
+        assert_eq!(cache.take_live_at(&1, start + Duration::from_secs(4)), None);
+        assert_eq!(
+            cache.take_live_at(&4, start + Duration::from_secs(4)),
+            Some("four")
+        );
+    }
+
+    #[test]
+    fn configured_pending_capacity_admits_the_next_entry_by_evicting_oldest() {
+        let start = Instant::now();
+        assert_eq!(crate::MAX_PENDING_ATTESTATIONS, 65_536);
+        assert_eq!(crate::PENDING_ATTESTATION_TTL, Duration::from_secs(5 * 60));
+        let capacity = crate::MAX_PENDING_ATTESTATIONS;
+        let mut cache = cache(capacity, crate::PENDING_ATTESTATION_TTL);
+
+        for key in 0..capacity {
+            assert_eq!(
+                cache.insert_evicting_at(key, (), start),
+                InsertOutcome::Inserted
+            );
+        }
+        assert_eq!(cache.len(), capacity);
+        assert_eq!(
+            cache.insert_evicting_at(capacity, (), start),
+            InsertOutcome::EvictedOldest
+        );
+        assert_eq!(cache.len(), capacity);
+        assert_eq!(cache.take_live_at(&0, start), None);
+        assert_eq!(cache.take_live_at(&capacity, start), Some(()));
+    }
+
+    #[test]
+    fn newest_survives_until_capacity_later_insertions() {
+        let start = Instant::now();
+        let mut cache = cache(4, Duration::from_secs(300));
+
+        cache.insert_evicting_at(0, 0, start);
+        for key in 1..4 {
+            cache.insert_evicting_at(key, key, start);
+        }
+        assert_eq!(cache.take_live_at(&0, start), Some(0));
+
+        cache.insert_evicting_at(10, 10, start);
+        for key in 11..14 {
+            cache.insert_evicting_at(key, key, start);
+            assert_eq!(cache.len(), 4);
+        }
+        assert_eq!(cache.take_live_at(&10, start), Some(10));
+
+        cache.insert_evicting_at(20, 20, start);
+        for key in 21..25 {
+            cache.insert_evicting_at(key, key, start);
+        }
+        assert_eq!(cache.take_live_at(&20, start), None);
+        assert_eq!(cache.take_live_at(&24, start), Some(24));
+    }
+
+    #[test]
+    fn duplicate_replaces_promotes_and_does_not_grow() {
+        let start = Instant::now();
+        let mut cache = cache(2, Duration::from_secs(10));
+
+        cache.insert_evicting_at(1, "old", start);
+        cache.insert_evicting_at(2, "two", start + Duration::from_secs(1));
+        assert_eq!(
+            cache.insert_evicting_at(1, "new", start + Duration::from_secs(2)),
+            InsertOutcome::Replaced
+        );
+        assert_eq!(cache.len(), 2);
+
+        cache.insert_evicting_at(3, "three", start + Duration::from_secs(3));
+        assert_eq!(cache.take_live_at(&2, start + Duration::from_secs(4)), None);
+        assert_eq!(
+            cache.take_live_at(&1, start + Duration::from_secs(11)),
+            Some("new")
+        );
+    }
+
+    #[test]
+    fn arbitrary_take_is_one_use() {
+        let start = Instant::now();
+        let mut cache = cache(3, Duration::from_secs(10));
+        cache.insert_evicting_at(1, "one", start);
+        cache.insert_evicting_at(2, "two", start);
+        cache.insert_evicting_at(3, "three", start);
+
+        assert_eq!(cache.take_live_at(&2, start), Some("two"));
+        assert_eq!(cache.take_live_at(&2, start), None);
+        assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn exact_ttl_boundary_is_expired() {
+        let start = Instant::now();
+        let mut cache = cache(2, Duration::from_secs(5));
+        cache.insert_evicting_at(1, "one", start);
+        assert_eq!(cache.take_live_at(&1, start + Duration::from_secs(5)), None);
+    }
+
+    #[test]
+    fn full_cache_reclaims_expired_oldest_before_live_entries() {
+        let start = Instant::now();
+        let mut cache = cache(2, Duration::from_secs(5));
+        cache.insert_evicting_at(1, "expired", start);
+        cache.insert_evicting_at(2, "live", start + Duration::from_secs(4));
+
+        assert_eq!(
+            cache.insert_evicting_at(3, "new", start + Duration::from_secs(5)),
+            InsertOutcome::ReclaimedExpired
+        );
+        assert_eq!(
+            cache.take_live_at(&2, start + Duration::from_secs(5)),
+            Some("live")
+        );
+        assert_eq!(
+            cache.take_live_at(&3, start + Duration::from_secs(5)),
+            Some("new")
+        );
+    }
+
+    struct DropSpy(Arc<AtomicUsize>);
+
+    impl Drop for DropSpy {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn removed_values_drop_immediately_for_every_removal_path() {
+        let start = Instant::now();
+        let drops = Arc::new(AtomicUsize::new(0));
+        let mut cache = cache(2, Duration::from_secs(5));
+
+        cache.insert_evicting_at(1, DropSpy(drops.clone()), start);
+        cache.insert_evicting_at(1, DropSpy(drops.clone()), start);
+        assert_eq!(drops.load(Ordering::SeqCst), 1, "replacement");
+
+        cache.insert_evicting_at(2, DropSpy(drops.clone()), start);
+        cache.insert_evicting_at(3, DropSpy(drops.clone()), start);
+        assert_eq!(drops.load(Ordering::SeqCst), 2, "capacity eviction");
+
+        assert!(cache
+            .take_live_at(&2, start + Duration::from_secs(5))
+            .is_none());
+        assert_eq!(drops.load(Ordering::SeqCst), 3, "expiry");
+
+        drop(cache);
+        assert_eq!(drops.load(Ordering::SeqCst), 4, "cache destruction");
+    }
+
+    #[tokio::test]
+    async fn actual_locking_pattern_never_exceeds_capacity() {
+        let cache = Arc::new(RwLock::new(cache(32, Duration::from_secs(300))));
+        let mut tasks = Vec::new();
+
+        for key in 0..512 {
+            let cache = cache.clone();
+            tasks.push(tokio::spawn(async move {
+                cache.write().await.insert_evicting(key, key);
+            }));
+        }
+
+        for task in tasks {
+            task.await.unwrap();
+        }
+        assert_eq!(cache.read().await.len(), 32);
+    }
+
+    #[tokio::test]
+    async fn concurrent_take_has_exactly_one_winner() {
+        let cache = Arc::new(RwLock::new(cache(1, Duration::from_secs(300))));
+        cache.write().await.insert_evicting(1, "one-use");
+
+        let mut tasks = Vec::new();
+        for _ in 0..32 {
+            let cache = cache.clone();
+            tasks.push(tokio::spawn(
+                async move { cache.write().await.take_live(&1) },
+            ));
+        }
+
+        let mut winners = 0;
+        for task in tasks {
+            if task.await.unwrap() == Some("one-use") {
+                winners += 1;
+            }
+        }
+        assert_eq!(winners, 1);
+        assert_eq!(cache.read().await.len(), 0);
+    }
+
+    #[test]
+    fn arbitrary_removal_and_extended_churn_remain_fixed_capacity() {
+        let start = Instant::now();
+        let mut cache = cache(128, Duration::from_secs(300));
+
+        for key in 0..128 {
+            cache.insert_evicting_at(key, key, start);
+        }
+        for key in (0..128).step_by(3) {
+            assert_eq!(cache.take_live_at(&key, start), Some(key));
+        }
+        for key in 128..(128 * 12) {
+            cache.insert_evicting_at(key, key, start);
+            assert!(cache.len() <= 128);
+        }
+
+        assert_eq!(cache.len(), 128);
+        assert_eq!(
+            cache.take_live_at(&(128 * 12 - 1), start),
+            Some(128 * 12 - 1)
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use crate::web::{
     responses_routes, web_routes,
 };
 use crate::{attestation_routes::SessionState, web::platform_routes};
+use bounded_ttl_cache::BoundedTtlCache;
 
 use crate::jwt::{AuthContext, AuthMethod};
 use crate::models::user_seed_wrappings::{NewUserSeedWrapping, UserSeedWrappingError};
@@ -64,6 +65,7 @@ use std::collections::HashMap;
 use std::env;
 use std::fmt;
 use std::io::Write;
+use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -83,6 +85,7 @@ use x25519_dalek::{EphemeralSecret, PublicKey};
 mod apple_signin;
 mod aws_credentials;
 mod billing;
+mod bounded_ttl_cache;
 mod brave;
 mod db;
 mod email;
@@ -134,6 +137,56 @@ const KAGI_API_KEY_NAME: &str = "kagi_api_key";
 const OS_FLAGS_API_KEY_NAME: &str = "os_flags_api_key";
 const OS_FLAGS_BASE_URL_NAME: &str = "os_flags_base_url";
 const PROVIDER_ROUTING_FLAGS_TIMEOUT_SECS: u64 = 5;
+const MAX_ATTESTATION_NONCE_BYTES: usize = 512;
+const MAX_PENDING_ATTESTATIONS: usize = 65_536;
+const PENDING_ATTESTATION_TTL: Duration = Duration::from_secs(5 * 60);
+
+type PendingAttestationKey = [u8; 32];
+
+fn validate_attestation_nonce(nonce: &str) -> Result<(), ApiError> {
+    if nonce.len() > MAX_ATTESTATION_NONCE_BYTES {
+        return Err(ApiError::BadRequest);
+    }
+    Ok(())
+}
+
+fn attestation_nonce_key(nonce: &str) -> PendingAttestationKey {
+    Sha256::digest(nonce.as_bytes()).into()
+}
+
+#[cfg(test)]
+mod pending_attestation_key_tests {
+    use super::*;
+
+    #[test]
+    fn nonce_limit_is_measured_in_bytes() {
+        assert!(validate_attestation_nonce(&"a".repeat(512)).is_ok());
+        assert!(matches!(
+            validate_attestation_nonce(&"a".repeat(513)),
+            Err(ApiError::BadRequest)
+        ));
+
+        assert!(validate_attestation_nonce(&"é".repeat(256)).is_ok());
+        assert!(matches!(
+            validate_attestation_nonce(&"é".repeat(257)),
+            Err(ApiError::BadRequest)
+        ));
+    }
+
+    #[test]
+    fn cache_key_is_a_fixed_sha256_digest() {
+        let first_nonce = Uuid::new_v4().to_string();
+        let different_nonce = Uuid::new_v4().to_string();
+        let first = attestation_nonce_key(&first_nonce);
+
+        assert_eq!(first, attestation_nonce_key(&first_nonce));
+        assert_ne!(first, attestation_nonce_key(&different_nonce));
+        assert_eq!(std::mem::size_of_val(&first), 32);
+
+        let expected: PendingAttestationKey = Sha256::digest(first_nonce.as_bytes()).into();
+        assert_eq!(first, expected);
+    }
+}
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct EnclaveRequest {
@@ -490,7 +543,7 @@ pub struct AppState {
     proxy_router: Arc<ProxyRouter>,
     provider_router: Arc<ProviderRouter>,
     resend_api_key: Option<String>,
-    ephemeral_keys: Arc<RwLock<HashMap<String, EphemeralSecret>>>,
+    ephemeral_keys: Arc<RwLock<BoundedTtlCache<PendingAttestationKey, EphemeralSecret>>>,
     session_states: Arc<tokio::sync::RwLock<HashMap<Uuid, SessionState>>>,
     oauth_manager: Arc<OAuthManager>,
     sqs_publisher: Option<Arc<SqsEventPublisher>>,
@@ -852,7 +905,11 @@ impl AppStateBuilder {
             proxy_router,
             provider_router,
             resend_api_key: self.resend_api_key,
-            ephemeral_keys: Arc::new(RwLock::new(HashMap::new())),
+            ephemeral_keys: Arc::new(RwLock::new(BoundedTtlCache::new(
+                NonZeroUsize::new(MAX_PENDING_ATTESTATIONS)
+                    .expect("pending attestation capacity must be non-zero"),
+                PENDING_ATTESTATION_TTL,
+            ))),
             session_states: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             oauth_manager,
             sqs_publisher,
@@ -1570,7 +1627,8 @@ impl AppState {
         self.enclave_key.clone()
     }
 
-    pub async fn create_ephemeral_key(&self, nonce: String) -> PublicKey {
+    pub async fn create_ephemeral_key(&self, nonce: &str) -> Result<PublicKey, ApiError> {
+        validate_attestation_nonce(nonce)?;
         let custom_rng = CustomRng::new();
 
         // Use a wrapper that implements RngCore and CryptoRng
@@ -1583,13 +1641,21 @@ impl AppState {
         self.ephemeral_keys
             .write()
             .await
-            .insert(nonce, ephemeral_secret);
+            .insert_evicting(attestation_nonce_key(nonce), ephemeral_secret);
 
-        public_key
+        Ok(public_key)
     }
 
-    pub async fn get_and_remove_ephemeral_secret(&self, nonce: &str) -> Option<EphemeralSecret> {
-        self.ephemeral_keys.write().await.remove(nonce)
+    pub async fn get_and_remove_ephemeral_secret(
+        &self,
+        nonce: &str,
+    ) -> Result<Option<EphemeralSecret>, ApiError> {
+        validate_attestation_nonce(nonce)?;
+        Ok(self
+            .ephemeral_keys
+            .write()
+            .await
+            .take_live(&attestation_nonce_key(nonce)))
     }
 
     pub async fn decrypt_session_data(

--- a/src/web/attestation_routes.rs
+++ b/src/web/attestation_routes.rs
@@ -82,7 +82,7 @@ async fn get_attestation(
 ) -> Result<(StatusCode, Json<AttestationResponse>), ApiError> {
     // Create an ephemeral key pair for this request
     trace!("Creating ephemeral key");
-    let enclave_public_key = data.create_ephemeral_key(nonce.clone()).await;
+    let enclave_public_key = data.create_ephemeral_key(&nonce).await?;
     trace!("Ephemeral key created");
 
     // Create a request for the attestation document
@@ -397,7 +397,7 @@ async fn key_exchange(
 
     let ephemeral_secret = data
         .get_and_remove_ephemeral_secret(&payload.nonce)
-        .await
+        .await?
         .ok_or(ApiError::BadRequest)?;
 
     let shared_secret = ephemeral_secret.diffie_hellman(&client_public_key);


### PR DESCRIPTION
## Summary

- cap pending attestation key exchanges at 65,536 entries with a five-minute TTL
- always admit new attestations by evicting the oldest pending entry instead of creating a reject-new capacity cliff
- cap nonces at Nitro's 512-byte limit and retain only their SHA-256 digests as cache keys
- preserve one-use key exchange under concurrent requests and zeroize discarded ephemeral secrets

## Compatibility and capacity

This is stack layer 2 of 5 and targets #224. Standard SDK UUID nonces and successful attestation/key-exchange wire behavior are unchanged. A nonce over 512 bytes, an expired entry, or an entry displaced by 65,536 later distinct-key insertions receives the existing generic `400`; duplicate nonces retain the historical latest-request-wins replacement behavior. This layer introduces no `429` response.

The pending-cache allocation is conservatively budgeted at 12 MiB. With distinct-nonce capacity churn, displacing a newly issued nonce within five seconds would require roughly 13,107 later attestations per second.

## Validation

- 11 focused cache tests and 2 nonce/key tests
- full exact-commit suite: 306 passed, 17 intentionally ignored, 0 failed
- strict all-target/all-feature Clippy, formatting, diff, and Nix checks
- independent exact-commit security, performance, dependency, and API review

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
