### PR TITLE
Bound cumulative Responses provider output

### DIFF
--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -28,7 +28,10 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::{sleep, timeout};
@@ -394,6 +397,8 @@ async fn provider_error_preview(response: ProviderResponse) -> Option<String> {
 enum ProviderStreamLimitError {
     #[error("provider stream exceeded the {limit}-byte total limit")]
     BodyTooLarge { limit: usize },
+    #[error("provider streams exceeded the {limit}-byte request-wide limit")]
+    RequestBudgetExceeded { limit: usize },
     #[error("provider SSE frame exceeded the {limit}-byte limit")]
     FrameTooLarge { limit: usize },
 }
@@ -407,6 +412,52 @@ fn add_stream_bytes(
         .checked_add(chunk_len)
         .filter(|next_total| *next_total <= limit)
         .ok_or(ProviderStreamLimitError::BodyTooLarge { limit })
+}
+
+/// Optional request-scoped budget shared by multiple sequential provider
+/// streams, such as the assistant turns in one Responses API request.
+#[derive(Clone, Debug)]
+pub(crate) struct CompletionStreamBudget {
+    consumed: Arc<AtomicUsize>,
+    limit: usize,
+}
+
+impl CompletionStreamBudget {
+    pub(crate) fn new(limit: usize) -> Self {
+        Self {
+            consumed: Arc::new(AtomicUsize::new(0)),
+            limit,
+        }
+    }
+
+    fn try_reserve(&self, bytes: usize) -> Result<(), ProviderStreamLimitError> {
+        self.consumed
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |consumed| {
+                consumed
+                    .checked_add(bytes)
+                    .filter(|next_consumed| *next_consumed <= self.limit)
+            })
+            .map(|_| ())
+            .map_err(|_| ProviderStreamLimitError::RequestBudgetExceeded { limit: self.limit })
+    }
+
+    #[cfg(test)]
+    fn consumed(&self) -> usize {
+        self.consumed.load(Ordering::Relaxed)
+    }
+}
+
+fn account_stream_bytes(
+    stream_total: usize,
+    chunk_len: usize,
+    stream_limit: usize,
+    request_budget: Option<&CompletionStreamBudget>,
+) -> Result<usize, ProviderStreamLimitError> {
+    let next_total = add_stream_bytes(stream_total, chunk_len, stream_limit)?;
+    if let Some(request_budget) = request_budget {
+        request_budget.try_reserve(chunk_len)?;
+    }
+    Ok(next_total)
 }
 
 #[derive(Default)]
