### PR TITLE
Purge expired enclave key material periodically

### DIFF
--- a/src/bounded_ttl_cache.rs
+++ b/src/bounded_ttl_cache.rs
@@ -3,6 +3,7 @@ use std::collections::hash_map::RandomState;
 use std::hash::Hash;
 use std::num::NonZeroUsize;
 use std::time::{Duration, Instant};
+use zeroize::Zeroize;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum InsertOutcome {
@@ -15,6 +16,19 @@ pub(crate) enum InsertOutcome {
 struct TimedEntry<V> {
     value: V,
     expires_at: Instant,
+}
+
+/// Values detached from the cache so their destructors and deallocation can
+/// run after the caller releases the cache lock.
+#[must_use = "keep retired values alive until after releasing the cache lock"]
+pub(crate) struct RetiredValues<V> {
+    entries: Vec<TimedEntry<V>>,
+}
+
+impl<V> RetiredValues<V> {
+    pub(crate) fn removed_count(&self) -> usize {
+        self.entries.len()
+    }
 }
 
 /// A private, fixed-capacity TTL cache with oldest-first admission.
@@ -95,6 +109,42 @@ where
         } else {
             Some(entry.value)
         }
+    }
+
+    /// Detaches the oldest expired values without scanning live entries.
+    ///
+    /// Insertion and replacement both move a value to MRU with a fresh fixed
+    /// TTL, so expiry order matches LRU order. Each value is zeroized in place
+    /// before removal so a Rust move cannot leave secret bytes in CLru's
+    /// preallocated backing storage. Returning the zeroized values lets the
+    /// caller release its lock before their destructors and deallocation run.
+    pub(crate) fn retire_expired_at(&mut self, now: Instant) -> RetiredValues<V>
+    where
+        V: Zeroize,
+    {
+        let expired_count = self
+            .entries
+            .iter()
+            .rev()
+            .take_while(|(_, entry)| entry.expires_at <= now)
+            .count();
+        // Allocate once so secret-bearing values are not repeatedly relocated
+        // as the retirement buffer grows.
+        let mut entries = Vec::with_capacity(expired_count);
+        for _ in 0..expired_count {
+            self.entries
+                .back_mut()
+                .expect("counted oldest cache entry must remain present")
+                .1
+                .value
+                .zeroize();
+            let (_, entry) = self
+                .entries
+                .pop_back()
+                .expect("peeked oldest cache entry must remain present");
+            entries.push(entry);
+        }
+        RetiredValues { entries }
     }
 
     #[cfg(test)]
@@ -234,6 +284,55 @@ mod tests {
     }
 
     #[test]
