### PR TITLE
ci: run Postgres-backed crypto regression tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,6 +66,20 @@ jobs:
   test:
     name: Test Suite
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17@sha256:7958605b474b3d264a969cb3a123d6aa00ad1e1fe9da8a69984dabb704d93317
+        env:
+          POSTGRES_USER: opensecret_user
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: opensecret
+        options: >-
+          --health-cmd "pg_isready -U opensecret_user -d opensecret"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -80,10 +94,29 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libpq-dev pkg-config libssl-dev
+          sudo apt-get install -y libpq-dev pkg-config libssl-dev postgresql-client
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
+      - name: Apply database migrations
+        env:
+          AEAD_TAMPER_TEST_DATABASE_URL: postgres://opensecret_user:password@localhost:5432/opensecret
+        run: |
+          set -euo pipefail
+          for migration in migrations/*/up.sql; do
+            psql "$AEAD_TAMPER_TEST_DATABASE_URL" \
+              --set ON_ERROR_STOP=1 \
+              --single-transaction \
+              --file "$migration"
+          done
+
       - name: Run tests
         run: cargo test --locked --all-features
+
+      - name: Run Postgres-backed security tests
+        env:
+          AEAD_TAMPER_TEST_DATABASE_URL: postgres://opensecret_user:password@localhost:5432/opensecret
+        run: |
+          cargo test --locked --all-features aead_db_tamper_tests:: -- --ignored --test-threads=1
+          cargo test --locked --all-features web::oauth_routes::tests::db_oauth_ -- --ignored --test-threads=1


### PR DESCRIPTION
## What this changes

The existing Rust test job now starts a disposable PostgreSQL 17 service, applies the repository's 31 SQL migrations, and runs the existing ignored database-security suites serially:

- 14 AEAD binding/tamper, password/reset, OAuth-wrap, and encrypted-storage tests
- 2 OAuth route database identity/linking tests

The official PostgreSQL multi-architecture image is pinned by digest. The test database and credentials exist only inside the ephemeral GitHub runner.

## Why

Ordinary `cargo test` skips these tests because they require a migrated disposable database. They exercise important fail-closed properties against row substitution and authentication-context tampering, so leaving them permanently outside CI creates a regression-coverage gap. This PR changes coverage, not production behavior, and does not claim a current vulnerability.

## Scope and compatibility

One workflow file only. No Rust source, test logic, migrations, application runtime, EIF, PCR, KMS policy, key material, or secret handling changes.

The migrations are plain SQL and currently contain no non-transactional operations, so each file is applied with `psql --single-transaction` and `ON_ERROR_STOP`. A future migration that must run outside a transaction will fail visibly and require revisiting this runner.

## Local validation

- workflow YAML parses
- patch passes whitespace validation
- all 31 `up.sql` migrations were inventoried
- no current migration uses `CREATE INDEX CONCURRENTLY`, `ALTER TYPE ... ADD VALUE`, or a no-transaction marker

The authoritative validation is this PR's GitHub-hosted Postgres/Rust CI run.
