### PR TITLE
ci: isolate pull-request Nix cache credentials

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,9 @@ jobs:
     # Custom runner required: ARM64 architecture needed for AWS Nitro Enclaves
     # 4 cores needed for efficient builds and PCR verification
     runs-on: ubuntu-22.04-arm64-4core
+    # This job executes pull-request code. Keep it outside the authenticated
+    # FlakeHub/OIDC trust boundary while retaining PR-scoped GitHub caching.
     permissions:
-      id-token: write
       contents: read
     steps:
       - name: Check out repository
@@ -34,8 +35,11 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/determinate-nix-action@bafaa638b9d5ec0e7e3ac1a7fc80453ef1fd265f # v3
       
-      - name: Enable FlakeHub Cache
-        uses: DeterminateSystems/flakehub-cache-action@1f9a51a2959d3e26c7838c6f3bf9f48acae525ea # v3
+      - name: Enable PR-scoped Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@3c034b51a9deec0a09ef1df8b436ac5db50fae94
+        with:
+          use-flakehub: disabled
+          use-gha-cache: enabled
 
       - name: Check flake.lock health
         uses: DeterminateSystems/flake-checker-action@0af51e37404acfb298f7e2eec77470be27eb57c5 # v10


### PR DESCRIPTION
## What this changes

The development EIF job, which executes pull-request code, no longer receives GitHub OIDC (`id-token: write`) and no longer authenticates to FlakeHub Cache. It uses the already-nested pinned Determinate Magic Nix Cache action explicitly in GitHub-Actions-cache-only mode.

The trusted production job remains unchanged and keeps its existing OIDC-backed FlakeHub cache. Artifact upload behavior is also unchanged.

## Why

This narrows the credential boundary around untrusted PR code without throwing away build caching. GitHub PR cache entries are scoped to the PR merge ref and cannot be restored by the base branch or other PRs. The previous FlakeHub wrapper would fall back non-fatally when OIDC was absent, but making GHA-only behavior explicit is quieter and less brittle.

This is preventive CI trust-boundary hardening; it is not evidence that a token or cache was compromised.

## Compatibility

Workflow only. No application, EIF input, PCR, key material, KMS policy, secret handling, or deployment behavior changes. Master development builds will also use GHA caching because the existing `dev` job handles both PR and trusted events; production builds retain FlakeHub caching.

## Validation

- workflow YAML parses locally
- pinned action and its `use-flakehub` / `use-gha-cache` inputs verified at the exact commit
- patch passes whitespace validation

The authoritative validation is successful installation/cache startup and an ARM EIF build in this PR.
