### PR TITLE
Reject unknown sessions before bodyless handlers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1658,6 +1658,14 @@ impl AppState {
             .take_live(&attestation_nonce_key(nonce)))
     }
 
+    pub(crate) async fn require_session(&self, session_id: &Uuid) -> Result<(), ApiError> {
+        if self.session_states.read().await.contains_key(session_id) {
+            Ok(())
+        } else {
+            Err(ApiError::BadRequest)
+        }
+    }
+
     pub async fn decrypt_session_data(
         &self,
         session_id: &Uuid,

--- a/src/web/encryption_middleware.rs
+++ b/src/web/encryption_middleware.rs
@@ -9,7 +9,7 @@ use axum::{
 use base64::Engine;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 use uuid::Uuid;
 
 use crate::{ApiError, AppState};
@@ -37,6 +37,33 @@ impl<T: Serialize> EncryptedResponse<T> {
     }
 }
 
+fn skips_encrypted_body<T: 'static>(method: &Method) -> bool {
+    method == Method::GET
+        || method == Method::DELETE
+        || std::any::TypeId::of::<T>() == std::any::TypeId::of::<()>()
+}
+
+async fn forward_bodyless_request<T, SessionCheck, RunNext, RunNextFuture>(
+    session_check: SessionCheck,
+    session_id: Uuid,
+    mut request: Request<Body>,
+    run_next: RunNext,
+) -> Result<Response, ApiError>
+where
+    T: 'static,
+    SessionCheck: Future<Output = Result<(), ApiError>>,
+    RunNext: FnOnce(Request<Body>) -> RunNextFuture,
+    RunNextFuture: Future<Output = Response>,
+{
+    session_check.await?;
+
+    if std::any::TypeId::of::<T>() == std::any::TypeId::of::<()>() {
+        request.extensions_mut().insert(());
+    }
+    request.extensions_mut().insert(session_id);
+    Ok(run_next(request).await)
+}
+
 pub async fn decrypt_request<T>(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
@@ -52,16 +79,17 @@ where
         .and_then(|v| Uuid::parse_str(v).ok())
         .ok_or(ApiError::BadRequest)?;
 
-    // Skip body processing for GET, DELETE, or when T is ()
-    if request.method() == Method::GET
-        || request.method() == Method::DELETE
-        || std::any::TypeId::of::<T>() == std::any::TypeId::of::<()>()
-    {
-        if std::any::TypeId::of::<T>() == std::any::TypeId::of::<()>() {
-            request.extensions_mut().insert(());
-        }
-        request.extensions_mut().insert(session_id);
-        return Ok(next.run(request).await);
+    // Skip body processing for GET, DELETE, or when T is ().
+    if skips_encrypted_body::<T>(request.method()) {
+        // Bodyless requests cannot prove possession by decrypting a payload.
+        // Reject an unknown session before a handler can perform side effects.
+        return forward_bodyless_request::<T, _, _, _>(
+            state.require_session(&session_id),
+            session_id,
+            request,
+            move |request| next.run(request),
+        )
+        .await;
     }
 
     let body = std::mem::replace(request.body_mut(), Body::empty());
@@ -99,4 +127,78 @@ pub async fn encrypt_response<T: Serialize>(
     Ok(Json(EncryptedResponse::new(
         base64::engine::general_purpose::STANDARD.encode(encrypted_response),
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::response::IntoResponse;
+    use std::future::ready;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[test]
+    fn classifies_every_bodyless_disjunct() {
+        assert!(skips_encrypted_body::<serde_json::Value>(&Method::GET));
+        assert!(skips_encrypted_body::<serde_json::Value>(&Method::DELETE));
+        assert!(skips_encrypted_body::<()>(&Method::POST));
+        assert!(!skips_encrypted_body::<serde_json::Value>(&Method::POST));
+    }
+
+    #[tokio::test]
+    async fn failed_session_check_never_calls_next() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let observed_calls = calls.clone();
+
+        let result = forward_bodyless_request::<(), _, _, _>(
+            ready(Err(ApiError::BadRequest)),
+            Uuid::new_v4(),
+            Request::builder()
+                .method(Method::POST)
+                .body(Body::empty())
+                .unwrap(),
+            move |_| {
+                observed_calls.fetch_add(1, Ordering::SeqCst);
+                async { Response::new(Body::empty()) }
+            },
+        )
+        .await;
+
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        let error = match result {
+            Err(error) => error,
+            Ok(_) => panic!("unknown session reached next"),
+        };
+        let response = error.into_response();
+        assert_eq!(response.status(), axum::http::StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(body.as_ref(), br#"{"status":400,"message":"Bad Request"}"#);
+    }
+
+    #[tokio::test]
+    async fn successful_session_check_calls_next_once_with_extensions() {
+        let session_id = Uuid::new_v4();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let observed_calls = calls.clone();
+
+        forward_bodyless_request::<(), _, _, _>(
+            ready(Ok(())),
+            session_id,
+            Request::builder()
+                .method(Method::POST)
+                .body(Body::empty())
+                .unwrap(),
+            move |request| {
+                assert_eq!(request.extensions().get::<Uuid>(), Some(&session_id));
+                assert!(request.extensions().get::<()>().is_some());
+                observed_calls.fetch_add(1, Ordering::SeqCst);
+                async { Response::new(Body::empty()) }
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
 }


### PR DESCRIPTION
## Summary

- validate that an encryption session exists before running GET, DELETE, and `T = ()` handlers
- reject a missing or unknown session before any bodyless handler can commit a side effect
- return the generic `400` stale-session signal so supported SDKs can re-attest and retry once

## Why

Previously a bodyless mutation could run first and discover the missing session only while encrypting its response. A retrying SDK could then replay an already-committed operation. This is the smallest fix: it changes the admission order without changing the protocol or handler APIs.

This is stack layer 3 of 5 and targets #242. All current encrypted route registrations were audited; bodyful routes remain on their existing decryption-first path. Successful request/response schemas, headers, and status codes are unchanged. Session expiry and recency updates are intentionally introduced only by the later cache layer.

## Validation

- focused tests prove GET/DELETE/unit-body classification, exact `400`, zero downstream calls on failure, and exactly one call on success
- full exact-commit suite: 309 passed, 17 intentionally ignored, 0 failed
- strict all-target/all-feature Clippy, formatting, diff, and Nix checks
- independent route-coverage, runtime, and current/historical SDK compatibility reviews

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
