### PR TITLE
fix: return a VSOCK error after empty responses

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -175,6 +175,28 @@
           fi
         '';
 
+        # A derived package cannot safely consume a path nested inside the Git
+        # submodule. Fetch the exact reviewed toolkit revision explicitly.
+        nitroToolkitVsockSource = pkgs.fetchFromGitHub {
+          owner = "OpenSecretCloud";
+          repo = "nitro-toolkit";
+          rev = "dcfea5f66c3f0aea232b649da2ce3661be54cc14";
+          hash = "sha256-Q1bcR2J1cGQzSXR/lTjY3k5HERcevQqNvlvicaHAuN0=";
+        };
+
+        vsockHelper = pkgs.runCommand
+          "opensecret-vsock-helper-empty-response"
+          { nativeBuildInputs = [ pkgs.patch ]; }
+          ''
+            install -m 0644 ${nitroToolkitVsockSource}/vsock_helper.py vsock_helper.py
+            patch -p1 --fuzz=0 --batch --forward < ${./nix/vsock-helper-empty-response.patch}
+            ${pkgs.python3}/bin/python3 -m py_compile vsock_helper.py
+            VSOCK_HELPER_UNDER_TEST="$PWD/vsock_helper.py" \
+              ${pkgs.python3}/bin/python3 ${./tests/vsock_helper_empty_response.py}
+            mkdir -p "$out/app"
+            install -m 0444 vsock_helper.py "$out/app/vsock_helper.py"
+          '';
+
         # Function to create rootfs with specific APP_MODE
         mkRootfs = { appMode, opensecretPkg ? opensecret }: pkgs.buildEnv {
           name = "opensecret-rootfs-${appMode}";
@@ -239,11 +261,7 @@
               text = builtins.readFile ./nitro-toolkit/traffic_forwarder.py;
               destination = "/app/traffic_forwarder.py";
             })
-            (pkgs.writeTextFile {
-              name = "vsock_helper";
-              text = builtins.readFile ./nitro-toolkit/vsock_helper.py;
-              destination = "/app/vsock_helper.py";
-            })
+            vsockHelper
             pkgs.bash
             pkgs.busybox
             pkgs.openssl
@@ -535,6 +553,7 @@
         checks = {
           entrypoint-entropy-preflight = entrypointEntropyPreflight;
           kernel-source-pin = kernelSourcePin;
+          vsock-helper-empty-response = vsockHelper;
         } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
           kernel-security-invariants = kernelSecurityInvariants;
           nitro-helper = nitro-bins;

