### PR TITLE
[HOLD — EXPERIMENT — DO NOT MERGE] cap VSOCK bootstrap responses

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -175,6 +175,28 @@
           fi
         '';
 
+        # Held response-size experiment. Fetch the exact Nitro toolkit revision
+        # currently pinned by the repository so the tested helper is also the
+        # helper packaged into the EIF.
+        nitroToolkitForVsockHelper = pkgs.fetchFromGitHub {
+          owner = "OpenSecretCloud";
+          repo = "nitro-toolkit";
+          rev = "dcfea5f66c3f0aea232b649da2ce3661be54cc14";
+          hash = "sha256-Q1bcR2J1cGQzSXR/lTjY3k5HERcevQqNvlvicaHAuN0=";
+        };
+        vsockHelper = pkgs.runCommand
+          "opensecret-vsock-helper-response-cap"
+          { nativeBuildInputs = [ pkgs.patch ]; }
+          ''
+            install -m 0644 ${nitroToolkitForVsockHelper}/vsock_helper.py vsock_helper.py
+            patch -p1 --fuzz=0 --batch --forward < ${./nix/vsock-helper-response-cap.patch}
+            ${pkgs.python3}/bin/python3 -m py_compile vsock_helper.py
+            VSOCK_HELPER_UNDER_TEST="$PWD/vsock_helper.py" \
+              ${pkgs.python3}/bin/python3 ${./tests/vsock_helper_response_cap.py}
+            mkdir -p "$out/app"
+            install -m 0444 vsock_helper.py "$out/app/vsock_helper.py"
+          '';
+
         # Function to create rootfs with specific APP_MODE
         mkRootfs = { appMode, opensecretPkg ? opensecret }: pkgs.buildEnv {
           name = "opensecret-rootfs-${appMode}";
@@ -239,11 +261,7 @@
               text = builtins.readFile ./nitro-toolkit/traffic_forwarder.py;
               destination = "/app/traffic_forwarder.py";
             })
-            (pkgs.writeTextFile {
-              name = "vsock_helper";
-              text = builtins.readFile ./nitro-toolkit/vsock_helper.py;
-              destination = "/app/vsock_helper.py";
-            })
+            vsockHelper
             pkgs.bash
             pkgs.busybox
             pkgs.openssl
@@ -535,6 +553,7 @@
         checks = {
           entrypoint-entropy-preflight = entrypointEntropyPreflight;
           kernel-source-pin = kernelSourcePin;
+          vsock-helper-response-cap = vsockHelper;
         } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
           kernel-security-invariants = kernelSecurityInvariants;
           nitro-helper = nitro-bins;

--- a/nix/vsock-helper-response-cap.patch
+++ b/nix/vsock-helper-response-cap.patch
@@ -1,0 +1,14 @@
+--- a/vsock_helper.py
++++ b/vsock_helper.py
+@@ -6,0 +7,4 @@
++
++# Bound the complete encoded parent response before appending each chunk.
++# Exactly 1 MiB is accepted; the first byte over the boundary fails closed.
++MAX_RESPONSE_BYTES = 1024 * 1024
+@@ -35,0 +40,6 @@
++                                if len(response) + len(chunk) > MAX_RESPONSE_BYTES:
++                                    print(
++                                        f"Response exceeded {MAX_RESPONSE_BYTES} byte limit",
++                                        file=sys.stderr,
++                                    )
++                                    return json.dumps({"error": "VSOCK response exceeded size limit"})

