### PR TITLE
security: fail closed on crypto admission errors

### DIFF
--- a/src/provider_client.rs
+++ b/src/provider_client.rs
@@ -12,7 +12,7 @@ use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::{Arc, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
@@ -29,6 +29,9 @@ const TINFOIL_UNINITIALIZED_BASE_URL: &str = "https://in-process.tinfoil.invalid
 pub enum ProviderClientError {
     #[error("failed to build provider HTTP client: {0}")]
     Client(#[from] reqwest_tinfoil::Error),
+
+    #[error("failed to install the required Ring crypto provider")]
+    CryptoProvider,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -510,7 +513,7 @@ pub struct ProviderClient {
 
 impl ProviderClient {
     pub async fn new(tinfoil_api_key: String) -> Result<Self, ProviderClientError> {
-        install_crypto_provider();
+        install_crypto_provider()?;
 
         let secure_transport = Arc::new(SecureTinfoilTransport {
             api_key: tinfoil_api_key,
@@ -531,7 +534,7 @@ impl ProviderClient {
 
     #[cfg(test)]
     fn uninitialized_for_test() -> Result<Self, ProviderClientError> {
-        install_crypto_provider();
+        install_crypto_provider()?;
 
         Ok(Self {
             tinfoil: TinfoilTransport::Secure(Arc::new(SecureTinfoilTransport {
@@ -551,7 +554,7 @@ impl ProviderClient {
 
     #[cfg(test)]
     pub fn for_test(base_url: String) -> Result<Self, ProviderClientError> {
-        install_crypto_provider();
+        install_crypto_provider()?;
         let client = test_http_client()?;
 
         Ok(Self {
@@ -793,8 +796,21 @@ fn standard_http_client() -> StandardHttpClient {
         .build::<_, HyperBody>(HttpsConnector::new())
 }
 
-fn install_crypto_provider() {
-    let _ = rustls::crypto::ring::default_provider().install_default();
+fn install_crypto_provider() -> Result<(), ProviderClientError> {
+    static INSTALLATION: OnceLock<Result<(), ()>> = OnceLock::new();
+
+    if INSTALLATION
+        .get_or_init(|| {
+            rustls::crypto::ring::default_provider()
+                .install_default()
+                .map_err(|_| ())
+        })
+        .is_err()
+    {
+        Err(ProviderClientError::CryptoProvider)
+    } else {
+        Ok(())
+    }
 }
 
 fn skipped_forward_headers(source: &HeaderMap) -> HashSet<HeaderName> {

--- a/src/web/attestation_routes.rs
+++ b/src/web/attestation_routes.rs
@@ -400,7 +400,7 @@ async fn key_exchange(
         .await?
         .ok_or(ApiError::BadRequest)?;
 
-    let shared_secret = ephemeral_secret.diffie_hellman(&client_public_key);
+    let shared_secret = derive_contributory_shared_secret(ephemeral_secret, &client_public_key)?;
 
     // Generate a random session key using your secure random function
     let session_state = SessionState::new(crate::encrypt::generate_random());
@@ -428,6 +428,18 @@ async fn key_exchange(
     }))
 }
 
+fn derive_contributory_shared_secret(
+    ephemeral_secret: x25519_dalek::EphemeralSecret,
+    client_public_key: &x25519_dalek::PublicKey,
+) -> Result<x25519_dalek::SharedSecret, ApiError> {
+    let shared_secret = ephemeral_secret.diffie_hellman(client_public_key);
+    if !shared_secret.was_contributory() {
+        return Err(ApiError::BadRequest);
+    }
+
+    Ok(shared_secret)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -441,5 +453,25 @@ mod tests {
         let mut state = SessionState::new([0xA5; 32]);
         state.zeroize();
         assert_eq!(state.get_session_key(), &[0; 32]);
+    }
+
+    #[test]
+    fn key_exchange_rejects_non_contributory_x25519_public_key() {
+        let ephemeral_secret = x25519_dalek::EphemeralSecret::random_from_rng(rand_core::OsRng);
+        let low_order_public_key = x25519_dalek::PublicKey::from([0u8; 32]);
+
+        assert!(matches!(
+            derive_contributory_shared_secret(ephemeral_secret, &low_order_public_key),
+            Err(ApiError::BadRequest)
+        ));
+    }
+
+    #[test]
+    fn key_exchange_accepts_honest_x25519_public_key() {
+        let ephemeral_secret = x25519_dalek::EphemeralSecret::random_from_rng(rand_core::OsRng);
+        let client_secret = x25519_dalek::EphemeralSecret::random_from_rng(rand_core::OsRng);
+        let client_public_key = x25519_dalek::PublicKey::from(&client_secret);
+
+        assert!(derive_contributory_shared_secret(ephemeral_secret, &client_public_key).is_ok());
     }
 }


### PR DESCRIPTION
## Summary

- Treat failure to install the required Ring rustls provider as a startup error instead of silently ignoring it.
- Cache the installation result so every provider-client constructor observes the same fail-closed outcome.
- Reject non-contributory X25519 public keys before generating or encrypting a session key.
- Add focused tests for honest and low-order X25519 inputs.

## Compatibility

This does not change key derivation, AEAD construction, nonce layout, stored cryptographic material, database formats, or honest-client wire behavior. Existing valid X25519 clients derive the same shared secret. Inputs that intentionally produce an all-zero shared secret now receive a bad-request error.

The backend already selects Ring. This layer makes a conflicting process-global rustls provider an explicit startup failure rather than continuing in an unknown provider state.

## Validation

- cargo fmt --all -- --check
- cargo test --locked key_exchange_
- cargo test --locked provider_client

## Stack

Depends on #251, which only retires the root Docker EIF entry point. This PR contains no Nix, kernel, helper, PCR-reference, KMS-policy, secret-handling, or CI-workflow changes.

<sub>Part of <a href="https://github.com/OpenSecretCloud/opensecret/stacks/253">stack #253</a></sub>

## Observed rollout status — August 7, 2026

Anthony reviewed and accepted this layer, and it merged on August 5. It was not booted as a standalone development checkpoint; the cumulative #254 dev smoke exercised existing login/chats and a new chat with this change included. It is included in the successful #260 production checkpoint.