--- a/nix/vsock-helper-empty-response.patch
+++ b/nix/vsock-helper-empty-response.patch
@@ -1,0 +1,9 @@
+--- a/vsock_helper.py
++++ b/vsock_helper.py
+@@ -68,3 +68,3 @@ def vsock_request(cid, port, request, max_retries=5, retry_delay=10, initial_del
+-        else:
+-            print("Max retries reached. Returning error JSON.", file=sys.stderr)
+-            return json.dumps({"error": f"VSOCK connection failed after {max_retries} attempts"})
++
++    print("Max retries reached. Returning error JSON.", file=sys.stderr)
++    return json.dumps({"error": f"VSOCK connection failed after {max_retries} attempts"})

--- a/tests/vsock_helper_empty_response.py
+++ b/tests/vsock_helper_empty_response.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+
+helper_path = Path(os.environ["VSOCK_HELPER_UNDER_TEST"])
+spec = importlib.util.spec_from_file_location("vsock_helper_under_test", helper_path)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"could not load {helper_path}")
+
+helper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(helper)
+if not hasattr(helper.socket, "AF_VSOCK"):
+    helper.socket.AF_VSOCK = 40
+
+SUCCESSFUL_RESPONSE_BYTES = b'{"ok": true, "message": "unchanged"}'
+
+
+def expected_error(max_retries):
+    return json.dumps(
+        {"error": f"VSOCK connection failed after {max_retries} attempts"}
+    )
+
+
+class SuccessfulResponseSocket:
+    def __init__(self):
+        # Exercise the existing multi-chunk path and retain the exact payload.
+        self.chunks = [
+            SUCCESSFUL_RESPONSE_BYTES[:7],
+            SUCCESSFUL_RESPONSE_BYTES[7:19],
+            SUCCESSFUL_RESPONSE_BYTES[19:],
+            b"",
+        ]
+
+    def close(self):
+        pass
+
+    def connect(self, _address):
+        pass
+
+    def recv(self, _length):
+        return self.chunks.pop(0)
+
+    def sendall(self, _request):
+        pass
+
+    def settimeout(self, _seconds):
+        pass
+
+
+class EmptyResponseSocket:
+    def close(self):
+        pass
+
+    def connect(self, _address):
+        pass
+
+    def recv(self, _length):
+        return b""
+
+    def sendall(self, _request):
+        pass
+
+    def settimeout(self, _seconds):
+        pass
+
+
+class ReceiveFailureSocket(EmptyResponseSocket):
+    def __init__(self, error):
+        self.error = error
+
+    def recv(self, _length):
+        raise self.error
+
+
+successful_attempts = 0
+
+
+def successful_response_socket(*_args, **_kwargs):
+    global successful_attempts
+    successful_attempts += 1
+    return SuccessfulResponseSocket()
+
+
+helper.socket.socket = successful_response_socket
+helper.select.select = lambda *_args, **_kwargs: ([object()], [], [])
+helper.time.sleep = lambda _seconds: None
+
+successful_response = helper.vsock_request(
+    3,
+    8003,
+    "{}",
+    max_retries=3,
+    retry_delay=0,
+    initial_delay=0,
+)
+
+assert successful_attempts == 1
+assert successful_response.encode() == SUCCESSFUL_RESPONSE_BYTES
+assert json.loads(successful_response) == {"ok": True, "message": "unchanged"}
+
+
+retry_then_success_attempts = 0
+
+
+def empty_then_successful_response_socket(*_args, **_kwargs):
+    global retry_then_success_attempts
+    retry_then_success_attempts += 1
+    if retry_then_success_attempts == 1:
+        return EmptyResponseSocket()
+    return SuccessfulResponseSocket()
+
+
+helper.socket.socket = empty_then_successful_response_socket
+
+retry_then_success_response = helper.vsock_request(
+    3,
+    8003,
+    "{}",
+    max_retries=3,
+    retry_delay=0,
+    initial_delay=0,
+)
+
+assert retry_then_success_attempts == 2
+assert retry_then_success_response.encode() == SUCCESSFUL_RESPONSE_BYTES
+assert json.loads(retry_then_success_response) == {
+    "ok": True,
+    "message": "unchanged",
+}
+
+
+attempts = 0
+
+
+def empty_response_socket(*_args, **_kwargs):
+    global attempts
+    attempts += 1
+    return EmptyResponseSocket()
+
+
+helper.socket.socket = empty_response_socket
+helper.select.select = lambda *_args, **_kwargs: ([object()], [], [])
+helper.time.sleep = lambda _seconds: None
+
+max_retries = 3
+response = helper.vsock_request(
+    3,
+    8003,
+    "{}",
+    max_retries=max_retries,
+    retry_delay=0,
+    initial_delay=0,
+)
+
+assert attempts == max_retries
+assert response == expected_error(max_retries)
+
+
+def assert_receive_failure_fails_closed(error):
+    receive_attempts = 0
+
+    def receive_failure_socket(*_args, **_kwargs):
+        nonlocal receive_attempts
+        receive_attempts += 1
+        return ReceiveFailureSocket(error)
+
+    helper.socket.socket = receive_failure_socket
+    helper.select.select = lambda *_args, **_kwargs: ([object()], [], [])
+
+    response = helper.vsock_request(
+        3,
+        8003,
+        "{}",
+        max_retries=max_retries,
+        retry_delay=0,
+        initial_delay=0,
+    )
+
+    assert receive_attempts == max_retries
+    assert response == expected_error(max_retries)
+
+
+assert_receive_failure_fails_closed(helper.socket.error("fixture read error"))
+assert_receive_failure_fails_closed(helper.socket.timeout("fixture read timeout"))
+
+
+def unexpected_socket(*_args, **_kwargs):
+    raise AssertionError("zero retries must not create a socket")
+
+
+helper.socket.socket = unexpected_socket
+zero_retry_response = helper.vsock_request(
+    3,
+    8003,
+    "{}",
+    max_retries=0,
+    retry_delay=0,
+    initial_delay=0,
+)
+assert zero_retry_response == expected_error(0)
+
+print("vsock helper empty-response regression test passed")


### PR DESCRIPTION
## What this changes

The Nix-packaged bootstrap VSOCK helper now returns its existing JSON error after all attempts that produce no bytes, including EOF, timeout, socket error, or zero configured retries. Previously those paths could fall out of the function and print Python `None`.

The patch is applied to the exact Nitro toolkit revision pinned by the repository, compiled, regression-tested with fake sockets, and then installed as `/app/vsock_helper.py` in the EIF.

## Why

This makes the parent/enclave bootstrap contract deterministic and improves startup diagnostics. The current shell already fails closed when `None` reaches `jq`, so this is correctness and availability hardening—not a credential bypass or a critical RNG fix. Successful, fragmented, and retry-then-success responses are preserved.

It does not change key material, crypto formats, KMS policies, or secret values.

## Validation completed

- empty EOF, socket-error, timeout, zero-retry, fragmented success, and retry-then-success fixtures
- Python bytecode compilation of the patched helper
- `nix build .#checks.aarch64-darwin.vsock-helper-empty-response --no-link`
- `nix flake check --no-build --no-write-lock-file`

## Before merge

- rebase onto the then-current `master`
- build the exact Linux ARM EIF and update/review all four PCR current/history files
- require green reproducible-build CI
- dev-enclave smoke: successful startup credential/secret retrieval, existing login/chat, and one new chat

This PR is independent of the Continuum stack and #266. The separately held response-size experiment is not included.
