### PR TITLE
[HOLD — EXPERIMENT — DO NOT MERGE] disable CPU entropy credit

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -438,10 +438,17 @@
           ];
         };
 
-        # Preserve the currently deployed Nitro boot behavior explicitly. A
-        # trust-policy experiment belongs in its own held draft PR.
+        # Held trust-policy experiment: do not credit CPU RNG input toward
+        # kernel RNG initialization; preserve the bootloader trust default.
+        unverifiedEnclaveKernelCmdline =
+          "reboot=k panic=30 pci=off nomodules console=ttyS0 random.trust_cpu=off root=/dev/ram0";
         enclaveKernelCmdline =
-          "reboot=k panic=30 pci=off nomodules console=ttyS0 random.trust_cpu=on root=/dev/ram0";
+          assert pkgs.lib.assertMsg (
+            pkgs.lib.hasInfix "random.trust_cpu=off" unverifiedEnclaveKernelCmdline
+            && !(pkgs.lib.hasInfix "random.trust_cpu=on" unverifiedEnclaveKernelCmdline)
+            && !(pkgs.lib.hasInfix "random.trust_bootloader=" unverifiedEnclaveKernelCmdline)
+          ) "The held CPU trust experiment must disable only CPU entropy trust";
+          unverifiedEnclaveKernelCmdline;
 
         # Function to create EIF with specific APP_MODE
         mkEif = { appMode, opensecretPkg ? opensecret, nameSuffix ? "" }: nitro.buildEif {


### PR DESCRIPTION
> **HELD EXPERIMENT — DO NOT MERGE OR DEPLOY.** This is outside the merge train and must not update production PCR authorization.

## Experiment

Changes only the enclave kernel command line from `random.trust_cpu=on` to `random.trust_cpu=off` and asserts that bootloader trust remains at its kernel default.

Linux will continue mixing architectural CPU-RNG input, but will not credit it toward CRNG initialization. This does not disable CPU RNG instructions, affect AWS-LC's direct hardware inputs, or establish an NSM-only entropy chain. The effect may be negligible if the Nitro/Graviton environment exposes no architectural CPU RNG.

Current `master` already has Linux 6.12.101, NSM selection, blocking `getrandom` admission, and fail-closed helper seeding. This experiment addresses no confirmed weak-key incident; it explores a stricter trust model.

## Compatibility and measurements

- no intended application, key-material, format, KMS-policy, database, rootfs, or secret-handling change
- EIF digest, PCR0, and PCR1 are expected to change because the command line is measured
- PCR2 should remain stable only if the measured ramdisk is empirically identical
- existing KMS/client measurement authorization may reject the candidate

## Evidence required before any decision

- Linux ARM on/off EIF builds from otherwise identical sources
- debug-mode boot diagnostics for effective cmdline, NSM/HWRNG, CRNG admission, and readiness timing; discard debug PCRs
- repeated non-debug Nitro cold boots, fresh attestation, KMS startup, existing-state and new-chat smoke
- explicit latency/failure budget and rollback to the retained `trust_cpu=on` EIF

Local flake evaluation passed. No Nitro runtime claim is made.
