### PR TITLE
Bound encryption sessions with lease-aware LRU eviction

### DIFF
--- a/src/lease_aware_cache.rs
+++ b/src/lease_aware_cache.rs
@@ -1,0 +1,494 @@
+use clru::CLruCache;
+use std::collections::hash_map::RandomState;
+use std::hash::Hash;
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InsertOutcome {
+    Inserted,
+    ReclaimedExpired,
+    EvictedLeastRecentlyUsed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InsertError {
+    DuplicateKey,
+    AllEntriesLeased,
+}
+
+struct LeaseSlot<V> {
+    value: V,
+    leases: AtomicUsize,
+}
+
+impl<V> LeaseSlot<V> {
+    fn new(value: V) -> Self {
+        Self {
+            value,
+            leases: AtomicUsize::new(0),
+        }
+    }
+
+    fn is_leased(&self) -> bool {
+        self.leases.load(Ordering::Acquire) != 0
+    }
+
+    fn try_acquire(&self) -> bool {
+        self.leases
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |leases| {
+                leases.checked_add(1)
+            })
+            .is_ok()
+    }
+}
+
+struct CachedValue<V> {
+    slot: Arc<LeaseSlot<V>>,
+    expires_at: Instant,
+}
+
+impl<V> CachedValue<V> {
+    fn has_external_lease(&self) -> bool {
+        self.slot.is_leased() || Arc::strong_count(&self.slot) != 1
+    }
+}
+
+/// An RAII lease that prevents its cached value from being expired or evicted.
+pub(crate) struct CacheLease<V> {
+    slot: Arc<LeaseSlot<V>>,
+}
+
+impl<V> CacheLease<V> {
+    pub(crate) fn value(&self) -> &V {
+        &self.slot.value
+    }
+}
+
+impl<V> Drop for CacheLease<V> {
+    fn drop(&mut self) {
+        let previous = self.slot.leases.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0, "cache lease count underflow");
+    }
+}
+
+/// A private, fixed-capacity sliding-TTL LRU cache whose in-flight values stay
+/// resident until their final request lease is dropped.
+///
+/// As with `BoundedTtlCache`, this deliberately exposes neither resizing nor
+/// mutable iteration. Values live behind an `Arc`, so LRU reordering moves only
+/// the handle rather than secret key bytes.
+pub(crate) struct LeaseAwareTtlCache<K, V> {
+    entries: CLruCache<K, CachedValue<V>, RandomState>,
+    ttl: Duration,
+}
+
+impl<K, V> LeaseAwareTtlCache<K, V>
+where
+    K: Clone + Eq + Hash,
+{
+    pub(crate) fn new(capacity: NonZeroUsize, ttl: Duration) -> Self {
+        Self {
+            entries: CLruCache::with_memory(capacity, capacity.get()),
+            ttl,
+        }
+    }
+
+    /// Inserts a value and evicts the least-recently-used unleased value when
+    /// full. The only capacity rejection is the true-overload case where every
+    /// resident value is concurrently leased by an in-flight response.
+    pub(crate) fn insert_evicting(
+        &mut self,
+        key: K,
+        value: V,
+    ) -> Result<InsertOutcome, InsertError> {
+        self.insert_evicting_at(key, value, Instant::now())
+    }
+
+    fn insert_evicting_at(
+        &mut self,
+        key: K,
+        value: V,
+        now: Instant,
+    ) -> Result<InsertOutcome, InsertError> {
+        if self.entries.peek(&key).is_some() {
+            drop(value);
+            return Err(InsertError::DuplicateKey);
+        }
+
+        let expires_at = self.expiry_at(now);
+        if !self.entries.is_full() {
+            self.insert_new(key, value, expires_at);
+            return Ok(InsertOutcome::Inserted);
+        }
+
+        // Scan from LRU toward MRU without changing recency. In particular,
+        // merely being pinned must not refresh idle TTL; only authenticated
+        // success (or an admitted bodyless request) calls `touch`.
+        let eviction_key = self
+            .entries
+            .iter()
+            .rev()
+            .find(|(_, entry)| !entry.has_external_lease())
+            .map(|(candidate_key, _)| candidate_key.clone());
+        let Some(eviction_key) = eviction_key else {
+            drop(value);
+            return Err(InsertError::AllEntriesLeased);
+        };
+
+        let evicted = self
+            .entries
+            .pop(&eviction_key)
+            .expect("selected unleased entry must remain present");
+        debug_assert_eq!(Arc::strong_count(&evicted.slot), 1);
+        let outcome = if evicted.expires_at <= now {
+            InsertOutcome::ReclaimedExpired
+        } else {
+            InsertOutcome::EvictedLeastRecentlyUsed
+        };
+        drop(evicted);
+        self.insert_new(key, value, expires_at);
+        Ok(outcome)
+    }
+
+    /// Acquires a request-lifetime lease without updating recency or idle TTL.
+    /// Call `touch` only after successful authenticated use (or immediately for
+    /// a valid bodyless request).
+    pub(crate) fn acquire(&mut self, key: &K) -> Option<CacheLease<V>> {
+        self.acquire_at(key, Instant::now())
+    }
+
+    fn acquire_at(&mut self, key: &K, now: Instant) -> Option<CacheLease<V>> {
+        let expired_and_unleased = {
+            let entry = self.entries.peek(key)?;
+            entry.expires_at <= now && !entry.has_external_lease()
+        };
+        if expired_and_unleased {
+            let expired = self.entries.pop(key);
+            debug_assert!(expired
+                .as_ref()
+                .is_none_or(|entry| Arc::strong_count(&entry.slot) == 1));
+            drop(expired);
+            return None;
+        }
+
+        let slot = Arc::clone(&self.entries.peek(key)?.slot);
+        if !slot.try_acquire() {
+            return None;
+        }
+        Some(CacheLease { slot })
+    }
+
+    /// Refreshes a value's sliding idle TTL and moves it to the MRU position.
+    pub(crate) fn touch(&mut self, key: &K) -> bool {
+        self.touch_at(key, Instant::now())
+    }
+
+    fn touch_at(&mut self, key: &K, now: Instant) -> bool {
+        let expired_and_unleased = match self.entries.peek(key) {
+            Some(entry) => entry.expires_at <= now && !entry.has_external_lease(),
+            None => return false,
+        };
+        if expired_and_unleased {
+            let expired = self.entries.pop(key);
+            debug_assert!(expired
+                .as_ref()
+                .is_none_or(|entry| Arc::strong_count(&entry.slot) == 1));
+            drop(expired);
+            return false;
+        }
+
+        let expires_at = self.expiry_at(now);
+        self.entries
+            .get_mut(key)
+            .expect("peeked cache entry must remain present")
+            .expires_at = expires_at;
+        true
+    }
+
+    fn expiry_at(&self, now: Instant) -> Instant {
+        now.checked_add(self.ttl)
+            .expect("lease-aware cache TTL must fit in Instant")
+    }
+
+    fn insert_new(&mut self, key: K, value: V, expires_at: Instant) {
+        let previous = self.entries.put(
+            key,
+            CachedValue {
+                slot: Arc::new(LeaseSlot::new(value)),
+                expires_at,
+            },
+        );
+        debug_assert!(previous.is_none());
+        debug_assert!(self.entries.len() <= self.entries.capacity());
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    #[cfg(test)]
+    fn lease_count(&self, key: &K) -> Option<usize> {
+        self.entries
+            .peek(key)
+            .map(|entry| entry.slot.leases.load(Ordering::Acquire))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::web::attestation_routes::SessionState;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn cache<K, V>(capacity: usize, ttl: Duration) -> LeaseAwareTtlCache<K, V>
+    where
+        K: Clone + Eq + Hash,
+    {
+        LeaseAwareTtlCache::new(NonZeroUsize::new(capacity).unwrap(), ttl)
+    }
+
+    #[test]
+    fn configured_policy_and_layout_fit_the_aggregate_budget() {
+        assert_eq!(crate::MAX_ENCRYPTION_SESSIONS, 2_097_152);
+        assert_eq!(
+            crate::ENCRYPTION_SESSION_IDLE_TTL,
+            Duration::from_secs(65 * 60)
+        );
+
+        let accounted_bytes_per_entry = 192;
+        let accounted_bytes = (crate::MAX_PENDING_ATTESTATIONS + crate::MAX_ENCRYPTION_SESSIONS)
+            * accounted_bytes_per_entry;
+        assert!(accounted_bytes <= 500 * 1024 * 1024);
+        assert_eq!(500 * 1024 * 1024 - accounted_bytes, 109_051_904);
+
+        #[cfg(target_pointer_width = "64")]
+        {
+            assert_eq!(std::mem::size_of::<SessionState>(), 32);
+            assert_eq!(std::mem::size_of::<LeaseSlot<SessionState>>(), 40);
+            assert_eq!(std::mem::size_of::<CachedValue<SessionState>>(), 24);
+            assert_eq!(std::mem::size_of::<CacheLease<SessionState>>(), 8);
+        }
+    }
+
+    #[test]
+    fn evicts_lru_and_always_admits_when_an_unleased_entry_exists() {
+        let start = Instant::now();
+        let mut cache = cache(2, Duration::from_secs(60));
+        cache.insert_evicting_at(1, "one", start).unwrap();
+        cache
+            .insert_evicting_at(2, "two", start + Duration::from_secs(1))
+            .unwrap();
+
+        assert_eq!(
+            cache.insert_evicting_at(3, "three", start + Duration::from_secs(2)),
+            Ok(InsertOutcome::EvictedLeastRecentlyUsed)
+        );
+        assert!(cache
+            .acquire_at(&1, start + Duration::from_secs(3))
+            .is_none());
+        assert_eq!(
+            cache
+                .acquire_at(&3, start + Duration::from_secs(3))
+                .unwrap()
+                .value(),
+            &"three"
+        );
+        assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn acquire_without_successful_touch_does_not_change_lru_order() {
+        let start = Instant::now();
+        let mut cache = cache(2, Duration::from_secs(60));
+        cache.insert_evicting_at(1, "one", start).unwrap();
+        cache
+            .insert_evicting_at(2, "two", start + Duration::from_secs(1))
+            .unwrap();
+
+        drop(
+            cache
+                .acquire_at(&1, start + Duration::from_secs(2))
+                .unwrap(),
+        );
+        cache
+            .insert_evicting_at(3, "three", start + Duration::from_secs(3))
+            .unwrap();
+        assert!(cache
+            .acquire_at(&1, start + Duration::from_secs(4))
+            .is_none());
+        assert!(cache
+            .acquire_at(&2, start + Duration::from_secs(4))
+            .is_some());
+    }
+
+    #[test]
+    fn successful_touch_refreshes_ttl_and_promotes_to_mru() {
+        let start = Instant::now();
+        let mut cache = cache(2, Duration::from_secs(10));
+        cache.insert_evicting_at(1, "one", start).unwrap();
+        cache
+            .insert_evicting_at(2, "two", start + Duration::from_secs(1))
+            .unwrap();
+
+        let lease = cache
+            .acquire_at(&1, start + Duration::from_secs(2))
+            .unwrap();
+        assert!(cache.touch_at(&1, start + Duration::from_secs(2)));
+        drop(lease);
+        cache
+            .insert_evicting_at(3, "three", start + Duration::from_secs(3))
+            .unwrap();
+
+        assert!(cache
+            .acquire_at(&2, start + Duration::from_secs(4))
+            .is_none());
+        assert!(cache
+            .acquire_at(&1, start + Duration::from_secs(11))
+            .is_some());
+    }
+
+    #[test]
+    fn exact_idle_ttl_boundary_is_expired_when_unleased() {
+        let start = Instant::now();
+        let mut cache = cache(1, Duration::from_secs(5));
+        cache.insert_evicting_at(1, "one", start).unwrap();
+        assert!(cache
+            .acquire_at(&1, start + Duration::from_secs(5))
+            .is_none());
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn pinned_lru_is_preserved_and_next_unleased_entry_is_evicted() {
+        let start = Instant::now();
+        let mut cache = cache(2, Duration::from_secs(60));
+        cache.insert_evicting_at(1, "one", start).unwrap();
+        cache
+            .insert_evicting_at(2, "two", start + Duration::from_secs(1))
+            .unwrap();
+        let lease = cache
+            .acquire_at(&1, start + Duration::from_secs(2))
+            .unwrap();
+
+        assert_eq!(
+            cache.insert_evicting_at(3, "three", start + Duration::from_secs(3)),
+            Ok(InsertOutcome::EvictedLeastRecentlyUsed)
+        );
+        assert!(cache
+            .acquire_at(&1, start + Duration::from_secs(4))
+            .is_some());
+        assert!(cache
+            .acquire_at(&2, start + Duration::from_secs(4))
+            .is_none());
+        drop(lease);
+    }
+
+    #[test]
+    fn all_pinned_is_bounded_true_overload_and_drops_rejected_value() {
+        struct DropSpy(Arc<AtomicUsize>);
+        impl Drop for DropSpy {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let start = Instant::now();
+        let drops = Arc::new(AtomicUsize::new(0));
+        let mut cache = cache(2, Duration::from_secs(60));
+        cache
+            .insert_evicting_at(1, DropSpy(drops.clone()), start)
+            .unwrap();
+        cache
+            .insert_evicting_at(2, DropSpy(drops.clone()), start)
+            .unwrap();
+        let first = cache.acquire_at(&1, start).unwrap();
+        let second = cache.acquire_at(&2, start).unwrap();
+
+        assert_eq!(
+            cache.insert_evicting_at(3, DropSpy(drops.clone()), start),
+            Err(InsertError::AllEntriesLeased)
+        );
+        assert_eq!(cache.len(), 2);
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+
+        drop(first);
+        assert!(cache
+            .insert_evicting_at(3, DropSpy(drops.clone()), start)
+            .is_ok());
+        assert_eq!(cache.len(), 2);
+        assert_eq!(drops.load(Ordering::SeqCst), 2);
+        drop(second);
+    }
+
+    #[test]
+    fn expired_pinned_entry_survives_until_final_lease_drops() {
+        let start = Instant::now();
+        let mut cache = cache(1, Duration::from_secs(5));
+        cache.insert_evicting_at(1, "one", start).unwrap();
+        let first = cache.acquire_at(&1, start).unwrap();
+
+        let second = cache
+            .acquire_at(&1, start + Duration::from_secs(6))
+            .expect("an in-flight session remains usable");
+        assert_eq!(cache.lease_count(&1), Some(2));
+        assert_eq!(
+            cache.insert_evicting_at(2, "two", start + Duration::from_secs(6)),
+            Err(InsertError::AllEntriesLeased)
+        );
+
+        drop(first);
+        drop(second);
+        assert!(!cache.touch_at(&1, start + Duration::from_secs(12)));
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn lease_drop_decrements_exactly_once() {
+        let start = Instant::now();
+        let mut cache = cache(1, Duration::from_secs(60));
+        cache.insert_evicting_at(1, "one", start).unwrap();
+        let lease = cache.acquire_at(&1, start).unwrap();
+        assert_eq!(cache.lease_count(&1), Some(1));
+        drop(lease);
+        assert_eq!(cache.lease_count(&1), Some(0));
+    }
+
+    #[test]
+    fn final_drop_gap_cannot_detach_a_still_referenced_value() {
+        let start = Instant::now();
+        let mut cache = cache(1, Duration::from_secs(60));
+        cache.insert_evicting_at(1, "one", start).unwrap();
+
+        // Models the narrow interval after CacheLease::drop decrements the
+        // explicit count but before Rust drops that lease's Arc field.
+        let lingering_arc = Arc::clone(&cache.entries.peek(&1).unwrap().slot);
+        assert_eq!(cache.lease_count(&1), Some(0));
+        assert_eq!(Arc::strong_count(&lingering_arc), 2);
+        assert_eq!(
+            cache.insert_evicting_at(2, "two", start),
+            Err(InsertError::AllEntriesLeased)
+        );
+        assert_eq!(lingering_arc.value, "one");
+
+        drop(lingering_arc);
+        assert!(cache.insert_evicting_at(2, "two", start).is_ok());
+    }
+
+    #[test]
+    fn duplicate_key_never_replaces_a_live_or_leased_session() {
+        let start = Instant::now();
+        let mut cache = cache(1, Duration::from_secs(60));
+        cache.insert_evicting_at(1, "original", start).unwrap();
+        let lease = cache.acquire_at(&1, start).unwrap();
+
+        assert_eq!(
+            cache.insert_evicting_at(1, "replacement", start),
+            Err(InsertError::DuplicateKey)
+        );
+        assert_eq!(lease.value(), &"original");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use crate::web::{
 };
 use crate::{attestation_routes::SessionState, web::platform_routes};
 use bounded_ttl_cache::BoundedTtlCache;
+use lease_aware_cache::{CacheLease, InsertError as SessionInsertError, LeaseAwareTtlCache};
 
 use crate::jwt::{AuthContext, AuthMethod};
 use crate::models::user_seed_wrappings::{NewUserSeedWrapping, UserSeedWrappingError};
@@ -61,7 +62,6 @@ use secp256k1::SecretKey;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
 use std::env;
 use std::fmt;
 use std::io::Write;
@@ -93,6 +93,7 @@ mod encrypt;
 mod jwt;
 mod kagi;
 mod kv;
+mod lease_aware_cache;
 mod message_signing;
 mod migrations;
 mod model_config;
@@ -140,16 +141,11 @@ const PROVIDER_ROUTING_FLAGS_TIMEOUT_SECS: u64 = 5;
 const MAX_ATTESTATION_NONCE_BYTES: usize = 512;
 const MAX_PENDING_ATTESTATIONS: usize = 65_536;
 const PENDING_ATTESTATION_TTL: Duration = Duration::from_secs(5 * 60);
+const MAX_ENCRYPTION_SESSIONS: usize = 2_097_152;
+const ENCRYPTION_SESSION_IDLE_TTL: Duration = Duration::from_secs(65 * 60);
 
 type PendingAttestationKey = [u8; 32];
-
-pub(crate) struct SessionLease(Arc<SessionState>);
-
-impl SessionLease {
-    pub(crate) fn value(&self) -> &SessionState {
-        &self.0
-    }
-}
+pub(crate) type SessionLease = CacheLease<SessionState>;
 
 fn validate_attestation_nonce(nonce: &str) -> Result<(), ApiError> {
     if nonce.len() > MAX_ATTESTATION_NONCE_BYTES {
@@ -552,7 +548,7 @@ pub struct AppState {
     provider_router: Arc<ProviderRouter>,
     resend_api_key: Option<String>,
     ephemeral_keys: Arc<RwLock<BoundedTtlCache<PendingAttestationKey, EphemeralSecret>>>,
-    session_states: Arc<tokio::sync::RwLock<HashMap<Uuid, Arc<SessionState>>>>,
+    session_states: Arc<tokio::sync::Mutex<LeaseAwareTtlCache<Uuid, SessionState>>>,
     oauth_manager: Arc<OAuthManager>,
     sqs_publisher: Option<Arc<SqsEventPublisher>>,
     billing_client: Option<BillingClient>,
@@ -918,7 +914,11 @@ impl AppStateBuilder {
                     .expect("pending attestation capacity must be non-zero"),
                 PENDING_ATTESTATION_TTL,
             ))),
-            session_states: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            session_states: Arc::new(tokio::sync::Mutex::new(LeaseAwareTtlCache::new(
+                NonZeroUsize::new(MAX_ENCRYPTION_SESSIONS)
+                    .expect("encryption session capacity must be non-zero"),
+                ENCRYPTION_SESSION_IDLE_TTL,
+            ))),
             oauth_manager,
             sqs_publisher,
             billing_client,
@@ -1666,17 +1666,40 @@ impl AppState {
             .take_live(&attestation_nonce_key(nonce)))
     }
 
+    pub(crate) async fn store_session_state(
+        &self,
+        session_id: Uuid,
+        session_state: SessionState,
+    ) -> Result<(), ApiError> {
+        match self
+            .session_states
+            .lock()
+            .await
+            .insert_evicting(session_id, session_state)
+        {
+            Ok(_) => Ok(()),
+            Err(SessionInsertError::DuplicateKey) => Err(ApiError::InternalServerError),
+            Err(SessionInsertError::AllEntriesLeased) => Err(ApiError::TooManyRequests),
+        }
+    }
+
     pub(crate) async fn acquire_session(
         &self,
         session_id: &Uuid,
     ) -> Result<SessionLease, ApiError> {
         self.session_states
-            .read()
+            .lock()
             .await
-            .get(session_id)
-            .cloned()
-            .map(SessionLease)
+            .acquire(session_id)
             .ok_or(ApiError::BadRequest)
+    }
+
+    pub(crate) async fn touch_session(&self, session_id: &Uuid) -> Result<(), ApiError> {
+        if self.session_states.lock().await.touch(session_id) {
+            Ok(())
+        } else {
+            Err(ApiError::BadRequest)
+        }
     }
 
     pub(crate) async fn decrypt_session_data(
@@ -1710,13 +1733,17 @@ impl AppState {
         tracing::trace!("nonce: {:?}", nonce_array);
         tracing::trace!("ciphertext length: {}", ciphertext.len());
 
-        session_lease
+        let decrypted = session_lease
             .value()
             .decrypt(ciphertext, &nonce_array)
             .map_err(|e| {
                 tracing::error!("Decryption failed: {:?}", e);
                 e
-            })
+            })?;
+
+        // Invalid ciphertext must not extend an attacker's retained session.
+        self.touch_session(session_id).await?;
+        Ok(decrypted)
     }
 
     pub async fn encrypt_session_data(
@@ -1724,15 +1751,14 @@ impl AppState {
         session_id: &Uuid,
         data: &[u8],
     ) -> Result<Vec<u8>, ApiError> {
-        let session_state = self
+        let session_lease = self
             .session_states
-            .read()
+            .lock()
             .await
-            .get(session_id)
-            .cloned()
-            .ok_or(ApiError::Unauthorized)?;
+            .acquire(session_id)
+            .ok_or(ApiError::BadRequest)?;
 
-        let session_key = session_state.get_session_key();
+        let session_key = session_lease.value().get_session_key();
         let key = Key::from_slice(session_key.as_ref());
 
         let nonce_bytes: [u8; 12] = crate::encrypt::generate_random();
@@ -1747,6 +1773,9 @@ impl AppState {
                 .map_err(|_| ApiError::InternalServerError)?,
         );
 
+        if !self.session_states.lock().await.touch(session_id) {
+            return Err(ApiError::BadRequest);
+        }
         Ok(encrypted_data)
     }
 

--- a/src/web/attestation_routes.rs
+++ b/src/web/attestation_routes.rs
@@ -419,11 +419,9 @@ async fn key_exchange(
     // Generate a new UUID for the session
     let session_id = Uuid::new_v4();
 
-    // Store the session state
-    data.session_states
-        .write()
-        .await
-        .insert(session_id, Arc::new(session_state));
+    // Store the session state, evicting the least-recently-used unleased
+    // session if the cache is full.
+    data.store_session_state(session_id, session_state).await?;
     Ok(Json(KeyExchangeResponse {
         session_id,
         encrypted_session_key: general_purpose::STANDARD.encode(&encrypted_session_key),

--- a/src/web/encryption_middleware.rs
+++ b/src/web/encryption_middleware.rs
@@ -90,7 +90,11 @@ where
         // Bodyless requests cannot prove possession by decrypting a payload.
         // Reject an unknown session before a handler can perform side effects.
         return forward_bodyless_request::<T, _, _, _, _>(
-            state.acquire_session(&session_id),
+            async {
+                let session_lease = state.acquire_session(&session_id).await?;
+                state.touch_session(&session_id).await?;
+                Ok(session_lease)
+            },
             session_id,
             request,
             move |request| next.run(request),
@@ -106,7 +110,7 @@ where
     let encrypted_request: EncryptedRequest =
         serde_json::from_slice(&body_bytes).map_err(|_| ApiError::BadRequest)?;
 
-    // Acquire only after the request body has arrived. A slow or abandoned
+    // Pin only after the request body has arrived. A slow or abandoned
     // upload therefore cannot retain a session indefinitely.
     let session_lease = state.acquire_session(&session_id).await?;
     let decrypted_data = state
@@ -182,6 +186,7 @@ pub async fn encrypt_response<T: Serialize>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lease_aware_cache::{InsertError, LeaseAwareTtlCache};
     use axum::{
         http::{HeaderMap, HeaderValue},
         response::IntoResponse,
@@ -189,7 +194,9 @@ mod tests {
     use std::convert::Infallible;
     use std::future::{poll_fn, ready};
     use std::io;
+    use std::num::NonZeroUsize;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
     #[test]
     fn classifies_every_bodyless_disjunct() {
@@ -276,6 +283,25 @@ mod tests {
         assert_eq!(drops.load(Ordering::SeqCst), 1);
     }
 
+    #[test]
+    fn streaming_response_lease_blocks_eviction_until_body_drop() {
+        let mut cache =
+            LeaseAwareTtlCache::new(NonZeroUsize::new(1).unwrap(), Duration::from_secs(60));
+        cache.insert_evicting(1, "active stream").unwrap();
+        let lease = cache.acquire(&1).unwrap();
+
+        let stream = futures::stream::pending::<Result<Bytes, io::Error>>();
+        let response = Response::new(Body::from_stream(stream));
+        let response = hold_resource_through_response_body(response, lease);
+
+        assert_eq!(
+            cache.insert_evicting(2, "new session"),
+            Err(InsertError::AllEntriesLeased)
+        );
+        drop(response);
+        assert!(cache.insert_evicting(2, "new session").is_ok());
+    }
+
     #[tokio::test]
     async fn wrapped_body_preserves_payload_and_exact_size_hint() {
         let drops = Arc::new(AtomicUsize::new(0));
@@ -325,7 +351,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn wrapped_body_preserves_trailers_and_resource_through_end_of_stream() {
+    async fn wrapped_body_preserves_trailers_and_lease_through_end_of_stream() {
         let drops = Arc::new(AtomicUsize::new(0));
         let response = Response::new(Body::new(DataThenTrailersBody { next_frame: 0 }));
         let response = hold_resource_through_response_body(response, DropSpy(drops.clone()));


### PR DESCRIPTION
## Summary

- cap encryption sessions at 2,097,152 entries with a 65-minute idle TTL
- refresh TTL/LRU position only after valid AEAD use or admission of a bodyless request; malformed ciphertext does not keep a session alive
- always admit a new session by evicting the oldest unleased entry
- return `429` only in the extraordinary case where all 2,097,152 entries are simultaneously leased/in flight
- keep request, handler, response, and SSE work pinned against concurrent eviction

## Capacity and compatibility

This is stack layer 5 of 5 and targets #244. Together with #242, the conservative cache accounting is 396 MiB: 384 MiB for sessions and 12 MiB for pending attestations, leaving 104 MiB inside the requested 500 MiB cache budget. An exact-capacity macOS allocator/churn benchmark peaked at 368.55 MiB RSS. This is an entry-count budget for these two caches, not a hard whole-process allocator limit; a dev-enclave canary is still required before calling it measured Linux/Nitro RSS.

Acquire, touch, and ordinary insertion are expected O(1). At full capacity, insertion is O(k) while it scans the leased LRU prefix under the single cache mutex; `k` can reach 2,097,152 in the worst case when all or nearly all entries ahead of the first unleased victim are in flight. The exact-capacity macOS benchmark measured the all-leased scan at about 8.4 ms median and 33 ms worst observed. Successful requests move leased sessions to the MRU end, so normal full-cache insertion should encounter an unleased LRU victim immediately.

Normal wire formats and client APIs are unchanged. Missing, expired, or evicted sessions continue to use the existing generic `400` re-attestation signal. Published TypeScript SDK 3.2.1 and Rust SDK 3.1.1 passed real local attestation, login, profile, and KV PUT/GET/LIST/DELETE flows against this commit.

## Validation

- 11 focused cache tests and 8 middleware/response tests, including a never-ending streaming body that blocks eviction until drop
- full exact-commit suite: 325 passed, 17 intentionally ignored, 0 failed
- strict all-target/all-feature Clippy, formatting, diff, and Nix checks
- managed full-workspace smoke plus Maple 3.2.1 GUI login and encrypted streaming Chat
- three independent exact-commit security/concurrency, performance/memory, and SDK/API reviews

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>
