### PR TITLE
build: update Continuum proxy to v1.51.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -517,8 +517,8 @@
         };
         continuum-proxy =
           assert pkgs.lib.assertMsg (
-            continuumProxyUpstream.version == "1.47.0"
-          ) "This layer must preserve the deployed Continuum 1.47.0 release";
+            continuumProxyUpstream.version == "1.51.0"
+          ) "This layer must use the reviewed Continuum 1.51.0 release";
           assert pkgs.lib.assertMsg (
             continuumProxyUpstream.tag == "v${continuumProxyUpstream.version}"
           ) "The Continuum tag must match its reviewed version";
@@ -531,7 +531,7 @@
           ) "Continuum source and Go dependencies must use immutable SRI hashes";
           assert pkgs.lib.assertMsg (
             pkgs.lib.versions.majorMinor pkgs.go_1_26.version == "1.26"
-          ) "Continuum 1.47.0 must be built with the reviewed Go 1.26 toolchain";
+          ) "Continuum 1.51.0 must be built with the reviewed Go 1.26 toolchain";
           pkgs.buildGo126Module {
             pname = "continuum-proxy";
             inherit (continuumProxyUpstream) version;
@@ -558,7 +558,7 @@
               source_vendor_hash="$(sed -n 's/.*vendorHash = "\([^"]*\)".*/\1/p' \
                 nix/packages/by-name/continuum-canonical-go-package/package.nix)"
               if [ "$source_vendor_hash" != "${continuumProxyUpstream.vendorHash}" ]; then
-                echo "Continuum vendor hash differs from the reviewed v1.47.0 source" >&2
+                echo "Continuum vendor hash differs from the reviewed v1.51.0 source" >&2
                 exit 1
               fi
             '';

--- a/justfile
+++ b/justfile
@@ -176,7 +176,7 @@ build-continuum-proxy:
     nix build .#continuum-proxy --no-link --print-out-paths
 
 # Retained as a fail-closed migration aid for existing operator muscle memory.
-update-continuum-proxy version="v1.47.0":
+update-continuum-proxy version="v1.51.0":
     @just update-continuum-proxy-version {{version}}
 
 ### Local macOS Proxy Commands ###

--- a/nix/continuum-proxy.nix
+++ b/nix/continuum-proxy.nix
@@ -1,12 +1,11 @@
-# The source-built proxy intentionally stays on the currently deployed release.
-# Upgrade the version, tag, revision, source hash, and vendor hash together in a
-# separate compatibility-tested layer.
+# Keep the version, tag, revision, source hash, and vendor hash synchronized as
+# one compatibility-tested source update.
 {
-  version = "1.47.0";
-  tag = "v1.47.0";
+  version = "1.51.0";
+  tag = "v1.51.0";
   owner = "edgelesssys";
   repo = "privatemode-public";
-  rev = "4b72dcbbd58940835b5ba32502c1e247721b9584";
-  hash = "sha256-j9WkzJYFCqZ+e48MYGEM7+AIojt8ZwYDXbds2f11Vaw=";
-  vendorHash = "sha256-PomvHU2qdyTIfu8s8bBOnFZxiRLr/EBuPLivaOBDspU=";
+  rev = "4e625ecb28aeeabde65fe3b5d78864e02af1932c";
+  hash = "sha256-/nkkiaeKPZ/KswfM1/Nr1SBMslcijEFf2UTWSb/vwYQ=";
+  vendorHash = "sha256-adHo+dzpeWVnWk3VDVohZJK4C080JJRe/9XqaieMkuI=";
 }

--- a/tests/continuum_proxy_source_build.sh
+++ b/tests/continuum_proxy_source_build.sh
@@ -19,15 +19,15 @@ if grep -Fq '${./continuum-proxy}' "$repo_root/flake.nix"; then
     exit 1
 fi
 
-grep -Fq 'version = "1.47.0";' "$repo_root/nix/continuum-proxy.nix"
-grep -Fq 'tag = "v1.47.0";' "$repo_root/nix/continuum-proxy.nix"
+grep -Fq 'version = "1.51.0";' "$repo_root/nix/continuum-proxy.nix"
+grep -Fq 'tag = "v1.51.0";' "$repo_root/nix/continuum-proxy.nix"
 grep -Fq 'owner = "edgelesssys";' "$repo_root/nix/continuum-proxy.nix"
 grep -Fq 'repo = "privatemode-public";' "$repo_root/nix/continuum-proxy.nix"
-grep -Fq 'rev = "4b72dcbbd58940835b5ba32502c1e247721b9584";' \
+grep -Fq 'rev = "4e625ecb28aeeabde65fe3b5d78864e02af1932c";' \
     "$repo_root/nix/continuum-proxy.nix"
-grep -Fq 'hash = "sha256-j9WkzJYFCqZ+e48MYGEM7+AIojt8ZwYDXbds2f11Vaw=";' \
+grep -Fq 'hash = "sha256-/nkkiaeKPZ/KswfM1/Nr1SBMslcijEFf2UTWSb/vwYQ=";' \
     "$repo_root/nix/continuum-proxy.nix"
-grep -Fq 'vendorHash = "sha256-PomvHU2qdyTIfu8s8bBOnFZxiRLr/EBuPLivaOBDspU=";' \
+grep -Fq 'vendorHash = "sha256-adHo+dzpeWVnWk3VDVohZJK4C080JJRe/9XqaieMkuI=";' \
     "$repo_root/nix/continuum-proxy.nix"
 
 grep -Fq 'pkgs.buildGo126Module {' "$repo_root/flake.nix"
@@ -46,7 +46,7 @@ grep -Fq 'nix build .#continuum-proxy --no-link --print-out-paths' \
 
 if [ -e "$repo_root/.git" ]; then
     gitlink="$(git -C "$repo_root" ls-files --stage privatemode-public | awk '{ print $2 }')"
-    if [ "$gitlink" != "4b72dcbbd58940835b5ba32502c1e247721b9584" ]; then
+    if [ "$gitlink" != "4e625ecb28aeeabde65fe3b5d78864e02af1932c" ]; then
         echo "the local Continuum gitlink differs from the source-build revision" >&2
         exit 1
     fi


### PR DESCRIPTION
## Stack position

Child of #267. GitHub should show only the version/pin update after the v1.47 source-build foundation.

## What this changes

Updates the source-built Continuum proxy from v1.47.0 to current v1.51.0 and moves the reviewed tag, immutable revision, source hash, submodule gitlink, version assertions, and tests together. The Go vendor hash is unchanged from v1.50 because v1.51 did not change the module closure.

## Why v1.51 instead of v1.50

v1.50 was the original reviewed target, but upstream released v1.51.0 before publication. The direct v1.50→v1.51 proxy delta is small: explicit prompt-cache salts may be loaded from a file and must be at least 32 bytes, an obsolete pre-v1.40 request-ID fallback is removed, and log wording changes. OpenSecret does not pass an explicit salt, so its current generated lifetime salt behavior is unchanged.

The larger v1.47→v1.51 proxy changes include newer Contrast attestation handling, clearer 502/504 upstream errors, and forced downstream aborts when a stream fails after headers so a truncated generation is not mistaken for successful completion. This is valuable correctness and maintenance work, not an emergency confidentiality fix.

No OpenSecret key material, crypto format, KMS policy, database schema, or secret-delivery contract changes.

## Validation completed

- exact v1.51 tag/revision and source hash independently verified
- `bash tests/continuum_proxy_source_build.sh`
- `nix flake check --no-build --no-write-lock-file`
- `nix build .#continuum-proxy --no-link --print-build-logs`
- complete configured Go test scope passed
- static-link, version, required-flag, and vendor-hash install checks passed

## Before merge

1. Merge #267 first, preserving its tested v1.47 EIF as rollback, then retarget this PR to `master` and verify the diff remains this one version layer.
2. Build Linux ARM dev/prod EIFs and update/review all four PCR current/history files.
3. Require green reproducible-build CI.
4. Dev smoke: proxy v1.51 startup and Contrast attestation, existing account/chat, non-streaming Kimi request, streaming request reaching a valid terminal event, continued multi-turn request/shared cache, transcription if enabled, upstream failure mapping, and stable memory/process behavior.
5. Soak before production promotion.
