### PR TITLE
build: make Nitro init compatibility explicit

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -381,6 +381,25 @@
             touch "$out"
           '';
 
+        # aws-nitro-util already source-builds this init by default. Keep the
+        # same source and build flags explicit while using the current
+        # buildGoModule API, so a Nixpkgs refresh cannot revive the deprecated
+        # top-level CGO_ENABLED argument.
+        nitroInitSrc = builtins.path {
+          path = "${nitro-util}/init";
+          name = "init";
+        };
+        nitroInit = pkgs.buildGoModule {
+          name = "eif-init";
+          src = nitroInitSrc;
+          vendorHash = null;
+          env.CGO_ENABLED = "0";
+          ldflags = [
+            "-s"
+            "-w"
+          ];
+        };
+
         # Preserve the currently deployed Nitro boot behavior explicitly. A
         # trust-policy experiment belongs in its own held draft PR.
         enclaveKernelCmdline =
@@ -402,6 +421,7 @@
           nsmKo = null;
           copyToRoot = mkRootfs { inherit appMode opensecretPkg; };
           entrypoint = "/bin/entrypoint";
+          init = "${nitroInit}/bin/init";
         };
 
         opensecret = pkgs.rustPlatform.buildRustPackage {
@@ -598,6 +618,7 @@
         packages = {
           default = opensecret;
         } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+          nitro-init = nitroInit;
           eif-dev = mkEif { appMode = "dev"; };
           eif-prod = mkEif { appMode = "prod"; };
           eif-preview = mkEif { appMode = "preview"; };


### PR DESCRIPTION
## Why

The pinned aws-nitro-util already source-builds its Go init, but it uses the deprecated top-level `CGO_ENABLED` Nix argument. The current baseline tolerates that with a warning; newer Nixpkgs rejects it during evaluation. This tiny layer removes that future platform-refresh blocker without changing the init artifact.

## What changes

- Build the same pinned `nitro-util/init` source explicitly with `pkgs.buildGoModule`.
- Preserve `CGO_ENABLED=0`, `vendorHash = null`, and the existing `-s -w` linker flags.
- Pass the resulting init path explicitly to `nitro.buildEif`.
- Export `packages.<linux-system>.nitro-init` for direct native validation.

## Proven no-op on the current baseline

Before and after this change:

- Nitro init derivation: `/nix/store/0rxb42rxd6vnmbpjzjmvkn9sj27md1f7-eif-init.drv`
- Development EIF derivation: `/nix/store/swqwpfaaxg6w4i5kznannn7rk8d9q9n4-opensecret-eif-dev.drv`

The derivations are byte-for-byte identical because source, name, build flags, Go toolchain, and dependencies are unchanged. Native AArch64 CI independently confirmed this at the produced-artifact level: the complete development EIF built successfully, and its PCR0, PCR1, and PCR2 are exactly identical to the immediately preceding #257 layer.

## Compatibility

No application, KMS, key, ciphertext, rootfs, boot protocol, or command-line semantics change. The following Nixpkgs-refresh layer will own any later Go compiler rebuild, PCR change, ARM build, and dev-enclave boot validation.

## Validation

- Exact old/new init and EIF derivation identity on the current pinned Nixpkgs.
- `nix flake check '.?submodules=1' --all-systems --no-build --no-write-lock-file`
- Clean diff check.
- Native AArch64 Linux CI realized the complete development EIF and reached the final PCR comparison. Its only failure was the expected mismatch with the intentionally unchanged checked-in development measurements; compilation and EIF construction succeeded.
- The realized PCRs exactly match #257: PCR0 `476392b64eef5873c0aedb9e3749589cf5a542e26f22470005b5b5c02e2ca0e7cf11c68db4365942898c16e7e9388dd3`, PCR1 `a189567eb9862fd282401a9a188681ff97ee3c066193a2f8f6e170d2eedad706ce213c431b6dd94f3764d8a2dbfc69b8`, and PCR2 `83b379d5613887558bc5fb32b63761be102e848dbc4a199e8d8857a2915344c98841fd96aab304b359d6d885308ec5ba`.

This is strong evidence that the layer is artifact-neutral on the current baseline. It is still construction evidence, not a Nitro runtime test, and no checked-in PCR value is changed here.

Part of stack #253. PR #250 remains an untouched draft reference.

## Observed rollout status — August 7, 2026

Anthony reviewed and accepted this explicit-wiring layer. Its PCR tuple matched #257, so no separate runtime deployment was required. It merged on August 6; later cumulative development boots passed and it is included in the successful #260 production checkpoint.