--- a/tests/vsock_helper_response_cap.py
+++ b/tests/vsock_helper_response_cap.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import io
+import json
+import os
+from contextlib import redirect_stderr
+from pathlib import Path
+
+
+helper_path = Path(os.environ["VSOCK_HELPER_UNDER_TEST"])
+spec = importlib.util.spec_from_file_location("vsock_helper_under_test", helper_path)
+if spec is None or spec.loader is None:
+    raise RuntimeError(f"could not load {helper_path}")
+
+helper = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(helper)
+if not hasattr(helper.socket, "AF_VSOCK"):
+    helper.socket.AF_VSOCK = 40
+assert helper.MAX_RESPONSE_BYTES == 1024 * 1024
+
+
+class ChunkedResponseSocket:
+    def __init__(self, chunks):
+        self.chunks = list(chunks)
+
+    def close(self):
+        pass
+
+    def connect(self, _address):
+        pass
+
+    def recv(self, length):
+        if not self.chunks:
+            raise AssertionError("helper read beyond the fixture response")
+        chunk = self.chunks.pop(0)
+        assert len(chunk) <= length
+        return chunk
+
+    def sendall(self, _request):
+        pass
+
+    def settimeout(self, _seconds):
+        pass
+
+
+def chunks_for(payload):
+    chunk_size = 4096
+    return [
+        payload[offset : offset + chunk_size]
+        for offset in range(0, len(payload), chunk_size)
+    ] + [b""]
+
+
+def request_with_payload(payload):
+    fake_socket = ChunkedResponseSocket(chunks_for(payload))
+    socket_attempts = 0
+
+    def socket_factory(*_args, **_kwargs):
+        nonlocal socket_attempts
+        socket_attempts += 1
+        return fake_socket
+
+    helper.socket.socket = socket_factory
+    helper.select.select = lambda *_args, **_kwargs: ([fake_socket], [], [])
+    helper.time.sleep = lambda _seconds: None
+    with redirect_stderr(io.StringIO()):
+        response = helper.vsock_request(
+            3,
+            8003,
+            "{}",
+            max_retries=3,
+            retry_delay=0,
+            initial_delay=0,
+        )
+    return response, fake_socket, socket_attempts
+
+
+json_prefix = b'{"ok":"'
+json_suffix = b'"}'
+json_overhead = len(json_prefix) + len(json_suffix)
+
+small_payload = json_prefix + b"x" * 8192 + json_suffix
+small_response, small_socket, small_attempts = request_with_payload(small_payload)
+assert json.loads(small_response) == {"ok": "x" * 8192}
+assert not small_socket.chunks
+assert small_attempts == 1
+
+at_limit_payload = (
+    json_prefix
+    + b"x" * (helper.MAX_RESPONSE_BYTES - json_overhead)
+    + json_suffix
+)
+assert len(at_limit_payload) == helper.MAX_RESPONSE_BYTES
+at_limit_response, at_limit_socket, at_limit_attempts = request_with_payload(
+    at_limit_payload
+)
+assert len(at_limit_response.encode()) == helper.MAX_RESPONSE_BYTES
+assert len(json.loads(at_limit_response)["ok"]) == (
+    helper.MAX_RESPONSE_BYTES - json_overhead
+)
+assert not at_limit_socket.chunks
+assert at_limit_attempts == 1
+
+over_limit_payload = (
+    json_prefix
+    + b"x" * (helper.MAX_RESPONSE_BYTES + 1 - json_overhead)
+    + json_suffix
+)
+assert len(over_limit_payload) == helper.MAX_RESPONSE_BYTES + 1
+over_limit_response, over_limit_socket, over_limit_attempts = request_with_payload(
+    over_limit_payload
+)
+assert json.loads(over_limit_response) == {
+    "error": "VSOCK response exceeded size limit"
+}
+# The helper rejects the byte that crosses the limit without waiting for EOF.
+assert over_limit_socket.chunks == [b""]
+assert over_limit_attempts == 1
+
+print("vsock helper response-cap boundary tests passed")


### PR DESCRIPTION
> **HELD EXPERIMENT — DO NOT MERGE OR DEPLOY.** The limit and compatibility contract are not approved.

## Experiment

Caps the complete encoded response read by the Python bootstrap VSOCK helper at exactly 1 MiB. The first byte over the boundary returns a synthetic JSON error and startup fails closed. Exactly 1 MiB remains accepted.

This bounds memory growth if the parent credential requester is buggy or compromised. It affects only bootstrap reads for credentials/secrets through `/app/vsock_helper.py`; it does not cap traffic/log forwarders or Rust runtime VSOCK reads. The Rust runtime path already has a separate 256 KiB limit.

## Why held

The threat is availability/resource exhaustion, not confidentiality or key integrity, and the parent can already deny enclave service. Known bootstrap responses are far smaller, but 1 MiB has not been justified as a durable protocol limit and a future legitimate larger response would become startup-fatal. The cap also does not stop a slow trickle below the size threshold.

No key material, crypto format, KMS policy, or secret value changes.

## Validation completed

- small fragmented response succeeds
- exactly 1 MiB succeeds
- 1 MiB + 1 byte rejects immediately without waiting for EOF
- patched helper compiles and the Nix-packaged fixture passes
- `nix flake check --no-build --no-write-lock-file`

Before consideration: choose and document a protocol limit, reconcile it with the 256 KiB Rust cap, test all four bootstrap response types on a real dev enclave, update PCRs, and prove rollback.
