### PR TITLE
ci: gate EIF builds on native flake checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,12 +42,22 @@ jobs:
         with:
           flake-lock-path: flake.lock
 
+      # Realize every native ARM security check exported by the current flake.
+      # New checks join this gate automatically instead of being duplicated in
+      # a hard-coded workflow list.
+      - name: Run native security checks
+        run: |
+          set -euo pipefail
+          nix flake check '.?submodules=1' --no-write-lock-file --print-build-logs
+          git diff --exit-code -- flake.lock
+
       # Build development EIF directly using Nix package
       - name: Build dev EIF
         id: build-dev
         run: |
           set -euo pipefail
-          nix build .?submodules=1#eif-dev
+          nix build '.?submodules=1#eif-dev' --no-write-lock-file --print-build-logs
+          git diff --exit-code -- flake.lock
           echo "Build completed successfully"
 
       # Verify PCR values match the reference
@@ -109,12 +119,21 @@ jobs:
         with:
           flake-lock-path: flake.lock
 
+      # Repeat the dynamic native gate so the independently scheduled
+      # production job cannot publish an EIF after a failed semantic check.
+      - name: Run native security checks
+        run: |
+          set -euo pipefail
+          nix flake check '.?submodules=1' --no-write-lock-file --print-build-logs
+          git diff --exit-code -- flake.lock
+
       # Build production EIF directly using Nix package
       - name: Build prod EIF
         id: build-prod
         run: |
           set -euo pipefail
-          nix build .?submodules=1#eif-prod
+          nix build '.?submodules=1#eif-prod' --no-write-lock-file --print-build-logs
+          git diff --exit-code -- flake.lock
           echo "Build completed successfully"
 
       # Verify PCR values match the reference

--- a/tests/entrypoint_entropy_preflight.sh
+++ b/tests/entrypoint_entropy_preflight.sh
@@ -27,17 +27,11 @@ if [ -z "$gate_line" ] || [ -z "$log_forwarder_line" ] || [ "$gate_line" -ge "$l
 fi
 
 pass_getrandom="$work_dir/pass-getrandom"
-cat > "$pass_getrandom" <<'EOF'
-#!/usr/bin/env bash
-exit 0
-EOF
+printf '#!%s\nexit 0\n' "$BASH" > "$pass_getrandom"
 chmod +x "$pass_getrandom"
 
 fail_getrandom="$work_dir/fail-getrandom"
-cat > "$fail_getrandom" <<'EOF'
-#!/usr/bin/env bash
-exit 1
-EOF
+printf '#!%s\nexit 1\n' "$BASH" > "$fail_getrandom"
 chmod +x "$fail_getrandom"
 
 rng_current="$work_dir/rng_current"


### PR DESCRIPTION
## What this changes

Before each ARM dev or production EIF build, CI now runs the security checks exported by the current flake and fails if evaluation mutates `flake.lock`. The EIF build itself also uses `--no-write-lock-file` and verifies the lock file remains unchanged.

This dynamically gates the checks that exist on the branch, so future rootfs, Continuum, or VSOCK checks join CI automatically. It does not resurrect #250's hard-coded gate script, whose check list and monolithic upstream-freshness assumptions are now obsolete.

The first native run immediately found a real portability defect in the existing entropy fixture: generated fake helpers used `/usr/bin/env`, which a Linux Nix sandbox does not provide. The fixture now writes the absolute path of the exact Bash running the test. Production entrypoint code is unchanged.

## Why

Current CI builds EIFs and compares PCRs, but it does not realize three independent merged semantic checks:

- entrypoint entropy admission/fail-close behavior
- the reviewed Linux 6.12.101 NSM source fixes
- the final kernel security configuration

PCR equality proves artifact consistency; it does not prove those semantic properties. This is process assurance, not a runtime or key-material change.

## Scope and compatibility

One workflow file plus one test-fixture portability fix. No application runtime, EIF input, PCR value, crypto format, KMS policy, secret, or deployment command changes. ARM CI will take longer, and any newly exported flake check becomes blocking by design.

## Validation

- workflow YAML parses locally
- direct entropy fixture passes
- Nix-packaged entropy fixture passes on Darwin
- `nix flake check --no-build --no-write-lock-file` passes locally
- patch passes whitespace validation

The authoritative test is the PR's native ARM workflow run.