+    fn retires_untouched_expired_values_below_capacity_and_drops_outside_cache() {
+        let start = Instant::now();
+        let zeroizes = Arc::new(AtomicUsize::new(0));
+        let drops = Arc::new(AtomicUsize::new(0));
+        let mut cache = cache(4, Duration::from_secs(5));
+
+        let spy = || ZeroizingDropSpy {
+            zeroizes: zeroizes.clone(),
+            drops: drops.clone(),
+        };
+        cache.insert_evicting_at(1, spy(), start);
+        cache.insert_evicting_at(2, spy(), start + Duration::from_secs(4));
+
+        let retired = cache.retire_expired_at(start + Duration::from_secs(5));
+        assert_eq!(retired.removed_count(), 1);
+        assert_eq!(cache.len(), 1);
+        assert_eq!(zeroizes.load(Ordering::SeqCst), 1);
+        assert_eq!(drops.load(Ordering::SeqCst), 0);
+
+        drop(retired);
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+        assert!(cache
+            .take_live_at(&2, start + Duration::from_secs(5))
+            .is_some());
+    }
+
+    #[test]
+    fn expiry_retirement_preserves_survivor_order() {
+        let start = Instant::now();
+        let mut cache = cache(3, Duration::from_secs(5));
+        cache.insert_evicting_at(1, 1_u8, start);
+        cache.insert_evicting_at(2, 2_u8, start + Duration::from_secs(4));
+        cache.insert_evicting_at(3, 3_u8, start + Duration::from_secs(4));
+
+        drop(cache.retire_expired_at(start + Duration::from_secs(5)));
+        cache.insert_evicting_at(4, 4_u8, start + Duration::from_secs(5));
+        assert_eq!(
+            cache.insert_evicting_at(5, 5_u8, start + Duration::from_secs(5)),
+            InsertOutcome::EvictedOldest
+        );
+
+        assert_eq!(cache.take_live_at(&2, start + Duration::from_secs(5)), None);
+        assert_eq!(
+            cache.take_live_at(&3, start + Duration::from_secs(5)),
+            Some(3)
+        );
+    }
+
+    #[test]
     fn full_cache_reclaims_expired_oldest_before_live_entries() {
         let start = Instant::now();
         let mut cache = cache(2, Duration::from_secs(5));
@@ -259,6 +358,23 @@ mod tests {
     impl Drop for DropSpy {
         fn drop(&mut self) {
             self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    struct ZeroizingDropSpy {
+        zeroizes: Arc<AtomicUsize>,
+        drops: Arc<AtomicUsize>,
+    }
+
+    impl Zeroize for ZeroizingDropSpy {
+        fn zeroize(&mut self) {
+            self.zeroizes.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    impl Drop for ZeroizingDropSpy {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, Ordering::SeqCst);
         }
     }
 

--- a/src/lease_aware_cache.rs
+++ b/src/lease_aware_cache.rs
@@ -56,6 +56,19 @@ impl<V> CachedValue<V> {
     }
 }
 
+/// Cache-owned slots detached for destruction after the caller releases the
+/// session-cache mutex.
+#[must_use = "keep retired values alive until after releasing the cache lock"]
+pub(crate) struct RetiredLeaseValues<V> {
+    slots: Vec<Arc<LeaseSlot<V>>>,
+}
+
+impl<V> RetiredLeaseValues<V> {
+    pub(crate) fn removed_count(&self) -> usize {
+        self.slots.len()
+    }
+}
+
 /// An RAII lease that prevents its cached value from being expired or evicted.
 pub(crate) struct CacheLease<V> {
     slot: Arc<LeaseSlot<V>>,
@@ -225,6 +238,57 @@ where
         debug_assert!(self.entries.len() <= self.entries.capacity());
     }
 
+    /// Takes one LRU-to-MRU snapshot of expired, currently unleased keys.
+    ///
+    /// A fresh deadline always moves an entry to MRU, while acquisition alone
+    /// changes neither deadline nor recency. Expired entries therefore form an
+    /// LRU suffix and this scan can stop at the first live entry. The caller can
+    /// process the snapshot in bounded batches without repeatedly rescanning
+    /// expired leased entries.
+    pub(crate) fn expired_unleased_keys_at(&self, now: Instant) -> Vec<K> {
+        let mut keys = Vec::new();
+        for (key, entry) in self.entries.iter().rev() {
+            if entry.expires_at > now {
+                break;
+            }
+            if !entry.has_external_lease() {
+                keys.push(key.clone());
+            }
+        }
+        keys
+    }
+
+    /// Revalidates and detaches a bounded candidate batch.
+    ///
+    /// Revalidation protects a newly inserted value if another operation
+    /// removed an expired candidate while the mutex was released. Returned
+    /// slots retain their values so secret destruction occurs outside the
+    /// mutex.
+    pub(crate) fn retire_expired_candidates_at(
+        &mut self,
+        keys: &[K],
+        now: Instant,
+    ) -> RetiredLeaseValues<V> {
+        let mut slots = Vec::with_capacity(keys.len());
+        for key in keys {
+            let should_retire = self
+                .entries
+                .peek(key)
+                .is_some_and(|entry| entry.expires_at <= now && !entry.has_external_lease());
+            if !should_retire {
+                continue;
+            }
+
+            let retired = self
+                .entries
+                .pop(key)
+                .expect("revalidated cache entry must remain present");
+            debug_assert_eq!(Arc::strong_count(&retired.slot), 1);
+            slots.push(retired.slot);
+        }
+        RetiredLeaseValues { slots }
+    }
+
     #[cfg(test)]
     fn len(&self) -> usize {
         self.entries.len()
@@ -271,6 +335,19 @@ mod tests {
             assert_eq!(std::mem::size_of::<LeaseSlot<SessionState>>(), 40);
             assert_eq!(std::mem::size_of::<CachedValue<SessionState>>(), 24);
             assert_eq!(std::mem::size_of::<CacheLease<SessionState>>(), 8);
+
+            // Cleanup can temporarily hold a UUID candidate snapshot while the
+            // fixed CLru backing allocation stays reserved. Budget for twice
+            // the final Vec payload to cover geometric growth/reallocation,
+            // plus one detached batch of Arc handles.
+            assert_eq!(std::mem::size_of::<uuid::Uuid>(), 16);
+            let cleanup_snapshot_peak =
+                crate::MAX_ENCRYPTION_SESSIONS * std::mem::size_of::<uuid::Uuid>() * 2;
+            let detached_batch = crate::secret_cache_maintenance::SESSION_RETIREMENT_BATCH_SIZE
+                * std::mem::size_of::<Arc<LeaseSlot<SessionState>>>();
+            let peak_accounted_bytes = accounted_bytes + cleanup_snapshot_peak + detached_batch;
+            assert!(peak_accounted_bytes <= 500 * 1024 * 1024);
+            assert_eq!(500 * 1024 * 1024 - peak_accounted_bytes, 41_910_272);
         }
     }
 
@@ -360,6 +437,148 @@ mod tests {
             .acquire_at(&1, start + Duration::from_secs(5))
             .is_none());
         assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn retires_untouched_expired_values_below_capacity_and_drops_outside_cache() {
+        struct DropSpy(Arc<AtomicUsize>);
+        impl Drop for DropSpy {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let start = Instant::now();
+        let drops = Arc::new(AtomicUsize::new(0));
+        let mut cache = cache(4, Duration::from_secs(5));
+        cache
+            .insert_evicting_at(1, DropSpy(drops.clone()), start)
+            .unwrap();
+        cache
+            .insert_evicting_at(2, DropSpy(drops.clone()), start + Duration::from_secs(4))
+            .unwrap();
+
+        let candidates = cache.expired_unleased_keys_at(start + Duration::from_secs(5));
+        assert_eq!(candidates, vec![1]);
+        let retired =
+            cache.retire_expired_candidates_at(&candidates, start + Duration::from_secs(5));
+        assert_eq!(retired.removed_count(), 1);
+        assert_eq!(cache.len(), 1);
+        assert_eq!(drops.load(Ordering::SeqCst), 0);
+
+        drop(retired);
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+        assert!(cache
+            .acquire_at(&2, start + Duration::from_secs(5))
+            .is_some());
+    }
+
+    #[test]
+    fn touched_value_survives_its_original_expiry_snapshot() {
+        let start = Instant::now();
+        let mut cache = cache(2, Duration::from_secs(5));
+        cache.insert_evicting_at(1, "one", start).unwrap();
+        assert!(cache.touch_at(&1, start + Duration::from_secs(4)));
+
+        assert!(cache
+            .expired_unleased_keys_at(start + Duration::from_secs(5))
+            .is_empty());
+        assert_eq!(
+            cache.expired_unleased_keys_at(start + Duration::from_secs(9)),
+            vec![1]
+        );
+    }
+
+    #[test]
+    fn leased_expired_value_waits_for_a_later_cleanup_pass() {
+        struct DropSpy(Arc<AtomicUsize>);
+        impl Drop for DropSpy {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let start = Instant::now();
+        let drops = Arc::new(AtomicUsize::new(0));
+        let mut cache = cache(2, Duration::from_secs(5));
+        cache
+            .insert_evicting_at(1, DropSpy(drops.clone()), start)
+            .unwrap();
+        let lease = cache.acquire_at(&1, start).unwrap();
+
+        let expired_at = start + Duration::from_secs(5);
+        assert!(cache.expired_unleased_keys_at(expired_at).is_empty());
+        assert_eq!(cache.len(), 1);
+        drop(lease);
+
+        let candidates = cache.expired_unleased_keys_at(expired_at);
+        let retired = cache.retire_expired_candidates_at(&candidates, expired_at);
+        assert_eq!(retired.removed_count(), 1);
+        assert_eq!(drops.load(Ordering::SeqCst), 0);
+        drop(retired);
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn cleanup_skips_leased_expiry_holes_and_preserves_survivor_order() {
+        let start = Instant::now();
+        let mut cache = cache(4, Duration::from_secs(5));
+        cache.insert_evicting_at(1, "leased", start).unwrap();
+        cache
+            .insert_evicting_at(2, "expired", start + Duration::from_secs(1))
+            .unwrap();
+        cache
+            .insert_evicting_at(3, "live", start + Duration::from_secs(2))
+            .unwrap();
+        let lease = cache
+            .acquire_at(&1, start + Duration::from_secs(2))
+            .unwrap();
+
+        let cutoff = start + Duration::from_secs(6);
+        let candidates = cache.expired_unleased_keys_at(cutoff);
+        assert_eq!(candidates, vec![2]);
+        drop(cache.retire_expired_candidates_at(&candidates, cutoff));
+
+        cache.insert_evicting_at(4, "new", cutoff).unwrap();
+        cache.insert_evicting_at(5, "newest", cutoff).unwrap();
+        assert_eq!(
+            cache.insert_evicting_at(6, "overflow", cutoff),
+            Ok(InsertOutcome::EvictedLeastRecentlyUsed)
+        );
+        assert!(cache.acquire_at(&3, cutoff).is_none());
+        assert_eq!(lease.value(), &"leased");
+        drop(lease);
+    }
+
+    #[test]
+    fn stale_cleanup_candidate_cannot_remove_a_replacement() {
+        let start = Instant::now();
+        let cutoff = start + Duration::from_secs(5);
+        let mut cache = cache(1, Duration::from_secs(5));
+        cache.insert_evicting_at(1, "old", start).unwrap();
+        let candidates = cache.expired_unleased_keys_at(cutoff);
+
+        assert!(cache.acquire_at(&1, cutoff).is_none());
+        cache.insert_evicting_at(1, "replacement", cutoff).unwrap();
+        let retired = cache.retire_expired_candidates_at(&candidates, cutoff);
+        assert_eq!(retired.removed_count(), 0);
+        assert_eq!(
+            cache.acquire_at(&1, cutoff).unwrap().value(),
+            &"replacement"
+        );
+    }
+
+    #[test]
+    fn lingering_arc_excludes_expired_value_from_cleanup_snapshot() {
+        let start = Instant::now();
+        let cutoff = start + Duration::from_secs(5);
+        let mut cache = cache(1, Duration::from_secs(5));
+        cache.insert_evicting_at(1, "one", start).unwrap();
+        let lingering_arc = Arc::clone(&cache.entries.peek(&1).unwrap().slot);
+
+        assert!(cache.expired_unleased_keys_at(cutoff).is_empty());
+        drop(lingering_arc);
+        assert_eq!(cache.expired_unleased_keys_at(cutoff), vec![1]);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,7 @@ mod private_key;
 mod provider_client;
 mod provider_routing;
 mod proxy_config;
+mod secret_cache_maintenance;
 #[cfg(test)]
 mod security_invariants;
 mod seed_wrapping;
@@ -3498,5 +3499,10 @@ async fn main() -> Result<(), Error> {
 
     tracing::info!("Listening on http://{}", bind_addr);
 
-    Ok(axum::serve(listener, app.into_make_service()).await?)
+    tokio::select! {
+        result = axum::serve(listener, app.into_make_service()) => Ok(result?),
+        _ = secret_cache_maintenance::run(app_state) => {
+            unreachable!("secret cache maintenance runs until the server stops")
+        }
+    }
 }

--- a/src/secret_cache_maintenance.rs
+++ b/src/secret_cache_maintenance.rs
@@ -1,0 +1,76 @@
+use crate::AppState;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::time::MissedTickBehavior;
+
+pub(crate) const SECRET_CACHE_MAINTENANCE_INTERVAL: Duration = Duration::from_secs(5 * 60);
+pub(crate) const SESSION_RETIREMENT_BATCH_SIZE: usize = 4_096;
+
+pub(crate) async fn run(app_state: Arc<AppState>) {
+    let first_tick = tokio::time::Instant::now() + SECRET_CACHE_MAINTENANCE_INTERVAL;
+    let mut interval = tokio::time::interval_at(first_tick, SECRET_CACHE_MAINTENANCE_INTERVAL);
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    loop {
+        interval.tick().await;
+        purge_expired_secret_state(&app_state, Instant::now()).await;
+    }
+}
+
+async fn purge_expired_secret_state(app_state: &AppState, now: Instant) {
+    // Never overlap the two cache locks. Pending key bytes are wiped in place;
+    // their destructors and deallocation run after releasing the write lock.
+    // Session values stay in stable Arc allocations and are both zeroized and
+    // deallocated after releasing their mutex.
+    let retired_pending = {
+        let mut pending = app_state.ephemeral_keys.write().await;
+        pending.retire_expired_at(now)
+    };
+    let pending_count = retired_pending.removed_count();
+    drop(retired_pending);
+
+    // Snapshot the ordered expired suffix once. Repeatedly rescanning it for
+    // each batch would become quadratic when expired leased entries remain.
+    let candidates = {
+        let sessions = app_state.session_states.lock().await;
+        sessions.expired_unleased_keys_at(now)
+    };
+
+    let mut session_count = 0;
+    let mut batches = candidates.chunks(SESSION_RETIREMENT_BATCH_SIZE).peekable();
+    while let Some(batch) = batches.next() {
+        let retired_sessions = {
+            let mut sessions = app_state.session_states.lock().await;
+            sessions.retire_expired_candidates_at(batch, now)
+        };
+        session_count += retired_sessions.removed_count();
+        drop(retired_sessions);
+
+        // Give waiting requests a scheduling point between bounded lock holds.
+        if batches.peek().is_some() {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    if pending_count != 0 || session_count != 0 {
+        tracing::debug!(
+            pending_attestations = pending_count,
+            encryption_sessions = session_count,
+            "Purged expired secret state"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maintenance_policy_is_five_minutes_with_bounded_session_batches() {
+        assert_eq!(
+            SECRET_CACHE_MAINTENANCE_INTERVAL,
+            Duration::from_secs(5 * 60)
+        );
+        assert_eq!(SESSION_RETIREMENT_BATCH_SIZE, 4_096);
+    }
+}


### PR DESCRIPTION
## Summary

- run one structured secret-cache maintenance future alongside the Axum server on a delayed five-minute cadence
- physically retire untouched expired pending-attestation secrets and unleased encryption sessions without changing request or insertion hot paths
- preserve active response/SSE leases, revalidate session candidates in 4,096-entry batches, and destroy session key material after releasing the mutex
- zeroize pending X25519 secrets in place before removal so their bytes cannot remain in CLru's preallocated backing storage

## Why

The TTL caches added in the preceding stack layers enforce logical expiry on direct access and under capacity pressure. An untouched entry below capacity can nevertheless remain physically resident until later access, eviction, or process exit. This layer closes that key-lifecycle gap while preserving the existing API and idle-TTL behavior.

This is stacked directly on #245. It does not change routes, payloads, headers, status codes, client requirements, cache limits, or TTLs. Unleased state is removed on the first completed sweep after expiry (best effort, so within roughly five additional minutes under normal scheduling). An expired session with an active request/response lease remains available until the final lease drops and a later sweep runs. CLru's bounded backing allocations remain reserved; the security goal is zeroizing and dropping key material, not forcing RSS to shrink.

## Performance and memory

Cleanup is expected linear in the expired prefix plus removals, not quadratic. The session cache takes one LRU-to-MRU candidate snapshot and then revalidates/removes each candidate once. At the absolute 2,097,152-session ceiling, the measured snapshot was about 22 ms and 32 MiB; 4,096-entry removal batches held the mutex for about 0.53 ms median with a 3.21 ms observed maximum. A synthetic full drain took about 425 ms total while yielding between 512 bounded batches. The budget test conservatively allows twice the final snapshot payload during allocation and still leaves about 40 MiB within the 500 MiB cache budget.

At the 65,536 pending-secret ceiling, in-place wiping adds 2 MiB of zero writes. Estimated full-purge write-lock time is roughly 3.8-3.9 ms on the benchmark host; secret destructors and deallocation still happen after the lock is released.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --all-features` (334 passed, 17 pre-existing environment-gated tests ignored)
- `cargo check --all-targets`
- `nix flake check --no-build --print-build-logs`
- exact-commit local startup and `/health-check` smoke
- independent security, concurrency/integration, and performance reviews of `d5f5907543838de0eea222f315ffe432dec8582e`

The development EIF/PCR check is expected to require the normal PCR update before deployment; this PR intentionally does not update release PCR artifacts.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