@@ -1001,7 +1052,40 @@ pub async fn get_chat_completion_response(
     user: &User,
     body: Value,
     headers: &HeaderMap,
+    billing_context: BillingContext,
+) -> Result<CompletionStream, ApiError> {
+    get_chat_completion_response_inner(state, user, body, headers, billing_context, None).await
+}
+
+/// Responses API entry point for sharing one raw-stream budget across multiple
+/// sequential assistant turns. Direct chat completions retain their existing
+/// independent per-response limit through `get_chat_completion_response`.
+pub(crate) async fn get_chat_completion_response_with_stream_budget(
+    state: &Arc<AppState>,
+    user: &User,
+    body: Value,
+    headers: &HeaderMap,
+    billing_context: BillingContext,
+    stream_budget: CompletionStreamBudget,
+) -> Result<CompletionStream, ApiError> {
+    get_chat_completion_response_inner(
+        state,
+        user,
+        body,
+        headers,
+        billing_context,
+        Some(stream_budget),
+    )
+    .await
+}
+
+async fn get_chat_completion_response_inner(
+    state: &Arc<AppState>,
+    user: &User,
+    body: Value,
+    headers: &HeaderMap,
     mut billing_context: BillingContext,
+    stream_budget: Option<CompletionStreamBudget>,
 ) -> Result<CompletionStream, ApiError> {
     if body.is_null() || body.as_object().is_none_or(|obj| obj.is_empty()) {
         error!("Request body is empty or invalid");
@@ -1219,10 +1303,11 @@ pub async fn get_chat_completion_response(
                 Ok(Some(chunk_result)) => {
                     match chunk_result {
                         Ok(bytes) => {
-                            stream_bytes = match add_stream_bytes(
+                            stream_bytes = match account_stream_bytes(
                                 stream_bytes,
                                 bytes.len(),
                                 MAX_COMPLETION_STREAM_BYTES,
+                                stream_budget.as_ref(),
                             ) {
                                 Ok(next_total) => next_total,
                                 Err(e) => {
@@ -2908,6 +2993,59 @@ mod tests {
             add_stream_bytes(usize::MAX, 1, usize::MAX),
             Err(ProviderStreamLimitError::BodyTooLarge { limit: usize::MAX })
         );
+    }
+
+    #[test]
+    fn request_stream_budget_is_shared_across_turns_and_failures_do_not_consume_it() {
+        let budget = CompletionStreamBudget::new(8);
+
+        assert_eq!(account_stream_bytes(0, 4, 8, Some(&budget)), Ok(4));
+        assert_eq!(account_stream_bytes(0, 4, 8, Some(&budget.clone())), Ok(4));
+        assert_eq!(budget.consumed(), 8);
+        assert_eq!(
+            account_stream_bytes(0, 1, 8, Some(&budget)),
+            Err(ProviderStreamLimitError::RequestBudgetExceeded { limit: 8 })
+        );
+        assert_eq!(budget.consumed(), 8);
+    }
+
+    #[test]
+    fn per_stream_limit_fails_before_charging_request_budget() {
+        let budget = CompletionStreamBudget::new(8);
+
+        assert_eq!(
+            account_stream_bytes(8, 1, 8, Some(&budget)),
+            Err(ProviderStreamLimitError::BodyTooLarge { limit: 8 })
+        );
+        assert_eq!(budget.consumed(), 0);
+    }
+
+    #[test]
+    fn request_stream_budget_rejects_overflow_and_clone_oversubscription() {
+        let overflow_budget = CompletionStreamBudget::new(usize::MAX);
+        assert!(overflow_budget.try_reserve(usize::MAX).is_ok());
+        assert_eq!(
+            overflow_budget.try_reserve(1),
+            Err(ProviderStreamLimitError::RequestBudgetExceeded { limit: usize::MAX })
+        );
+        assert_eq!(overflow_budget.consumed(), usize::MAX);
+
+        let shared_budget = CompletionStreamBudget::new(32);
+        let successful_reservations = AtomicUsize::new(0);
+        std::thread::scope(|scope| {
+            for _ in 0..64 {
+                let budget = shared_budget.clone();
+                let successes = &successful_reservations;
+                scope.spawn(move || {
+                    if budget.try_reserve(1).is_ok() {
+                        successes.fetch_add(1, Ordering::Relaxed);
+                    }
+                });
+            }
+        });
+
+        assert_eq!(successful_reservations.load(Ordering::Relaxed), 32);
+        assert_eq!(shared_budget.consumed(), 32);
     }
 
     #[tokio::test]

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -15,7 +15,10 @@ use crate::{
     os_flags::KAGI_WEB_SEARCH_FLAG_KEY,
     web::{
         encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
-        openai::get_chat_completion_response,
+        openai::{
+            get_chat_completion_response, get_chat_completion_response_with_stream_budget,
+            CompletionStreamBudget,
+        },
         responses::{
             build_prompt, build_prompt_with_token_reserve, build_usage, constants::*,
             error_mapping, prompt_token_budget, storage_task, tools, ContentPartBuilder,
@@ -54,6 +57,8 @@ use uuid::Uuid;
 
 const RESPONSES_SSE_KEEPALIVE_INTERVAL_SECS: u64 = 1;
 const MAX_WEB_SEARCH_TOOL_TURNS: usize = 30;
+const MAX_RESPONSES_PROVIDER_STREAM_BYTES: usize = 32 * 1024 * 1024;
+const MAX_RESPONSES_TOOL_ARGUMENT_BYTES_PER_TURN: usize = 256 * 1024;
 
 // Default functions for serde
 fn default_store() -> bool {
@@ -328,6 +333,53 @@ fn build_model_turn_request(
     chat_request
 }
 
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+enum ResponsesOutputLimitError {
+    #[error("streamed tool-call arguments exceeded the {limit}-byte per-turn limit")]
+    ToolArgumentsTooLarge { limit: usize },
+}
+
+fn add_bounded_output_bytes(
+    total: usize,
+    added: usize,
+    limit: usize,
+) -> Result<usize, ResponsesOutputLimitError> {
+    total
+        .checked_add(added)
+        .filter(|next_total| *next_total <= limit)
+        .ok_or(ResponsesOutputLimitError::ToolArgumentsTooLarge { limit })
+}
+
+fn account_streamed_tool_argument_bytes(
+    total: usize,
+    tool_call_delta: &Value,
+    limit: usize,
+) -> Result<usize, ResponsesOutputLimitError> {
+    let Some(tool_call_entries) = tool_call_delta.as_array() else {
+        return Ok(total);
+    };
+
+    tool_call_entries
+        .iter()
+        .try_fold(total, |total, tool_call| {
+            let index = tool_call
+                .get("index")
+                .and_then(|index| index.as_u64())
+                .unwrap_or(0);
+            if index != 0 {
+                return Ok(total);
+            }
+
+            let arguments = tool_call
+                .get("function")
+                .and_then(|function| function.get("arguments"))
+                .and_then(Value::as_str)
+                .map(str::len)
+                .unwrap_or_default();
+            add_bounded_output_bytes(total, arguments, limit)
+        })
+}
+
 fn append_streamed_tool_calls(tool_calls: &mut Vec<StreamedToolCall>, tool_call_delta: &Value) {
     let Some(tool_call_entries) = tool_call_delta.as_array() else {
         return;
@@ -418,13 +470,14 @@ fn final_assistant_finish_reason(tools_enabled: bool, finish_reason: Option<Stri
 #[cfg(test)]
 mod tests {
     use super::{
-        append_streamed_tool_calls, apply_responses_model_defaults,
-        assistant_turn_finished_with_tool_call, build_internal_system_prompt_for_now,
-        build_model_turn_request, build_provider_tools, choose_web_search_provider,
-        final_assistant_finish_reason, finalize_first_model_tool_call,
+        account_streamed_tool_argument_bytes, add_bounded_output_bytes, append_streamed_tool_calls,
+        apply_responses_model_defaults, assistant_turn_finished_with_tool_call,
+        build_internal_system_prompt_for_now, build_model_turn_request, build_provider_tools,
+        choose_web_search_provider, final_assistant_finish_reason, finalize_first_model_tool_call,
         has_streamed_tool_call_entries, resolve_responses_sampling, wait_for_response_cancellation,
         ClientResponseState, ConversationParam, InputMessage, ResponsesCreateRequest,
-        StorageMessage, StreamedToolCall, MAPLE_KAGI_WEB_SEARCH_PROMPT, MAPLE_WEB_SEARCH_PROMPT,
+        ResponsesOutputLimitError, StorageMessage, StreamedToolCall, MAPLE_KAGI_WEB_SEARCH_PROMPT,
+        MAPLE_WEB_SEARCH_PROMPT, MAX_RESPONSES_TOOL_ARGUMENT_BYTES_PER_TURN,
         MAX_WEB_SEARCH_TOOL_TURNS,
     };
     use crate::web::responses::tools::WebSearchProvider;
@@ -786,6 +839,65 @@ mod tests {
         assert_eq!(tool_calls.capacity(), initial_capacity);
         assert_eq!(tool_calls[0].name.as_deref(), Some("web_search"));
         assert_eq!(tool_calls[0].arguments, "{\"query\":\"existing\"}");
+    }
+
+    #[test]
+    fn streamed_tool_argument_budget_spans_fragments_and_accepts_exact_limit() {
+        let limit = MAX_RESPONSES_TOOL_ARGUMENT_BYTES_PER_TURN;
+        let first = json!([{
+            "index": 0,
+            "function": { "arguments": "x".repeat(limit - 1) }
+        }]);
+        let second = json!([{
+            "index": 0,
+            "function": { "arguments": "y" }
+        }]);
+
+        let total = account_streamed_tool_argument_bytes(0, &first, limit).unwrap();
+        assert_eq!(
+            account_streamed_tool_argument_bytes(total, &second, limit),
+            Ok(limit)
+        );
+    }
+
+    #[test]
+    fn streamed_tool_argument_budget_rejects_supported_entries_over_limit() {
+        let limit = 8;
+        let delta = json!([
+            { "index": 0, "function": { "arguments": "1234" } },
+            { "index": 0, "function": { "arguments": "56789" } }
+        ]);
+
+        assert_eq!(
+            account_streamed_tool_argument_bytes(0, &delta, limit),
+            Err(ResponsesOutputLimitError::ToolArgumentsTooLarge { limit })
+        );
+        assert_eq!(
+            account_streamed_tool_argument_bytes(7, &json!(null), limit),
+            Ok(7)
+        );
+    }
+
+    #[test]
+    fn streamed_tool_argument_budget_ignores_unsupported_indices() {
+        let limit = 8;
+        let delta = json!([
+            { "index": u64::MAX, "function": { "arguments": "x".repeat(limit + 1) } },
+            { "index": 0, "function": { "arguments": "1234" } }
+        ]);
+
+        assert_eq!(
+            account_streamed_tool_argument_bytes(0, &delta, limit),
+            Ok(4)
+        );
+    }
+
+    #[test]
+    fn bounded_output_byte_accounting_rejects_integer_overflow() {
+        assert_eq!(
+            add_bounded_output_bytes(usize::MAX, 1, usize::MAX),
+            Err(ResponsesOutputLimitError::ToolArgumentsTooLarge { limit: usize::MAX })
+        );
     }
 
     #[test]
@@ -2633,6 +2745,7 @@ async fn stream_one_assistant_turn(
     headers: &HeaderMap,
     prompt_messages: &[Value],
     tools_enabled: bool,
+    stream_budget: &CompletionStreamBudget,
     web_search_provider: Option<tools::WebSearchProvider>,
     tx_client: &mpsc::Sender<StorageMessage>,
     tx_storage: &mpsc::Sender<StorageMessage>,
@@ -2674,9 +2787,15 @@ async fn stream_one_assistant_turn(
         body.model.clone(),
     );
 
-    let mut completion =
-        get_chat_completion_response(state, user, chat_request.take(), headers, billing_context)
-            .await?;
+    let mut completion = get_chat_completion_response_with_stream_budget(
+        state,
+        user,
+        chat_request.take(),
+        headers,
+        billing_context,
+        stream_budget.clone(),
+    )
+    .await?;
 
     debug!(
         "Received completion from provider: {} (model: {})",
@@ -2689,6 +2808,7 @@ async fn stream_one_assistant_turn(
     let mut reasoning = ReasoningState::NotStarted;
     let mut saw_tool_calls = false;
     let mut ignored_disabled_tool_calls = false;
+    let mut streamed_tool_argument_bytes = 0usize;
 
     while let Some(chunk) = completion.stream.recv().await {
         match chunk {
@@ -2773,6 +2893,19 @@ async fn stream_one_assistant_turn(
                             ignored_disabled_tool_calls = true;
                         }
                     } else {
+                        streamed_tool_argument_bytes = account_streamed_tool_argument_bytes(
+                            streamed_tool_argument_bytes,
+                            tool_call_delta,
+                            MAX_RESPONSES_TOOL_ARGUMENT_BYTES_PER_TURN,
+                        )
+                        .map_err(|e| {
+                            warn!(
+                                "Rejecting oversized streamed tool-call arguments for response {}: {}",
+                                response_uuid, e
+                            );
+                            ApiError::InternalServerError
+                        })?;
+
                         if !saw_tool_calls {
                             debug!(
                                 "Assistant turn received first tool_call delta from model stream"
@@ -2945,6 +3078,7 @@ async fn setup_completion_processor(
     let mut prompt_messages = Arc::as_ref(&context.prompt_messages).clone();
     let mut prompt_token_estimate = context.total_prompt_tokens;
     let mut kagi_allowed_urls = tools::collect_kagi_allowed_urls_from_prompt(&prompt_messages);
+    let stream_budget = CompletionStreamBudget::new(MAX_RESPONSES_PROVIDER_STREAM_BYTES);
 
     let loop_result: Result<(), ApiError> = async {
         let mut next_message_id = Some(prepared.assistant_message_id);
@@ -2957,6 +3091,7 @@ async fn setup_completion_processor(
                 headers,
                 &prompt_messages,
                 tools_enabled,
+                &stream_budget,
                 web_search_provider,
                 &tx_client,
                 &tx_storage,


### PR DESCRIPTION
## Summary

- share one 32 MiB raw provider-stream budget across every assistant turn in a single Responses API request
- cap accumulated supported tool-call arguments at 256 KiB per assistant turn before string append, JSON parsing, or cloning
- preserve direct chat-completion and background-title behavior, including their independent existing limits

## Why

The per-stream limit in #248 resets for each assistant/tool turn. A Responses request can make 30 tool-producing provider calls plus one final call, so its theoretical raw allowance remained 496 MiB. Retained output and parsed tool arguments can amplify that substantially during JSON construction, encryption, and base64 encoding.

The request-wide budget uses an atomic checked reservation shared across turns. Per-stream validation runs first, failed reservations do not consume capacity, and overflow fails closed. Tool-argument accounting follows #223's index-0-only behavior, so unsupported nonzero indices are ignored consistently rather than consuming budget.

Responses within the limits keep the existing API and billing behavior. Limit exhaustion follows the existing stream-failure path. This change does not alter generic chat completions or title generation.

## Stack

1. #223 — bound streamed Responses tool-call indices
2. #226 — bound buffered provider response bodies
3. #248 — bound each streamed upstream provider response
4. this PR — bound cumulative output across one Responses request

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- full suite: 351 passed, 0 failed, 17 ignored DB/live-only tests
- focused exact-limit, fragmentation, overflow, failed-reservation, clone-oversubscription, and unsupported-index tests
- independent exact-head reviews of atomic budgeting, tool-argument handling, and stack topology: approve

No paid or live model-completion load test was run.
