### PR TITLE
docs: add concise agent guidance and safer local setup

### DIFF
--- a/.agents/skills/change-opensecret-api/SKILL.md
+++ b/.agents/skills/change-opensecret-api/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: change-opensecret-api
+description: Change or review OpenSecret HTTP APIs and their Maple or SDK consumers. Use for route, authentication, attestation-session, encrypted request or response, OpenAI-compatible payload, Responses or conversation persistence, error-status, SSE streaming, or cross-client compatibility work in the opensecret backend.
+---
+
+# Change the OpenSecret API
+
+Treat the backend, released SDKs, and Maple as one protocol. Preserve the security envelope and existing public behavior unless the task explicitly changes the contract.
+
+## Establish the live contract
+
+1. Read the repository `AGENTS.md` and relevant local docs.
+2. Confirm the checkout, base, and existing changes before editing. Preserve unrelated work.
+3. Derive the current route inventory from source; never trust a copied endpoint table:
+
+   ```sh
+   rg -n -C 2 '\.route\(' src/web
+   sed -n '3660,3735p' src/main.rs
+   ```
+
+4. Trace one route end to end: router method and middleware, request type, handler, storage/provider calls, response type, tests, SDK method, and Maple call site.
+5. Classify the route before changing it:
+
+   - Health and attestation bootstrap routes are unauthenticated and unencrypted.
+   - Login, registration, password recovery, and OAuth bootstrap routes are not JWT-authenticated, but still use the attested encryption session.
+   - Protected, Responses, conversation, instruction, project, and direct web routes require a user JWT plus the encryption session.
+   - OpenAI-shaped inference routes accept a user JWT or a UUID API key plus the encryption session.
+   - `/platform/*` belongs to a separate control-plane surface. Leave it out of Maple-facing work unless the task names it.
+
+Use `src/main.rs` router composition as the authority for outer authentication middleware and each route module as the authority for inner decryption middleware.
+
+## Preserve the transport boundary
+
+The public OpenAI-shaped API is not a plaintext OpenAI wire API. Clients must use an OpenSecret SDK or reproduce its verified protocol.
+
+- `GET /attestation/:nonce` binds a one-time server X25519 key to the attestation document.
+- `POST /key_exchange` consumes that nonce and returns a session ID plus an encrypted session key.
+- Every protected request carries `x-session-id`.
+- A mutating request body is JSON shaped as `{"encrypted":"<base64>"}`. The decoded bytes are `12-byte nonce || ChaCha20-Poly1305 ciphertext and tag`.
+- GET, DELETE, and typed bodyless requests omit the encrypted body, but still require a live session. They are not public simply because the body is empty.
+- A successful non-streaming response is an encrypted JSON envelope. Do not return successful plaintext data from an encrypted route.
+- Normal SSE `data:` payloads are independently encrypted and base64-encoded. Chat's terminal `data: [DONE]` marker is the only normal plaintext data frame.
+- Keep a session lease alive through the complete response body. A streaming handler must not release or evict its session while the client is reading.
+
+Inspect the live limits rather than copying their values:
+
+```sh
+rg -n 'MAX_ENCRYPTED_BODY_BYTES|MAX_ATTESTATION_NONCE_BYTES|MAX_PENDING_ATTESTATIONS|PENDING_ATTESTATION_TTL|MAX_ENCRYPTION_SESSIONS|ENCRYPTION_SESSION_IDLE_TTL' src
+```
+
+Security-sensitive implementation lives in:
+
+- `src/web/attestation_routes.rs`
+- `src/web/encryption_middleware.rs`
+- the session-cache and encrypt/decrypt methods in `src/main.rs`
+- `src/lease_aware_cache.rs` and `src/bounded_ttl_cache.rs`
+
+Do not bypass attestation in a non-local client, weaken the contributory X25519 check, reuse a consumed nonce, log session keys or plaintext payloads, or accept an unknown session on a bodyless route.
+
+## Preserve authentication semantics
+
+Use `src/web/openai_auth.rs` and `src/jwt.rs` as the source of truth.
+
+- `Authorization: Bearer <uuid>` is an API key only on the OpenAI-shaped router. The backend hashes the canonical UUID string before lookup.
+- Otherwise the credential is a user access JWT. Validation includes user lookup, project binding, and active seed-wrap verification.
+- General protected routes use JWT authentication, not API-key fallback.
+- An API key changes usage attribution and quota selection. Keep `AuthMethod` intact through inference and usage code.
+- Never accept project or user identity from a request body when middleware has already established it.
+
+API keys are created and managed through authenticated protected routes. Do not expose stored hashes, reconstruct a key, or add provider credentials to the client API.
+
+## Handle errors without breaking SDK recovery
+
+Pre-stream failures use the ordinary HTTP status and a plaintext JSON body shaped as `{"status": number, "message": string}`. Successful encrypted responses remain encrypted. Derive the current mapping from `ApiError::into_response` in `src/main.rs`.
+
+Preserve these distinctions:
+
+- 400: malformed request, encrypted payload, or stale/unknown session.
+- 401: invalid user/API authentication.
+- 403: entitlement or usage denial.
+- 404/409/413/422/429: their specific resource or validation conditions.
+- 503: a temporarily unavailable required upstream.
+- 500: an internal or non-recoverable provider failure.
+
+Do not casually change 400 or 401 behavior. Released clients may perform one re-attestation retry after a 400 and one auth refresh after a 401. Validate all provider-free input before writes so a replay cannot duplicate side effects. For a new side-effecting route, prefer an explicit idempotency mechanism or a distinct stale-session signal over relying on ambiguous retry behavior.
+
+Once an SSE response has started, send a typed encrypted error event. Never
+insert plaintext `data: Error...`, `data: encryption_failed`, or another
+non-terminal plaintext payload: strict SDK transports reject it as corrupt
+rather than exposing unauthenticated inference output.
+
+## Work with OpenAI-shaped inference routes
+
+Derive the exact inference routes and payload structs from `src/web/openai.rs`:
+
+```sh
+rg -n -C 3 'pub fn router|struct TTSRequest|struct TranscriptionRequest|struct EmbeddingRequest' src/web/openai.rs
+```
+
+Keep these non-obvious contracts in mind:
+
+- Chat completions intentionally accept an extensible JSON object, but require a model. Provider-owned request fields are rewritten at the backend boundary.
+- Non-streaming chat returns encrypted completion JSON. Streaming chat preserves upstream JSON chunks, canonicalizes the public model ID, encrypts each data frame, and terminates once.
+- `/v1/models` and `/v1/models/catalog` are backend-owned public views. They are not raw provider discovery results.
+- Speech accepts a JSON payload, validates and supplies backend-owned model/voice defaults, and returns audio through an encrypted payload containing base64 bytes and content type. SDK custom-fetch adapters may present those bytes as an ordinary audio response to Maple.
+- Transcription accepts a JSON request whose `file` is base64 audio. It is not the ordinary public OpenAI multipart contract, even though the backend builds multipart at the provider boundary.
+- Embeddings accept a string or array input and return encrypted provider-compatible JSON.
+
+For any changed request or response, verify status, headers, exact body shape, streaming/non-streaming behavior, size limits, cancellation, and usage. Do not infer compatibility from the route name alone.
+
+## Work with Responses and stored conversations
+
+The Responses surface is deliberately OpenAI-shaped but not a complete OpenAI implementation. Re-read `src/web/responses/handlers.rs`, `constants.rs`, `events.rs`, `context_builder.rs`, and the conversation/instruction/project modules before changing it.
+
+Current behavior that must be preserved or changed deliberately:
+
+- `conversation` is required and accepts a UUID string or `{id: UUID}`.
+- `input` accepts a string or message array, but the current persistence path uses the first normalized message as the new user message. Do not claim arbitrary multi-message semantics without implementing and testing them.
+- Creation always returns SSE. The `stream` field is recorded/logged but does not currently select a non-streaming response.
+- The request and generated items are persisted even when `store` is false; the flag is stored on the response record. Do not describe it as a no-storage guarantee.
+- User-visible web search is requested as `{"type":"web_search"}`. The backend maps it to provider function tools and forces one tool call at a time.
+- Tool-loop exhaustion disables tools and lets the model finish with accumulated context; retain the internal untrusted-web safety prompt.
+
+Keep the persistence phases ordered:
+
+1. Validate authentication, ownership, payload features, and model access.
+2. Derive the user encryption key, normalize content, count tokens, and enforce context/entitlement limits.
+3. Build context without writes.
+4. Persist the response and user message only after validation succeeds.
+5. Persist assistant, reasoning, tool-call, and tool-output items in emitted order as the stream advances.
+6. Continue the storage/orchestration work when the client disconnects unless an explicit cancellation is recorded.
+
+Conversation content, attachment text, instructions, response metadata, and tool data that can contain user content must remain encrypted at rest with the user's derived key. Ownership checks precede decryption and mutation. Cancellation only applies to an active response; deletion must preserve the intended cascade and ownership rules.
+
+Derive event names and sequence behavior from source:
+
+```sh
+rg -n 'EVENT_|STATUS_' src/web/responses/constants.rs
+rg -n 'ResponseEvent|sequence_number|responses_sse_response' src/web/responses/events.rs src/web/responses/handlers.rs
+```
+
+Keep the SSE `event:` name and decrypted JSON `type` consistent. Sequence numbers advance only under the policy encoded in `ResponseEvent`; cancellation/error behavior is intentionally different from ordinary events. Preserve `Cache-Control: no-cache`, disabled proxy buffering, keepalives, terminal completion/cancellation/error, and durable item ordering.
+
+## Check every client boundary
+
+Locate consumers rather than assuming a sibling layout:
+
+```sh
+rg -n 'VITE_OPEN_SECRET_API_URL|aiCustomFetch|/v1/chat/completions|/v1/models|/v1/audio/speech' ../maple frontend 2>/dev/null
+rg -n '@opensecret/react|opensecret = |name = "opensecret"' ../maple/frontend/package.json ../maple/frontend/src-tauri/Cargo.toml ../maple/frontend/src-tauri/Cargo.lock 2>/dev/null
+```
+
+At minimum, inspect these Maple seams when present:
+
+- Browser Research chat constructs an OpenAI client around
+  `useOpenSecret().aiCustomFetch` and sends stored streaming requests through
+  `/v1/responses` plus the Conversations API.
+- Browser TTS also uses `aiCustomFetch` and expects the SDK adapter's audio response behavior.
+- Native Agent Mode separately sends caller-owned chat-completion bytes through
+  the pinned Rust SDK inference transport to `/v1/chat/completions`; it does
+  not internally use Responses or Maple's local proxy.
+- Maple's local OpenAI-compatible proxy exposes models/chat to local tools and ultimately depends on the same backend contract.
+
+A semantic field intended for both Research chat and Agent Mode is not one
+shared wire-field change. Model it in the Responses request/context/provider
+turn and independently in the chat-completions/Goose request path, then prove
+each pinned client transport.
+
+For a Responses field, trace `ResponsesCreateRequest`,
+`build_model_turn_request`, and `persist_request_data` in
+`src/web/responses/handlers.rs`, plus `src/models/responses.rs` and the generated
+Responses tables in `src/models/schema.rs`. For a chat/provider or usage field,
+trace the shared handoff and usage accumulator/publication in
+`src/web/openai.rs`, `UsageEvent` in `src/sqs.rs`, and the local token-usage
+model/schema. This reveals whether the change is transport-only, persisted,
+metered, or all three.
+
+Use the versions pinned by Maple, not a convenient SDK checkout. For a changed route:
+
+- Update SDK request/response types and typed methods where applicable.
+- If the Rust lossless inference transport must expose a new route, update its explicit method/path allowlist and header/body/SSE tests.
+- Update the React/JavaScript SDK custom-fetch transformation if content type or envelope behavior changes.
+- Update Maple call sites, mocks, fixtures, and user-facing error mapping.
+- Test both old-client/new-server and new-client/old-server behavior for the
+  pinned TypeScript Research path and Rust Agent path. Do not rely on unknown
+  fields being rejected, ignored, or preserved unless tests prove that exact
+  behavior. Prefer a server-first rollout for additive OpenSecret fields; use
+  an explicit capability/version gate when either direction cannot interoperate.
+  Do not silently require an unreleased SDK.
+
+## Validate the change
+
+Run targeted tests while iterating, then the repository validation skill. Useful discovery and targeted commands include:
+
+```sh
+rg -n '#\[cfg\(test\)\]|#\[tokio::test\]|#\[test\]' src/web src/jwt.rs
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c cargo test --locked --all-features web::openai::tests
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c cargo test --locked --all-features web::responses::handlers::tests
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c cargo test --locked --all-features web::encryption_middleware::tests
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c cargo fmt --all -- --check
+git diff --check
+```
+
+Use a single Cargo test filter per command. Run the full locked all-feature test and Clippy gates before handoff.
+
+For smoke testing, plain `curl` is appropriate for `/health-check` and `/health-check-extended` only. Exercise encrypted routes through a released/pinned SDK and test both JWT and API-key authentication when the change affects the OpenAI router. Use a disposable local database, run Diesel schema migrations first, and point Maple at the chosen local/dev/prod OpenSecret URL. Billing and flag services are external API dependencies; configure their URLs/keys only when the scenario needs their entitlement or flag behavior, and treat them solely as HTTP API boundaries.
+
+Report exactly what was exercised: unit contract, local encrypted SDK call, provider-backed stream, Maple browser path, Maple native path, or GUI smoke. A backend test alone is not end-to-end proof.

--- a/.agents/skills/change-opensecret-api/SKILL.md
+++ b/.agents/skills/change-opensecret-api/SKILL.md
@@ -1,212 +1,117 @@
 ---
 name: change-opensecret-api
-description: Change or review OpenSecret HTTP APIs and their Maple or SDK consumers. Use for route, authentication, attestation-session, encrypted request or response, OpenAI-compatible payload, Responses or conversation persistence, error-status, SSE streaming, or cross-client compatibility work in the opensecret backend.
+description: Change or review OpenSecret HTTP contracts and their SDK or Maple consumers. Use for routes, authentication context, attested encrypted requests or responses, OpenAI-shaped payloads, Responses or conversation persistence, errors, SSE streaming, cancellation, or cross-client compatibility.
 ---
 
 # Change the OpenSecret API
 
-Treat the backend, released SDKs, and Maple as one protocol. Preserve the security envelope and existing public behavior unless the task explicitly changes the contract.
+Treat OpenSecret, released SDKs, and affected Maple paths as one versioned
+protocol. Preserve existing public behavior unless the task deliberately
+changes it.
 
-## Establish the live contract
+Normative rules in this skill govern new or changed code; they do not certify
+untouched paths. Re-confirm current behavior from source and tests. If an
+unrelated path conflicts with a rule, keep that observation task-local and do
+not broaden the change without user approval.
 
-1. Read the repository `AGENTS.md` and relevant local docs.
-2. Confirm the checkout, base, and existing changes before editing. Preserve unrelated work.
-3. Derive the current route inventory from source; never trust a copied endpoint table:
+## Trace the live contract
 
-   ```sh
-   rg -n -C 2 '\.route\(' src/web
-   sed -n '3660,3735p' src/main.rs
-   ```
+Derive the route from current router assembly in `src/main.rs` and its module in
+`src/web/`; do not maintain a copied endpoint table. Trace one request through:
 
-4. Trace one route end to end: router method and middleware, request type, handler, storage/provider calls, response type, tests, SDK method, and Maple call site.
-5. Classify the route before changing it:
+1. method, path, middleware order, and established auth context;
+2. decryption and typed or extensible request validation;
+3. authorization, storage, provider, and usage side effects;
+4. status, headers, body or SSE projection, and error mapping;
+5. focused tests, released SDK support, and pinned Maple consumers.
 
-   - Health and attestation bootstrap routes are unauthenticated and unencrypted.
-   - Login, registration, password recovery, and OAuth bootstrap routes are not JWT-authenticated, but still use the attested encryption session.
-   - Protected, Responses, conversation, instruction, project, and direct web routes require a user JWT plus the encryption session.
-   - OpenAI-shaped inference routes accept a user JWT or a UUID API key plus the encryption session.
-   - `/platform/*` belongs to a separate control-plane surface. Leave it out of Maple-facing work unless the task names it.
+Use router assembly as the authority for outer authentication and the route
+module as the authority for inner session/decryption middleware. Use
+`src/web/openai.rs` for OpenAI-shaped inference routes and
+`src/web/responses/` for Responses, conversations, tools, persistence, and
+events.
 
-Use `src/main.rs` router composition as the authority for outer authentication middleware and each route module as the authority for inner decryption middleware.
+## Preserve transport and identity boundaries
 
-## Preserve the transport boundary
+- OpenAI-shaped describes the decrypted payload, not a plaintext wire API.
+  Protected routes require the OpenSecret attestation/session protocol and a
+  route-appropriate auth context.
+- A session protects transport; it does not establish user identity, project
+  membership, or storage-key ownership. Bodyless protected routes still
+  validate and touch the session.
+- JWT and API-key contexts are distinct. Preserve the auth method through
+  authorization, persistence eligibility, quota, and usage attribution.
+- Hold the session lease for the complete response body or stream. Successful
+  protected responses and ordinary stream events remain encrypted according to
+  the established client protocol.
+- Validate provider-free input before writes. Pinned clients may recover from
+  selected session or auth failures by retrying, so a side-effecting change
+  needs explicit idempotency or proof that validation precedes the effect.
 
-The public OpenAI-shaped API is not a plaintext OpenAI wire API. Clients must use an OpenSecret SDK or reproduce its verified protocol.
+Inspect `src/web/attestation_routes.rs`,
+`src/web/encryption_middleware.rs`, session state in `src/main.rs`,
+`src/web/openai_auth.rs`, and `src/jwt.rs` when the change reaches those
+boundaries. Do not duplicate their policy inside a handler.
 
-- `GET /attestation/:nonce` binds a one-time server X25519 key to the attestation document.
-- `POST /key_exchange` consumes that nonce and returns a session ID plus an encrypted session key.
-- Every protected request carries `x-session-id`.
-- A mutating request body is JSON shaped as `{"encrypted":"<base64>"}`. The decoded bytes are `12-byte nonce || ChaCha20-Poly1305 ciphertext and tag`.
-- GET, DELETE, and typed bodyless requests omit the encrypted body, but still require a live session. They are not public simply because the body is empty.
-- A successful non-streaming response is an encrypted JSON envelope. Do not return successful plaintext data from an encrypted route.
-- Normal SSE `data:` payloads are independently encrypted and base64-encoded. Chat's terminal `data: [DONE]` marker is the only normal plaintext data frame.
-- Keep a session lease alive through the complete response body. A streaming handler must not release or evict its session while the client is reading.
+Derive errors from the response type actually returned by the route. Handlers
+returning `ApiError` use its mapping in `src/main.rs`; route-local error types
+may intentionally differ. For a new or intentionally revised contract, use
+stable HTTP semantics and sanitized public bodies. Once a changed stream has
+started, use its typed encrypted error event rather than introducing an
+unauthenticated plaintext data frame.
 
-Inspect the live limits rather than copying their values:
+## Preserve stateful Responses behavior
 
-```sh
-rg -n 'MAX_ENCRYPTED_BODY_BYTES|MAX_ATTESTATION_NONCE_BYTES|MAX_PENDING_ATTESTATIONS|PENDING_ATTESTATION_TTL|MAX_ENCRYPTION_SESSIONS|ENCRYPTION_SESSION_IDLE_TTL' src
-```
+Read `src/web/responses/handlers.rs`, `constants.rs`, `events.rs`, and
+`context_builder.rs` together with the response/conversation models and
+schema. Derive supported fields and event names from those files rather than
+from upstream API documentation.
 
-Security-sensitive implementation lives in:
+Preserve these ordering rules unless the contract change explicitly replaces
+them:
 
-- `src/web/attestation_routes.rs`
-- `src/web/encryption_middleware.rs`
-- the session-cache and encrypt/decrypt methods in `src/main.rs`
-- `src/lease_aware_cache.rs` and `src/bounded_ttl_cache.rs`
+- authenticate, authorize ownership, validate payload/model limits, and build
+  context before durable writes;
+- check ownership before decrypting or mutating user content;
+- keep user content in its established user-key encryption domain;
+- persist assistant, reasoning, tool, and output items in emitted order;
+- keep event names, decrypted `type`, sequence policy, terminal status,
+  cancellation, and durable item ordering consistent.
 
-Do not bypass attestation in a non-local client, weaken the contributory X25519 check, reuse a consumed nonce, log session keys or plaintext payloads, or accept an unknown session on a bodyless route.
+Do not equate a dropped client stream with explicit cancellation. Define and
+test the disconnect points affected by the change, and claim background
+continuation only after source and tests establish independent task ownership
+at those points.
 
-## Preserve authentication semantics
+## Coordinate pinned consumers
 
-Use `src/web/openai_auth.rs` and `src/jwt.rs` as the source of truth.
+Resolve OpenSecret SDK and Maple checkouts independently. Search each available
+repository from its own root, without hiding errors, and follow its checked-in
+`AGENTS.md` and applicable skills when present. If a consumer checkout is
+unavailable, report compatibility as unverified rather than claiming there are
+no consumers.
 
-- `Authorization: Bearer <uuid>` is an API key only on the OpenAI-shaped router. The backend hashes the canonical UUID string before lookup.
-- Otherwise the credential is a user access JWT. Validation includes user lookup, project binding, and active seed-wrap verification.
-- General protected routes use JWT authentication, not API-key fallback.
-- An API key changes usage attribution and quota selection. Keep `AuthMethod` intact through inference and usage code.
-- Never accept project or user identity from a request body when middleware has already established it.
+Maple's browser Research path uses Responses/Conversations through the
+TypeScript client, while native Agent Mode uses chat completions through the
+Rust client. A semantic change intended for both is two protocol integrations,
+not one shared wire-field edit. Trace request construction, provider handoff,
+persistence, and usage in each affected path.
 
-API keys are created and managed through authenticated protected routes. Do not expose stored hashes, reconstruct a key, or add provider credentials to the client API.
+Use the versions pinned by the selected Maple revision. Update SDK types,
+custom-fetch adaptation, native transport allowlists, call sites, mocks, and
+fixtures only where the contract reaches them. Test old-client/new-server and
+new-client/old-server behavior. Prefer server-first rollout for compatible
+additions; use an explicit capability/version gate when either direction cannot
+interoperate.
 
-## Handle errors without breaking SDK recovery
+## Validate the changed boundary
 
-Pre-stream failures use the ordinary HTTP status and a plaintext JSON body shaped as `{"status": number, "message": string}`. Successful encrypted responses remain encrypted. Derive the current mapping from `ApiError::into_response` in `src/main.rs`.
+Run focused owning-module tests while iterating, then load
+`$validate-opensecret` for the complete gate. Exercise protected contracts
+through a pinned encrypted client, not plaintext `curl`, and cover each auth
+mode the change affects. Include the applicable Maple browser or native path
+for a client-facing change.
 
-Preserve these distinctions:
-
-- 400: malformed request, encrypted payload, or stale/unknown session.
-- 401: invalid user/API authentication.
-- 403: entitlement or usage denial.
-- 404/409/413/422/429: their specific resource or validation conditions.
-- 503: a temporarily unavailable required upstream.
-- 500: an internal or non-recoverable provider failure.
-
-Do not casually change 400 or 401 behavior. Released clients may perform one re-attestation retry after a 400 and one auth refresh after a 401. Validate all provider-free input before writes so a replay cannot duplicate side effects. For a new side-effecting route, prefer an explicit idempotency mechanism or a distinct stale-session signal over relying on ambiguous retry behavior.
-
-Once an SSE response has started, send a typed encrypted error event. Never
-insert plaintext `data: Error...`, `data: encryption_failed`, or another
-non-terminal plaintext payload: strict SDK transports reject it as corrupt
-rather than exposing unauthenticated inference output.
-
-## Work with OpenAI-shaped inference routes
-
-Derive the exact inference routes and payload structs from `src/web/openai.rs`:
-
-```sh
-rg -n -C 3 'pub fn router|struct TTSRequest|struct TranscriptionRequest|struct EmbeddingRequest' src/web/openai.rs
-```
-
-Keep these non-obvious contracts in mind:
-
-- Chat completions intentionally accept an extensible JSON object, but require a model. Provider-owned request fields are rewritten at the backend boundary.
-- Non-streaming chat returns encrypted completion JSON. Streaming chat preserves upstream JSON chunks, canonicalizes the public model ID, encrypts each data frame, and terminates once.
-- `/v1/models` and `/v1/models/catalog` are backend-owned public views. They are not raw provider discovery results.
-- Speech accepts a JSON payload, validates and supplies backend-owned model/voice defaults, and returns audio through an encrypted payload containing base64 bytes and content type. SDK custom-fetch adapters may present those bytes as an ordinary audio response to Maple.
-- Transcription accepts a JSON request whose `file` is base64 audio. It is not the ordinary public OpenAI multipart contract, even though the backend builds multipart at the provider boundary.
-- Embeddings accept a string or array input and return encrypted provider-compatible JSON.
-
-For any changed request or response, verify status, headers, exact body shape, streaming/non-streaming behavior, size limits, cancellation, and usage. Do not infer compatibility from the route name alone.
-
-## Work with Responses and stored conversations
-
-The Responses surface is deliberately OpenAI-shaped but not a complete OpenAI implementation. Re-read `src/web/responses/handlers.rs`, `constants.rs`, `events.rs`, `context_builder.rs`, and the conversation/instruction/project modules before changing it.
-
-Current behavior that must be preserved or changed deliberately:
-
-- `conversation` is required and accepts a UUID string or `{id: UUID}`.
-- `input` accepts a string or message array, but the current persistence path uses the first normalized message as the new user message. Do not claim arbitrary multi-message semantics without implementing and testing them.
-- Creation always returns SSE. The `stream` field is recorded/logged but does not currently select a non-streaming response.
-- The request and generated items are persisted even when `store` is false; the flag is stored on the response record. Do not describe it as a no-storage guarantee.
-- User-visible web search is requested as `{"type":"web_search"}`. The backend maps it to provider function tools and forces one tool call at a time.
-- Tool-loop exhaustion disables tools and lets the model finish with accumulated context; retain the internal untrusted-web safety prompt.
-
-Keep the persistence phases ordered:
-
-1. Validate authentication, ownership, payload features, and model access.
-2. Derive the user encryption key, normalize content, count tokens, and enforce context/entitlement limits.
-3. Build context without writes.
-4. Persist the response and user message only after validation succeeds.
-5. Persist assistant, reasoning, tool-call, and tool-output items in emitted order as the stream advances.
-6. Continue the storage/orchestration work when the client disconnects unless an explicit cancellation is recorded.
-
-Conversation content, attachment text, instructions, response metadata, and tool data that can contain user content must remain encrypted at rest with the user's derived key. Ownership checks precede decryption and mutation. Cancellation only applies to an active response; deletion must preserve the intended cascade and ownership rules.
-
-Derive event names and sequence behavior from source:
-
-```sh
-rg -n 'EVENT_|STATUS_' src/web/responses/constants.rs
-rg -n 'ResponseEvent|sequence_number|responses_sse_response' src/web/responses/events.rs src/web/responses/handlers.rs
-```
-
-Keep the SSE `event:` name and decrypted JSON `type` consistent. Sequence numbers advance only under the policy encoded in `ResponseEvent`; cancellation/error behavior is intentionally different from ordinary events. Preserve `Cache-Control: no-cache`, disabled proxy buffering, keepalives, terminal completion/cancellation/error, and durable item ordering.
-
-## Check every client boundary
-
-Locate consumers rather than assuming a sibling layout:
-
-```sh
-rg -n 'VITE_OPEN_SECRET_API_URL|aiCustomFetch|/v1/chat/completions|/v1/models|/v1/audio/speech' ../maple frontend 2>/dev/null
-rg -n '@opensecret/react|opensecret = |name = "opensecret"' ../maple/frontend/package.json ../maple/frontend/src-tauri/Cargo.toml ../maple/frontend/src-tauri/Cargo.lock 2>/dev/null
-```
-
-At minimum, inspect these Maple seams when present:
-
-- Browser Research chat constructs an OpenAI client around
-  `useOpenSecret().aiCustomFetch` and sends stored streaming requests through
-  `/v1/responses` plus the Conversations API.
-- Browser TTS also uses `aiCustomFetch` and expects the SDK adapter's audio response behavior.
-- Native Agent Mode separately sends caller-owned chat-completion bytes through
-  the pinned Rust SDK inference transport to `/v1/chat/completions`; it does
-  not internally use Responses or Maple's local proxy.
-- Maple's local OpenAI-compatible proxy exposes models/chat to local tools and ultimately depends on the same backend contract.
-
-A semantic field intended for both Research chat and Agent Mode is not one
-shared wire-field change. Model it in the Responses request/context/provider
-turn and independently in the chat-completions/Goose request path, then prove
-each pinned client transport.
-
-For a Responses field, trace `ResponsesCreateRequest`,
-`build_model_turn_request`, and `persist_request_data` in
-`src/web/responses/handlers.rs`, plus `src/models/responses.rs` and the generated
-Responses tables in `src/models/schema.rs`. For a chat/provider or usage field,
-trace the shared handoff and usage accumulator/publication in
-`src/web/openai.rs`, `UsageEvent` in `src/sqs.rs`, and the local token-usage
-model/schema. This reveals whether the change is transport-only, persisted,
-metered, or all three.
-
-Use the versions pinned by Maple, not a convenient SDK checkout. For a changed route:
-
-- Update SDK request/response types and typed methods where applicable.
-- If the Rust lossless inference transport must expose a new route, update its explicit method/path allowlist and header/body/SSE tests.
-- Update the React/JavaScript SDK custom-fetch transformation if content type or envelope behavior changes.
-- Update Maple call sites, mocks, fixtures, and user-facing error mapping.
-- Test both old-client/new-server and new-client/old-server behavior for the
-  pinned TypeScript Research path and Rust Agent path. Do not rely on unknown
-  fields being rejected, ignored, or preserved unless tests prove that exact
-  behavior. Prefer a server-first rollout for additive OpenSecret fields; use
-  an explicit capability/version gate when either direction cannot interoperate.
-  Do not silently require an unreleased SDK.
-
-## Validate the change
-
-Run targeted tests while iterating, then the repository validation skill. Useful discovery and targeted commands include:
-
-```sh
-rg -n '#\[cfg\(test\)\]|#\[tokio::test\]|#\[test\]' src/web src/jwt.rs
-OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c cargo test --locked --all-features web::openai::tests
-OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c cargo test --locked --all-features web::responses::handlers::tests
-OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c cargo test --locked --all-features web::encryption_middleware::tests
-OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c cargo fmt --all -- --check
-git diff --check
-```
-
-Use a single Cargo test filter per command. Run the full locked all-feature test and Clippy gates before handoff.
-
-For smoke testing, plain `curl` is appropriate for `/health-check` and `/health-check-extended` only. Exercise encrypted routes through a released/pinned SDK and test both JWT and API-key authentication when the change affects the OpenAI router. Use a disposable local database, run Diesel schema migrations first, and point Maple at the chosen local/dev/prod OpenSecret URL. Billing and flag services are external API dependencies; configure their URLs/keys only when the scenario needs their entitlement or flag behavior, and treat them solely as HTTP API boundaries.
-
-Report exactly what was exercised: unit contract, local encrypted SDK call, provider-backed stream, Maple browser path, Maple native path, or GUI smoke. A backend test alone is not end-to-end proof.
+Label evidence precisely: unit contract, encrypted SDK call, provider-backed
+stream, Maple browser, Maple native, or deployed environment. One layer does
+not prove the others.

--- a/.agents/skills/change-opensecret-api/agents/openai.yaml
+++ b/.agents/skills/change-opensecret-api/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Change OpenSecret API"
+  short_description: "Evolve encrypted and OpenAI-compatible APIs"
+  default_prompt: "Use $change-opensecret-api to evolve this OpenSecret API contract safely."

--- a/.agents/skills/change-opensecret-provider/SKILL.md
+++ b/.agents/skills/change-opensecret-provider/SKILL.md
@@ -1,224 +1,122 @@
 ---
 name: change-opensecret-provider
-description: Change or review OpenSecret inference and web-provider integrations. Use for model catalog entries or aliases, Tinfoil or Continuum routing, provider credentials and attestation, request or response canonicalization, retries, headers, cache fields, usage accounting, health checks, web search or extraction providers, and direct provider parity testing.
+description: Change or review OpenSecret inference and web-provider integrations. Use for model catalog entries or aliases, provider routing, Tinfoil or standard-provider transport, credentials, attestation, request or response canonicalization, retries, headers, cache namespaces, usage accounting, audio or embeddings, web search, or extraction.
 ---
 
-# Change an OpenSecret Provider
-
-Keep providers behind the backend boundary. Maple and public API clients choose public capabilities and model IDs; OpenSecret owns provider selection, credentials, transport security, provider model translation, request policy, response normalization, and usage attribution.
-
-## Establish the live provider graph
-
-Read `AGENTS.md`, inspect the checkout, and derive the current graph from source. Provider and model inventories change frequently; never copy a static list from this skill into code or documentation.
-
-```sh
-rg -n 'MODEL_CONFIGS|MODEL_ALIAS_ENTRIES|QUICK_MODEL_ID|POWERFUL_MODEL_ID|openai_models_response|model_catalog_response' src/model_config.rs
-rg -n 'PROVIDERS|MODEL_ROUTES|ModelProviderRoute|default_provider|flag_key|select_completion_route' src/provider_routing.rs
-rg -n 'get_completion_proxy|get_default_proxy|get_tinfoil_proxy|provider_name' src/proxy_config.rs
-rg -n 'ProviderClient|ProviderRequest|TinfoilUnavailable|send_standard|forwarded_headers|skipped_forward_headers' src/provider_client.rs
-```
-
-Trace the requested model through:
-
-1. Public alias and access resolution in `src/model_config.rs`.
-2. User-specific model-access and routing flags in `src/main.rs` and `src/os_flags.rs`.
-3. Provider route selection in `src/provider_routing.rs`.
-4. Provider-model translation and managed request fields in `src/web/openai.rs`.
-5. Transport construction in `src/provider_client.rs`.
-6. Public response-model canonicalization and usage publication.
-7. Responses-specific sampling, reasoning history, and tool behavior.
-
-The checked-in code is authoritative. Design notes and old parity evidence explain intent but may describe a previous provider set or launch phase.
-
-## Preserve the public model contract
-
-Centralize model behavior in `src/model_config.rs`. A model change may affect all of these together:
-
-- canonical public ID and provider ID;
-- display/catalog metadata and ordering;
-- listed versus API-only visibility;
-- enabled and feature-gated access;
-- access tier and chat/vision/reasoning/tool-use capabilities;
-- context window and prompt budget;
-- Responses sampling and current-turn thinking behavior;
-- prior-reasoning replay strategy;
-- public aliases and quick/powerful defaults;
-- `/v1/models`, `/v1/models/catalog`, audio/embedding entries, and Maple selectors.
-
-Do not add an ID in one response builder or route handler. Add it to the centralized configuration and test alias resolution, access filtering, both model-list surfaces, completion validation, Responses context limits, and the actual upstream provider ID.
-
-Keep public IDs provider-neutral and pinned. Do not expose `latest`, provider hostnames, routing flags, weights, or provider-specific model spellings. Translate only immediately before sending and canonicalize returned `model` fields to the public ID for non-streaming and streaming responses.
-
-Reasoning is model-specific. Distinguish:
-
-- emitting reasoning in the current turn;
-- preserving prior assistant reasoning in later prompt history;
-- provider-specific template kwargs needed for either behavior.
-
-Never infer replay support from visible answer quality. Prove it with direct provider probes that compare prompt-token deltas and a recall prompt, then encode the result in the model strategy and unit tests.
-
-## Preserve routing semantics
-
-Use `src/provider_routing.rs` as the sole completion-routing policy. The current architecture supports model-specific eligible routes, provider and route weights, an explicit default, stable UUID bucketing when no preference wins, and user-specific flag preferences.
-
-Do not describe configured weights as active traffic distribution without tracing precedence. An explicit flag preference or model default can bypass weighted selection entirely. Missing flag configuration, missing flag values, timeouts, and flag-service errors fall back to the model's default route rather than exposing control-plane failure to the client.
-
-Maintain these boundaries:
-
-- Route using the authenticated account UUID, not a request-provided identity.
-- Keep aliases resolved before routing.
-- Keep feature-flag keys canonical in `src/os_flags.rs`.
-- Keep selection deterministic for the same account/configuration.
-- Record the actual provider but bill and respond with the canonical public model.
-- Return a client error for an unsupported public model and an internal error for a valid model with no eligible configured route.
-- Do not accept a client-specified provider or provider-model ID.
-
-Chat completion currently selects one route and tries it once. Do not add backend-level cross-provider replay after a timeout, ambiguous body error, partial stream, or provider status. A POST may already have caused computation and usage. If product requirements call for failover, design idempotency, side-effect accounting, stream semantics, and rollout observability first.
-
-## Preserve provider transport security
-
-Tinfoil and ordinary OpenAI-compatible transports are intentionally different.
-
-### Tinfoil
-
-- `TINFOIL_API_KEY` is a hard backend startup requirement. Local mode may read the gitignored `.local/secrets/tinfoil_api_key`.
-- The in-process Tinfoil SDK discovers and attests an enclave in the background, pins TLS to the verified enclave, and shares its connection pool.
-- Backend startup and non-Tinfoil routes do not wait for discovery. Tinfoil-dependent requests return 503 while the attested client is unavailable.
-- Discovery attempts are bounded and back off. Derive current timings from `provider_client.rs`.
-- A typed DNS/TCP/TLS connect failure may trigger one single-flight rediscovery/attestation and one identical-byte retry. Request, body, response, timeout, provider-status, and partially streamed failures are not replayed by this layer.
-- Recovery tasks must not retain a request body or be cancelled when one caller times out.
-
-Do not replace this path with an unauthenticated localhost sidecar, ordinary CA-only TLS, a caller-selected enclave, or a fallback that skips attestation.
-
-### Continuum or another standard provider
-
-- `OPENAI_API_BASE` configures the ordinary compatible base. The supported
-  local Continuum recipe uses the loopback URL documented in
-  `docs/local-macos-stack.md` and does not need an OpenAI credential. Treat any
-  other custom base as a credential boundary: derive URL classification and
-  header behavior from current source and cover it with exact-host and
-  adversarial-host tests before using credentials.
-- Local macOS Continuum runs as its own native proxy; Tinfoil does not have a local proxy port.
-- Adding another provider requires a clear transport/authentication policy. Do not route a confidential workload through the ordinary client merely because its API is OpenAI-shaped.
-
-Provider secrets stay server-side, in environment/gitignored local secret files or the existing non-local secret path. Never place a real key in `.env.sample`, source, tests, evidence, logs, URLs, client headers, Maple configuration, or shell history.
-
-## Sanitize and own request fields
-
-Both transports must strip inbound authorization, host, content length/type controlled by the backend, hop-by-hop headers, and every header named by `Connection`. Preserve only safe end-to-end headers, then set the provider credential and content type explicitly. Extend both Tinfoil and standard sanitizers together and add network-boundary tests for any header-policy change.
-
-OpenSecret also owns provider cache fields:
-
-- Strip caller-supplied `cache_salt`.
-- For Tinfoil, replace `user_cache_secret` with the stable SHA-256 namespace derived from the authenticated user UUID.
-- For other providers, strip caller-supplied `user_cache_secret`.
-
-Do not expose the raw user UUID to a provider when a derived namespace is sufficient. Do not let a caller select another user's cache namespace.
-
-Log bounded request metadata, not prompts, images, audio, credentials, full
-headers, or full responses. Redact provider diagnostics before returning them
-publicly, and add semantic tests or source invariants for newly introduced
-sensitive fields where practical.
-
-## Preserve response, stream, and usage semantics
-
-For chat completions:
-
-- Force `stream_options.include_usage=true` on streaming upstream requests.
-- Parse SSE at complete frame boundaries and support LF and CRLF framing.
-- Preserve complete upstream JSON chunks while replacing provider model IDs with the canonical public ID.
-- Treat `[DONE]` as the authoritative terminal marker. A finish reason is terminal evidence, but a later usage-only frame may still arrive.
-- If the upstream ends without `[DONE]`, use the existing terminal-evidence policy; do not publish partial usage as successful usage without that evidence.
-- Emit exactly one public `[DONE]` and exactly one usage publication.
-
-Usage parsing clamps numeric values, tracks prompt and completion tokens, and bounds cached prompt tokens by total prompt tokens. Preserve:
-
-- actual provider name;
-- canonical public model name;
-- JWT versus API-key attribution;
-- cached input tokens when present;
-- asynchronous local persistence and optional event publication;
-- no event when both token counts are zero.
-
-The local cost field is observability, not the authoritative billing price.
-When entitlement behavior matters, configure the external billing API URL/key
-and test the backend's public outcomes: allowed, denied, unavailable, and guest
-behavior. Treat billing solely as an HTTP API boundary.
-
-Responses calls the shared completion sender, so provider changes can affect stored conversations, tool loops, title generation, reasoning history, and usage aggregation. Ensure the Responses orchestrator does not publish duplicate usage for a multi-turn tool response.
-
-## Treat audio and embeddings as provider contracts
-
-Derive the current provider choice, model translations, size limits, and retries from `src/web/openai.rs` and `src/web/audio_utils.rs`.
-
-- Speech is currently provider-owned through the Tinfoil transport and has paid-entitlement, timeout, model, voice, and encrypted base64-response behavior.
-- Transcription accepts base64 input at the public boundary, splits audio when necessary, maps model IDs per provider, and has explicit primary/fallback behavior. This is separate from chat's no-failover rule.
-- Embeddings use their configured provider, validate non-empty input, encrypt the public response, and publish prompt-token usage.
-
-When changing any of these, test both public payload compatibility and the exact provider request. Do not generalize transcription retry behavior to chat or speech.
-
-## Keep web providers and web content untrusted
-
-There are two related but distinct surfaces:
-
-1. Direct authenticated `/v1/web/search` and `/v1/web/extract` are provider-neutral public APIs implemented by `src/web/web_routes.rs`. Their current adapter is Kagi.
-2. The Responses `web_search` tool chooses an available Brave or Kagi tool implementation. Kagi additionally exposes internal `open_urls` extraction to the model.
-
-Derive the exact schemas, limits, and selection rules:
-
-```sh
-rg -n 'WEB_SEARCH_PATH|WEB_EXTRACT_PATH|MAX_|DEFAULT_|deny_unknown_fields' src/web/web_routes.rs src/kagi.rs src/brave.rs
-rg -n 'choose_web_search_provider|ToolRegistry|web_search|open_urls|allowed_urls' src/web/responses/handlers.rs src/web/responses/tools.rs
-```
-
-Preserve these security properties:
-
-- Keep search and page extraction separate. Search metadata is not page content.
-- Accept extraction only for normalized public HTTPS URLs. Reject credentials, local/reserved/metadata hosts, control characters, non-HTTPS schemes, and duplicates.
-- Treat titles, snippets, diagnostics, and extracted Markdown as untrusted data. Strip image embeds and bound text before putting it into model context.
-- Authorize Kagi `open_urls` from exact normalized URLs visibly supplied by the user or canonical URL fields generated by trusted Kagi formatters.
-- Never authorize a URL merely because it appears in assistant text, a title/snippet, diagnostics, Brave free-form output, or an extracted page body.
-- Reconstruct authorized URLs from visible persisted history on continuation; do not rely only on request-local discovery state.
-- Keep provider traces sanitized and bounded. Do not return provider-specific experimental payloads or arbitrary personalization controls.
-
-If the external flag API is absent or fails, preserve the documented provider
-fallback. Configure its base URL/key for a specific dev/prod environment when
-testing flag behavior and treat it solely as an HTTP API boundary.
-
-## Interpret health correctly
-
-`/health-check` is process liveness only and does not test the database. `/health-check-extended` performs a bounded direct Tinfoil model-list request. It demonstrates current Tinfoil discovery/attestation/connectivity, not database readiness, billing, flags, Brave, Kagi, Continuum, migrations, or Maple compatibility.
-
-Use the successful Tinfoil discovery/attestation log plus extended health as provider-readiness evidence. Repeated discovery failures, attestation/certificate errors, timeouts, 503s, or connection failures are actionable. Normal HTTP/2 connection rotation or graceful shutdown logs alone are not failure proof.
-
-## Validate safely
-
-Start with deterministic unit and boundary tests:
-
-```sh
-OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c cargo test --locked --all-features provider_routing::tests
-OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c cargo test --locked --all-features model_config::tests
-OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c cargo test --locked --all-features provider_client::tests
-OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c cargo test --locked --all-features web::openai::tests
-OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c cargo test --locked --all-features web::web_routes::tests
-OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c cargo test --locked --all-features web::web_safety::tests
-OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c cargo test --locked --all-features web::responses::tools::tests
-OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c cargo fmt --all -- --check
-git diff --check
-```
-
-Use one Cargo filter per command. Then run the repository's full validation skill, including locked all-feature tests and strict Clippy.
-
-Run live provider probes only when the task needs them and credentials/egress are authorized. Prefer deterministic prompts and paid/free fixtures that make routing and usage observable without recording user data. Keep raw evidence outside the repository and redact credentials, authorization headers, enclave proof metadata, and sensitive response content.
-
-For the existing ignored Tinfoil parity test, derive the exact test name and evidence variables from `docs/tinfoil-rust-sdk-parity.md` and `src/provider_client.rs`; do not paste a possibly stale command. Its parity boundary is decrypted method/path/query, safe end-to-end headers, exact request bytes, status/content type/schema, ordered SSE semantics, numeric usage, and one terminal marker—not TLS record bytes, header order/casing, connection reuse, or generated text/chunk boundaries.
-
-For a model reasoning claim, probe the provider directly before changing backend policy. For an application contract claim, also smoke the encrypted OpenSecret route through the SDK. For a Maple compatibility claim, run the relevant browser or native Maple path. Report each layer separately and never call a provider-only check end-to-end proof.
+# Change an OpenSecret provider
+
+Keep providers behind the backend boundary. Clients select public models and
+capabilities; OpenSecret owns provider selection, credentials, transport,
+provider-model translation, request policy, response normalization, and usage
+attribution.
+
+## Trace the live provider path
+
+Derive the current graph from source instead of copying provider or model
+inventories:
+
+- `src/model_config.rs`: canonical public IDs, aliases, capabilities, limits,
+  visibility, and access.
+- `src/provider_routing.rs` and `src/os_flags.rs`: eligible routes and backend
+  selection policy.
+- `src/proxy_config.rs`: provider endpoints and credentials.
+- `src/provider_client.rs`: standard and attested transport, headers,
+  streaming, and retry decisions.
+- `src/web/openai.rs` and `src/web/responses/`: route-specific request
+  rewriting, canonical response projection, tools, and usage.
+- `src/web/web_routes.rs`, `src/brave.rs`, and `src/kagi.rs`: public web
+  contracts and provider adapters.
+
+Trace the changed public model or capability through every affected layer and
+its tests. Historical parity notes can explain intent, but current source and
+pinned consumers define the contract.
+
+## Preserve the public contract
+
+- Configure public model behavior centrally. Do not add an ID only in a route
+  response or selector.
+- Keep public IDs provider-neutral and pinned. Resolve aliases before routing,
+  translate immediately before send, and canonicalize provider IDs in both
+  streaming and non-streaming responses.
+- Route from authenticated identity and backend policy. Never accept a
+  caller-supplied provider, upstream model ID, routing flag, or another user's
+  cache namespace.
+- Keep model capability, access, routing, endpoint/credential resolution,
+  transport, and route orchestration in their owning layers.
+- Treat current-turn reasoning and replay of prior reasoning as separate model
+  capabilities. Prove provider-specific behavior before encoding it as policy.
+
+When billing or feature flags affect the path, treat them only as configured
+external HTTP APIs. Keep their credentials backend-only and test the changed
+call site's unavailable, timeout, denial, fallback, and success semantics.
+
+## Preserve transport and retry safety
+
+Tinfoil and ordinary OpenAI-compatible providers are distinct trust boundaries.
+Preserve Tinfoil discovery, attestation, origin-bound TLS, bounded recovery,
+and the no-downgrade rule. A new standard provider needs an explicit endpoint,
+authentication, confidentiality, and error policy; an OpenAI-shaped API alone
+does not establish those properties.
+
+Classify custom provider bases and credential forwarding from parsed current
+configuration, not string intuition. Cover exact approved hosts and adversarial
+hostnames when changing URL or credential behavior.
+
+Retry only when the transport proves request bytes were not accepted. Do not
+replay an ambiguous completion POST after a timeout, response error, provider
+status, or partial stream without an explicit idempotency and accounting
+design. A refresh task must not retain a request body or inherit one caller's
+cancellation accidentally.
+
+## Own outbound data
+
+- Replace inbound authorization with the configured provider credential and
+  keep secrets out of URLs, public responses, client configuration, evidence,
+  and logs.
+- Review forwarded headers and `Connection`-named headers explicitly. The
+  backend owns host, framing, content type, credentials, and provider-managed
+  request fields.
+- Derive cache namespaces from authenticated backend identity. Strip or
+  replace caller-controlled provider cache fields according to the selected
+  provider policy.
+- Log only bounded, allowlisted metadata. Sanitize upstream errors before
+  returning them publicly.
+
+Add boundary tests for every changed header, credential, URL, cache, or request
+rewrite rule.
+
+## Preserve streams and usage
+
+Parse complete frames, support the established line endings, preserve ordered
+JSON chunks, canonicalize model IDs, propagate cancellation, and emit exactly
+one terminal condition. Distinguish finish evidence from final usage frames.
+
+Normalize usage once and retain the actual provider, canonical public model,
+and established JWT/API-key attribution. Do not publish successful usage for a
+partial or unterminated response unless the owning contract explicitly defines
+that outcome. Review Responses multi-turn aggregation so a tool loop does not
+duplicate usage.
+
+Audio, transcription, and embeddings have independent payload, provider,
+limit, and retry policies in `src/web/openai.rs` and
+`src/web/audio_utils.rs`; do not generalize chat behavior to them.
+
+## Keep web content untrusted
+
+Keep search and extraction separate. Normalize and authorize public HTTPS URLs
+under the current provenance and SSRF policy, and bound all provider results
+before placing them in model context. Do not grant URL authority from assistant
+text, snippets, diagnostics, or extracted page content. When continuation can
+resume tool history, reconstruct authority only from visible persisted inputs
+and trusted structured provider output.
+
+## Validate the changed layers
+
+Run focused model, routing, transport, route, usage, or web-safety tests while
+iterating, then load `$validate-opensecret`. Live provider probes require
+explicit credential, egress, and cost authorization; keep raw evidence outside
+the repository and redact it.
+
+Use `docs/tinfoil-rust-sdk-parity.md` for the named Tinfoil live boundary. A
+provider-direct probe, encrypted OpenSecret SDK smoke, and Maple smoke prove
+different layers; run and report each layer that the change claims.

--- a/.agents/skills/change-opensecret-provider/SKILL.md
+++ b/.agents/skills/change-opensecret-provider/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: change-opensecret-provider
+description: Change or review OpenSecret inference and web-provider integrations. Use for model catalog entries or aliases, Tinfoil or Continuum routing, provider credentials and attestation, request or response canonicalization, retries, headers, cache fields, usage accounting, health checks, web search or extraction providers, and direct provider parity testing.
+---
+
+# Change an OpenSecret Provider
+
+Keep providers behind the backend boundary. Maple and public API clients choose public capabilities and model IDs; OpenSecret owns provider selection, credentials, transport security, provider model translation, request policy, response normalization, and usage attribution.
+
+## Establish the live provider graph
+
+Read `AGENTS.md`, inspect the checkout, and derive the current graph from source. Provider and model inventories change frequently; never copy a static list from this skill into code or documentation.
+
+```sh
+rg -n 'MODEL_CONFIGS|MODEL_ALIAS_ENTRIES|QUICK_MODEL_ID|POWERFUL_MODEL_ID|openai_models_response|model_catalog_response' src/model_config.rs
+rg -n 'PROVIDERS|MODEL_ROUTES|ModelProviderRoute|default_provider|flag_key|select_completion_route' src/provider_routing.rs
+rg -n 'get_completion_proxy|get_default_proxy|get_tinfoil_proxy|provider_name' src/proxy_config.rs
+rg -n 'ProviderClient|ProviderRequest|TinfoilUnavailable|send_standard|forwarded_headers|skipped_forward_headers' src/provider_client.rs
+```
+
+Trace the requested model through:
+
+1. Public alias and access resolution in `src/model_config.rs`.
+2. User-specific model-access and routing flags in `src/main.rs` and `src/os_flags.rs`.
+3. Provider route selection in `src/provider_routing.rs`.
+4. Provider-model translation and managed request fields in `src/web/openai.rs`.
+5. Transport construction in `src/provider_client.rs`.
+6. Public response-model canonicalization and usage publication.
+7. Responses-specific sampling, reasoning history, and tool behavior.
+
+The checked-in code is authoritative. Design notes and old parity evidence explain intent but may describe a previous provider set or launch phase.
+
+## Preserve the public model contract
+
+Centralize model behavior in `src/model_config.rs`. A model change may affect all of these together:
+
+- canonical public ID and provider ID;
+- display/catalog metadata and ordering;
+- listed versus API-only visibility;
+- enabled and feature-gated access;
+- access tier and chat/vision/reasoning/tool-use capabilities;
+- context window and prompt budget;
+- Responses sampling and current-turn thinking behavior;
+- prior-reasoning replay strategy;
+- public aliases and quick/powerful defaults;
+- `/v1/models`, `/v1/models/catalog`, audio/embedding entries, and Maple selectors.
+
+Do not add an ID in one response builder or route handler. Add it to the centralized configuration and test alias resolution, access filtering, both model-list surfaces, completion validation, Responses context limits, and the actual upstream provider ID.
+
+Keep public IDs provider-neutral and pinned. Do not expose `latest`, provider hostnames, routing flags, weights, or provider-specific model spellings. Translate only immediately before sending and canonicalize returned `model` fields to the public ID for non-streaming and streaming responses.
+
+Reasoning is model-specific. Distinguish:
+
+- emitting reasoning in the current turn;
+- preserving prior assistant reasoning in later prompt history;
+- provider-specific template kwargs needed for either behavior.
+
+Never infer replay support from visible answer quality. Prove it with direct provider probes that compare prompt-token deltas and a recall prompt, then encode the result in the model strategy and unit tests.
+
+## Preserve routing semantics
+
+Use `src/provider_routing.rs` as the sole completion-routing policy. The current architecture supports model-specific eligible routes, provider and route weights, an explicit default, stable UUID bucketing when no preference wins, and user-specific flag preferences.
+
+Do not describe configured weights as active traffic distribution without tracing precedence. An explicit flag preference or model default can bypass weighted selection entirely. Missing flag configuration, missing flag values, timeouts, and flag-service errors fall back to the model's default route rather than exposing control-plane failure to the client.
+
+Maintain these boundaries:
+
+- Route using the authenticated account UUID, not a request-provided identity.
+- Keep aliases resolved before routing.
+- Keep feature-flag keys canonical in `src/os_flags.rs`.
+- Keep selection deterministic for the same account/configuration.
+- Record the actual provider but bill and respond with the canonical public model.
+- Return a client error for an unsupported public model and an internal error for a valid model with no eligible configured route.
+- Do not accept a client-specified provider or provider-model ID.
+
+Chat completion currently selects one route and tries it once. Do not add backend-level cross-provider replay after a timeout, ambiguous body error, partial stream, or provider status. A POST may already have caused computation and usage. If product requirements call for failover, design idempotency, side-effect accounting, stream semantics, and rollout observability first.
+
+## Preserve provider transport security
+
+Tinfoil and ordinary OpenAI-compatible transports are intentionally different.
+
+### Tinfoil
+
+- `TINFOIL_API_KEY` is a hard backend startup requirement. Local mode may read the gitignored `.local/secrets/tinfoil_api_key`.
+- The in-process Tinfoil SDK discovers and attests an enclave in the background, pins TLS to the verified enclave, and shares its connection pool.
+- Backend startup and non-Tinfoil routes do not wait for discovery. Tinfoil-dependent requests return 503 while the attested client is unavailable.
+- Discovery attempts are bounded and back off. Derive current timings from `provider_client.rs`.
+- A typed DNS/TCP/TLS connect failure may trigger one single-flight rediscovery/attestation and one identical-byte retry. Request, body, response, timeout, provider-status, and partially streamed failures are not replayed by this layer.
+- Recovery tasks must not retain a request body or be cancelled when one caller times out.
+
+Do not replace this path with an unauthenticated localhost sidecar, ordinary CA-only TLS, a caller-selected enclave, or a fallback that skips attestation.
+
+### Continuum or another standard provider
+
+- `OPENAI_API_BASE` configures the ordinary compatible base. The supported
+  local Continuum recipe uses the loopback URL documented in
+  `docs/local-macos-stack.md` and does not need an OpenAI credential. Treat any
+  other custom base as a credential boundary: derive URL classification and
+  header behavior from current source and cover it with exact-host and
+  adversarial-host tests before using credentials.
+- Local macOS Continuum runs as its own native proxy; Tinfoil does not have a local proxy port.
+- Adding another provider requires a clear transport/authentication policy. Do not route a confidential workload through the ordinary client merely because its API is OpenAI-shaped.
+
+Provider secrets stay server-side, in environment/gitignored local secret files or the existing non-local secret path. Never place a real key in `.env.sample`, source, tests, evidence, logs, URLs, client headers, Maple configuration, or shell history.
+
+## Sanitize and own request fields
+
+Both transports must strip inbound authorization, host, content length/type controlled by the backend, hop-by-hop headers, and every header named by `Connection`. Preserve only safe end-to-end headers, then set the provider credential and content type explicitly. Extend both Tinfoil and standard sanitizers together and add network-boundary tests for any header-policy change.
+
+OpenSecret also owns provider cache fields:
+
+- Strip caller-supplied `cache_salt`.
+- For Tinfoil, replace `user_cache_secret` with the stable SHA-256 namespace derived from the authenticated user UUID.
+- For other providers, strip caller-supplied `user_cache_secret`.
+
+Do not expose the raw user UUID to a provider when a derived namespace is sufficient. Do not let a caller select another user's cache namespace.
+
+Log bounded request metadata, not prompts, images, audio, credentials, full
+headers, or full responses. Redact provider diagnostics before returning them
+publicly, and add semantic tests or source invariants for newly introduced
+sensitive fields where practical.
+
+## Preserve response, stream, and usage semantics
+
+For chat completions:
+
+- Force `stream_options.include_usage=true` on streaming upstream requests.
+- Parse SSE at complete frame boundaries and support LF and CRLF framing.
+- Preserve complete upstream JSON chunks while replacing provider model IDs with the canonical public ID.
+- Treat `[DONE]` as the authoritative terminal marker. A finish reason is terminal evidence, but a later usage-only frame may still arrive.
+- If the upstream ends without `[DONE]`, use the existing terminal-evidence policy; do not publish partial usage as successful usage without that evidence.
+- Emit exactly one public `[DONE]` and exactly one usage publication.
+
+Usage parsing clamps numeric values, tracks prompt and completion tokens, and bounds cached prompt tokens by total prompt tokens. Preserve:
+
+- actual provider name;
+- canonical public model name;
+- JWT versus API-key attribution;
+- cached input tokens when present;
+- asynchronous local persistence and optional event publication;
+- no event when both token counts are zero.
+
+The local cost field is observability, not the authoritative billing price.
+When entitlement behavior matters, configure the external billing API URL/key
+and test the backend's public outcomes: allowed, denied, unavailable, and guest
+behavior. Treat billing solely as an HTTP API boundary.
+
+Responses calls the shared completion sender, so provider changes can affect stored conversations, tool loops, title generation, reasoning history, and usage aggregation. Ensure the Responses orchestrator does not publish duplicate usage for a multi-turn tool response.
+
+## Treat audio and embeddings as provider contracts
+
+Derive the current provider choice, model translations, size limits, and retries from `src/web/openai.rs` and `src/web/audio_utils.rs`.
+
+- Speech is currently provider-owned through the Tinfoil transport and has paid-entitlement, timeout, model, voice, and encrypted base64-response behavior.
+- Transcription accepts base64 input at the public boundary, splits audio when necessary, maps model IDs per provider, and has explicit primary/fallback behavior. This is separate from chat's no-failover rule.
+- Embeddings use their configured provider, validate non-empty input, encrypt the public response, and publish prompt-token usage.
+
+When changing any of these, test both public payload compatibility and the exact provider request. Do not generalize transcription retry behavior to chat or speech.
+
+## Keep web providers and web content untrusted
+
+There are two related but distinct surfaces:
+
+1. Direct authenticated `/v1/web/search` and `/v1/web/extract` are provider-neutral public APIs implemented by `src/web/web_routes.rs`. Their current adapter is Kagi.
+2. The Responses `web_search` tool chooses an available Brave or Kagi tool implementation. Kagi additionally exposes internal `open_urls` extraction to the model.
+
+Derive the exact schemas, limits, and selection rules:
+
+```sh
+rg -n 'WEB_SEARCH_PATH|WEB_EXTRACT_PATH|MAX_|DEFAULT_|deny_unknown_fields' src/web/web_routes.rs src/kagi.rs src/brave.rs
+rg -n 'choose_web_search_provider|ToolRegistry|web_search|open_urls|allowed_urls' src/web/responses/handlers.rs src/web/responses/tools.rs
+```
+
+Preserve these security properties:
+
+- Keep search and page extraction separate. Search metadata is not page content.
+- Accept extraction only for normalized public HTTPS URLs. Reject credentials, local/reserved/metadata hosts, control characters, non-HTTPS schemes, and duplicates.
+- Treat titles, snippets, diagnostics, and extracted Markdown as untrusted data. Strip image embeds and bound text before putting it into model context.
+- Authorize Kagi `open_urls` from exact normalized URLs visibly supplied by the user or canonical URL fields generated by trusted Kagi formatters.
+- Never authorize a URL merely because it appears in assistant text, a title/snippet, diagnostics, Brave free-form output, or an extracted page body.
+- Reconstruct authorized URLs from visible persisted history on continuation; do not rely only on request-local discovery state.
+- Keep provider traces sanitized and bounded. Do not return provider-specific experimental payloads or arbitrary personalization controls.
+
+If the external flag API is absent or fails, preserve the documented provider
+fallback. Configure its base URL/key for a specific dev/prod environment when
+testing flag behavior and treat it solely as an HTTP API boundary.
+
+## Interpret health correctly
+
+`/health-check` is process liveness only and does not test the database. `/health-check-extended` performs a bounded direct Tinfoil model-list request. It demonstrates current Tinfoil discovery/attestation/connectivity, not database readiness, billing, flags, Brave, Kagi, Continuum, migrations, or Maple compatibility.
+
+Use the successful Tinfoil discovery/attestation log plus extended health as provider-readiness evidence. Repeated discovery failures, attestation/certificate errors, timeouts, 503s, or connection failures are actionable. Normal HTTP/2 connection rotation or graceful shutdown logs alone are not failure proof.
+
+## Validate safely
+
+Start with deterministic unit and boundary tests:
+
+```sh
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c cargo test --locked --all-features provider_routing::tests
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c cargo test --locked --all-features model_config::tests
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c cargo test --locked --all-features provider_client::tests
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c cargo test --locked --all-features web::openai::tests
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c cargo test --locked --all-features web::web_routes::tests
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c cargo test --locked --all-features web::web_safety::tests
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c cargo test --locked --all-features web::responses::tools::tests
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c cargo fmt --all -- --check
+git diff --check
+```
+
+Use one Cargo filter per command. Then run the repository's full validation skill, including locked all-feature tests and strict Clippy.
+
+Run live provider probes only when the task needs them and credentials/egress are authorized. Prefer deterministic prompts and paid/free fixtures that make routing and usage observable without recording user data. Keep raw evidence outside the repository and redact credentials, authorization headers, enclave proof metadata, and sensitive response content.
+
+For the existing ignored Tinfoil parity test, derive the exact test name and evidence variables from `docs/tinfoil-rust-sdk-parity.md` and `src/provider_client.rs`; do not paste a possibly stale command. Its parity boundary is decrypted method/path/query, safe end-to-end headers, exact request bytes, status/content type/schema, ordered SSE semantics, numeric usage, and one terminal marker—not TLS record bytes, header order/casing, connection reuse, or generated text/chunk boundaries.
+
+For a model reasoning claim, probe the provider directly before changing backend policy. For an application contract claim, also smoke the encrypted OpenSecret route through the SDK. For a Maple compatibility claim, run the relevant browser or native Maple path. Report each layer separately and never call a provider-only check end-to-end proof.

--- a/.agents/skills/change-opensecret-provider/agents/openai.yaml
+++ b/.agents/skills/change-opensecret-provider/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Change OpenSecret Provider"
+  short_description: "Modify routing with provider parity evidence"
+  default_prompt: "Use $change-opensecret-provider to implement or validate this provider change."

--- a/.agents/skills/develop-opensecret/SKILL.md
+++ b/.agents/skills/develop-opensecret/SKILL.md
@@ -1,189 +1,88 @@
 ---
 name: develop-opensecret
-description: Set up, run, and navigate the open-source OpenSecret Rust backend. Use when starting work in this repository, preparing its Nix and PostgreSQL environment, initializing submodules, running Diesel migrations, configuring local provider endpoints and credentials, locating the correct implementation layer, or deciding whether routine work belongs in OpenSecret or its frontend client.
+description: Set up and run the open-source OpenSecret Rust backend. Use when starting backend work, entering its pinned Nix/PostgreSQL environment, initializing submodules, running Diesel migrations, configuring the local provider stack, or deciding whether behavior belongs in OpenSecret or a client.
 ---
 
 # Develop OpenSecret
 
-## Establish a safe starting point
+## Start safely
 
-1. Read `AGENTS.md` and the files it routes to before changing code.
-2. Inspect `git status --short --branch` and preserve all unrelated or pre-existing work.
-3. For new work, fetch `origin` and start from current `origin/master` unless the task names another base. Do not switch, rebase, or rewrite a dirty checkout.
-4. Initialize the pinned public submodules before building:
+Read `AGENTS.md`, inspect the worktree, and preserve unrelated changes. For new
+work, prefer current `origin/master` unless the task names another base.
+Initialize public submodules before building:
 
-   ```sh
-   git submodule update --init --recursive
-   ```
+```sh
+git submodule update --init --recursive
+```
 
-5. Change a submodule pointer only when the task explicitly requires a dependency upgrade. Review the submodule diff and upstream revision as part of that change.
-6. Keep deployment, shared-database migration, PCR, signing, and remote-enclave commands out of routine development. Run them only with explicit authorization for the exact environment.
+Use the pinned Nix environment and run Cargo from the repository root; this is
+one Rust package. Keep deployment, shared migration, PCR mutation, signing, and
+remote-enclave operations outside routine development unless the user
+authorizes the exact action and environment.
 
-## Use the repository toolchain
-
-Use the pinned Nix shell instead of installing ad hoc system packages:
+## Enter the toolchain deliberately
 
 ```sh
 OPENSECRET_DEV_CONTAINERS=0 nix develop
 ```
 
-The shell provides the pinned Rust toolchain, `rustfmt`, Clippy, PostgreSQL,
-Diesel CLI, OpenSSL, `just`, compiler/linker dependencies, and repository
-security tools. Use `OPENSECRET_DEV_CONTAINERS=0 nix develop -c <command>` for
-reproducible one-shot commands unless the task needs the container helpers.
+The shell may reuse a PostgreSQL listener, start `.pgdata`, and create `.env`
+when absent. On Linux, container setup also changes user-level state unless
+disabled. Read `docs/dev-shell.md` for controls and concurrent-checkout
+isolation. Treat `.env`, `.pgdata/`, and `.local/` as private, gitignored state;
+never point local migrations or tests at a shared, preview, or production
+database.
 
-Treat `.env`, `.pgdata/`, and `.local/` as local, gitignored state. Never commit their contents.
+## Prepare PostgreSQL
 
-By default, entering `nix develop`:
-
-- checks any PostgreSQL listener on `localhost:$PGPORT` before inspecting
-  `.pgdata`; if one responds, it reuses that listener and skips checkout-local
-  cluster, role, and database initialization;
-- otherwise initializes or starts PostgreSQL under `.pgdata` on port `5432`
-  and creates the local role and database when needed;
-- creates `.env` from `.env.sample` only when `.env` is absent, then generates
-  local enclave and JWT secrets; and
-- on Linux, rewrites user-level container configuration when container setup
-  is enabled.
-
-Keep `OPENSECRET_DEV_CONTAINERS=0` for routine development and one-shot
-commands. Enable container setup only for a task that intentionally needs the
-local container helpers.
-
-Do not overwrite an existing `.env`; it belongs to the developer. Use these controls when the defaults conflict with another checkout or an externally managed service:
-
-```sh
-OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_CONTAINERS=0 nix develop
-OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 nix develop
-OPENSECRET_DEV_CONTAINERS=0 nix develop
-PGDATA=/tmp/opensecret-feature/pgdata PGPORT=32417 \
-  OPENSECRET_DEV_CONTAINERS=0 nix develop
-OPENSECRET_DEV_DATABASE_URL=postgres://opensecret_user:password@localhost:32417/opensecret \
-  OPENSECRET_DEV_CONTAINERS=0 nix develop
-```
-
-Keep each concurrently running checkout on distinct PostgreSQL state, database URL, and backend port. Do not point tests or migrations at a shared, preview, or production database.
-
-## Prepare PostgreSQL correctly
-
-Run Diesel schema migrations before starting the backend:
+Run SQL migrations before starting the backend:
 
 ```sh
 OPENSECRET_DEV_CONTAINERS=0 nix develop -c just diesel-migration-run-local
 ```
 
-Do not mistake `src/migrations.rs` for the Diesel migration runner. The server invokes that module for application-data migration after connecting; it assumes the SQL schema and seeded `OpenSecret` organization and `Maple` project already exist.
-
-Use the repository recipes for schema work:
-
-```sh
-OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop -c just diesel-migration-generate add_user_preferences
-OPENSECRET_DEV_CONTAINERS=0 nix develop -c just diesel-migration-run-local
-```
-
-Replace `add_user_preferences` with a concise snake-case description of the schema change.
-
-Add reversible `up.sql` and `down.sql` behavior. Let Diesel regenerate `src/models/schema.rs` according to `diesel.toml`; do not hand-maintain generated schema drift. Preserve existing migrations rather than editing migrations that may already have run elsewhere.
-
-Before changing a persisted ciphertext, trace the write and read paths to its
-owning key domain. User-private content uses a credential-derived user key that
-is available only in an authenticated user context. Server-owned material such
-as OAuth access tokens, project secrets, and password verifiers uses its
-enclave/system-secret domain. Do not collapse these domains or assume a key is
-available merely because startup can reach the row.
-
-Make ciphertext formats explicitly versioned. For user-key rows, deploy
-dual-read/new-write behavior, then lazily and transactionally rewrite the old
-format only after authenticated access makes that user's key available. Use a
-startup application-data migration only for rows whose owning key is actually
-available there, such as enclave/system-key data, and make that migration
-idempotent and retry-safe. Diesel SQL can evolve columns and constraints, but
-cannot safely re-encrypt opaque bytes without the owning key.
-
-Route migration verification, disposable-database setup, rollback checks, and database-backed tamper tests through `.agents/skills/validate-opensecret/SKILL.md`.
-
-## Configure local runtime state
-
-Use `APP_MODE=local`. Confirm these values before startup:
-
-- `DATABASE_URL`: point to the migrated local PostgreSQL database.
-- `ENCLAVE_SECRET_MOCK`: use exactly 32 random bytes encoded as hex.
-- `JWT_SECRET`: use a local random secret.
-- `TINFOIL_API_KEY`: provide a non-empty key; the in-process attested Tinfoil client is a runtime requirement.
-- `OPENAI_API_BASE`: set the default OpenAI-compatible provider endpoint. The
-  documented loopback Continuum recipe does not need `OPENAI_API_KEY`.
-  Treat any other custom base as a credential boundary and review its exact
-  URL, authentication headers, and forwarding behavior.
-- `OPENSECRET_BIND_ADDR`: override `127.0.0.1:3000` when the default port is unavailable.
-
-Prefer gitignored secret files for day-to-day provider credentials:
-
-```text
-.local/secrets/tinfoil_api_key
-.local/secrets/continuum_api_key
-```
-
-Never print, log, paste into tracked files, or expose provider credentials in command output. Prefer a protected environment variable when a secret file is unsuitable.
-
-Configure optional capabilities only when the task exercises them:
-
-- `RESEND_API_KEY` for email delivery.
-- GitHub or Google client ID and secret variables for the corresponding OAuth flow.
-- `BRAVE_API_KEY` and `KAGI_API_KEY` for web-search providers.
-- `BILLING_SERVER_URL` plus `BILLING_API_KEY` for the configurable billing API boundary.
-- `OS_FLAGS_BASE_URL` plus `OS_FLAGS_API_KEY` for the configurable feature-flag API boundary.
-
-Do not require billing or feature-flag APIs for ordinary registered-user local development. Test their unavailable, timeout, and denial behavior deliberately when changing those boundaries.
-
-## Run the backend
-
-For a direct local run, ensure PostgreSQL is running, migrations have completed, and the required provider configuration is present, then run:
+`src/migrations.rs` is application-data migration logic, not the Diesel runner.
+For a schema change, create a new reversible migration and let Diesel regenerate
+`src/models/schema.rs`:
 
 ```sh
-OPENSECRET_DEV_CONTAINERS=0 nix develop -c cargo run
+OPENSECRET_DEV_CONTAINERS=0 nix develop -c \
+  just diesel-migration-generate add_user_preferences
 ```
 
-On macOS, use the documented local Continuum-compatible path when that provider is part of the task:
+Replace the example name with the change being made. Use
+`$validate-opensecret` for rollback, upgrade-shaped data, encrypted persistence,
+and ignored database-test proof.
 
-```sh
-nix develop -c just build-local-proxies-macos   # one-time or after its submodule changes
-nix develop -c just run-continuum-proxy-macos   # terminal 1
-nix develop -c just diesel-migration-run-local  # after every schema change
-nix develop -c just run-local-backend-macos     # terminal 2
-```
+## Configure and run locally
 
-Read `docs/local-macos-stack.md` for the exact local process shape and `docs/dev-shell.md` for shell-hook controls. Do not create a separate local Tinfoil sidecar; Tinfoil runs through the Rust SDK inside OpenSecret.
+Derive supported configuration from `.env.sample` and startup source. Tinfoil
+is an in-process provider dependency; the macOS stack can also run the native
+Continuum proxy. Follow `docs/local-macos-stack.md` for protected credential
+files, process topology, and Maple wiring. Do not start a Tinfoil sidecar.
 
-Use `/health-check` only as a process-liveness probe. It does not verify PostgreSQL. Use `/health-check-extended` to verify live outbound Tinfoil model discovery, and expect it to require valid credentials and network access.
+Billing and feature flags are optional external HTTP API boundaries. Configure
+their URLs and backend-only credentials only when the task exercises their
+public outcomes; do not pull their server implementations into this setup.
 
-Route authenticated, encrypted API and frontend smoke testing through `.agents/skills/validate-opensecret/SKILL.md`; plaintext `curl` requests do not exercise the real protected protocol.
+Plain `curl` is suitable for health probes, not protected-route proof. Use a
+pinned OpenSecret SDK or Maple for authenticated encrypted smoke tests.
 
-## Place changes by responsibility
+## Follow ownership
 
-Keep this repository responsible for server-controlled security and policy:
+Use the source map and frontend/backend boundary in `AGENTS.md`. In particular,
+keep server policy, provider credentials/routing, authorization, durable
+storage, and cryptography in OpenSecret; keep presentation, device integration,
+and local user interaction in clients.
 
-- Put startup configuration, shared application state, and router composition in `src/main.rs`.
-- Put HTTP route parsing, middleware, response envelopes, and streaming behavior in `src/web/`.
-- Put domain records and Diesel mappings in `src/models/`.
-- Put database operations behind `DBConnection` in `src/db.rs`.
-- Put SQL schema evolution in `migrations/` and generated schema in `src/models/schema.rs`.
-- Put JWT validation and claims in `src/jwt.rs`.
-- Put encryption primitives and credential-bound seed handling in `src/encrypt.rs` and `src/seed_wrapping.rs`; trace each persisted field's owning key from its call sites before changing its format.
-- Put model catalog and public IDs in `src/model_config.rs`.
-- Put provider selection policy in `src/provider_routing.rs`, endpoint configuration in `src/proxy_config.rs`, and outbound transport in `src/provider_client.rs`.
-- Put stateful Responses behavior in `src/web/responses/`; keep direct web-search contracts in `src/web/web_routes.rs` and provider adapters in `src/brave.rs` or `src/kagi.rs`.
-- Put periodic in-process maintenance beside the state it maintains; do not infer a worker implementation merely from a database table.
+Load the narrow sibling workflow when the task reaches it:
 
-Keep provider credentials, routing policy, authorization, durable storage, billing/flag decisions, and cryptographic operations in the backend. Keep presentation, local interaction, and device-specific behavior in the frontend. Treat public API shape, attestation, session encryption, and streamed event changes as coordinated client-and-backend work.
+- `$change-opensecret-api` for routes, middleware, encrypted contracts,
+  Responses, or client compatibility.
+- `$change-opensecret-provider` for models, routing, transport, provider
+  adapters, headers, retries, or usage.
+- `$review-opensecret-security` for a trust-boundary change or security review.
+- `$validate-opensecret` before claiming implementation complete.
 
-## Load the specialized workflow
-
-Load the narrow sibling skill before editing a sensitive surface:
-
-- Use `.agents/skills/change-opensecret-api/SKILL.md` for routes, request/response contracts, middleware ordering, Responses behavior, and coordinated client API changes.
-- Use `.agents/skills/change-opensecret-provider/SKILL.md` for models, routing, provider endpoints, attested transport, retries, headers, and usage attribution.
-- Use `.agents/skills/review-opensecret-security/SKILL.md` for authentication, encryption, key handling, privacy, logging, account deletion/reset, or threat-model review.
-- Use `.agents/skills/validate-opensecret/SKILL.md` before claiming any implementation complete and whenever tests, migrations, local API smoke tests, or full frontend/backend smoke tests are required.
-
-When a task crosses multiple surfaces, load each applicable skill and keep the change at the narrowest owning layer. Preserve existing public behavior unless the task explicitly changes the contract.
+Apply the union when a task crosses skills, but keep code at the narrowest
+owning layer.

--- a/.agents/skills/develop-opensecret/SKILL.md
+++ b/.agents/skills/develop-opensecret/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: develop-opensecret
+description: Set up, run, and navigate the open-source OpenSecret Rust backend. Use when starting work in this repository, preparing its Nix and PostgreSQL environment, initializing submodules, running Diesel migrations, configuring local provider endpoints and credentials, locating the correct implementation layer, or deciding whether routine work belongs in OpenSecret or its frontend client.
+---
+
+# Develop OpenSecret
+
+## Establish a safe starting point
+
+1. Read `AGENTS.md` and the files it routes to before changing code.
+2. Inspect `git status --short --branch` and preserve all unrelated or pre-existing work.
+3. For new work, fetch `origin` and start from current `origin/master` unless the task names another base. Do not switch, rebase, or rewrite a dirty checkout.
+4. Initialize the pinned public submodules before building:
+
+   ```sh
+   git submodule update --init --recursive
+   ```
+
+5. Change a submodule pointer only when the task explicitly requires a dependency upgrade. Review the submodule diff and upstream revision as part of that change.
+6. Keep deployment, shared-database migration, PCR, signing, and remote-enclave commands out of routine development. Run them only with explicit authorization for the exact environment.
+
+## Use the repository toolchain
+
+Use the pinned Nix shell instead of installing ad hoc system packages:
+
+```sh
+OPENSECRET_DEV_CONTAINERS=0 nix develop
+```
+
+The shell provides the pinned Rust toolchain, `rustfmt`, Clippy, PostgreSQL,
+Diesel CLI, OpenSSL, `just`, compiler/linker dependencies, and repository
+security tools. Use `OPENSECRET_DEV_CONTAINERS=0 nix develop -c <command>` for
+reproducible one-shot commands unless the task needs the container helpers.
+
+Treat `.env`, `.pgdata/`, and `.local/` as local, gitignored state. Never commit their contents.
+
+By default, entering `nix develop`:
+
+- checks any PostgreSQL listener on `localhost:$PGPORT` before inspecting
+  `.pgdata`; if one responds, it reuses that listener and skips checkout-local
+  cluster, role, and database initialization;
+- otherwise initializes or starts PostgreSQL under `.pgdata` on port `5432`
+  and creates the local role and database when needed;
+- creates `.env` from `.env.sample` only when `.env` is absent, then generates
+  local enclave and JWT secrets; and
+- on Linux, rewrites user-level container configuration when container setup
+  is enabled.
+
+Keep `OPENSECRET_DEV_CONTAINERS=0` for routine development and one-shot
+commands. Enable container setup only for a task that intentionally needs the
+local container helpers.
+
+Do not overwrite an existing `.env`; it belongs to the developer. Use these controls when the defaults conflict with another checkout or an externally managed service:
+
+```sh
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_CONTAINERS=0 nix develop
+OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 nix develop
+OPENSECRET_DEV_CONTAINERS=0 nix develop
+PGDATA=/tmp/opensecret-feature/pgdata PGPORT=32417 \
+  OPENSECRET_DEV_CONTAINERS=0 nix develop
+OPENSECRET_DEV_DATABASE_URL=postgres://opensecret_user:password@localhost:32417/opensecret \
+  OPENSECRET_DEV_CONTAINERS=0 nix develop
+```
+
+Keep each concurrently running checkout on distinct PostgreSQL state, database URL, and backend port. Do not point tests or migrations at a shared, preview, or production database.
+
+## Prepare PostgreSQL correctly
+
+Run Diesel schema migrations before starting the backend:
+
+```sh
+OPENSECRET_DEV_CONTAINERS=0 nix develop -c just diesel-migration-run-local
+```
+
+Do not mistake `src/migrations.rs` for the Diesel migration runner. The server invokes that module for application-data migration after connecting; it assumes the SQL schema and seeded `OpenSecret` organization and `Maple` project already exist.
+
+Use the repository recipes for schema work:
+
+```sh
+OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop -c just diesel-migration-generate add_user_preferences
+OPENSECRET_DEV_CONTAINERS=0 nix develop -c just diesel-migration-run-local
+```
+
+Replace `add_user_preferences` with a concise snake-case description of the schema change.
+
+Add reversible `up.sql` and `down.sql` behavior. Let Diesel regenerate `src/models/schema.rs` according to `diesel.toml`; do not hand-maintain generated schema drift. Preserve existing migrations rather than editing migrations that may already have run elsewhere.
+
+Before changing a persisted ciphertext, trace the write and read paths to its
+owning key domain. User-private content uses a credential-derived user key that
+is available only in an authenticated user context. Server-owned material such
+as OAuth access tokens, project secrets, and password verifiers uses its
+enclave/system-secret domain. Do not collapse these domains or assume a key is
+available merely because startup can reach the row.
+
+Make ciphertext formats explicitly versioned. For user-key rows, deploy
+dual-read/new-write behavior, then lazily and transactionally rewrite the old
+format only after authenticated access makes that user's key available. Use a
+startup application-data migration only for rows whose owning key is actually
+available there, such as enclave/system-key data, and make that migration
+idempotent and retry-safe. Diesel SQL can evolve columns and constraints, but
+cannot safely re-encrypt opaque bytes without the owning key.
+
+Route migration verification, disposable-database setup, rollback checks, and database-backed tamper tests through `.agents/skills/validate-opensecret/SKILL.md`.
+
+## Configure local runtime state
+
+Use `APP_MODE=local`. Confirm these values before startup:
+
+- `DATABASE_URL`: point to the migrated local PostgreSQL database.
+- `ENCLAVE_SECRET_MOCK`: use exactly 32 random bytes encoded as hex.
+- `JWT_SECRET`: use a local random secret.
+- `TINFOIL_API_KEY`: provide a non-empty key; the in-process attested Tinfoil client is a runtime requirement.
+- `OPENAI_API_BASE`: set the default OpenAI-compatible provider endpoint. The
+  documented loopback Continuum recipe does not need `OPENAI_API_KEY`.
+  Treat any other custom base as a credential boundary and review its exact
+  URL, authentication headers, and forwarding behavior.
+- `OPENSECRET_BIND_ADDR`: override `127.0.0.1:3000` when the default port is unavailable.
+
+Prefer gitignored secret files for day-to-day provider credentials:
+
+```text
+.local/secrets/tinfoil_api_key
+.local/secrets/continuum_api_key
+```
+
+Never print, log, paste into tracked files, or expose provider credentials in command output. Prefer a protected environment variable when a secret file is unsuitable.
+
+Configure optional capabilities only when the task exercises them:
+
+- `RESEND_API_KEY` for email delivery.
+- GitHub or Google client ID and secret variables for the corresponding OAuth flow.
+- `BRAVE_API_KEY` and `KAGI_API_KEY` for web-search providers.
+- `BILLING_SERVER_URL` plus `BILLING_API_KEY` for the configurable billing API boundary.
+- `OS_FLAGS_BASE_URL` plus `OS_FLAGS_API_KEY` for the configurable feature-flag API boundary.
+
+Do not require billing or feature-flag APIs for ordinary registered-user local development. Test their unavailable, timeout, and denial behavior deliberately when changing those boundaries.
+
+## Run the backend
+
+For a direct local run, ensure PostgreSQL is running, migrations have completed, and the required provider configuration is present, then run:
+
+```sh
+OPENSECRET_DEV_CONTAINERS=0 nix develop -c cargo run
+```
+
+On macOS, use the documented local Continuum-compatible path when that provider is part of the task:
+
+```sh
+nix develop -c just build-local-proxies-macos   # one-time or after its submodule changes
+nix develop -c just run-continuum-proxy-macos   # terminal 1
+nix develop -c just diesel-migration-run-local  # after every schema change
+nix develop -c just run-local-backend-macos     # terminal 2
+```
+
+Read `docs/local-macos-stack.md` for the exact local process shape and `docs/dev-shell.md` for shell-hook controls. Do not create a separate local Tinfoil sidecar; Tinfoil runs through the Rust SDK inside OpenSecret.
+
+Use `/health-check` only as a process-liveness probe. It does not verify PostgreSQL. Use `/health-check-extended` to verify live outbound Tinfoil model discovery, and expect it to require valid credentials and network access.
+
+Route authenticated, encrypted API and frontend smoke testing through `.agents/skills/validate-opensecret/SKILL.md`; plaintext `curl` requests do not exercise the real protected protocol.
+
+## Place changes by responsibility
+
+Keep this repository responsible for server-controlled security and policy:
+
+- Put startup configuration, shared application state, and router composition in `src/main.rs`.
+- Put HTTP route parsing, middleware, response envelopes, and streaming behavior in `src/web/`.
+- Put domain records and Diesel mappings in `src/models/`.
+- Put database operations behind `DBConnection` in `src/db.rs`.
+- Put SQL schema evolution in `migrations/` and generated schema in `src/models/schema.rs`.
+- Put JWT validation and claims in `src/jwt.rs`.
+- Put encryption primitives and credential-bound seed handling in `src/encrypt.rs` and `src/seed_wrapping.rs`; trace each persisted field's owning key from its call sites before changing its format.
+- Put model catalog and public IDs in `src/model_config.rs`.
+- Put provider selection policy in `src/provider_routing.rs`, endpoint configuration in `src/proxy_config.rs`, and outbound transport in `src/provider_client.rs`.
+- Put stateful Responses behavior in `src/web/responses/`; keep direct web-search contracts in `src/web/web_routes.rs` and provider adapters in `src/brave.rs` or `src/kagi.rs`.
+- Put periodic in-process maintenance beside the state it maintains; do not infer a worker implementation merely from a database table.
+
+Keep provider credentials, routing policy, authorization, durable storage, billing/flag decisions, and cryptographic operations in the backend. Keep presentation, local interaction, and device-specific behavior in the frontend. Treat public API shape, attestation, session encryption, and streamed event changes as coordinated client-and-backend work.
+
+## Load the specialized workflow
+
+Load the narrow sibling skill before editing a sensitive surface:
+
+- Use `.agents/skills/change-opensecret-api/SKILL.md` for routes, request/response contracts, middleware ordering, Responses behavior, and coordinated client API changes.
+- Use `.agents/skills/change-opensecret-provider/SKILL.md` for models, routing, provider endpoints, attested transport, retries, headers, and usage attribution.
+- Use `.agents/skills/review-opensecret-security/SKILL.md` for authentication, encryption, key handling, privacy, logging, account deletion/reset, or threat-model review.
+- Use `.agents/skills/validate-opensecret/SKILL.md` before claiming any implementation complete and whenever tests, migrations, local API smoke tests, or full frontend/backend smoke tests are required.
+
+When a task crosses multiple surfaces, load each applicable skill and keep the change at the narrowest owning layer. Preserve existing public behavior unless the task explicitly changes the contract.

--- a/.agents/skills/develop-opensecret/agents/openai.yaml
+++ b/.agents/skills/develop-opensecret/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Develop OpenSecret"
+  short_description: "Implement backend changes in the right layer"
+  default_prompt: "Use $develop-opensecret to plan and implement this OpenSecret backend change."

--- a/.agents/skills/review-opensecret-security/SKILL.md
+++ b/.agents/skills/review-opensecret-security/SKILL.md
@@ -1,332 +1,144 @@
 ---
 name: review-opensecret-security
-description: Review security-sensitive OpenSecret backend changes and claims. Use for attestation, client-enclave sessions, AEAD or key derivation, JWT/API-key/OAuth authentication, encrypted persistence, migrations, provider routing, web tools and URL provenance, billing or flag API boundaries, secrets, logging, Nitro/KMS/PCR evidence, streaming, and release-affecting diffs.
+description: Review security-sensitive OpenSecret changes and claims. Use when a diff reaches attestation, encrypted sessions, authentication or OAuth, key ownership, encrypted persistence, provider or web trust, external billing or flag APIs, secrets, logs, Nitro/KMS/PCR evidence, or another boundary where source, artifact, and deployed-environment claims must be separated.
 ---
 
-# Review OpenSecret Security
+# Review OpenSecret security
 
-Review the current source and diff as evidence. This skill defines durable
-review standards; it does not catalogue current findings. Default to a
-read-only review and implement changes only when the user asks.
+Review the current source and diff as evidence. This skill defines a method; it
+does not catalogue current findings. Default to read-only review and implement
+changes only when the user asks.
 
-## Establish scope and evidence
+## Establish the comparison
 
-1. Read the repository `AGENTS.md`, the relevant source, tests, migrations, and
-   public documentation before forming a verdict.
-2. Confirm the revision and comparison base. Prefer current `master`; do not
-   rebase, reset, or fetch over user work merely to obtain it.
-3. Inspect the complete change, including generated schema, lockfile, submodule,
-   Nix, workflow, environment, and migration changes:
+1. Read `AGENTS.md`, relevant source, tests, migrations, and public docs.
+2. Confirm the revision, intended base, worktree state, and submodule revisions.
+   Do not rewrite user work to manufacture a clean comparison.
+3. Inspect committed, staged, unstaged, untracked, generated, lockfile,
+   workflow, Nix, environment, migration, and submodule changes. For an
+   `origin/master` comparison, include:
 
    ```sh
    git status --short --branch
-   git diff --stat origin/master...HEAD
    git diff origin/master...HEAD --
    git diff --cached --
    git diff --
    git ls-files --others --exclude-standard
    git submodule status
+   git diff --check origin/master...HEAD --
+   git diff --cached --check
    git diff --check
    ```
 
-4. Trace each changed value from input through authorization, decryption,
-   persistence, provider calls, response encryption, and logs. Do not review a
-   handler in isolation from router middleware or database scoping.
-5. Label every conclusion with one of these evidence classes:
+4. Trace each changed value from input through authority, decryption,
+   persistence, external calls, response encryption, errors, and logs.
 
-   - **source-confirmed**: the reviewed revision directly establishes the behavior;
-   - **test-confirmed**: a named test exercised the relevant behavior in this run;
-   - **build-confirmed**: a named reproducible build or artifact check passed;
-   - **live-confirmed**: the exact deployed environment was inspected or exercised;
-   - **inferred**: the conclusion follows from source plus stated assumptions;
-   - **unverified**: deployment configuration or an external system was not inspected.
+Classify each observation as introduced, worsened or newly relied upon,
+pre-existing baseline, unrelated, or indeterminate. Only introduced or
+materially worsened/newly relied-upon behavior determines a scoped diff verdict.
+Mention baseline behavior only when needed to explain the change; keep it
+task-local and non-blocking unless the change depends on it, expands it, or the
+user requested a repository-wide audit. Mark a verdict provisional when the
+comparison base is uncertain.
 
-Keep claims within the evidence available. Local tests do not prove live DB
-TLS, IAM, KMS policy, Nitro measurements, client trust policy, provider
-behavior, billing decisions, or log retention.
+## Label the evidence
 
-## Map the trust boundaries
+- **source-confirmed**: the reviewed revision directly establishes the claim.
+- **test-confirmed**: a named test exercised it in this run.
+- **build-confirmed**: a named reproducible build or artifact check passed.
+- **live-confirmed**: the named deployed or external environment was exercised.
+- **inferred**: the claim follows from stated evidence and assumptions.
+- **unverified**: the required source, system, or environment was not inspected.
 
-State which boundaries the change crosses:
+Local source and tests do not establish live database transport, provider
+behavior, billing decisions, logging policy, IAM/KMS policy, PCR trust, artifact
+identity, or which revision serves an environment.
 
-- Maple or another client to the OpenSecret enclave;
-- the public HTTP router to JWT, API-key, OAuth, and project authorization;
-- enclave plaintext to host-accessible Postgres or logs;
-- OpenSecret to Tinfoil, Continuum/OpenAI-compatible providers, Brave, Kagi,
-  OAuth providers, billing, or flags;
-- enclave to its parent instance over VSOCK for AWS credentials, secrets, and logs;
-- source to Nix build, EIF/PCR evidence, CI, KMS policy, and deployed enclave.
+## Map the boundary
 
-Distinguish the client's attestation of OpenSecret from OpenSecret's attested
-connection to an upstream Tinfoil enclave. A local mock attestation exercises
-protocol shape only; it is not Nitro or production trust evidence.
+Identify every link the change crosses:
 
-## Enforce placement rules
+- client to the OpenSecret enclave and encrypted session;
+- router to user, API-key, OAuth, project, and record authority;
+- enclave plaintext to host-visible persistence, metadata, errors, or logs;
+- OpenSecret to external model, web, OAuth, email, billing, or flag APIs;
+- enclave to its parent over VSOCK for credentials, secrets, and logs;
+- source and Nix build to EIF/PCR evidence, KMS policy, and deployment.
 
-Keep these responsibilities in the backend:
+Client attestation of OpenSecret and OpenSecret’s attested connection to an
+upstream enclave prove different links. Local mock attestation proves protocol
+shape, not Nitro or production trust.
 
-- authentication, authorization, project scoping, token issuance, and revocation policy;
-- provider selection, provider model IDs, provider-only request fields, retries,
-  provider credentials, and upstream error sanitization;
-- URL authorization and SSRF policy for model-initiated tools;
-- billing and feature-flag decisions at their HTTP API boundary;
-- encryption-at-rest formats, migrations, destructive-reset behavior, and audit logs.
+## Review end to end
 
-Keep presentation and user interaction in Maple. Do not make Maple select a
-confidential provider, supply provider secrets, or reproduce backend policy.
-Changes to attestation documents, key exchange, encrypted envelopes, headers,
-streaming, token lifecycle, or error schemas are shared protocol changes: update
-and test backend and client implementations together with an explicit version or
-compatibility plan.
+For the changed boundary, answer:
 
-Treat billing and flags as external APIs only. Review OpenSecret's request,
-response, timeout, caching, authentication, and failure semantics without
-relying on server-internal implementation details. Local setup may point those
-clients at approved development or production endpoints as appropriate.
+1. What authenticated identity or capability authorizes the operation, and
+   where is project/record ownership enforced?
+2. Who owns each key, plaintext value, persisted row, provider credential, and
+   policy decision? Is that authority ever taken from untrusted input?
+3. Where are size, count, time, concurrency, expiry, replay, cancellation, and
+   cleanup bounds enforced on success and failure paths?
+4. What crosses into host-visible storage, metadata, logs, errors, parent
+   services, or external APIs? Is it necessary, bounded, and sanitized?
+5. Can client, model, provider, database, or parent-instance data gain URL,
+   identity, routing, key, or execution authority?
+6. Are ambiguous retries, partial streams, disconnects, and restarts safe for
+   persistence, usage, and external side effects?
+7. Does the change alter a shared SDK/client protocol, persisted format,
+   provider contract, or deployment trust claim? What compatibility and
+   rollback path is required?
 
-## Review client-enclave transport
+Apply these OpenSecret-specific invariants:
 
-Inspect `src/web/attestation_routes.rs`, `src/web/encryption_middleware.rs`, the
-session/cache implementation in `src/main.rs`, and every affected router.
+- An encryption session is transport state, not identity or authorization.
+- JWT, API-key, OAuth, user-key, and enclave/system-key domains are not
+  interchangeable.
+- Ownership checks precede decryption or mutation; query scoping is part of
+  authorization.
+- Provider and model output is untrusted. Provider choice, credentials, cache
+  namespaces, URL provenance, and SSRF policy remain backend-owned.
+- Sensitive or user-controlled plaintext must not enter logs or public errors.
+  Safe metadata is bounded and allowlisted.
+- A changed ciphertext format needs explicit versioning, compatibility,
+  rollback, and access to the owning key; ordinary startup lacks user keys.
+- Shared protocol changes require coordinated testing of pinned SDKs and
+  affected Maple paths.
 
-- Require a fresh, unpredictable client nonce and one-time ephemeral key use.
-- Verify nonce/body limits, TTLs, capacities, eviction, lease lifetime, and
-  cleanup on malformed, abandoned, concurrent, and failed requests.
-- Reject non-contributory X25519 inputs and zeroize secret/session material.
-- Confirm every sensitive route validates a live encryption session, including
-  GET, DELETE, and handlers with `()` bodies, before side effects.
-- Separately confirm route authentication and authorization. Possession of an
-  `x-session-id` is not automatically proof of JWT identity, project membership,
-  or durable-credential possession.
-- For AEAD, review key direction, domain separation, nonce uniqueness, canonical
-  AAD, method/path/query/session/request binding, replay handling, and response
-  association. Parser differences are not cryptographic domain separation.
-- Keep plaintext credentials and sensitive payloads out of query strings, URLs,
-  and other host-visible metadata.
-- Move blocking NSM or cryptographic work off async executor threads and bound
-  admission if the current path can be driven publicly.
+Use `$change-opensecret-api` or `$change-opensecret-provider` for the detailed
+contract procedure rather than duplicating it here.
 
-Do not silently change the existing encrypted protocol. Require compatibility
-vectors for success, tamper, wrong-session, wrong-route, replay, bodyless, error,
-and streaming cases.
+## Match claims to proof and authority
 
-## Review authentication and OAuth
+Keep the evidence ladder separate:
 
-Inspect `src/jwt.rs`, `src/web/openai_auth.rs`, login routes, `src/oauth.rs`,
-OAuth routes, seed wrapping, and the router composition in `src/main.rs`.
+1. Rust tests establish local implementation behavior.
+2. Nix checks establish reviewed source/build invariants.
+3. An EIF build plus comparison with a reviewed PCR reference establishes an
+   artifact measurement.
+4. Inspection of live KMS/IAM, client trust policy, deployed EIF, parent
+   services, and runtime smoke establishes deployment behavior.
 
-- Keep internal access/refresh tokens distinct from project-issued third-party
-  tokens. Confirm algorithm, audience, token format, subject, project, and auth
-  context for the exact token domain.
-- Issue or refresh user tokens only after the signed `AuthContext` matches the
-  user project and an active credential-bound seed wrap successfully verifies.
-- Preserve the signed auth context during refresh; do not silently recompute it
-  from mutable database fields.
-- Treat OpenAI-compatible API-key auth as a separate capability. Do not derive or
-  expose user-private storage keys unless an API-key-bound seed-wrap design exists.
-- Check expiry, maturity, clock-skew, rotation, replay, logout, and revocation as
-  separate properties. Never infer server-side revocation from client token deletion.
-- Make OAuth state random, bounded, expiring, exact-match, and atomically one-use.
-  Review whether it is bound to the initiating encrypted session and redirect flow.
-- Derive OAuth identity from verified provider subject plus project. Distinguish
-  signed claims from client hints, especially native Apple nonce, email, and name.
-- Unwrap the credential-bound seed before issuing tokens. Test provider-subject,
-  project, verifier, wrap, and reset-row substitution.
+Load `$validate-opensecret` and run the tiers reached by the diff. Report local,
+database, provider, client, build/artifact, and live evidence separately.
 
-## Review encrypted persistence and migrations
-
-Inspect `src/encrypt.rs`, `src/seed_wrapping.rs`, `src/db.rs`, affected models,
-`src/models/schema.rs`, SQL migrations, `src/migrations.rs`,
-`src/security_invariants.rs`, and `src/aead_db_tamper_tests.rs`.
-
-- For new sensitive data, define a versioned, domain-separated envelope with a
-  purpose-specific HKDF key and canonical AAD covering the necessary owner,
-  project, row, field, credential kind, and version.
-- Never change an existing ciphertext format in place. Design dual-read/write,
-  rollback, restart, and deletion behavior explicitly, then remove temporary
-  translation code after rollout.
-- Test round trip, single-bit tamper, wrong key, wrong AAD, row/account/project
-  substitution, credential change, destructive reset, and concurrent stale state.
-- Preserve transaction boundaries around credential verifier, seed wrap, user,
-  provider connection, and reset changes.
-- Classify every new user-key-encrypted table in the destructive-reset invariant.
-  Confirm ownership foreign keys, cascades, uniqueness, checks, and access-path indexes.
-- Distinguish Diesel schema migrations from application-data migrations.
-  Ordinary startup code does not have each user's credential-derived key. A
-  user-private ciphertext change therefore needs versioned dual-read/new-write
-  behavior and lazy rewrite after authenticated key recovery, unless a separate
-  authorized backfill is explicitly designed. Startup rewriting is suitable
-  only for data whose system/enclave key is actually available; it must be
-  idempotent, restart-safe, bounded, and fail closed.
-- Verify what API options such as `store` actually do by tracing persistence;
-  do not promise ephemeral behavior from a response field or comment alone.
-- Run migration and tamper checks only against a disposable, migrated local database.
-
-## Review providers, headers, and streaming
-
-Inspect `src/provider_routing.rs`, `src/proxy_config.rs`,
-`src/provider_client.rs`, model configuration, and the calling route.
-
-- Accept public/canonical model IDs at the API boundary. Keep provider choice,
-  provider model translation, feature-flag preference, fallback, and provider-only
-  fields behind the backend routing boundary.
-- Load credentials only from approved runtime secret inputs. Replace inbound
-  authorization with the configured upstream credential and mark secret headers
-  sensitive. Never log or return provider keys.
-- Review every forwarded header. Prefer an explicit allowlist for a new
-  boundary, and prove that client authorization, proxy credentials, hop-by-hop
-  headers, `Connection`-named headers, host, content length, and
-  provider-managed fields cannot cross.
-- For Tinfoil, preserve discovery, attestation, TLS pinning, single-flight refresh,
-  bounded attempts, and connection reuse. Retry only failures known to occur
-  before request bytes were accepted; do not replay ambiguous completion requests.
-- Treat cache namespace material separately from API credentials and from a
-  client-held secret. Document who can derive it and its stability requirements.
-- Preserve decrypted HTTP and SSE contracts: method, path/query, body bytes,
-  application content type, ordered events, numeric usage, error mapping, and
-  exactly one terminal `[DONE]` where the endpoint promises it.
-- Sanitize upstream errors by status, category, and bounded identifiers. Raw
-  bodies and headers can contain prompts, PII, tokens, or provider diagnostics.
-
-## Review web tools and request provenance
-
-Inspect `src/web/web_safety.rs`, Responses tool execution and prompt rebuilding,
-and direct web routes.
-
-- Treat URL provenance as authorization. For model-initiated `open_urls`, allow
-  only exact normalized URLs from visible user text or canonical structured URL
-  fields emitted by trusted backend formatters.
-- Never authorize URLs found in assistant/system text, titles, snippets,
-  diagnostics, image parts, or extracted page bodies. Those are untrusted data.
-- Preserve HTTPS-only, no-credentials, public-host checks and the private,
-  reserved, metadata, IPv4, IPv6, 6to4, and NAT64 defenses.
-- Keep direct authenticated extraction and model-generated extraction as separate
-  trust models. Do not weaken model provenance because a direct endpoint exists.
-- Reassess DNS, redirects, rebinding, and destination revalidation when changing
-  which component performs the fetch. Lexical checks for a remote fetcher do not
-  automatically secure a new local fetcher.
-- Bound query length, URL count, URL length, result count, output size, tool turns,
-  timeouts, and retained provenance. Sanitize image/HTML embeds.
-- Keep untrusted-content guidance in the rebuilt prompt after tool schemas are
-  removed or a continuation resumes prior tool history.
-- Add adversarial tests for encoded and literal internal targets, URL variants,
-  continuation history, user-versus-assistant provenance, and page-content injection.
-
-## Review billing and flag boundaries
-
-Inspect `src/billing.rs`, `src/os_flags.rs`, their initialization, and every
-caller's decision logic.
-
-- Verify the exact external endpoint, authentication header, product/user inputs,
-  response schema, timeout, cache key, and cache TTL without describing the
-  external service implementation.
-- Review missing-client, missing-flag, denial, malformed response, timeout, and
-  service-error behavior per route. Do not generalize one route's fail-open,
-  fail-closed, fallback, or local-development exception to all features.
-- Keep model-access defaults, provider-routing fallback, web-search fallback,
-  paid-feature checks, guest policy, and ordinary chat quota checks distinct.
-- Treat changes to entitlement failure semantics, metering order, idempotency,
-  reservation/settlement, or usage events as backend API/security changes.
-- Never commit service keys or production endpoints as secrets. Use documented
-  environment variables and approved development/production servers.
-
-## Review logs and errors
-
-Assume enclave stdout/stderr can cross VSOCK to a host-visible logging system.
-Treat every log level, including `trace`, as an external disclosure boundary.
-
-- Never log decrypted request/response bodies, prompts, reasoning, instructions,
-  metadata, OAuth profiles/emails, authorization headers, cookies, tokens, reset
-  codes, passwords/verifiers, session/enclave/provider keys, KMS plaintext, or
-  raw credential/secret-service responses.
-- Prefer request IDs, operation names, provider names, status classes, bounded
-  counts, durations, and sanitized trace IDs. Minimize stable user identifiers.
-- Do not assume `Debug` is safe. Inspect custom `Debug` implementations and nested
-  error types before logging `{:?}` or propagating an error string.
-- Do not log raw upstream error bodies or response headers. Map them to bounded,
-  non-sensitive categories and return generic public errors.
-- Run the source logging invariants, but also inspect semantically sensitive
-  payload structs: identifier-based scanners cannot prove that content is absent.
-
-## Review Nitro, KMS, build, and release evidence
-
-Inspect `flake.nix`, pinned Nitro helper sources, entrypoint/VSOCK code, CI,
-environment-specific EIF outputs, PCR references/history tooling, and current
-public deployment docs.
-
-- Keep these claims separate:
-
-  1. Rust tests establish local code behavior.
-  2. Nix checks establish reviewed source/build invariants.
-  3. An EIF build and PCR match establish a reproducible artifact measurement.
-  4. Signed history establishes only what the current signature format and key policy cover.
-  5. Live KMS/IAM, client trust policy, deployed EIF, parent services, and staging
-     smoke establish deployment behavior.
-
-- Verify the current repository's actual release format; do not describe an
-  unmerged future signing or transparency design as deployed.
-- Review KMS key/alias identity, account, region, encryption context, recipient
-  attestation conditions, Secrets Manager identity, parent VSOCK provenance,
-  credential permissions, signing-key custody, rollback, and revocation. Mark
-  all live-policy claims unverified until inspected.
-- Never run PCR copy/update/append/signing, remote migration, SCP, enclave
-  terminate/run, debug-console, stage, or deploy recipes without explicit user
-  authorization for the exact environment. Verification commands can still
-  build artifacts; inspect their recipes first.
-
-## Keep findings task-local
-
-Re-derive behavior from the revision under review. Keep revision-specific
-findings in task-local review notes or the requested code-review output rather
-than evergreen skills or `AGENTS.md`. Promote only stable engineering rules and
-repeatable review methods back into repository guidance.
-
-## Validate proportionally
-
-Use the Nix shell and mirror CI. Disable shell-hook Postgres and `.env` creation
-for compile-only/unit checks when they are unnecessary:
-
-```sh
-OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c cargo fmt --all -- --check
-OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c env RUSTFLAGS='-D warnings' \
-  cargo clippy --locked --all-targets --all-features -- -D warnings
-OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c env RUSTFLAGS='-D warnings' \
-  cargo test --locked --all-features
-git diff --check
-```
-
-The full test command includes crypto property tests and source-level security
-invariants but skips ignored integration/live tests. For security-sensitive
-changes, also name the focused test module or exact test in the report.
-
-For credential, seed-wrap, reset, or encrypted-schema changes, use the
-fail-closed disposable-database procedure in `$validate-opensecret`. Do not copy
-an abbreviated test command here: the validation procedure verifies the target
-cluster and database, confirms the intended tests were discovered and executed,
-and keeps live-provider ignored tests separate.
-
-Run the exact live Tinfoil parity test only when the user has authorized egress
-and provided an approved credential source, following
-`docs/tinfoil-rust-sdk-parity.md`.
-
-Run Linux/ARM EIF and PCR checks only when the change reaches that boundary and
-the compatible builder is available. Report local, CI, artifact, and live smoke
-evidence separately; do not fill an untested layer with inference.
+Local artifact builds and read-only PCR comparison are validation when in
+scope. Require explicit authorization for PCR reference/history mutation,
+signing, KMS/IAM changes, shared or remote migrations, artifact transfer,
+enclave or remote-service lifecycle, secret writes, staging, deployment, or
+release actions. Inspect recipes before deciding whether they are read-only.
 
 ## Report the review
 
-Lead with the verdict and prioritized findings. For each finding include:
+Lead with the verdict and prioritized diff findings. For each finding, state:
 
-- evidence class and exact file/symbol;
-- affected trust boundary and attacker or failure preconditions;
+- evidence class and exact file or symbol;
+- affected boundary and required preconditions;
 - concrete impact without incident language;
-- the invariant or design change required;
-- focused regression tests and any coordinated Maple/API migration;
-- deployment evidence still needed.
+- invariant or design change required;
+- regression proof and client/deployment coordination still needed.
 
-Then list commands actually run, ignored or unavailable checks, and residual
-risk. If there are no findings, say which boundaries were checked; do not imply
-that uninspected deployment systems are secure.
+Then list commands run, omitted or unavailable checks, and residual uncertainty.
+If there are no findings, name the boundaries reviewed without implying that
+uninspected systems are secure. Keep revision-specific observations in the
+review output; promote only durable methods back into repository guidance.

--- a/.agents/skills/review-opensecret-security/SKILL.md
+++ b/.agents/skills/review-opensecret-security/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: review-opensecret-security
+description: Review security-sensitive OpenSecret backend changes and claims. Use for attestation, client-enclave sessions, AEAD or key derivation, JWT/API-key/OAuth authentication, encrypted persistence, migrations, provider routing, web tools and URL provenance, billing or flag API boundaries, secrets, logging, Nitro/KMS/PCR evidence, streaming, and release-affecting diffs.
+---
+
+# Review OpenSecret Security
+
+Review the current source and diff as evidence. This skill defines durable
+review standards; it does not catalogue current findings. Default to a
+read-only review and implement changes only when the user asks.
+
+## Establish scope and evidence
+
+1. Read the repository `AGENTS.md`, the relevant source, tests, migrations, and
+   public documentation before forming a verdict.
+2. Confirm the revision and comparison base. Prefer current `master`; do not
+   rebase, reset, or fetch over user work merely to obtain it.
+3. Inspect the complete change, including generated schema, lockfile, submodule,
+   Nix, workflow, environment, and migration changes:
+
+   ```sh
+   git status --short --branch
+   git diff --stat origin/master...HEAD
+   git diff origin/master...HEAD --
+   git diff --cached --
+   git diff --
+   git ls-files --others --exclude-standard
+   git submodule status
+   git diff --check
+   ```
+
+4. Trace each changed value from input through authorization, decryption,
+   persistence, provider calls, response encryption, and logs. Do not review a
+   handler in isolation from router middleware or database scoping.
+5. Label every conclusion with one of these evidence classes:
+
+   - **source-confirmed**: the reviewed revision directly establishes the behavior;
+   - **test-confirmed**: a named test exercised the relevant behavior in this run;
+   - **build-confirmed**: a named reproducible build or artifact check passed;
+   - **live-confirmed**: the exact deployed environment was inspected or exercised;
+   - **inferred**: the conclusion follows from source plus stated assumptions;
+   - **unverified**: deployment configuration or an external system was not inspected.
+
+Keep claims within the evidence available. Local tests do not prove live DB
+TLS, IAM, KMS policy, Nitro measurements, client trust policy, provider
+behavior, billing decisions, or log retention.
+
+## Map the trust boundaries
+
+State which boundaries the change crosses:
+
+- Maple or another client to the OpenSecret enclave;
+- the public HTTP router to JWT, API-key, OAuth, and project authorization;
+- enclave plaintext to host-accessible Postgres or logs;
+- OpenSecret to Tinfoil, Continuum/OpenAI-compatible providers, Brave, Kagi,
+  OAuth providers, billing, or flags;
+- enclave to its parent instance over VSOCK for AWS credentials, secrets, and logs;
+- source to Nix build, EIF/PCR evidence, CI, KMS policy, and deployed enclave.
+
+Distinguish the client's attestation of OpenSecret from OpenSecret's attested
+connection to an upstream Tinfoil enclave. A local mock attestation exercises
+protocol shape only; it is not Nitro or production trust evidence.
+
+## Enforce placement rules
+
+Keep these responsibilities in the backend:
+
+- authentication, authorization, project scoping, token issuance, and revocation policy;
+- provider selection, provider model IDs, provider-only request fields, retries,
+  provider credentials, and upstream error sanitization;
+- URL authorization and SSRF policy for model-initiated tools;
+- billing and feature-flag decisions at their HTTP API boundary;
+- encryption-at-rest formats, migrations, destructive-reset behavior, and audit logs.
+
+Keep presentation and user interaction in Maple. Do not make Maple select a
+confidential provider, supply provider secrets, or reproduce backend policy.
+Changes to attestation documents, key exchange, encrypted envelopes, headers,
+streaming, token lifecycle, or error schemas are shared protocol changes: update
+and test backend and client implementations together with an explicit version or
+compatibility plan.
+
+Treat billing and flags as external APIs only. Review OpenSecret's request,
+response, timeout, caching, authentication, and failure semantics without
+relying on server-internal implementation details. Local setup may point those
+clients at approved development or production endpoints as appropriate.
+
+## Review client-enclave transport
+
+Inspect `src/web/attestation_routes.rs`, `src/web/encryption_middleware.rs`, the
+session/cache implementation in `src/main.rs`, and every affected router.
+
+- Require a fresh, unpredictable client nonce and one-time ephemeral key use.
+- Verify nonce/body limits, TTLs, capacities, eviction, lease lifetime, and
+  cleanup on malformed, abandoned, concurrent, and failed requests.
+- Reject non-contributory X25519 inputs and zeroize secret/session material.
+- Confirm every sensitive route validates a live encryption session, including
+  GET, DELETE, and handlers with `()` bodies, before side effects.
+- Separately confirm route authentication and authorization. Possession of an
+  `x-session-id` is not automatically proof of JWT identity, project membership,
+  or durable-credential possession.
+- For AEAD, review key direction, domain separation, nonce uniqueness, canonical
+  AAD, method/path/query/session/request binding, replay handling, and response
+  association. Parser differences are not cryptographic domain separation.
+- Keep plaintext credentials and sensitive payloads out of query strings, URLs,
+  and other host-visible metadata.
+- Move blocking NSM or cryptographic work off async executor threads and bound
+  admission if the current path can be driven publicly.
+
+Do not silently change the existing encrypted protocol. Require compatibility
+vectors for success, tamper, wrong-session, wrong-route, replay, bodyless, error,
+and streaming cases.
+
+## Review authentication and OAuth
+
+Inspect `src/jwt.rs`, `src/web/openai_auth.rs`, login routes, `src/oauth.rs`,
+OAuth routes, seed wrapping, and the router composition in `src/main.rs`.
+
+- Keep internal access/refresh tokens distinct from project-issued third-party
+  tokens. Confirm algorithm, audience, token format, subject, project, and auth
+  context for the exact token domain.
+- Issue or refresh user tokens only after the signed `AuthContext` matches the
+  user project and an active credential-bound seed wrap successfully verifies.
+- Preserve the signed auth context during refresh; do not silently recompute it
+  from mutable database fields.
+- Treat OpenAI-compatible API-key auth as a separate capability. Do not derive or
+  expose user-private storage keys unless an API-key-bound seed-wrap design exists.
+- Check expiry, maturity, clock-skew, rotation, replay, logout, and revocation as
+  separate properties. Never infer server-side revocation from client token deletion.
+- Make OAuth state random, bounded, expiring, exact-match, and atomically one-use.
+  Review whether it is bound to the initiating encrypted session and redirect flow.
+- Derive OAuth identity from verified provider subject plus project. Distinguish
+  signed claims from client hints, especially native Apple nonce, email, and name.
+- Unwrap the credential-bound seed before issuing tokens. Test provider-subject,
+  project, verifier, wrap, and reset-row substitution.
+
+## Review encrypted persistence and migrations
+
+Inspect `src/encrypt.rs`, `src/seed_wrapping.rs`, `src/db.rs`, affected models,
+`src/models/schema.rs`, SQL migrations, `src/migrations.rs`,
+`src/security_invariants.rs`, and `src/aead_db_tamper_tests.rs`.
+
+- For new sensitive data, define a versioned, domain-separated envelope with a
+  purpose-specific HKDF key and canonical AAD covering the necessary owner,
+  project, row, field, credential kind, and version.
+- Never change an existing ciphertext format in place. Design dual-read/write,
+  rollback, restart, and deletion behavior explicitly, then remove temporary
+  translation code after rollout.
+- Test round trip, single-bit tamper, wrong key, wrong AAD, row/account/project
+  substitution, credential change, destructive reset, and concurrent stale state.
+- Preserve transaction boundaries around credential verifier, seed wrap, user,
+  provider connection, and reset changes.
+- Classify every new user-key-encrypted table in the destructive-reset invariant.
+  Confirm ownership foreign keys, cascades, uniqueness, checks, and access-path indexes.
+- Distinguish Diesel schema migrations from application-data migrations.
+  Ordinary startup code does not have each user's credential-derived key. A
+  user-private ciphertext change therefore needs versioned dual-read/new-write
+  behavior and lazy rewrite after authenticated key recovery, unless a separate
+  authorized backfill is explicitly designed. Startup rewriting is suitable
+  only for data whose system/enclave key is actually available; it must be
+  idempotent, restart-safe, bounded, and fail closed.
+- Verify what API options such as `store` actually do by tracing persistence;
+  do not promise ephemeral behavior from a response field or comment alone.
+- Run migration and tamper checks only against a disposable, migrated local database.
+
+## Review providers, headers, and streaming
+
+Inspect `src/provider_routing.rs`, `src/proxy_config.rs`,
+`src/provider_client.rs`, model configuration, and the calling route.
+
+- Accept public/canonical model IDs at the API boundary. Keep provider choice,
+  provider model translation, feature-flag preference, fallback, and provider-only
+  fields behind the backend routing boundary.
+- Load credentials only from approved runtime secret inputs. Replace inbound
+  authorization with the configured upstream credential and mark secret headers
+  sensitive. Never log or return provider keys.
+- Review every forwarded header. Prefer an explicit allowlist for a new
+  boundary, and prove that client authorization, proxy credentials, hop-by-hop
+  headers, `Connection`-named headers, host, content length, and
+  provider-managed fields cannot cross.
+- For Tinfoil, preserve discovery, attestation, TLS pinning, single-flight refresh,
+  bounded attempts, and connection reuse. Retry only failures known to occur
+  before request bytes were accepted; do not replay ambiguous completion requests.
+- Treat cache namespace material separately from API credentials and from a
+  client-held secret. Document who can derive it and its stability requirements.
+- Preserve decrypted HTTP and SSE contracts: method, path/query, body bytes,
+  application content type, ordered events, numeric usage, error mapping, and
+  exactly one terminal `[DONE]` where the endpoint promises it.
+- Sanitize upstream errors by status, category, and bounded identifiers. Raw
+  bodies and headers can contain prompts, PII, tokens, or provider diagnostics.
+
+## Review web tools and request provenance
+
+Inspect `src/web/web_safety.rs`, Responses tool execution and prompt rebuilding,
+and direct web routes.
+
+- Treat URL provenance as authorization. For model-initiated `open_urls`, allow
+  only exact normalized URLs from visible user text or canonical structured URL
+  fields emitted by trusted backend formatters.
+- Never authorize URLs found in assistant/system text, titles, snippets,
+  diagnostics, image parts, or extracted page bodies. Those are untrusted data.
+- Preserve HTTPS-only, no-credentials, public-host checks and the private,
+  reserved, metadata, IPv4, IPv6, 6to4, and NAT64 defenses.
+- Keep direct authenticated extraction and model-generated extraction as separate
+  trust models. Do not weaken model provenance because a direct endpoint exists.
+- Reassess DNS, redirects, rebinding, and destination revalidation when changing
+  which component performs the fetch. Lexical checks for a remote fetcher do not
+  automatically secure a new local fetcher.
+- Bound query length, URL count, URL length, result count, output size, tool turns,
+  timeouts, and retained provenance. Sanitize image/HTML embeds.
+- Keep untrusted-content guidance in the rebuilt prompt after tool schemas are
+  removed or a continuation resumes prior tool history.
+- Add adversarial tests for encoded and literal internal targets, URL variants,
+  continuation history, user-versus-assistant provenance, and page-content injection.
+
+## Review billing and flag boundaries
+
+Inspect `src/billing.rs`, `src/os_flags.rs`, their initialization, and every
+caller's decision logic.
+
+- Verify the exact external endpoint, authentication header, product/user inputs,
+  response schema, timeout, cache key, and cache TTL without describing the
+  external service implementation.
+- Review missing-client, missing-flag, denial, malformed response, timeout, and
+  service-error behavior per route. Do not generalize one route's fail-open,
+  fail-closed, fallback, or local-development exception to all features.
+- Keep model-access defaults, provider-routing fallback, web-search fallback,
+  paid-feature checks, guest policy, and ordinary chat quota checks distinct.
+- Treat changes to entitlement failure semantics, metering order, idempotency,
+  reservation/settlement, or usage events as backend API/security changes.
+- Never commit service keys or production endpoints as secrets. Use documented
+  environment variables and approved development/production servers.
+
+## Review logs and errors
+
+Assume enclave stdout/stderr can cross VSOCK to a host-visible logging system.
+Treat every log level, including `trace`, as an external disclosure boundary.
+
+- Never log decrypted request/response bodies, prompts, reasoning, instructions,
+  metadata, OAuth profiles/emails, authorization headers, cookies, tokens, reset
+  codes, passwords/verifiers, session/enclave/provider keys, KMS plaintext, or
+  raw credential/secret-service responses.
+- Prefer request IDs, operation names, provider names, status classes, bounded
+  counts, durations, and sanitized trace IDs. Minimize stable user identifiers.
+- Do not assume `Debug` is safe. Inspect custom `Debug` implementations and nested
+  error types before logging `{:?}` or propagating an error string.
+- Do not log raw upstream error bodies or response headers. Map them to bounded,
+  non-sensitive categories and return generic public errors.
+- Run the source logging invariants, but also inspect semantically sensitive
+  payload structs: identifier-based scanners cannot prove that content is absent.
+
+## Review Nitro, KMS, build, and release evidence
+
+Inspect `flake.nix`, pinned Nitro helper sources, entrypoint/VSOCK code, CI,
+environment-specific EIF outputs, PCR references/history tooling, and current
+public deployment docs.
+
+- Keep these claims separate:
+
+  1. Rust tests establish local code behavior.
+  2. Nix checks establish reviewed source/build invariants.
+  3. An EIF build and PCR match establish a reproducible artifact measurement.
+  4. Signed history establishes only what the current signature format and key policy cover.
+  5. Live KMS/IAM, client trust policy, deployed EIF, parent services, and staging
+     smoke establish deployment behavior.
+
+- Verify the current repository's actual release format; do not describe an
+  unmerged future signing or transparency design as deployed.
+- Review KMS key/alias identity, account, region, encryption context, recipient
+  attestation conditions, Secrets Manager identity, parent VSOCK provenance,
+  credential permissions, signing-key custody, rollback, and revocation. Mark
+  all live-policy claims unverified until inspected.
+- Never run PCR copy/update/append/signing, remote migration, SCP, enclave
+  terminate/run, debug-console, stage, or deploy recipes without explicit user
+  authorization for the exact environment. Verification commands can still
+  build artifacts; inspect their recipes first.
+
+## Keep findings task-local
+
+Re-derive behavior from the revision under review. Keep revision-specific
+findings in task-local review notes or the requested code-review output rather
+than evergreen skills or `AGENTS.md`. Promote only stable engineering rules and
+repeatable review methods back into repository guidance.
+
+## Validate proportionally
+
+Use the Nix shell and mirror CI. Disable shell-hook Postgres and `.env` creation
+for compile-only/unit checks when they are unnecessary:
+
+```sh
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c cargo fmt --all -- --check
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c env RUSTFLAGS='-D warnings' \
+  cargo clippy --locked --all-targets --all-features -- -D warnings
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c env RUSTFLAGS='-D warnings' \
+  cargo test --locked --all-features
+git diff --check
+```
+
+The full test command includes crypto property tests and source-level security
+invariants but skips ignored integration/live tests. For security-sensitive
+changes, also name the focused test module or exact test in the report.
+
+For credential, seed-wrap, reset, or encrypted-schema changes, use the
+fail-closed disposable-database procedure in `$validate-opensecret`. Do not copy
+an abbreviated test command here: the validation procedure verifies the target
+cluster and database, confirms the intended tests were discovered and executed,
+and keeps live-provider ignored tests separate.
+
+Run the exact live Tinfoil parity test only when the user has authorized egress
+and provided an approved credential source, following
+`docs/tinfoil-rust-sdk-parity.md`.
+
+Run Linux/ARM EIF and PCR checks only when the change reaches that boundary and
+the compatible builder is available. Report local, CI, artifact, and live smoke
+evidence separately; do not fill an untested layer with inference.
+
+## Report the review
+
+Lead with the verdict and prioritized findings. For each finding include:
+
+- evidence class and exact file/symbol;
+- affected trust boundary and attacker or failure preconditions;
+- concrete impact without incident language;
+- the invariant or design change required;
+- focused regression tests and any coordinated Maple/API migration;
+- deployment evidence still needed.
+
+Then list commands actually run, ignored or unavailable checks, and residual
+risk. If there are no findings, say which boundaries were checked; do not imply
+that uninspected deployment systems are secure.

--- a/.agents/skills/review-opensecret-security/agents/openai.yaml
+++ b/.agents/skills/review-opensecret-security/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review OpenSecret Security"
+  short_description: "Review backend trust and crypto boundaries"
+  default_prompt: "Use $review-opensecret-security to review this backend change for security regressions."

--- a/.agents/skills/validate-opensecret/SKILL.md
+++ b/.agents/skills/validate-opensecret/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: validate-opensecret
-description: Validate OpenSecret changes with focused Rust tests, exact CI parity, disposable PostgreSQL migration and ignored-test proof, separately authorized provider checks, encrypted SDK or Maple smoke tests, and Nix/EIF/PCR evidence. Use before claiming backend work complete or when reviewing whether test evidence matches a changed API, provider, persistence, security, build, or deployment boundary.
+description: Validate OpenSecret changes with focused Rust tests, exact Rust CI parity, disposable PostgreSQL migration and ignored-test proof, separately authorized provider checks, encrypted SDK or Maple smoke tests, Nix checks, and release-only EIF/PCR evidence. Use before claiming backend work complete or when reviewing whether test evidence matches a changed API, provider, persistence, security, build, or deployment boundary.
 ---
 
 # Validate OpenSecret
@@ -17,7 +17,8 @@ applicable tiers. A higher tier supplements rather than replaces lower tiers.
 | Auth, encryption, persistence, reset, or SQL migration | Tier 1 plus Tier 2 when database state is involved. |
 | HTTP, middleware, SSE, Responses, or client contract | Tier 1 plus Tier 4; include affected SDK/Maple paths. |
 | Provider, model, routing, headers, usage, or attestation | Tier 1 plus focused provider tests; add authorized Tiers 3 and 4 when the claim reaches them. |
-| Nix, entrypoint, kernel, Nitro, EIF, or PCR | Tier 1 when Rust is affected plus Tier 5 on each available platform. |
+| Nix, entrypoint, kernel, or packaging | Tier 1 when Rust is affected plus applicable current-host Tier 5 checks. |
+| Authorized dev or prod publish/deployment | Tier 5 release EIF/PCR evidence on the supported Linux/ARM64 builder. |
 
 Keep credentials and user data out of commands, logs, fixtures, and tracked
 files. Never blanket-run `cargo test -- --ignored`: ignored tests mix
@@ -77,7 +78,7 @@ OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
   ./.agents/skills/validate-opensecret/scripts/disposable_db_tests.sh
 ```
 
-When the diff adds or changes the latest reversible migration, use
+When the diff adds a new, unreleased latest reversible migration, use
 `--redo-latest` instead. It includes the same validation and also exercises the
 latest down/up cycle inside that disposable lifecycle:
 
@@ -149,7 +150,7 @@ Configure billing or feature-flag API URLs/keys only when their public backend
 outcome is in scope. Treat them as external HTTP dependencies and test the
 changed success, denial, timeout, and unavailable behavior.
 
-## Tier 5: validate Nix, EIF, and PCR boundaries
+## Tier 5: validate Nix and release artifacts
 
 For current-host flake or packaging changes:
 
@@ -159,27 +160,30 @@ nix flake check --no-write-lock-file --print-build-logs
 nix build --no-link --no-write-lock-file .#default
 ```
 
-Current-host checks do not prove Linux/ARM EIF construction. On the supported
-Linux/ARM builder, development artifact/PCR validation is:
+EIF construction, PCR comparison, and reference/history updates are
+release-only work. Ordinary development and pull-request completion do not run
+or block on the all-PR PCR comparison. If CI successfully builds an EIF and
+then fails only because compiled inputs changed its measurements, report
+deferred release work and do not copy or sign CI values to make it green. Treat
+an EIF build failure separately.
 
-```sh
-nix build '.?submodules=1#eif-dev'
-cmp -s result/pcr.json pcrDev.json
-```
-
-Use production outputs only when production-image validation is in scope.
-Record the derivation and comparison result. Building and read-only comparison
-are not deployment; PCR mutation, artifact transfer, KMS changes, enclave
-lifecycle, staging, and deployment require explicit authorization.
+Immediately before an authorized dev or prod publish/deployment, use the
+supported Linux/ARM64 release builder and the operator runbook in
+`docs/nitro-deploy.md` to build the exact target, review its measurements, and
+deliberately update and verify the appropriate references and history. PCR
+mutation, signing, artifact transfer, KMS changes, enclave lifecycle, staging,
+and deployment require explicit authorization.
 
 ## Report without overclaiming
 
 Record the commit and dirty state, host, exact commands, test/ignored/skip
 counts, disposable database lifecycle, external authorization category, client
-configuration, artifact/PCR source, and every unrun or unavailable layer.
+configuration, and every unrun or unavailable layer. For release evidence,
+also record the target artifact and PCR source.
 
-Use narrow labels: **static/unit**, **disposable DB**, **live provider**,
-**local encrypted full stack**, **Linux/Nitro/PCR**, or **deployed** validated.
+Use narrow labels: **static/unit**, **disposable DB**, **live provider**, or
+**local encrypted full stack**. Use **Linux/Nitro/PCR** or **deployed** only for
+authorized release/deployment evidence.
 Failed, skipped, ignored, interrupted, timing-dependent, and unavailable checks
 remain exactly that; do not turn partial evidence into “fully tested” or
 “production ready.”

--- a/.agents/skills/validate-opensecret/SKILL.md
+++ b/.agents/skills/validate-opensecret/SKILL.md
@@ -1,68 +1,46 @@
 ---
 name: validate-opensecret
-description: Validate OpenSecret backend changes with side-effect-free Rust checks, exact CI-parity commands, targeted security and API tests, disposable PostgreSQL migration and tamper tests, explicit live-provider contracts, encrypted frontend/backend smoke tests, and platform-specific Nix or EIF checks. Use before claiming an OpenSecret implementation complete, when reviewing test evidence, or when changes touch Rust code, authentication, encryption, Responses or OpenAI-compatible APIs, streaming, providers, migrations, Nix, entrypoints, or enclave PCRs.
+description: Validate OpenSecret changes with focused Rust tests, exact CI parity, disposable PostgreSQL migration and ignored-test proof, separately authorized provider checks, encrypted SDK or Maple smoke tests, and Nix/EIF/PCR evidence. Use before claiming backend work complete or when reviewing whether test evidence matches a changed API, provider, persistence, security, build, or deployment boundary.
 ---
 
 # Validate OpenSecret
 
-## Build an evidence plan from the diff
+## Select evidence from the diff
 
-1. Read `AGENTS.md`, inspect `git status --short --branch`, and identify every changed trust boundary.
-2. Select the union of all applicable tiers below. A higher tier supplements; it does not replace the lower tiers.
-3. Run the narrowest relevant test while iterating, then run the required completion tiers.
-4. Keep secrets out of commands, logs, fixtures, and tracked files. Use `.local/secrets/` or protected environment variables.
-5. Never run all ignored tests with a blanket `cargo test -- --ignored`. The ignored set mixes destructive disposable-database tests with a credentialed live-network test. Invoke only an explicit module or exact test name.
+Read `AGENTS.md`, inspect the complete worktree, and select the union of the
+applicable tiers. A higher tier supplements rather than replaces lower tiers.
 
-| Change | Required validation |
+| Change | Required evidence |
 | --- | --- |
-| Documentation only | Verify every referenced path, command, environment variable, and behavior against the checkout; inspect the rendered diff. |
-| Any Rust behavior or dependency | Side-effect-free targeted tests while iterating, then Tier 1 CI parity. |
-| Auth, session, encryption, seed wrapping, persisted ciphertext, deletion, or reset | Tier 1 plus the relevant security/property tests; add Tier 2 database tests when persistence is involved. |
-| Diesel models, schema, SQL, or application-data migration | Tiers 1 and 2; add a boot or full-stack smoke when startup/data migration behavior changes. |
-| HTTP contract, middleware, SSE, OpenAI-compatible route, or Responses API | Tier 1 plus Tier 4 encrypted/authenticated smoke; include Maple when the public client contract changes. |
-| Provider transport, routing, model catalog, headers, usage, or attestation | Tier 1 plus targeted provider tests; add the explicitly named Tier 3 live test and Tier 4 app smoke when credentials and egress are authorized. |
-| `flake.nix`, `flake.lock`, `entrypoint.sh`, kernel, Nitro, EIF, or PCR | Tier 1 when Rust is affected plus Tier 5 on every available platform; require Linux/ARM CI evidence for Linux/Nitro claims. |
+| Documentation only | Verify every changed path, command, variable, link, and behavioral claim. |
+| Rust behavior or dependency | Focused tests, then Tier 1. |
+| Auth, encryption, persistence, reset, or SQL migration | Tier 1 plus Tier 2 when database state is involved. |
+| HTTP, middleware, SSE, Responses, or client contract | Tier 1 plus Tier 4; include affected SDK/Maple paths. |
+| Provider, model, routing, headers, usage, or attestation | Tier 1 plus focused provider tests; add authorized Tiers 3 and 4 when the claim reaches them. |
+| Nix, entrypoint, kernel, Nitro, EIF, or PCR | Tier 1 when Rust is affected plus Tier 5 on each available platform. |
 
-## Keep ordinary checks side-effect-free
+Keep credentials and user data out of commands, logs, fixtures, and tracked
+files. Never blanket-run `cargo test -- --ignored`: ignored tests mix
+disposable-database mutation with a credentialed live-provider test.
 
-The default `nix develop` shell hook may initialize or start `.pgdata`, create `.env` with local secrets, and on Linux configure local container state. Disable all three behaviors for formatting, linting, unit tests, and flake evaluation:
+## Tier 0: iterate narrowly
 
-```sh
-OPENSECRET_DEV_POSTGRES=0 \
-OPENSECRET_DEV_ENV=0 \
-OPENSECRET_DEV_CONTAINERS=0 \
-nix develop --no-write-lock-file -c <command>
-```
-
-Use the stateful shell only when the selected tier genuinely needs local services. Give concurrent checkouts distinct `PGDATA`, `PGPORT`, `DATABASE_URL`, backend ports, and test databases. Never point local validation at shared, preview, or production state.
-
-Do not treat `cargo audit`, `cargo deny`, or `cargo machete` as repository CI gates merely because the Nix shell provides them. Run one only when the task calls for it, state its configuration and network conditions, and report it separately.
-
-## Tier 0: iterate with focused pure checks
-
-Run focused unit tests after locating the owning module. Preserve `--locked --all-features` so local resolution and feature coverage do not silently diverge:
+Disable stateful shell hooks for pure checks. For example:
 
 ```sh
 OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
   nix develop --no-write-lock-file -c \
-  cargo test --locked --all-features <module_or_test_filter>
+  cargo test --locked --all-features provider_client::tests
 ```
 
-Useful filters include:
-
-```sh
-cargo test --locked --all-features security_invariants
-cargo test --locked --all-features crypto_property_tests
-cargo test --locked --all-features provider_client::tests
-cargo test --locked --all-features web::openai::tests
-cargo test --locked --all-features web::responses
-```
-
-Choose filters from the changed code rather than using this list mechanically. Focused success is iteration evidence, not completion evidence.
+Choose a filter from the owning code. Focused success is iteration evidence,
+not completion evidence.
 
 ## Tier 1: reproduce Rust CI
 
-Initialize public submodules recursively, then run the same inner commands and warning policy as `.github/workflows/rust.yml` through the pinned Nix environment:
+Initialize submodules when building or testing, then run the exact inner gates
+from `.github/workflows/rust.yml` through the pinned, side-effect-disabled Nix
+environment:
 
 ```sh
 git submodule update --init --recursive
@@ -71,235 +49,109 @@ OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
   nix develop --no-write-lock-file -c cargo fmt --all -- --check
 
 OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c \
-  env RUSTFLAGS="-D warnings" \
+  nix develop --no-write-lock-file -c env RUSTFLAGS='-D warnings' \
   cargo clippy --locked --all-targets --all-features -- -D warnings
 
 OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c \
-  env RUSTFLAGS="-D warnings" cargo test --locked --all-features
+  nix develop --no-write-lock-file -c env RUSTFLAGS='-D warnings' \
+  cargo test --locked --all-features
 ```
 
-Read the test summary. The default suite intentionally does not execute ignored tests. Report its passed, failed, and ignored counts; do not summarize it as “all tests” when ignored tests remain.
+Report passed, failed, and ignored counts. Default CI has no PostgreSQL service
+and does not execute ignored tests. Do not substitute an aggregate recipe
+unless its checked-in definition preserves the same targets, features,
+lockfile, and warning policy.
 
-Do not substitute an unverified aggregate recipe for the exact commands above.
-Before relying on one, inspect its checked-in definition and prove that it
-preserves the same targets, features, lockfile, and warning policy.
+## Tier 2: prove migrations and database-backed tests
 
-## Tier 2: validate migrations and database-backed security
-
-The ignored tests mutate and delete rows. Run them only in a fresh PostgreSQL
-cluster whose data directory, listener, role, and database are created for this
-command. Do not use the default stateful shell hook: it may reuse any server
-already answering on `localhost:$PGPORT` before it inspects `.pgdata`.
-
-From the repository root, the following procedure disables all shell-hook
-state, starts a temporary cluster on an OS-selected loopback port, proves the
-connected data directory, port, database, user, owner, empty schema, and Diesel
-migration count, discovers the ignored subsets, executes them serially with
-visible output, and removes only the guarded temporary cluster on exit:
-
-```sh
-OPENSECRET_DEV_POSTGRES=0 \
-OPENSECRET_DEV_ENV=0 \
-OPENSECRET_DEV_CONTAINERS=0 \
-nix develop --no-write-lock-file -c bash <<'BASH'
-set -euo pipefail
-
-OPENSECRET_TEST_TMPROOT="${TMPDIR:-/tmp}"
-OPENSECRET_TEST_TMPROOT="${OPENSECRET_TEST_TMPROOT%/}"
-PGDATA="$(mktemp -d "$OPENSECRET_TEST_TMPROOT/opensecret-db-tests.XXXXXX")"
-readonly OPENSECRET_TEST_PGDATA="$PGDATA"
-PGSOCKETS="$PGDATA/sockets"
-PGPORT="$(python3 - <<'PY'
-import socket
-
-with socket.socket() as sock:
-    sock.bind(("127.0.0.1", 0))
-    print(sock.getsockname()[1])
-PY
-)"
-OPENSECRET_TEST_DB="opensecret_agent_test_$(openssl rand -hex 6)"
-OPENSECRET_TESTS_PASSED=0
-export PGDATA PGSOCKETS PGPORT OPENSECRET_TEST_DB
-
-cleanup() {
-  status=$?
-  trap - EXIT
-  if [[ "${PGDATA:-}" != "$OPENSECRET_TEST_PGDATA" ||
-        "$OPENSECRET_TEST_PGDATA" !=
-          "$OPENSECRET_TEST_TMPROOT"/opensecret-db-tests.* ]]; then
-    printf 'refusing to clean unexpected PGDATA: %s\n' \
-      "${PGDATA:-<unset>}" >&2
-    exit 1
-  fi
-  if [ -f "$PGDATA/PG_VERSION" ] && \
-     pg_ctl status -D "$PGDATA" >/dev/null 2>&1 && \
-     ! pg_ctl stop -D "$PGDATA" -m fast >/dev/null; then
-    printf 'PostgreSQL did not stop; preserving temporary state at %s\n' \
-      "$PGDATA" >&2
-    exit 1
-  fi
-  rm -rf -- "$PGDATA"
-  if [ "$status" -eq 0 ] && [ "$OPENSECRET_TESTS_PASSED" -eq 1 ]; then
-    printf '%s\n' \
-      'Disposable-DB evidence: 14 AEAD/database tests and 2 OAuth database tests passed; no tests skipped; temporary cluster removed.'
-  fi
-  exit "$status"
-}
-trap cleanup EXIT
-
-initdb -D "$PGDATA" --username="${USER:?}" \
-  --auth-local=trust --auth-host=scram-sha-256 >/dev/null
-mkdir -p "$PGSOCKETS"
-pg_ctl start -D "$PGDATA" \
-  -o "-h 127.0.0.1 -p $PGPORT -k $PGSOCKETS" \
-  -l "$PGDATA/postgres.log" -w >/dev/null
-
-expected_pgdata="$(cd "$PGDATA" && pwd -P)"
-reported_pgdata="$(psql -h "$PGSOCKETS" -p "$PGPORT" -U "$USER" \
-  -d postgres -Atqc 'SHOW data_directory')"
-reported_pgdata="$(cd "$reported_pgdata" && pwd -P)"
-test "$reported_pgdata" = "$expected_pgdata"
-test "$(psql -h "$PGSOCKETS" -p "$PGPORT" -U "$USER" \
-  -d postgres -Atqc 'SHOW port')" = "$PGPORT"
-
-psql -h "$PGSOCKETS" -p "$PGPORT" -U "$USER" -d postgres \
-  -v ON_ERROR_STOP=1 \
-  -c "CREATE USER opensecret_user WITH PASSWORD 'password'" >/dev/null
-createdb -h "$PGSOCKETS" -p "$PGPORT" -U "$USER" \
-  --maintenance-db=postgres --owner=opensecret_user "$OPENSECRET_TEST_DB"
-
-AEAD_TAMPER_TEST_DATABASE_URL="postgres://opensecret_user:password@127.0.0.1:${PGPORT}/${OPENSECRET_TEST_DB}"
-export AEAD_TAMPER_TEST_DATABASE_URL
-
-db_identity="$(psql "$AEAD_TAMPER_TEST_DATABASE_URL" -Atqc \
-  "SELECT current_database() || '|' || current_user || '|' ||
-          pg_get_userbyid(datdba)
-     FROM pg_database
-    WHERE datname = current_database()")"
-test "$db_identity" = \
-  "$OPENSECRET_TEST_DB|opensecret_user|opensecret_user"
-test "$(psql "$AEAD_TAMPER_TEST_DATABASE_URL" -Atqc \
-  "SELECT count(*) FROM information_schema.tables
-    WHERE table_schema = 'public'")" -eq 0
-
-diesel migration run --database-url "$AEAD_TAMPER_TEST_DATABASE_URL"
-expected_migrations="$(find migrations -type f -name up.sql | wc -l | tr -d ' ')"
-applied_migrations="$(psql "$AEAD_TAMPER_TEST_DATABASE_URL" -Atqc \
-  'SELECT count(*) FROM __diesel_schema_migrations')"
-test "$expected_migrations" -gt 0
-test "$applied_migrations" -eq "$expected_migrations"
-
-cargo test --locked --all-features aead_db_tamper_tests \
-  -- --ignored --list | tee "$PGDATA/aead-tests.list"
-test "$(grep -Ec '^aead_db_tamper_tests::.*: test$' \
-  "$PGDATA/aead-tests.list")" -eq 14
-
-cargo test --locked --all-features web::oauth_routes::tests::db_ \
-  -- --ignored --list | tee "$PGDATA/oauth-tests.list"
-test "$(grep -Ec '^web::oauth_routes::tests::db_.*: test$' \
-  "$PGDATA/oauth-tests.list")" -eq 2
-
-cargo test --locked --all-features aead_db_tamper_tests \
-  -- --ignored --test-threads=1 --nocapture 2>&1 | \
-  tee "$PGDATA/aead-tests.log"
-if grep -q 'skipping: AEAD_TAMPER_TEST_DATABASE_URL' \
-  "$PGDATA/aead-tests.log"; then
-  exit 1
-fi
-grep -Eq 'test result: ok\. 14 passed; 0 failed; 0 ignored;' \
-  "$PGDATA/aead-tests.log"
-
-cargo test --locked --all-features web::oauth_routes::tests::db_ \
-  -- --ignored --test-threads=1 --nocapture 2>&1 | \
-  tee "$PGDATA/oauth-tests.log"
-if grep -q 'skipping: AEAD_TAMPER_TEST_DATABASE_URL' \
-  "$PGDATA/oauth-tests.log"; then
-  exit 1
-fi
-grep -Eq 'test result: ok\. 2 passed; 0 failed; 0 ignored;' \
-  "$PGDATA/oauth-tests.log"
-OPENSECRET_TESTS_PASSED=1
-BASH
-```
-
-The exact discovery assertions above are 14 tests under
-`aead_db_tamper_tests` and 2 under `web::oauth_routes::tests::db_` for this
-checkout. If either count changes, stop and reconcile the filter and expected
-count with the test source before accepting evidence. The first subset covers
-database-backed seed-wrap, password/reset, tamper, deletion, and persisted
-response invariants. The OAuth subset proves only its two synthetic local
-database cases: subject/e-mail linking behavior and initial seed-wrap/login
-behavior. It does not exercise an OAuth provider, redirect/callback transport,
-state or nonce validation, token exchange, or a full encrypted client flow.
-
-For every new migration:
-
-1. Run the entire migration chain against an empty disposable database.
-2. On that disposable database, run `diesel migration redo --database-url "$AEAD_TAMPER_TEST_DATABASE_URL"` for the new latest reversible migration, then run the full chain again.
-3. Confirm `src/models/schema.rs` contains only the expected Diesel-generated change.
-4. Test an upgrade-shaped database containing representative pre-change rows. A clean-database migration cannot prove data conversion, constraints, or startup application-data migration.
-5. For a persisted ciphertext format, write an explicit version discriminator and deploy dual-read/new-write behavior before retiring the old reader. For user-key rows, perform the authenticated rewrite lazily and transactionally only after that user's credential-derived key is available. Do not attempt to re-encrypt those rows in SQL or at server startup.
-6. Use a startup application-data migration only when the owning key is available there, such as enclave/system-key data. Make it idempotent and retry-safe, then boot the backend against an upgrade-shaped database. `src/migrations.rs` is application-data migration logic, not a replacement for `diesel migration run`.
-7. Preserve old migration files. Add a new migration instead of rewriting history that another installation may already have applied.
-
-## Tier 3: isolate live provider proof
-
-Run live provider checks only with explicit authorization for credentials, network egress, cost, and the named provider. Keep them separate from the default suite.
-
-For the named Tinfoil live contract, set `TINFOIL_API_KEY` or provide
-`.local/secrets/tinfoil_api_key`, then run exactly:
+For persistence changes that do not add a migration, run the bundled helper
+from the repository root. It disables the default shell hooks, creates an
+isolated loopback PostgreSQL cluster and database, verifies their identity and
+empty schema, runs the full migration chain, discovers the selected ignored-test
+counts, runs each subset serially with visible output, fails on a skip or count
+mismatch, and cleans only its guarded temporary data directory:
 
 ```sh
 OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c cargo test \
+  nix develop --no-write-lock-file -c bash \
+  ./.agents/skills/validate-opensecret/scripts/disposable_db_tests.sh
+```
+
+When the diff adds or changes the latest reversible migration, use
+`--redo-latest` instead. It includes the same validation and also exercises the
+latest down/up cycle inside that disposable lifecycle:
+
+```sh
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c bash \
+  ./.agents/skills/validate-opensecret/scripts/disposable_db_tests.sh --redo-latest
+```
+
+The helper proves an empty-database migration and the selected local synthetic
+database suites. It does not prove an OAuth provider flow, encrypted client
+transport, or a data conversion from representative old rows.
+
+For a data migration, separately build an upgrade-shaped disposable database
+with representative pre-change rows and verify restart, rollback, and retry
+behavior. A user-key ciphertext change needs versioned dual-read/new-write and
+authenticated lazy rewrite; SQL/startup cannot prove re-encryption without the
+owning user key.
+
+## Tier 3: isolate live-provider proof
+
+Run a live check only with explicit authorization for the credential, network
+egress, likely cost, and named provider. Keep it separate from default tests.
+For the checked-in Tinfoil boundary test, configure the normal protected secret
+source and run:
+
+```sh
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c cargo test --locked --all-features \
   provider_client::tests::live_tinfoil_models_and_completions_match_the_legacy_api_contract \
   -- --ignored --exact
 ```
 
-This proves live Tinfoil attestation and provider-boundary models, non-streaming completion, streaming SSE framing, terminal `[DONE]`, and numeric usage for that credential and moment. It does not prove OpenSecret authentication, request encryption, database persistence, Responses behavior, Maple integration, another provider, or a deployed enclave.
+This proves only the named provider boundary at that time. Follow
+`docs/tinfoil-rust-sdk-parity.md` for its contract and evidence controls. If a
+provider has no live harness, report live behavior unverified rather than
+borrowing another provider's result.
 
-For providers without an explicit live test, run their local mock/boundary tests and an authorized Tier 4 smoke through the application. If neither exists, report that live provider behavior remains unverified; do not generalize Tinfoil evidence.
+## Tier 4: smoke the encrypted application
 
-## Tier 4: smoke the real encrypted application boundary
-
-Health endpoints are preliminary probes only:
+Health probes are preliminary only:
 
 ```sh
 curl --fail --silent --show-error http://127.0.0.1:3000/health-check
 curl --fail --silent --show-error http://127.0.0.1:3000/health-check-extended
 ```
 
-- `/health-check` fabricates liveness success and does not query PostgreSQL.
-- `/health-check-extended` performs a five-second outbound Tinfoil model-list check. It does not prove PostgreSQL, authentication, session encryption, persistence, or every provider.
+The first is process liveness; the second checks Tinfoil model connectivity.
+Neither proves PostgreSQL, auth, encryption, persistence, routing, billing,
+flags, or a user flow.
 
-Protected routes require attestation/key exchange, an `x-session-id`, encrypted request envelopes, and route-appropriate JWT or API-key authorization. Do not use plaintext `curl` as API evidence. OpenAI-shaped routes are compatible payloads inside the OpenSecret encrypted protocol, not ordinary plaintext OpenAI SDK endpoints.
+Exercise protected routes through a pinned OpenSecret SDK or Maple:
 
-Use the open-source Maple client or its OpenSecret client implementation for full-stack smoke:
+1. Start an isolated migrated backend with the authorized external services.
+2. Exercise the exact changed success and failure paths with route-appropriate
+   auth and a live encrypted session.
+3. Verify persistence after reload/re-entry when data changes.
+4. For streams, verify decrypted order, cancellation/disconnect behavior,
+   usage when promised, and one terminal condition.
+5. Inspect bounded logs for accidental sensitive content.
 
-1. Start local PostgreSQL, run Diesel migrations, configure authorized provider credentials, and start OpenSecret.
-2. In the Maple checkout, follow its `AGENTS.md` and validation skill. Set `VITE_OPEN_SECRET_API_URL=http://127.0.0.1:3000`, then start Maple with its repository-native command.
-3. Exercise attestation/key exchange, registration, login, session refresh or re-entry, and at least one authenticated protected read and write using a dedicated local test account.
-4. Verify missing, invalid, or stale authentication and unknown sessions fail closed without creating data or leaking decrypted content.
-5. Exercise the exact feature changed and verify both UI-visible behavior and backend persistence after reload or a fresh session.
-6. For OpenAI-shaped chat completions, exercise non-streaming and streaming forms when the changed contract affects both. Verify decryptable ordered chunks, expected model/content, usage when promised, clean cancellation or completion, and exactly one terminal `[DONE]`.
-7. For Responses changes, verify ordered lifecycle events, reasoning/text/tool event reconstruction, terminal status and usage, persistence and retrieval, continuation, cancellation, and deletion as applicable. Unit tests in `src/web/responses/` do not by themselves prove the complete encrypted HTTP/SSE path.
-8. For model catalog, embeddings, speech, transcription, web search, conversations, projects, or instructions, exercise the changed route through the real client and verify its failure path as well as success.
-9. Inspect logs for secrets, tokens, plaintext prompts, decrypted responses, or sensitive provider payloads before calling the smoke successful.
+In the selected Maple revision, follow its checked-in `AGENTS.md` and matching
+validation skill when present. Otherwise derive commands from that revision's
+repository-native docs and build metadata. Test browser Research and native
+Agent paths independently when both consume the change. An unavailable client
+checkout leaves that layer unverified.
 
-Derive the permitted JWT or API-key context from current router assembly and test each context changed. Do not infer that API-key requests can use user-owned persistence keys. Describe only the OpenAI or Responses fields, events, and stream modes implemented by the current route; passing the project-specific subset is not proof of complete upstream API compatibility.
+Configure billing or feature-flag API URLs/keys only when their public backend
+outcome is in scope. Treat them as external HTTP dependencies and test the
+changed success, denial, timeout, and unavailable behavior.
 
-If optional billing or feature-flag behavior is in scope, configure the documented API base URL and key for an authorized development or production API server. Treat it as an external boundary: test unavailable, timeout, denial, and success behavior explicitly, and do not claim it from an unconfigured local run.
+## Tier 5: validate Nix, EIF, and PCR boundaries
 
-When Maple cannot exercise a backend-only contract, use an existing open-source
-encrypted client or add a focused integration harness. If no harness can
-exercise it, mark the E2E layer unverified rather than downgrading to plaintext
-requests.
-
-## Tier 5: validate Nix, entrypoint, EIF, and PCR changes
-
-For flake, entrypoint, or packaging changes, run on the current platform:
+For current-host flake or packaging changes:
 
 ```sh
 nix flake show --all-systems --no-write-lock-file
@@ -307,47 +159,27 @@ nix flake check --no-write-lock-file --print-build-logs
 nix build --no-link --no-write-lock-file .#default
 ```
 
-`nix flake check` covers the current platform's exported checks, including the entrypoint entropy preflight and kernel-source pin. On Linux it additionally exposes kernel-security invariants and the Nitro helper. GitHub's EIF workflow builds images but does not substitute for explicitly running every flake check.
-
-EIF and PCR evidence requires the supported Linux/ARM build runner. `.github/workflows/build.yml` builds the development EIF and compares `result/pcr.json` with `pcrDev.json`; production runs only on its restricted events. A macOS package build or flake evaluation cannot prove EIF construction, Nitro boot, Linux kernel configuration, attestation, PCR equality, or deployment health.
-
-On that supported runner, reproduce the development image/PCR gate with:
+Current-host checks do not prove Linux/ARM EIF construction. On the supported
+Linux/ARM builder, development artifact/PCR validation is:
 
 ```sh
 nix build '.?submodules=1#eif-dev'
 cmp -s result/pcr.json pcrDev.json
 ```
 
-Use `#eif-prod` and `pcrProd.json` only when production-image validation is in scope. Record the built derivation and comparison result; a successful build without the comparison is not PCR proof.
+Use production outputs only when production-image validation is in scope.
+Record the derivation and comparison result. Building and read-only comparison
+are not deployment; PCR mutation, artifact transfer, KMS changes, enclave
+lifecycle, staging, and deployment require explicit authorization.
 
-Do not run submodule-update, PCR copy/update/sign, SCP, remote enclave start/stop, or deployment recipes without explicit authorization for that exact mutation and environment. Building is not deployment authorization.
+## Report without overclaiming
 
-Treat a PCR recipe as verification only when it compares the built result with
-a reviewed, checked-in reference through the matching workflow and the values
-match exactly. A successful build or a recipe that performs no comparison is
-not PCR evidence.
+Record the commit and dirty state, host, exact commands, test/ignored/skip
+counts, disposable database lifecycle, external authorization category, client
+configuration, artifact/PCR source, and every unrun or unavailable layer.
 
-## Report evidence without overclaiming
-
-Conclude with a compact validation record containing:
-
-- checkout commit and dirty-state summary;
-- host platform and whether commands ran through the pinned Nix shell;
-- exact commands or named test filters;
-- pass/fail counts, ignored counts, and any skip messages;
-- disposable database creation, migration, executed subsets, and cleanup;
-- external provider, credential source category, egress, and cost authorization without revealing secrets;
-- client/backend configuration and exact smoke scenarios;
-- Nix system evaluated or built, PCR comparison source, and CI job when relevant;
-- every unrun, unavailable, flaky, or platform-specific layer.
-
-Use claims no broader than the evidence:
-
-- **Static/unit validated** means formatting, Clippy, and local unit/property tests only.
-- **Disposable-DB validated** means a named ignored subset actually ran against a fresh migrated local database.
-- **Live-provider validated** means an explicitly named credentialed test passed for that provider at that time.
-- **Local full-stack validated** means a real encrypted client exercised the named flow against local OpenSecret and records what external services were configured.
-- **Linux/Nitro/PCR validated** requires the matching Linux/ARM build, check, comparison, or runtime evidence.
-- **Deployed validated** requires direct evidence from the named deployed environment; no local tier implies it.
-
-Treat failed, ignored, skipped, interrupted, timing-dependent, and unavailable checks as such. Never convert partial proof into “fully tested,” “production ready,” or “all tests pass.”
+Use narrow labels: **static/unit**, **disposable DB**, **live provider**,
+**local encrypted full stack**, **Linux/Nitro/PCR**, or **deployed** validated.
+Failed, skipped, ignored, interrupted, timing-dependent, and unavailable checks
+remain exactly that; do not turn partial evidence into “fully tested” or
+“production ready.”

--- a/.agents/skills/validate-opensecret/SKILL.md
+++ b/.agents/skills/validate-opensecret/SKILL.md
@@ -1,0 +1,353 @@
+---
+name: validate-opensecret
+description: Validate OpenSecret backend changes with side-effect-free Rust checks, exact CI-parity commands, targeted security and API tests, disposable PostgreSQL migration and tamper tests, explicit live-provider contracts, encrypted frontend/backend smoke tests, and platform-specific Nix or EIF checks. Use before claiming an OpenSecret implementation complete, when reviewing test evidence, or when changes touch Rust code, authentication, encryption, Responses or OpenAI-compatible APIs, streaming, providers, migrations, Nix, entrypoints, or enclave PCRs.
+---
+
+# Validate OpenSecret
+
+## Build an evidence plan from the diff
+
+1. Read `AGENTS.md`, inspect `git status --short --branch`, and identify every changed trust boundary.
+2. Select the union of all applicable tiers below. A higher tier supplements; it does not replace the lower tiers.
+3. Run the narrowest relevant test while iterating, then run the required completion tiers.
+4. Keep secrets out of commands, logs, fixtures, and tracked files. Use `.local/secrets/` or protected environment variables.
+5. Never run all ignored tests with a blanket `cargo test -- --ignored`. The ignored set mixes destructive disposable-database tests with a credentialed live-network test. Invoke only an explicit module or exact test name.
+
+| Change | Required validation |
+| --- | --- |
+| Documentation only | Verify every referenced path, command, environment variable, and behavior against the checkout; inspect the rendered diff. |
+| Any Rust behavior or dependency | Side-effect-free targeted tests while iterating, then Tier 1 CI parity. |
+| Auth, session, encryption, seed wrapping, persisted ciphertext, deletion, or reset | Tier 1 plus the relevant security/property tests; add Tier 2 database tests when persistence is involved. |
+| Diesel models, schema, SQL, or application-data migration | Tiers 1 and 2; add a boot or full-stack smoke when startup/data migration behavior changes. |
+| HTTP contract, middleware, SSE, OpenAI-compatible route, or Responses API | Tier 1 plus Tier 4 encrypted/authenticated smoke; include Maple when the public client contract changes. |
+| Provider transport, routing, model catalog, headers, usage, or attestation | Tier 1 plus targeted provider tests; add the explicitly named Tier 3 live test and Tier 4 app smoke when credentials and egress are authorized. |
+| `flake.nix`, `flake.lock`, `entrypoint.sh`, kernel, Nitro, EIF, or PCR | Tier 1 when Rust is affected plus Tier 5 on every available platform; require Linux/ARM CI evidence for Linux/Nitro claims. |
+
+## Keep ordinary checks side-effect-free
+
+The default `nix develop` shell hook may initialize or start `.pgdata`, create `.env` with local secrets, and on Linux configure local container state. Disable all three behaviors for formatting, linting, unit tests, and flake evaluation:
+
+```sh
+OPENSECRET_DEV_POSTGRES=0 \
+OPENSECRET_DEV_ENV=0 \
+OPENSECRET_DEV_CONTAINERS=0 \
+nix develop --no-write-lock-file -c <command>
+```
+
+Use the stateful shell only when the selected tier genuinely needs local services. Give concurrent checkouts distinct `PGDATA`, `PGPORT`, `DATABASE_URL`, backend ports, and test databases. Never point local validation at shared, preview, or production state.
+
+Do not treat `cargo audit`, `cargo deny`, or `cargo machete` as repository CI gates merely because the Nix shell provides them. Run one only when the task calls for it, state its configuration and network conditions, and report it separately.
+
+## Tier 0: iterate with focused pure checks
+
+Run focused unit tests after locating the owning module. Preserve `--locked --all-features` so local resolution and feature coverage do not silently diverge:
+
+```sh
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c \
+  cargo test --locked --all-features <module_or_test_filter>
+```
+
+Useful filters include:
+
+```sh
+cargo test --locked --all-features security_invariants
+cargo test --locked --all-features crypto_property_tests
+cargo test --locked --all-features provider_client::tests
+cargo test --locked --all-features web::openai::tests
+cargo test --locked --all-features web::responses
+```
+
+Choose filters from the changed code rather than using this list mechanically. Focused success is iteration evidence, not completion evidence.
+
+## Tier 1: reproduce Rust CI
+
+Initialize public submodules recursively, then run the same inner commands and warning policy as `.github/workflows/rust.yml` through the pinned Nix environment:
+
+```sh
+git submodule update --init --recursive
+
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c cargo fmt --all -- --check
+
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c \
+  env RUSTFLAGS="-D warnings" \
+  cargo clippy --locked --all-targets --all-features -- -D warnings
+
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c \
+  env RUSTFLAGS="-D warnings" cargo test --locked --all-features
+```
+
+Read the test summary. The default suite intentionally does not execute ignored tests. Report its passed, failed, and ignored counts; do not summarize it as “all tests” when ignored tests remain.
+
+Do not substitute an unverified aggregate recipe for the exact commands above.
+Before relying on one, inspect its checked-in definition and prove that it
+preserves the same targets, features, lockfile, and warning policy.
+
+## Tier 2: validate migrations and database-backed security
+
+The ignored tests mutate and delete rows. Run them only in a fresh PostgreSQL
+cluster whose data directory, listener, role, and database are created for this
+command. Do not use the default stateful shell hook: it may reuse any server
+already answering on `localhost:$PGPORT` before it inspects `.pgdata`.
+
+From the repository root, the following procedure disables all shell-hook
+state, starts a temporary cluster on an OS-selected loopback port, proves the
+connected data directory, port, database, user, owner, empty schema, and Diesel
+migration count, discovers the ignored subsets, executes them serially with
+visible output, and removes only the guarded temporary cluster on exit:
+
+```sh
+OPENSECRET_DEV_POSTGRES=0 \
+OPENSECRET_DEV_ENV=0 \
+OPENSECRET_DEV_CONTAINERS=0 \
+nix develop --no-write-lock-file -c bash <<'BASH'
+set -euo pipefail
+
+OPENSECRET_TEST_TMPROOT="${TMPDIR:-/tmp}"
+OPENSECRET_TEST_TMPROOT="${OPENSECRET_TEST_TMPROOT%/}"
+PGDATA="$(mktemp -d "$OPENSECRET_TEST_TMPROOT/opensecret-db-tests.XXXXXX")"
+readonly OPENSECRET_TEST_PGDATA="$PGDATA"
+PGSOCKETS="$PGDATA/sockets"
+PGPORT="$(python3 - <<'PY'
+import socket
+
+with socket.socket() as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+)"
+OPENSECRET_TEST_DB="opensecret_agent_test_$(openssl rand -hex 6)"
+OPENSECRET_TESTS_PASSED=0
+export PGDATA PGSOCKETS PGPORT OPENSECRET_TEST_DB
+
+cleanup() {
+  status=$?
+  trap - EXIT
+  if [[ "${PGDATA:-}" != "$OPENSECRET_TEST_PGDATA" ||
+        "$OPENSECRET_TEST_PGDATA" !=
+          "$OPENSECRET_TEST_TMPROOT"/opensecret-db-tests.* ]]; then
+    printf 'refusing to clean unexpected PGDATA: %s\n' \
+      "${PGDATA:-<unset>}" >&2
+    exit 1
+  fi
+  if [ -f "$PGDATA/PG_VERSION" ] && \
+     pg_ctl status -D "$PGDATA" >/dev/null 2>&1 && \
+     ! pg_ctl stop -D "$PGDATA" -m fast >/dev/null; then
+    printf 'PostgreSQL did not stop; preserving temporary state at %s\n' \
+      "$PGDATA" >&2
+    exit 1
+  fi
+  rm -rf -- "$PGDATA"
+  if [ "$status" -eq 0 ] && [ "$OPENSECRET_TESTS_PASSED" -eq 1 ]; then
+    printf '%s\n' \
+      'Disposable-DB evidence: 14 AEAD/database tests and 2 OAuth database tests passed; no tests skipped; temporary cluster removed.'
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+initdb -D "$PGDATA" --username="${USER:?}" \
+  --auth-local=trust --auth-host=scram-sha-256 >/dev/null
+mkdir -p "$PGSOCKETS"
+pg_ctl start -D "$PGDATA" \
+  -o "-h 127.0.0.1 -p $PGPORT -k $PGSOCKETS" \
+  -l "$PGDATA/postgres.log" -w >/dev/null
+
+expected_pgdata="$(cd "$PGDATA" && pwd -P)"
+reported_pgdata="$(psql -h "$PGSOCKETS" -p "$PGPORT" -U "$USER" \
+  -d postgres -Atqc 'SHOW data_directory')"
+reported_pgdata="$(cd "$reported_pgdata" && pwd -P)"
+test "$reported_pgdata" = "$expected_pgdata"
+test "$(psql -h "$PGSOCKETS" -p "$PGPORT" -U "$USER" \
+  -d postgres -Atqc 'SHOW port')" = "$PGPORT"
+
+psql -h "$PGSOCKETS" -p "$PGPORT" -U "$USER" -d postgres \
+  -v ON_ERROR_STOP=1 \
+  -c "CREATE USER opensecret_user WITH PASSWORD 'password'" >/dev/null
+createdb -h "$PGSOCKETS" -p "$PGPORT" -U "$USER" \
+  --maintenance-db=postgres --owner=opensecret_user "$OPENSECRET_TEST_DB"
+
+AEAD_TAMPER_TEST_DATABASE_URL="postgres://opensecret_user:password@127.0.0.1:${PGPORT}/${OPENSECRET_TEST_DB}"
+export AEAD_TAMPER_TEST_DATABASE_URL
+
+db_identity="$(psql "$AEAD_TAMPER_TEST_DATABASE_URL" -Atqc \
+  "SELECT current_database() || '|' || current_user || '|' ||
+          pg_get_userbyid(datdba)
+     FROM pg_database
+    WHERE datname = current_database()")"
+test "$db_identity" = \
+  "$OPENSECRET_TEST_DB|opensecret_user|opensecret_user"
+test "$(psql "$AEAD_TAMPER_TEST_DATABASE_URL" -Atqc \
+  "SELECT count(*) FROM information_schema.tables
+    WHERE table_schema = 'public'")" -eq 0
+
+diesel migration run --database-url "$AEAD_TAMPER_TEST_DATABASE_URL"
+expected_migrations="$(find migrations -type f -name up.sql | wc -l | tr -d ' ')"
+applied_migrations="$(psql "$AEAD_TAMPER_TEST_DATABASE_URL" -Atqc \
+  'SELECT count(*) FROM __diesel_schema_migrations')"
+test "$expected_migrations" -gt 0
+test "$applied_migrations" -eq "$expected_migrations"
+
+cargo test --locked --all-features aead_db_tamper_tests \
+  -- --ignored --list | tee "$PGDATA/aead-tests.list"
+test "$(grep -Ec '^aead_db_tamper_tests::.*: test$' \
+  "$PGDATA/aead-tests.list")" -eq 14
+
+cargo test --locked --all-features web::oauth_routes::tests::db_ \
+  -- --ignored --list | tee "$PGDATA/oauth-tests.list"
+test "$(grep -Ec '^web::oauth_routes::tests::db_.*: test$' \
+  "$PGDATA/oauth-tests.list")" -eq 2
+
+cargo test --locked --all-features aead_db_tamper_tests \
+  -- --ignored --test-threads=1 --nocapture 2>&1 | \
+  tee "$PGDATA/aead-tests.log"
+if grep -q 'skipping: AEAD_TAMPER_TEST_DATABASE_URL' \
+  "$PGDATA/aead-tests.log"; then
+  exit 1
+fi
+grep -Eq 'test result: ok\. 14 passed; 0 failed; 0 ignored;' \
+  "$PGDATA/aead-tests.log"
+
+cargo test --locked --all-features web::oauth_routes::tests::db_ \
+  -- --ignored --test-threads=1 --nocapture 2>&1 | \
+  tee "$PGDATA/oauth-tests.log"
+if grep -q 'skipping: AEAD_TAMPER_TEST_DATABASE_URL' \
+  "$PGDATA/oauth-tests.log"; then
+  exit 1
+fi
+grep -Eq 'test result: ok\. 2 passed; 0 failed; 0 ignored;' \
+  "$PGDATA/oauth-tests.log"
+OPENSECRET_TESTS_PASSED=1
+BASH
+```
+
+The exact discovery assertions above are 14 tests under
+`aead_db_tamper_tests` and 2 under `web::oauth_routes::tests::db_` for this
+checkout. If either count changes, stop and reconcile the filter and expected
+count with the test source before accepting evidence. The first subset covers
+database-backed seed-wrap, password/reset, tamper, deletion, and persisted
+response invariants. The OAuth subset proves only its two synthetic local
+database cases: subject/e-mail linking behavior and initial seed-wrap/login
+behavior. It does not exercise an OAuth provider, redirect/callback transport,
+state or nonce validation, token exchange, or a full encrypted client flow.
+
+For every new migration:
+
+1. Run the entire migration chain against an empty disposable database.
+2. On that disposable database, run `diesel migration redo --database-url "$AEAD_TAMPER_TEST_DATABASE_URL"` for the new latest reversible migration, then run the full chain again.
+3. Confirm `src/models/schema.rs` contains only the expected Diesel-generated change.
+4. Test an upgrade-shaped database containing representative pre-change rows. A clean-database migration cannot prove data conversion, constraints, or startup application-data migration.
+5. For a persisted ciphertext format, write an explicit version discriminator and deploy dual-read/new-write behavior before retiring the old reader. For user-key rows, perform the authenticated rewrite lazily and transactionally only after that user's credential-derived key is available. Do not attempt to re-encrypt those rows in SQL or at server startup.
+6. Use a startup application-data migration only when the owning key is available there, such as enclave/system-key data. Make it idempotent and retry-safe, then boot the backend against an upgrade-shaped database. `src/migrations.rs` is application-data migration logic, not a replacement for `diesel migration run`.
+7. Preserve old migration files. Add a new migration instead of rewriting history that another installation may already have applied.
+
+## Tier 3: isolate live provider proof
+
+Run live provider checks only with explicit authorization for credentials, network egress, cost, and the named provider. Keep them separate from the default suite.
+
+For the named Tinfoil live contract, set `TINFOIL_API_KEY` or provide
+`.local/secrets/tinfoil_api_key`, then run exactly:
+
+```sh
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c cargo test \
+  provider_client::tests::live_tinfoil_models_and_completions_match_the_legacy_api_contract \
+  -- --ignored --exact
+```
+
+This proves live Tinfoil attestation and provider-boundary models, non-streaming completion, streaming SSE framing, terminal `[DONE]`, and numeric usage for that credential and moment. It does not prove OpenSecret authentication, request encryption, database persistence, Responses behavior, Maple integration, another provider, or a deployed enclave.
+
+For providers without an explicit live test, run their local mock/boundary tests and an authorized Tier 4 smoke through the application. If neither exists, report that live provider behavior remains unverified; do not generalize Tinfoil evidence.
+
+## Tier 4: smoke the real encrypted application boundary
+
+Health endpoints are preliminary probes only:
+
+```sh
+curl --fail --silent --show-error http://127.0.0.1:3000/health-check
+curl --fail --silent --show-error http://127.0.0.1:3000/health-check-extended
+```
+
+- `/health-check` fabricates liveness success and does not query PostgreSQL.
+- `/health-check-extended` performs a five-second outbound Tinfoil model-list check. It does not prove PostgreSQL, authentication, session encryption, persistence, or every provider.
+
+Protected routes require attestation/key exchange, an `x-session-id`, encrypted request envelopes, and route-appropriate JWT or API-key authorization. Do not use plaintext `curl` as API evidence. OpenAI-shaped routes are compatible payloads inside the OpenSecret encrypted protocol, not ordinary plaintext OpenAI SDK endpoints.
+
+Use the open-source Maple client or its OpenSecret client implementation for full-stack smoke:
+
+1. Start local PostgreSQL, run Diesel migrations, configure authorized provider credentials, and start OpenSecret.
+2. In the Maple checkout, follow its `AGENTS.md` and validation skill. Set `VITE_OPEN_SECRET_API_URL=http://127.0.0.1:3000`, then start Maple with its repository-native command.
+3. Exercise attestation/key exchange, registration, login, session refresh or re-entry, and at least one authenticated protected read and write using a dedicated local test account.
+4. Verify missing, invalid, or stale authentication and unknown sessions fail closed without creating data or leaking decrypted content.
+5. Exercise the exact feature changed and verify both UI-visible behavior and backend persistence after reload or a fresh session.
+6. For OpenAI-shaped chat completions, exercise non-streaming and streaming forms when the changed contract affects both. Verify decryptable ordered chunks, expected model/content, usage when promised, clean cancellation or completion, and exactly one terminal `[DONE]`.
+7. For Responses changes, verify ordered lifecycle events, reasoning/text/tool event reconstruction, terminal status and usage, persistence and retrieval, continuation, cancellation, and deletion as applicable. Unit tests in `src/web/responses/` do not by themselves prove the complete encrypted HTTP/SSE path.
+8. For model catalog, embeddings, speech, transcription, web search, conversations, projects, or instructions, exercise the changed route through the real client and verify its failure path as well as success.
+9. Inspect logs for secrets, tokens, plaintext prompts, decrypted responses, or sensitive provider payloads before calling the smoke successful.
+
+Derive the permitted JWT or API-key context from current router assembly and test each context changed. Do not infer that API-key requests can use user-owned persistence keys. Describe only the OpenAI or Responses fields, events, and stream modes implemented by the current route; passing the project-specific subset is not proof of complete upstream API compatibility.
+
+If optional billing or feature-flag behavior is in scope, configure the documented API base URL and key for an authorized development or production API server. Treat it as an external boundary: test unavailable, timeout, denial, and success behavior explicitly, and do not claim it from an unconfigured local run.
+
+When Maple cannot exercise a backend-only contract, use an existing open-source
+encrypted client or add a focused integration harness. If no harness can
+exercise it, mark the E2E layer unverified rather than downgrading to plaintext
+requests.
+
+## Tier 5: validate Nix, entrypoint, EIF, and PCR changes
+
+For flake, entrypoint, or packaging changes, run on the current platform:
+
+```sh
+nix flake show --all-systems --no-write-lock-file
+nix flake check --no-write-lock-file --print-build-logs
+nix build --no-link --no-write-lock-file .#default
+```
+
+`nix flake check` covers the current platform's exported checks, including the entrypoint entropy preflight and kernel-source pin. On Linux it additionally exposes kernel-security invariants and the Nitro helper. GitHub's EIF workflow builds images but does not substitute for explicitly running every flake check.
+
+EIF and PCR evidence requires the supported Linux/ARM build runner. `.github/workflows/build.yml` builds the development EIF and compares `result/pcr.json` with `pcrDev.json`; production runs only on its restricted events. A macOS package build or flake evaluation cannot prove EIF construction, Nitro boot, Linux kernel configuration, attestation, PCR equality, or deployment health.
+
+On that supported runner, reproduce the development image/PCR gate with:
+
+```sh
+nix build '.?submodules=1#eif-dev'
+cmp -s result/pcr.json pcrDev.json
+```
+
+Use `#eif-prod` and `pcrProd.json` only when production-image validation is in scope. Record the built derivation and comparison result; a successful build without the comparison is not PCR proof.
+
+Do not run submodule-update, PCR copy/update/sign, SCP, remote enclave start/stop, or deployment recipes without explicit authorization for that exact mutation and environment. Building is not deployment authorization.
+
+Treat a PCR recipe as verification only when it compares the built result with
+a reviewed, checked-in reference through the matching workflow and the values
+match exactly. A successful build or a recipe that performs no comparison is
+not PCR evidence.
+
+## Report evidence without overclaiming
+
+Conclude with a compact validation record containing:
+
+- checkout commit and dirty-state summary;
+- host platform and whether commands ran through the pinned Nix shell;
+- exact commands or named test filters;
+- pass/fail counts, ignored counts, and any skip messages;
+- disposable database creation, migration, executed subsets, and cleanup;
+- external provider, credential source category, egress, and cost authorization without revealing secrets;
+- client/backend configuration and exact smoke scenarios;
+- Nix system evaluated or built, PCR comparison source, and CI job when relevant;
+- every unrun, unavailable, flaky, or platform-specific layer.
+
+Use claims no broader than the evidence:
+
+- **Static/unit validated** means formatting, Clippy, and local unit/property tests only.
+- **Disposable-DB validated** means a named ignored subset actually ran against a fresh migrated local database.
+- **Live-provider validated** means an explicitly named credentialed test passed for that provider at that time.
+- **Local full-stack validated** means a real encrypted client exercised the named flow against local OpenSecret and records what external services were configured.
+- **Linux/Nitro/PCR validated** requires the matching Linux/ARM build, check, comparison, or runtime evidence.
+- **Deployed validated** requires direct evidence from the named deployed environment; no local tier implies it.
+
+Treat failed, ignored, skipped, interrupted, timing-dependent, and unavailable checks as such. Never convert partial proof into “fully tested,” “production ready,” or “all tests pass.”

--- a/.agents/skills/validate-opensecret/agents/openai.yaml
+++ b/.agents/skills/validate-opensecret/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Validate OpenSecret"
+  short_description: "Run backend checks and evidence-based smokes"
+  default_prompt: "Use $validate-opensecret to validate this backend change at the right depth."

--- a/.agents/skills/validate-opensecret/scripts/disposable_db_tests.sh
+++ b/.agents/skills/validate-opensecret/scripts/disposable_db_tests.sh
@@ -100,7 +100,7 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 trap 'status=$?; printf "disposable database validation failed at line %s (status %s)\n" "$LINENO" "$status" >&2; exit "$status"' ERR
 
-initdb -D "$pgdata" --username="$admin_user" \
+initdb -D "$pgdata" --username="$admin_user" --encoding=UTF8 \
   --auth-local=trust --auth-host=scram-sha-256 >/dev/null
 mkdir -p "$pgsockets"
 pg_ctl start -D "$pgdata" \
@@ -153,14 +153,15 @@ test "$(psql "$AEAD_TAMPER_TEST_DATABASE_URL" -Atqc \
   "SELECT count(*) FROM information_schema.tables
     WHERE table_schema = 'public'")" -eq 0
 
-diesel migration run --database-url "$AEAD_TAMPER_TEST_DATABASE_URL"
+diesel migration run --locked-schema \
+  --database-url "$AEAD_TAMPER_TEST_DATABASE_URL"
 expected_migrations="$(find migrations -type f -name up.sql | wc -l | tr -d ' ')"
 test "$expected_migrations" -gt 0
 assert_migration_count
 
 if [ "$redo_latest" -eq 1 ]; then
-  diesel migration redo --database-url "$AEAD_TAMPER_TEST_DATABASE_URL"
-  diesel migration run --database-url "$AEAD_TAMPER_TEST_DATABASE_URL"
+  diesel migration redo --locked-schema \
+    --database-url "$AEAD_TAMPER_TEST_DATABASE_URL"
   assert_migration_count
 fi
 

--- a/.agents/skills/validate-opensecret/scripts/disposable_db_tests.sh
+++ b/.agents/skills/validate-opensecret/scripts/disposable_db_tests.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 077
+export LC_ALL=C
+
+usage() {
+  printf 'usage: %s [--redo-latest]\n' "${0##*/}" >&2
+}
+
+redo_latest=0
+case "${1:-}" in
+  "") ;;
+  --redo-latest) redo_latest=1 ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac
+if [ "$#" -gt 1 ]; then
+  usage
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
+cd "$repo_root"
+
+for required_command in initdb pg_ctl psql createdb diesel cargo python3 openssl; do
+  if ! command -v "$required_command" >/dev/null 2>&1; then
+    printf 'missing required command: %s\n' "$required_command" >&2
+    exit 1
+  fi
+done
+
+tmp_parent="${TMPDIR:-/tmp}"
+tmp_parent="$(cd "$tmp_parent" && pwd -P)"
+workdir="$(mktemp -d "$tmp_parent/opensecret-db-tests.XXXXXX")"
+pgdata="$workdir/pgdata"
+readonly workdir pgdata tmp_parent
+pgsockets="$workdir/sockets"
+run_token="$(openssl rand -hex 16)"
+marker="$workdir/.opensecret-disposable-db"
+printf '%s\n' "$run_token" >"$marker"
+pgport="$(python3 - <<'PY'
+import socket
+
+with socket.socket() as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+)"
+admin_user="$(id -un)"
+test_database="opensecret_agent_test_$(openssl rand -hex 6)"
+tests_passed=0
+
+cleanup() {
+  status=$?
+  trap - EXIT INT TERM ERR
+
+  case "$workdir" in
+    "$tmp_parent"/opensecret-db-tests.*) ;;
+    *)
+      printf 'refusing to clean unexpected temporary directory: %s\n' \
+        "$workdir" >&2
+      exit 1
+      ;;
+  esac
+
+  if [ -L "$workdir" ] || [ ! -d "$workdir" ] ||
+    [ "$(dirname "$workdir")" != "$tmp_parent" ] ||
+    [ "$pgdata" != "$workdir/pgdata" ] ||
+    [ "$(cat "$marker" 2>/dev/null || true)" != "$run_token" ] ||
+    [ "$(find "$workdir" -prune -user "$(id -u)" -print)" != "$workdir" ]; then
+    printf 'refusing to clean unverified temporary directory: %s\n' \
+      "$workdir" >&2
+    exit 1
+  fi
+
+  if [ -f "$pgdata/PG_VERSION" ] && pg_ctl status -D "$pgdata" >/dev/null 2>&1; then
+    if ! pg_ctl stop -D "$pgdata" -m fast >/dev/null; then
+      printf 'PostgreSQL did not stop; preserving temporary state at %s\n' "$pgdata" >&2
+      exit 1
+    fi
+  fi
+  if [ -f "$pgdata/PG_VERSION" ] && pg_ctl status -D "$pgdata" >/dev/null 2>&1; then
+    printf 'PostgreSQL still reports running; preserving temporary state at %s\n' \
+      "$pgdata" >&2
+    exit 1
+  fi
+  rm -rf -- "$workdir"
+
+  if [ "$status" -eq 0 ] && [ "$tests_passed" -eq 1 ]; then
+    printf 'Disposable-DB evidence: %s AEAD/database tests and %s OAuth database tests passed; no tests skipped; temporary cluster removed.\n' \
+      "$aead_count" "$oauth_count"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'status=$?; printf "disposable database validation failed at line %s (status %s)\n" "$LINENO" "$status" >&2; exit "$status"' ERR
+
+initdb -D "$pgdata" --username="$admin_user" \
+  --auth-local=trust --auth-host=scram-sha-256 >/dev/null
+mkdir -p "$pgsockets"
+pg_ctl start -D "$pgdata" \
+  -o "-h 127.0.0.1 -p $pgport -k $pgsockets" \
+  -l "$workdir/postgres.log" -w >/dev/null
+
+expected_pgdata="$(cd "$pgdata" && pwd -P)"
+reported_pgdata="$(psql -h "$pgsockets" -p "$pgport" -U "$admin_user" \
+  -d postgres -Atqc 'SHOW data_directory')"
+reported_pgdata="$(cd "$reported_pgdata" && pwd -P)"
+test "$reported_pgdata" = "$expected_pgdata"
+test "$(psql -h "$pgsockets" -p "$pgport" -U "$admin_user" \
+  -d postgres -Atqc 'SHOW port')" = "$pgport"
+
+psql -h "$pgsockets" -p "$pgport" -U "$admin_user" -d postgres \
+  -v ON_ERROR_STOP=1 \
+  -c "CREATE USER opensecret_user WITH PASSWORD 'password'" >/dev/null
+createdb -h "$pgsockets" -p "$pgport" -U "$admin_user" \
+  --maintenance-db=postgres --owner=opensecret_user "$test_database"
+
+export DATABASE_URL="postgres://opensecret_user:password@127.0.0.1:${pgport}/${test_database}"
+export AEAD_TAMPER_TEST_DATABASE_URL="$DATABASE_URL"
+
+assert_database_identity() {
+  local db_identity
+  local expected_identity
+  db_identity="$(psql "$AEAD_TAMPER_TEST_DATABASE_URL" -Atqc \
+    "SELECT current_database() || '|' || current_user || '|' ||
+            pg_get_userbyid(datdba) || '|' || host(inet_server_addr()) || '|' ||
+            current_setting('port')
+       FROM pg_database
+      WHERE datname = current_database()")"
+  expected_identity="$test_database|opensecret_user|opensecret_user|127.0.0.1|$pgport"
+  if [ "$db_identity" != "$expected_identity" ]; then
+    printf 'unexpected database identity: expected %s, received %s\n' \
+      "$expected_identity" "$db_identity" >&2
+    return 1
+  fi
+}
+
+assert_migration_count() {
+  local applied_migrations
+  applied_migrations="$(psql "$AEAD_TAMPER_TEST_DATABASE_URL" -Atqc \
+    'SELECT count(*) FROM __diesel_schema_migrations')"
+  test "$applied_migrations" -eq "$expected_migrations"
+}
+
+assert_database_identity
+test "$(psql "$AEAD_TAMPER_TEST_DATABASE_URL" -Atqc \
+  "SELECT count(*) FROM information_schema.tables
+    WHERE table_schema = 'public'")" -eq 0
+
+diesel migration run --database-url "$AEAD_TAMPER_TEST_DATABASE_URL"
+expected_migrations="$(find migrations -type f -name up.sql | wc -l | tr -d ' ')"
+test "$expected_migrations" -gt 0
+assert_migration_count
+
+if [ "$redo_latest" -eq 1 ]; then
+  diesel migration redo --database-url "$AEAD_TAMPER_TEST_DATABASE_URL"
+  diesel migration run --database-url "$AEAD_TAMPER_TEST_DATABASE_URL"
+  assert_migration_count
+fi
+
+cargo test --locked --all-features aead_db_tamper_tests \
+  -- --ignored --list | tee "$workdir/aead-tests.list"
+aead_count="$(awk '/^aead_db_tamper_tests::.*: test$/ { count++ }
+  END { print count + 0 }' "$workdir/aead-tests.list")"
+test "$aead_count" -gt 0
+
+cargo test --locked --all-features web::oauth_routes::tests::db_ \
+  -- --ignored --list | tee "$workdir/oauth-tests.list"
+oauth_count="$(awk '/^web::oauth_routes::tests::db_.*: test$/ { count++ }
+  END { print count + 0 }' "$workdir/oauth-tests.list")"
+test "$oauth_count" -gt 0
+
+cargo test --locked --all-features aead_db_tamper_tests \
+  -- --ignored --test-threads=1 --nocapture 2>&1 | tee "$workdir/aead-tests.log"
+if grep -qi 'skipping:' "$workdir/aead-tests.log"; then
+  printf 'AEAD/database test output contained a skip marker\n' >&2
+  exit 1
+fi
+grep -Eq "test result: ok\\. ${aead_count} passed; 0 failed; 0 ignored;" \
+  "$workdir/aead-tests.log"
+
+cargo test --locked --all-features web::oauth_routes::tests::db_ \
+  -- --ignored --test-threads=1 --nocapture 2>&1 | tee "$workdir/oauth-tests.log"
+if grep -qi 'skipping:' "$workdir/oauth-tests.log"; then
+  printf 'OAuth database test output contained a skip marker\n' >&2
+  exit 1
+fi
+grep -Eq "test result: ok\\. ${oauth_count} passed; 0 failed; 0 ignored;" \
+  "$workdir/oauth-tests.log"
+
+assert_database_identity
+assert_migration_count
+tests_passed=1

--- a/.env.sample
+++ b/.env.sample
@@ -1,13 +1,30 @@
 DATABASE_URL=postgres://localhost/opensecret
 APP_MODE=local
+# Listener defaults to 127.0.0.1:3000 when omitted.
+OPENSECRET_BIND_ADDR=127.0.0.1:3000
+# The supported local Continuum recipe uses this loopback base and does not
+# require OPENAI_API_KEY. Review credential/header behavior before using any
+# other custom provider base.
+OPENAI_API_BASE=http://127.0.0.1:8092
 OPENAI_API_KEY=
 # Required by the in-process Tinfoil Rust SDK.
 TINFOIL_API_KEY=
 ENCLAVE_SECRET_MOCK=
 JWT_SECRET=
 RESEND_API_KEY=
+# Optional local OAuth applications.
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
 # Optional web-search providers. Kagi is selected only for users enabled by
 # the web-search.kagi flag; missing or false flags retain Brave.
 BRAVE_API_KEY=
 KAGI_API_KEY=
+# Optional external billing API. These values are server-side secrets and must
+# never be copied into a public client.
+BILLING_SERVER_URL=
+BILLING_API_KEY=
+# Optional external feature-flags API.
 OS_FLAGS_BASE_URL=
+OS_FLAGS_API_KEY=

--- a/.env.sample
+++ b/.env.sample
@@ -1,30 +1,23 @@
 DATABASE_URL=postgres://localhost/opensecret
 APP_MODE=local
-# Listener defaults to 127.0.0.1:3000 when omitted.
 OPENSECRET_BIND_ADDR=127.0.0.1:3000
-# The supported local Continuum recipe uses this loopback base and does not
-# require OPENAI_API_KEY. Review credential/header behavior before using any
-# other custom provider base.
+# Local Continuum provider.
 OPENAI_API_BASE=http://127.0.0.1:8092
-OPENAI_API_KEY=
-# Required by the in-process Tinfoil Rust SDK.
+# OPENAI_API_KEY=
+# Required provider.
 TINFOIL_API_KEY=
 ENCLAVE_SECRET_MOCK=
 JWT_SECRET=
-RESEND_API_KEY=
-# Optional local OAuth applications.
-GITHUB_CLIENT_ID=
-GITHUB_CLIENT_SECRET=
-GOOGLE_CLIENT_ID=
-GOOGLE_CLIENT_SECRET=
-# Optional web-search providers. Kagi is selected only for users enabled by
-# the web-search.kagi flag; missing or false flags retain Brave.
-BRAVE_API_KEY=
-KAGI_API_KEY=
-# Optional external billing API. These values are server-side secrets and must
-# never be copied into a public client.
-BILLING_SERVER_URL=
-BILLING_API_KEY=
-# Optional external feature-flags API.
-OS_FLAGS_BASE_URL=
-OS_FLAGS_API_KEY=
+# Optional server integrations.
+# RESEND_API_KEY=
+# GITHUB_CLIENT_ID=
+# GITHUB_CLIENT_SECRET=
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+# BRAVE_API_KEY=
+# KAGI_API_KEY=
+# Optional external APIs.
+# BILLING_SERVER_URL=
+# BILLING_API_KEY=
+# OS_FLAGS_BASE_URL=
+# OS_FLAGS_API_KEY=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,10 @@ specialized work.
 1. Inspect the checkout, branch, remotes, submodules, and worktree before
    editing. Preserve unrelated changes. For new work, prefer current
    `origin/master` unless the task names another base.
-2. Initialize dependencies with `git submodule update --init --recursive` and
-   use the pinned Nix toolchain. Do not install substitute system toolchains
-   merely to bypass the repository environment.
+2. Inspect submodule status during review. Initialize dependencies with
+   `git submodule update --init --recursive` when building, testing, or working
+   in their contents. Use the pinned Nix toolchain; do not install substitute
+   system toolchains merely to bypass the repository environment.
 3. Remember that `nix develop` has stateful PostgreSQL, `.env`, and Linux
    container hooks. Use `docs/dev-shell.md` for controls and give concurrent
    checkouts distinct state and ports.
@@ -128,16 +129,22 @@ guidance.
 Use `$develop-opensecret` for the local stack and code-placement workflow. Use
 `$validate-opensecret` to choose focused tests, exact Rust CI parity,
 disposable-database validation, authorized provider probes, encrypted client
-smoke tests, and Nix/EIF checks.
+smoke tests, Nix checks, and release-only EIF/PCR evidence.
 
 Match evidence to the changed boundary. Report exact commands, counts, ignored
 or skipped tests, configured external services, and every unverified layer.
 
 ## Operator authority
 
-Local builds and read-only comparison of a built PCR against a reviewed,
-checked-in reference are validation when the task reaches that boundary. They
-are not deployment.
+EIF/PCR parity is a release and deployment gate, not an ordinary development
+or pull-request gate. If CI successfully builds an EIF and then fails only the
+PCR comparison after compiled inputs changed, record deferred release work;
+do not update references merely to make CI green. Treat an EIF build failure
+separately.
+
+Before publishing or deploying an authorized dev or prod EIF, build it on the
+supported Linux/ARM64 release builder, intentionally review its measurements,
+and complete the authorized reference, history, signing, and comparison work.
 
 Require explicit authorization for changing PCR references or histories, KMS
 or IAM policy, shared or remote migrations, copying artifacts to hosts,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,305 @@
+# OpenSecret agent guide
+
+This file applies to the entire repository. It contains the durable rules for
+developing and reviewing the OpenSecret backend. Detailed, task-specific
+procedures live under `.agents/skills/`; load the matching skill before doing
+that work.
+
+## Start here
+
+1. Confirm the checkout, branch, remote state, and worktree status. Preserve
+   unrelated changes; never rewrite a dirty checkout to make it match a task.
+2. Initialize submodules with `git submodule update --init --recursive`.
+3. Enter the pinned toolchain with
+   `OPENSECRET_DEV_CONTAINERS=0 nix develop` unless the task needs the local
+   container helpers. The stateful shell hook checks any PostgreSQL listener
+   on `localhost:$PGPORT` before initializing this checkout, so a responding
+   listener is reused and `.pgdata`, its role, and its database are not
+   guaranteed to be the active state. It also creates `.env` from
+   `.env.sample` when absent. On Linux, leaving container setup enabled rewrites
+   user-level container configuration.
+4. Run `just diesel-migration-run-local` before starting the backend. Startup
+   does not run Diesel schema migrations; `src/migrations.rs` performs a
+   different application-data migration.
+5. Configure the required provider credentials in ignored files or the local
+   environment. Tinfoil is a hard runtime dependency. Never commit credentials,
+   generated `.env`, local databases, provider captures, or decrypted traffic.
+6. Read the relevant route, middleware, model, migration, and tests before
+   choosing placement. Exact route, model, and provider inventories drift;
+   derive them from current source rather than copying an old table.
+
+This repository is one Rust package and binary, not a Cargo workspace. Run
+Cargo commands at the repository root.
+
+## Architecture and ownership
+
+- `src/main.rs` composes configuration, shared state, middleware, and the
+  router. Keep bootstrap and wiring here; put domain behavior in focused
+  modules.
+- `src/web/` owns HTTP transport, request validation, authentication context,
+  encryption middleware, response/error mapping, and route orchestration.
+- `src/web/responses/` owns the stateful Responses implementation: persistent
+  items and conversations, tool loops, encrypted SSE projection,
+  continuation, cancellation, and deletion.
+- `src/models/`, `src/db.rs`, `migrations/`, and `src/models/schema.rs` own
+  persistence. A schema change normally spans a reversible SQL migration,
+  generated Diesel schema, model/query code, scoping, and tests.
+- `src/encrypt.rs`, `src/seed_wrapping.rs`, `src/jwt.rs`, attestation/session code,
+  and `src/security_invariants.rs` define cryptographic and authentication
+  boundaries. Do not duplicate their policy in route handlers.
+- `src/model_config.rs` owns the public model catalog and capabilities.
+  `src/provider_routing.rs` owns provider selection and upstream model IDs.
+  `src/proxy_config.rs` owns provider endpoints/credentials, and
+  `src/provider_client.rs` owns provider transport, attestation-aware clients,
+  streaming, and retry decisions. `src/web/openai.rs` and
+  `src/web/responses/` own route-specific usage observation, normalization,
+  metering, and event capture.
+- `src/brave.rs` and `src/kagi.rs` own provider-specific search/extraction
+  adapters. Keep public web routes provider-neutral.
+- Billing, flags, email, OAuth providers, and event queues are external API
+  boundaries. Their administrative credentials remain server-side and their
+  absence/failure behavior must be explicit in the feature being changed.
+
+OpenSecret owns authentication/session encryption, encrypted-at-rest
+persistence, provider credentials/routing/model canonicalization, entitlement
+enforcement, and usage capture. Clients own UI and device behavior. Published
+OpenSecret SDKs own attestation, encrypted transport, and client retry policy;
+do not advise Maple or another client to call protected routes with plain
+`fetch`, `curl`, or `reqwest`.
+
+## API contract rules
+
+- Health and attestation/key-establishment endpoints are explicit public
+  plaintext exceptions. Authentication bootstrap routes use a live encrypted
+  session without requiring an existing JWT. Protected application routes add
+  route-appropriate JWT or API-key authentication to that session. Bodyless
+  protected routes must still validate and touch the session. Treat
+  `/platform/*` as a separate control-plane surface and derive its policy from
+  current router assembly rather than these Maple-facing rules.
+- OpenAI-shaped paths describe the decrypted payload contract; they are not a
+  plaintext OpenAI wire API. A valid smoke test uses an OpenSecret SDK or Maple
+  to perform attestation/key exchange, sends `x-session-id`, encrypts the
+  request, and decrypts the response or SSE frames.
+- Derive each route's exact authentication from router assembly. JWT and API
+  key auth have different contexts; API-key requests do not automatically have
+  a user's storage keys. Do not add persistence to an API-key route without an
+  explicit authorization and key-ownership design.
+- Validate method, path/query, decrypted request schema, status, content type,
+  error shape, and response schema. For streaming, also preserve event order,
+  sequence semantics, usage, cancellation, encryption, and exactly one
+  terminal condition.
+- Reject malformed data at the boundary and return stable, sanitized errors.
+  Never leak internal provider bodies, credentials, decrypted content, SQL
+  details, or cryptographic errors to clients.
+- Responses is stateful and persistent. Do not describe `store: false` as
+  ephemeral unless current source and tests prove that behavior.
+- API changes require a compatibility review of published SDKs and all affected
+  Maple paths. Keep a backwards-compatible transition when clients can update
+  independently.
+
+Load `$change-opensecret-api` for route, payload, auth, SSE, persistence, or
+client-contract work.
+
+## Provider and model rules
+
+- Keep public model IDs separate from provider IDs. Canonicalize at the
+  OpenSecret boundary so upstream aliases never leak into stored or returned
+  API state.
+- Model availability/capabilities, provider routing weights and stickiness,
+  endpoint/credential resolution, transport, and route orchestration are
+  different concerns. Change each in its owning layer.
+- Provider secrets, administrative headers, and raw attestation material never
+  enter client-visible responses or logs. Review forwarded headers explicitly;
+  prefer an allowlist for a new boundary.
+- Retry only operations known to be safe. Connection establishment before a
+  request is sent is different from an ambiguous failure after a POST may have
+  reached a provider. Preserve Tinfoil attestation/origin binding and refresh
+  only on its typed connection-establishment failure.
+- Streaming adapters must handle bounded frames, cancellation, protocol errors,
+  usage, and a single terminal marker. A provider-direct test does not prove
+  OpenSecret authentication, E2EE, persistence, billing, routing, or Maple.
+- Usage is security- and billing-relevant. Normalize it once, retain model and
+  provider attribution internally, and test missing/partial provider usage.
+
+Load `$change-opensecret-provider` for model catalog, routing, credentials,
+provider transport, retries, search/extraction adapters, or usage work.
+
+## Persistence and migration rules
+
+- Use a new timestamped Diesel migration. Never edit an already-deployed
+  migration to change history.
+- Run the complete migration chain against an empty disposable database. When
+  `down.sql` or data transformation changes, also test down/up and an
+  upgrade-shaped database with representative encrypted rows.
+- Regenerate and review `src/models/schema.rs`; do not hand-edit it into a state
+  the migration does not produce.
+- Preserve user/project scoping in the database trait and concrete query.
+  Filtering in the handler after an unscoped read is not authorization.
+- Identify the owning key domain before changing an encrypted field.
+  User-private content uses the credential-derived user-key path; server-owned
+  material such as OAuth access tokens, project secrets, and password
+  verifiers remains in its enclave/system-secret domain. Do not make one
+  domain's migration depend on a key available only in another.
+- Version persisted ciphertext formats. For rows encrypted by a user key,
+  deploy dual-read/new-write behavior and lazily perform the authenticated
+  rewrite only after that user's key is available. A startup migration may
+  rewrite enclave/system-key data only when its owning key is available there;
+  a SQL migration alone cannot re-encrypt opaque ciphertext safely.
+- Preserve tamper detection, purpose and row binding, seed-wrap/source
+  invariants, transactionality, zeroization where present, and non-secret
+  indexes/metadata only where the design permits them.
+- Use only a dedicated disposable Postgres database for ignored tamper/OAuth
+  suites. Fail closed on database identity, migration status, selected-test
+  count, skip output, pass count, and cleanup; a successful test-process exit
+  is insufficient evidence that an ignored database test executed.
+
+## Security and privacy invariants
+
+- Treat source-confirmed behavior, test-confirmed behavior, deployed
+  configuration, and live-environment observations as distinct evidence.
+  Source alone cannot prove deployed PCRs, KMS/IAM policy, logging policy,
+  network placement, or which artifact is serving production.
+- Never log secrets, session material, tokens, OAuth provider payloads,
+  prompts, reasoning, response deltas, decrypted bodies, user email/profile
+  data, provider bodies, or raw headers. Metadata must be bounded and
+  allowlisted. Logs leave the enclave boundary, so `trace` is not a safe place
+  for sensitive content.
+- Preserve bounded, expiring, one-use or leased state for pending attestations,
+  sessions, OAuth state, and other unauthenticated resources. Cleanup paths and
+  failure paths receive the same bounds as success paths.
+- Preserve session liveness and key ownership across every protected route.
+  Cryptographic review must cover nonce generation, direction separation,
+  additional authenticated data, replay behavior, bodyless requests, error
+  encryption, and concurrency—not only the happy-path primitive.
+- Authentication changes must review access and refresh token lifecycle,
+  revocation/logout, reset and verification codes, OAuth state/nonce binding,
+  account linking, native callbacks, and enumeration-resistant errors.
+- Billing and flags may fail differently across registered, guest, chat,
+  Responses, web, audio, and other paths. Treat that matrix as an explicit
+  product/security decision; do not generalize one route's behavior.
+- Provider response data and model output are untrusted. Bound sizes and loops,
+  validate content types/schemas, enforce URL provenance and SSRF policy, and
+  avoid replaying hidden provider state without evidence.
+
+Load `$review-opensecret-security` before changing cryptography, auth, OAuth,
+sessions, storage encryption, provider headers, billing enforcement, URL
+fetching, logging, Nitro/KMS integration, or another trust boundary.
+
+## Development workflow
+
+For the normal local macOS stack:
+
+```bash
+git submodule update --init --recursive
+OPENSECRET_DEV_CONTAINERS=0 nix develop
+just build-local-proxies-macos
+just diesel-migration-run-local
+```
+
+Then run the Continuum proxy and backend in separate shells:
+
+```bash
+nix develop -c just run-continuum-proxy-macos
+nix develop -c just run-local-backend-macos
+```
+
+The Tinfoil client runs in-process; there is no local Tinfoil sidecar. See
+`docs/local-macos-stack.md` and `$develop-opensecret` for credential files,
+ports, alternative direct-provider configuration, and debugging.
+
+For read-only or CI-style checks, prevent the Nix shell hook from starting
+Postgres, writing `.env`, or changing Linux container configuration:
+
+```bash
+OPENSECRET_DEV_POSTGRES=0 \
+OPENSECRET_DEV_ENV=0 \
+OPENSECRET_DEV_CONTAINERS=0 \
+nix develop --no-write-lock-file -c <command>
+```
+
+## Validation and evidence
+
+The Rust CI gate is:
+
+```bash
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c cargo fmt --all -- --check
+
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c \
+  env RUSTFLAGS='-D warnings' \
+  cargo clippy --locked --all-targets --all-features -- -D warnings
+
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c \
+  env RUSTFLAGS='-D warnings' cargo test --locked --all-features
+```
+
+Run focused tests while iterating, then the full gate. Add
+`nix flake check --print-build-logs` for Nix, entrypoint, Nitro helper, kernel,
+or security-build changes. Current-host flake checks do not prove ARM Linux EIF
+construction or PCR reproducibility.
+
+Default CI has no PostgreSQL service and skips all ignored tests. Never run all
+ignored tests as one group:
+
+- the AEAD tamper and OAuth database subsets require a fully migrated,
+  disposable database via `AEAD_TAMPER_TEST_DATABASE_URL` and serialized test
+  execution;
+- the Tinfoil parity test requires a live credential and network and must be
+  run separately with explicit authorization.
+
+`/health-check` is process liveness only and does not query PostgreSQL.
+`/health-check-extended` checks Tinfoil model-list connectivity only. Neither
+proves auth, E2EE, persistence, routing, billing, flags, or full-stack behavior.
+Use `$validate-opensecret` for the exact risk matrix, ignored-test commands,
+SDK-driven encrypted smoke, and evidence report.
+
+## Review and authority
+
+Review the changed contract end to end: route assembly, middleware order,
+cryptographic ownership, authorization/scoping, persistence, provider effects,
+usage, error/log content, cancellation, tests, and client compatibility. Cite
+current source for claims and state what remains unverified.
+
+Building an EIF is not deployment. PCR comparison, KMS policy changes, copying
+artifacts to hosts, terminating/running enclaves, restarting proxies, writing
+secrets, and invoking any `deploy-*`, `stage-*`, `run-eif-*`, or PCR mutation
+recipe require explicit operator authorization. Treat PCR verification as a
+gate only when it compares the built result with a reviewed, checked-in
+reference through the matching workflow; a recipe that performs no comparison
+is not PCR evidence.
+
+## Skills
+
+- `$develop-opensecret`: local setup, Postgres, environment, migrations,
+  process topology, placement, and implementation loop.
+- `$change-opensecret-api`: routes, auth context, encrypted payloads, errors,
+  SSE, Responses persistence, and client compatibility.
+- `$change-opensecret-provider`: model catalog, routing, provider credentials,
+  transport/attestation, retries, usage, and search/extraction adapters.
+- `$validate-opensecret`: focused tests, CI parity, disposable-database suites,
+  provider probes, encrypted API/full-stack smoke, and evidence reporting.
+- `$review-opensecret-security`: cryptography, attestation/session/auth/OAuth,
+  persistence, provider headers, logging, billing policy, and deployment-trust
+  review.
+
+## Maintaining this guidance
+
+Treat this guide and the repository skills as living operational documentation,
+not infallible rules. Re-check prescriptive language against the current source,
+tooling, and architecture. If guidance appears stale, materially wrong,
+unnecessarily absolute, or repeatedly creates development friction, surface the
+mismatch and confirm the intended correction with the user before changing it.
+Do not churn guidance for stylistic preferences or isolated nits; do narrow
+words such as "always" or "never" when they claim more than the invariant
+actually requires.
+
+Update the relevant guide or skill in the same branch when a material change
+adds, removes, or rearchitects a workflow, ownership boundary, validation path,
+or recurring development procedure. If you discover unrelated drift, keep the
+current task scoped and propose a standalone change with evidence and reasoning.
+Add a new skill when a genuinely reusable workflow does not fit an existing one;
+otherwise prefer improving or consolidating current guidance. Ground every
+update in current source or executed workflow experience, keep it concise, and
+validate every command or path it prescribes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,305 +1,174 @@
 # OpenSecret agent guide
 
-This file applies to the entire repository. It contains the durable rules for
-developing and reviewing the OpenSecret backend. Detailed, task-specific
-procedures live under `.agents/skills/`; load the matching skill before doing
-that work.
+This file applies to the whole repository. It contains durable project rules;
+task procedures live in `.agents/skills/`. Load the matching skill before doing
+specialized work.
 
-## Start here
+## Work safely
 
-1. Confirm the checkout, branch, remote state, and worktree status. Preserve
-   unrelated changes; never rewrite a dirty checkout to make it match a task.
-2. Initialize submodules with `git submodule update --init --recursive`.
-3. Enter the pinned toolchain with
-   `OPENSECRET_DEV_CONTAINERS=0 nix develop` unless the task needs the local
-   container helpers. The stateful shell hook checks any PostgreSQL listener
-   on `localhost:$PGPORT` before initializing this checkout, so a responding
-   listener is reused and `.pgdata`, its role, and its database are not
-   guaranteed to be the active state. It also creates `.env` from
-   `.env.sample` when absent. On Linux, leaving container setup enabled rewrites
-   user-level container configuration.
-4. Run `just diesel-migration-run-local` before starting the backend. Startup
-   does not run Diesel schema migrations; `src/migrations.rs` performs a
-   different application-data migration.
-5. Configure the required provider credentials in ignored files or the local
-   environment. Tinfoil is a hard runtime dependency. Never commit credentials,
-   generated `.env`, local databases, provider captures, or decrypted traffic.
-6. Read the relevant route, middleware, model, migration, and tests before
-   choosing placement. Exact route, model, and provider inventories drift;
-   derive them from current source rather than copying an old table.
+1. Inspect the checkout, branch, remotes, submodules, and worktree before
+   editing. Preserve unrelated changes. For new work, prefer current
+   `origin/master` unless the task names another base.
+2. Initialize dependencies with `git submodule update --init --recursive` and
+   use the pinned Nix toolchain. Do not install substitute system toolchains
+   merely to bypass the repository environment.
+3. Remember that `nix develop` has stateful PostgreSQL, `.env`, and Linux
+   container hooks. Use `docs/dev-shell.md` for controls and give concurrent
+   checkouts distinct state and ports.
+4. Run `just diesel-migration-run-local` before the backend. Startup does not
+   run Diesel schema migrations; `src/migrations.rs` is separate
+   application-data migration logic.
+5. Keep credentials and generated local state in ignored files or protected
+   environment variables. Never commit `.env`, `.pgdata/`, `.local/`, provider
+   captures, decrypted traffic, or secrets.
 
 This repository is one Rust package and binary, not a Cargo workspace. Run
-Cargo commands at the repository root.
+Cargo commands from the repository root.
 
-## Architecture and ownership
+## Ownership
 
-- `src/main.rs` composes configuration, shared state, middleware, and the
-  router. Keep bootstrap and wiring here; put domain behavior in focused
-  modules.
-- `src/web/` owns HTTP transport, request validation, authentication context,
-  encryption middleware, response/error mapping, and route orchestration.
-- `src/web/responses/` owns the stateful Responses implementation: persistent
-  items and conversations, tool loops, encrypted SSE projection,
-  continuation, cancellation, and deletion.
-- `src/models/`, `src/db.rs`, `migrations/`, and `src/models/schema.rs` own
-  persistence. A schema change normally spans a reversible SQL migration,
-  generated Diesel schema, model/query code, scoping, and tests.
-- `src/encrypt.rs`, `src/seed_wrapping.rs`, `src/jwt.rs`, attestation/session code,
-  and `src/security_invariants.rs` define cryptographic and authentication
-  boundaries. Do not duplicate their policy in route handlers.
-- `src/model_config.rs` owns the public model catalog and capabilities.
-  `src/provider_routing.rs` owns provider selection and upstream model IDs.
-  `src/proxy_config.rs` owns provider endpoints/credentials, and
-  `src/provider_client.rs` owns provider transport, attestation-aware clients,
-  streaming, and retry decisions. `src/web/openai.rs` and
-  `src/web/responses/` own route-specific usage observation, normalization,
-  metering, and event capture.
-- `src/brave.rs` and `src/kagi.rs` own provider-specific search/extraction
-  adapters. Keep public web routes provider-neutral.
-- Billing, flags, email, OAuth providers, and event queues are external API
-  boundaries. Their administrative credentials remain server-side and their
-  absence/failure behavior must be explicit in the feature being changed.
+- `src/main.rs`: configuration, shared state, middleware, and router assembly.
+- `src/web/`: HTTP boundaries, authentication context, encryption middleware,
+  errors, streaming, route orchestration, and Responses/conversation behavior.
+- `src/models/`, `src/db.rs`, `migrations/`, and `src/models/schema.rs`:
+  persistence and schema evolution.
+- `src/encrypt.rs`, `src/seed_wrapping.rs`, `src/jwt.rs`, attestation/session
+  code, and `src/security_invariants.rs`: cryptographic and identity boundaries.
+- `src/model_config.rs`: public model catalog and capabilities.
+- `src/provider_routing.rs`: provider selection and upstream model mapping.
+- `src/proxy_config.rs` and `src/provider_client.rs`: provider endpoints,
+  credentials, transport, attestation, streaming, and safe retry decisions.
+- `src/brave.rs`, `src/kagi.rs`, and `src/web/web_routes.rs`: provider-specific
+  web adapters and provider-neutral public web routes.
 
-OpenSecret owns authentication/session encryption, encrypted-at-rest
-persistence, provider credentials/routing/model canonicalization, entitlement
-enforcement, and usage capture. Clients own UI and device behavior. Published
-OpenSecret SDKs own attestation, encrypted transport, and client retry policy;
-do not advise Maple or another client to call protected routes with plain
-`fetch`, `curl`, or `reqwest`.
+Keep server-controlled authentication, authorization, encryption, persistence,
+provider credentials and routing, entitlement decisions, and usage accounting
+in OpenSecret. Keep presentation, device integration, and local interaction in
+clients such as Maple. Published OpenSecret SDKs own attestation and encrypted
+transport; protected routes are not ordinary plaintext `fetch`, `curl`, or
+`reqwest` APIs.
 
-## API contract rules
+## Durable API and security rules
 
-- Health and attestation/key-establishment endpoints are explicit public
-  plaintext exceptions. Authentication bootstrap routes use a live encrypted
-  session without requiring an existing JWT. Protected application routes add
-  route-appropriate JWT or API-key authentication to that session. Bodyless
-  protected routes must still validate and touch the session. Treat
-  `/platform/*` as a separate control-plane surface and derive its policy from
-  current router assembly rather than these Maple-facing rules.
-- OpenAI-shaped paths describe the decrypted payload contract; they are not a
-  plaintext OpenAI wire API. A valid smoke test uses an OpenSecret SDK or Maple
-  to perform attestation/key exchange, sends `x-session-id`, encrypts the
-  request, and decrypts the response or SSE frames.
-- Derive each route's exact authentication from router assembly. JWT and API
-  key auth have different contexts; API-key requests do not automatically have
-  a user's storage keys. Do not add persistence to an API-key route without an
-  explicit authorization and key-ownership design.
-- Validate method, path/query, decrypted request schema, status, content type,
-  error shape, and response schema. For streaming, also preserve event order,
-  sequence semantics, usage, cancellation, encryption, and exactly one
-  terminal condition.
-- Reject malformed data at the boundary and return stable, sanitized errors.
-  Never leak internal provider bodies, credentials, decrypted content, SQL
-  details, or cryptographic errors to clients.
-- Responses is stateful and persistent. Do not describe `store: false` as
-  ephemeral unless current source and tests prove that behavior.
-- API changes require a compatibility review of published SDKs and all affected
-  Maple paths. Keep a backwards-compatible transition when clients can update
-  independently.
+- Derive route authentication and middleware order from current router
+  assembly. An encryption session establishes a protected transport, not user
+  identity or authorization. Bodyless protected routes still require a live
+  session.
+- OpenAI-shaped routes describe decrypted payloads inside the OpenSecret
+  protocol. Exercise protected routes through a pinned OpenSecret SDK or Maple.
+- JWT and API-key contexts are different. Do not give an API-key path access to
+  user-private storage without an explicit key-ownership and authorization
+  design.
+- Validate all client-controlled input before writes or provider side effects.
+  Preserve method, status, content type, error shape, streaming order,
+  cancellation, usage, encryption, and one terminal condition when changing a
+  public contract.
+- Return stable, sanitized errors. Do not expose provider bodies, credentials,
+  decrypted content, SQL details, or cryptographic internals.
+- Treat released SDKs and Maple as protocol consumers. Review both old-client /
+  new-server and new-client / old-server behavior when they can update
+  independently; gate or stage incompatible changes.
 
-Load `$change-opensecret-api` for route, payload, auth, SSE, persistence, or
-client-contract work.
+## Durable provider rules
 
-## Provider and model rules
+- Keep canonical public model IDs separate from provider IDs, routing policy,
+  feature flags, and credentials. Translate at the provider boundary and
+  canonicalize client-visible responses.
+- Route from authenticated identity and backend policy, never a caller-supplied
+  provider or account identity.
+- Review forwarded headers and provider-managed fields explicitly. Provider
+  credentials, raw attestation material, and user cache namespaces must not
+  cross into client responses or logs.
+- Retry only when the failure is known to precede request acceptance. An
+  ambiguous POST, response failure, or partial stream is not generally safe to
+  replay.
+- Treat provider responses, model output, web results, and extracted pages as
+  untrusted. Bound data and loops, preserve URL provenance, and enforce the
+  current SSRF policy.
+- Keep usage tied to the actual provider and canonical public model while
+  preserving the established user or API-key attribution.
 
-- Keep public model IDs separate from provider IDs. Canonicalize at the
-  OpenSecret boundary so upstream aliases never leak into stored or returned
-  API state.
-- Model availability/capabilities, provider routing weights and stickiness,
-  endpoint/credential resolution, transport, and route orchestration are
-  different concerns. Change each in its owning layer.
-- Provider secrets, administrative headers, and raw attestation material never
-  enter client-visible responses or logs. Review forwarded headers explicitly;
-  prefer an allowlist for a new boundary.
-- Retry only operations known to be safe. Connection establishment before a
-  request is sent is different from an ambiguous failure after a POST may have
-  reached a provider. Preserve Tinfoil attestation/origin binding and refresh
-  only on its typed connection-establishment failure.
-- Streaming adapters must handle bounded frames, cancellation, protocol errors,
-  usage, and a single terminal marker. A provider-direct test does not prove
-  OpenSecret authentication, E2EE, persistence, billing, routing, or Maple.
-- Usage is security- and billing-relevant. Normalize it once, retain model and
-  provider attribution internally, and test missing/partial provider usage.
+## Persistence and migrations
 
-Load `$change-opensecret-provider` for model catalog, routing, credentials,
-provider transport, retries, search/extraction adapters, or usage work.
+- Add a new timestamped Diesel migration; do not rewrite deployed history.
+  Review `up.sql`, `down.sql`, generated schema, model/query changes, scoping,
+  and indexes together.
+- Enforce ownership in database queries. Filtering an unscoped result in a
+  handler is not authorization.
+- Identify the owning key before changing encrypted data. User-private content
+  uses credential-derived user keys; server-owned secrets use their designated
+  enclave/system key domain.
+- Version ciphertext formats. User-key data normally needs dual-read/new-write
+  plus lazy authenticated rewrite after the user's key is available. SQL or
+  startup code cannot safely re-encrypt opaque user data without that key.
+- Run migration and database-backed security tests only against an identified,
+  disposable, fully migrated database.
 
-## Persistence and migration rules
+## Privacy and evidence
 
-- Use a new timestamped Diesel migration. Never edit an already-deployed
-  migration to change history.
-- Run the complete migration chain against an empty disposable database. When
-  `down.sql` or data transformation changes, also test down/up and an
-  upgrade-shaped database with representative encrypted rows.
-- Regenerate and review `src/models/schema.rs`; do not hand-edit it into a state
-  the migration does not produce.
-- Preserve user/project scoping in the database trait and concrete query.
-  Filtering in the handler after an unscoped read is not authorization.
-- Identify the owning key domain before changing an encrypted field.
-  User-private content uses the credential-derived user-key path; server-owned
-  material such as OAuth access tokens, project secrets, and password
-  verifiers remains in its enclave/system-secret domain. Do not make one
-  domain's migration depend on a key available only in another.
-- Version persisted ciphertext formats. For rows encrypted by a user key,
-  deploy dual-read/new-write behavior and lazily perform the authenticated
-  rewrite only after that user's key is available. A startup migration may
-  rewrite enclave/system-key data only when its owning key is available there;
-  a SQL migration alone cannot re-encrypt opaque ciphertext safely.
-- Preserve tamper detection, purpose and row binding, seed-wrap/source
-  invariants, transactionality, zeroization where present, and non-secret
-  indexes/metadata only where the design permits them.
-- Use only a dedicated disposable Postgres database for ignored tamper/OAuth
-  suites. Fail closed on database identity, migration status, selected-test
-  count, skip output, pass count, and cleanup; a successful test-process exit
-  is insufficient evidence that an ignored database test executed.
+- Do not log secrets, tokens, session material, raw headers, OAuth payloads,
+  prompts, reasoning, decrypted bodies, response deltas, provider bodies, or
+  other sensitive user content. Safe metadata must be bounded and allowlisted;
+  `trace` is not a private channel.
+- Preserve capacity, expiry, one-use/lease, cleanup, cancellation, and failure
+  behavior at unauthenticated, cryptographic, streaming, and external-service
+  boundaries.
+- Treat billing and feature flags only as configurable external HTTP APIs.
+  Their server credentials remain backend-only, and each changed call site
+  must define its own unavailable, timeout, denial, and success behavior.
+- Separate source-confirmed, test-confirmed, build-confirmed, live-confirmed,
+  inferred, and unverified claims. Source and local tests do not prove deployed
+  PCRs, KMS/IAM policy, artifact identity, network placement, or log retention.
 
-## Security and privacy invariants
+Keep revision-specific findings in the review, not in evergreen repository
+guidance.
 
-- Treat source-confirmed behavior, test-confirmed behavior, deployed
-  configuration, and live-environment observations as distinct evidence.
-  Source alone cannot prove deployed PCRs, KMS/IAM policy, logging policy,
-  network placement, or which artifact is serving production.
-- Never log secrets, session material, tokens, OAuth provider payloads,
-  prompts, reasoning, response deltas, decrypted bodies, user email/profile
-  data, provider bodies, or raw headers. Metadata must be bounded and
-  allowlisted. Logs leave the enclave boundary, so `trace` is not a safe place
-  for sensitive content.
-- Preserve bounded, expiring, one-use or leased state for pending attestations,
-  sessions, OAuth state, and other unauthenticated resources. Cleanup paths and
-  failure paths receive the same bounds as success paths.
-- Preserve session liveness and key ownership across every protected route.
-  Cryptographic review must cover nonce generation, direction separation,
-  additional authenticated data, replay behavior, bodyless requests, error
-  encryption, and concurrency—not only the happy-path primitive.
-- Authentication changes must review access and refresh token lifecycle,
-  revocation/logout, reset and verification codes, OAuth state/nonce binding,
-  account linking, native callbacks, and enumeration-resistant errors.
-- Billing and flags may fail differently across registered, guest, chat,
-  Responses, web, audio, and other paths. Treat that matrix as an explicit
-  product/security decision; do not generalize one route's behavior.
-- Provider response data and model output are untrusted. Bound sizes and loops,
-  validate content types/schemas, enforce URL provenance and SSRF policy, and
-  avoid replaying hidden provider state without evidence.
+## Development and validation
 
-Load `$review-opensecret-security` before changing cryptography, auth, OAuth,
-sessions, storage encryption, provider headers, billing enforcement, URL
-fetching, logging, Nitro/KMS integration, or another trust boundary.
+Use `$develop-opensecret` for the local stack and code-placement workflow. Use
+`$validate-opensecret` to choose focused tests, exact Rust CI parity,
+disposable-database validation, authorized provider probes, encrypted client
+smoke tests, and Nix/EIF checks.
 
-## Development workflow
+Match evidence to the changed boundary. Report exact commands, counts, ignored
+or skipped tests, configured external services, and every unverified layer.
 
-For the normal local macOS stack:
+## Operator authority
 
-```bash
-git submodule update --init --recursive
-OPENSECRET_DEV_CONTAINERS=0 nix develop
-just build-local-proxies-macos
-just diesel-migration-run-local
-```
+Local builds and read-only comparison of a built PCR against a reviewed,
+checked-in reference are validation when the task reaches that boundary. They
+are not deployment.
 
-Then run the Continuum proxy and backend in separate shells:
-
-```bash
-nix develop -c just run-continuum-proxy-macos
-nix develop -c just run-local-backend-macos
-```
-
-The Tinfoil client runs in-process; there is no local Tinfoil sidecar. See
-`docs/local-macos-stack.md` and `$develop-opensecret` for credential files,
-ports, alternative direct-provider configuration, and debugging.
-
-For read-only or CI-style checks, prevent the Nix shell hook from starting
-Postgres, writing `.env`, or changing Linux container configuration:
-
-```bash
-OPENSECRET_DEV_POSTGRES=0 \
-OPENSECRET_DEV_ENV=0 \
-OPENSECRET_DEV_CONTAINERS=0 \
-nix develop --no-write-lock-file -c <command>
-```
-
-## Validation and evidence
-
-The Rust CI gate is:
-
-```bash
-OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c cargo fmt --all -- --check
-
-OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c \
-  env RUSTFLAGS='-D warnings' \
-  cargo clippy --locked --all-targets --all-features -- -D warnings
-
-OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c \
-  env RUSTFLAGS='-D warnings' cargo test --locked --all-features
-```
-
-Run focused tests while iterating, then the full gate. Add
-`nix flake check --print-build-logs` for Nix, entrypoint, Nitro helper, kernel,
-or security-build changes. Current-host flake checks do not prove ARM Linux EIF
-construction or PCR reproducibility.
-
-Default CI has no PostgreSQL service and skips all ignored tests. Never run all
-ignored tests as one group:
-
-- the AEAD tamper and OAuth database subsets require a fully migrated,
-  disposable database via `AEAD_TAMPER_TEST_DATABASE_URL` and serialized test
-  execution;
-- the Tinfoil parity test requires a live credential and network and must be
-  run separately with explicit authorization.
-
-`/health-check` is process liveness only and does not query PostgreSQL.
-`/health-check-extended` checks Tinfoil model-list connectivity only. Neither
-proves auth, E2EE, persistence, routing, billing, flags, or full-stack behavior.
-Use `$validate-opensecret` for the exact risk matrix, ignored-test commands,
-SDK-driven encrypted smoke, and evidence report.
-
-## Review and authority
-
-Review the changed contract end to end: route assembly, middleware order,
-cryptographic ownership, authorization/scoping, persistence, provider effects,
-usage, error/log content, cancellation, tests, and client compatibility. Cite
-current source for claims and state what remains unverified.
-
-Building an EIF is not deployment. PCR comparison, KMS policy changes, copying
-artifacts to hosts, terminating/running enclaves, restarting proxies, writing
-secrets, and invoking any `deploy-*`, `stage-*`, `run-eif-*`, or PCR mutation
-recipe require explicit operator authorization. Treat PCR verification as a
-gate only when it compares the built result with a reviewed, checked-in
-reference through the matching workflow; a recipe that performs no comparison
-is not PCR evidence.
+Require explicit authorization for changing PCR references or histories, KMS
+or IAM policy, shared or remote migrations, copying artifacts to hosts,
+starting or terminating enclaves, restarting remote services, writing remote
+secrets, staging, deployment, release, or signing operations. Inspect a recipe
+before running it; its name alone does not establish whether it mutates state.
 
 ## Skills
 
-- `$develop-opensecret`: local setup, Postgres, environment, migrations,
-  process topology, placement, and implementation loop.
-- `$change-opensecret-api`: routes, auth context, encrypted payloads, errors,
-  SSE, Responses persistence, and client compatibility.
-- `$change-opensecret-provider`: model catalog, routing, provider credentials,
-  transport/attestation, retries, usage, and search/extraction adapters.
-- `$validate-opensecret`: focused tests, CI parity, disposable-database suites,
-  provider probes, encrypted API/full-stack smoke, and evidence reporting.
-- `$review-opensecret-security`: cryptography, attestation/session/auth/OAuth,
-  persistence, provider headers, logging, billing policy, and deployment-trust
-  review.
+- `$develop-opensecret`: local setup, migrations, process topology, and code
+  placement.
+- `$change-opensecret-api`: encrypted API contracts, Responses persistence,
+  streaming, and client compatibility.
+- `$change-opensecret-provider`: models, routing, transport, provider adapters,
+  retries, and usage.
+- `$validate-opensecret`: proportional test and smoke evidence.
+- `$review-opensecret-security`: trust-boundary review and evidence claims.
 
 ## Maintaining this guidance
 
 Treat this guide and the repository skills as living operational documentation,
-not infallible rules. Re-check prescriptive language against the current source,
+not infallible rules. Re-check prescriptive language against current source,
 tooling, and architecture. If guidance appears stale, materially wrong,
 unnecessarily absolute, or repeatedly creates development friction, surface the
 mismatch and confirm the intended correction with the user before changing it.
-Do not churn guidance for stylistic preferences or isolated nits; do narrow
-words such as "always" or "never" when they claim more than the invariant
-actually requires.
+Avoid churn for stylistic preferences or isolated nits; do narrow words such as
+"always" or "never" when they claim more than the invariant requires.
 
 Update the relevant guide or skill in the same branch when a material change
 adds, removes, or rearchitects a workflow, ownership boundary, validation path,
-or recurring development procedure. If you discover unrelated drift, keep the
+or recurring development procedure. If unrelated drift is discovered, keep the
 current task scoped and propose a standalone change with evidence and reasoning.
-Add a new skill when a genuinely reusable workflow does not fit an existing one;
-otherwise prefer improving or consolidating current guidance. Ground every
-update in current source or executed workflow experience, keep it concise, and
-validate every command or path it prescribes.
+Add a new skill only for a genuinely reusable workflow; otherwise consolidate
+existing guidance. Validate every command and path the update prescribes.

--- a/README.md
+++ b/README.md
@@ -16,60 +16,35 @@ deployed environment.
 The Nix flake pins the Rust toolchain, PostgreSQL, Diesel, native libraries, and
 provider dependencies.
 
+Before running migrations, confirm that the PostgreSQL listener and database
+belong to this checkout. The development shell may reuse any listener answering
+on its configured port; use distinct state and ports for concurrent checkouts.
+It may also start `.pgdata` and create `.env` from `.env.sample`. On Linux,
+container setup changes user-level state unless disabled. See
+[`docs/dev-shell.md`](docs/dev-shell.md) for controls.
+
 ```sh
 git submodule update --init --recursive
 OPENSECRET_DEV_CONTAINERS=0 nix develop
 just diesel-migration-run-local
 ```
 
-The development shell may reuse a PostgreSQL listener, start `.pgdata`, and
-create `.env` from `.env.sample`. On Linux, container setup also changes
-user-level container configuration unless disabled. See
-[`docs/dev-shell.md`](docs/dev-shell.md) before running check-only commands or
-multiple checkouts.
-
 Backend startup does not run Diesel schema migrations;
 `src/migrations.rs` is separate application-data migration logic.
 
 ### Provider credentials and macOS stack
 
-Tinfoil runs in-process and requires a credential. The supported macOS local
-stack can also use a native Continuum proxy. Store credentials in these
-gitignored files:
-
-```text
-.local/secrets/tinfoil_api_key
-.local/secrets/continuum_api_key
-```
-
-Build the local proxy once, then run the long-lived processes in separate
-terminals:
-
-```sh
-nix develop -c just build-local-proxies-macos
-```
-
-Terminal 1:
-
-```sh
-nix develop -c just run-continuum-proxy-macos
-```
-
-Terminal 2:
-
-```sh
-nix develop -c just run-local-backend-macos
-```
-
-See [`docs/local-macos-stack.md`](docs/local-macos-stack.md) for topology and
-Maple wiring. There is no local Tinfoil sidecar.
+Tinfoil runs in-process; there is no local Tinfoil sidecar. For protected
+credential files, the native Continuum proxy, process topology, and Maple
+wiring, follow [`docs/local-macos-stack.md`](docs/local-macos-stack.md).
 
 ## Configuration and API boundary
 
-`.env.sample` is the configuration inventory. Keep all real credentials in
-ignored files or protected environment variables. Billing and feature flags
-are optional external HTTP APIs whose administrative credentials remain in the
-backend; their server implementations are not part of this repository setup.
+`.env.sample` is the supported local-development starting point; current
+startup source is authoritative. Keep real credentials in ignored files or
+protected environment variables. Billing and feature flags are optional
+external HTTP APIs whose administrative credentials remain in the backend;
+their server implementations are not part of this repository setup.
 
 Protected routes require OpenSecret attestation/key exchange and encrypted
 sessions. “OpenAI-shaped” describes decrypted payloads, not a plaintext
@@ -101,13 +76,19 @@ OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
 Default CI does not run ignored database or live-provider tests. Use the
 [`validate-opensecret`](.agents/skills/validate-opensecret/SKILL.md) workflow
 for disposable PostgreSQL tests, authorized provider checks, encrypted-client
-smoke tests, and Nix/EIF/PCR evidence. Report those layers separately.
+smoke tests, Nix checks, and release-only EIF/PCR evidence. Report those layers
+separately.
 
 ## Nitro builds and deployment
 
 The supported EIF outputs are `eif-dev`, `eif-preview`, and `eif-prod`, built
 with the repository's Nix flake on the appropriate Linux/ARM environment. Build,
 PCR comparison, deployment, and live trust verification are distinct evidence.
+
+Routine pull requests do not require EIF/PCR parity. Before an authorized dev
+or prod publish/deployment, use the supported Linux/ARM64 release builder to
+review and deliberately update/verify the target measurements; never update
+checked-in PCRs solely to clear ordinary pull-request CI.
 
 See [`docs/nitro-deploy.md`](docs/nitro-deploy.md) for operator procedures.
 Changing PCR references or KMS policy, copying artifacts, starting or stopping

--- a/README.md
+++ b/README.md
@@ -1,153 +1,222 @@
 # OpenSecret
 
-This is the platform code for running OpenSecret's backend. This is intended to run on AWS Nitro inside an enclave.
+OpenSecret is the open-source Rust backend for confidential AI applications
+such as [Maple](https://github.com/OpenSecretCloud/Maple). It owns
+authentication, encrypted client sessions, encrypted persistence, model and
+provider routing, usage accounting, and OpenAI-shaped/Responses APIs carried
+inside the OpenSecret encrypted transport.
 
-## AWS Nitro Deployment
+Production is designed to run inside AWS Nitro Enclaves. A source checkout or
+local build can validate implementation and build invariants, but cannot by
+itself prove the PCRs, KMS/IAM policy, logging configuration, artifact identity,
+or network placement of a deployed environment.
 
-When deploying to AWS Nitro, you'll need to choose the appropriate environment:
-- `dev` for development environment
-- `preview` for preview/staging environment  
-- `prod` for production environment
+## Local development
 
-The current flake exports only those three named EIFs. Supporting another
-environment requires adding and reviewing another named flake output.
+The Nix flake pins Rust, PostgreSQL, Diesel, native libraries, provider tooling,
+and the repository's submodule dependencies.
 
-Each environment has its own configuration, secrets, and infrastructure. Make sure to use the correct environment variables and AWS resources for your target environment.
-
-### New Nix-based Deployment
-
-The new deployment process uses Nix to create reproducible builds:
-
-1. Nix builds the pinned Nitro KMS/NSM helper sources as part of the EIF.
-   To inspect that helper closure independently on Linux ARM:
 ```bash
-just build-nitro-bins
+git submodule update --init --recursive
+OPENSECRET_DEV_CONTAINERS=0 nix develop
 ```
 
-2. Build the EIF for your target environment:
+The default shell hook first checks for any PostgreSQL server responding on
+`localhost:$PGPORT`. If one responds, the hook reuses that listener and skips
+initializing this checkout's `.pgdata`, role, and database. Otherwise it starts
+the checkout-local cluster. The hook also creates a gitignored `.env` from
+`.env.sample` when one is absent. On Linux, enabling the container setup
+rewrites user-level container configuration; keep
+`OPENSECRET_DEV_CONTAINERS=0` unless the task intentionally uses those local
+container helpers. For all shell-hook controls, see
+[`docs/dev-shell.md`](docs/dev-shell.md).
+
+SQL migrations are a required, separate step:
+
 ```bash
-# For development
+just diesel-migration-run-local
+```
+
+Backend startup does not run Diesel schema migrations. `src/migrations.rs`
+contains application-data migration logic and is not a replacement for the
+command above.
+
+### Provider credentials
+
+Tinfoil is a hard runtime dependency. On macOS, the supported local stack also
+uses a native Continuum proxy. Put credentials in gitignored files so they do
+not enter shell history:
+
+```text
+.local/secrets/tinfoil_api_key
+.local/secrets/continuum_api_key
+```
+
+Environment variables `TINFOIL_API_KEY` and `CONTINUUM_API_KEY` override those
+files. Provider credentials are secrets: never commit them, print them in
+diagnostics, or copy them into Maple.
+
+Build the local Continuum binary once:
+
+```bash
+nix develop -c just build-local-proxies-macos
+```
+
+Then use separate terminals for the provider proxy and backend:
+
+```bash
+nix develop -c just run-continuum-proxy-macos
+nix develop -c just run-local-backend-macos
+```
+
+The defaults are:
+
+```text
+Continuum proxy   http://127.0.0.1:8092
+OpenSecret API    http://127.0.0.1:3000
+```
+
+The attested Tinfoil client runs inside the OpenSecret process; there is no
+local Tinfoil sidecar or port. See
+[`docs/local-macos-stack.md`](docs/local-macos-stack.md) for the complete local
+topology and provider configuration.
+
+Point Maple's ignored `frontend/.env.local` at this API:
+
+```dotenv
+VITE_OPEN_SECRET_API_URL=http://127.0.0.1:3000
+```
+
+Keep the default Vite origin when testing OAuth or verification callbacks
+unless the callback contract is the feature being changed.
+
+## Configuration
+
+`.env.sample` documents local configuration. The important boundaries are:
+
+- `DATABASE_URL`, `APP_MODE`, `ENCLAVE_SECRET_MOCK`, and `JWT_SECRET` configure
+  local persistence and cryptographic development state.
+- `OPENSECRET_BIND_ADDR` changes the API listener from its default
+  `127.0.0.1:3000`.
+- `OPENAI_API_BASE` selects the default OpenAI-compatible provider. The
+  documented loopback Continuum recipe does not need `OPENAI_API_KEY`.
+  Arbitrary custom bases are credential boundaries: review the exact URL,
+  authentication headers, and forwarding behavior rather than inferring them
+  from the base URL alone.
+- `TINFOIL_API_KEY` is always required.
+- `BRAVE_API_KEY` and `KAGI_API_KEY` enable optional web providers.
+- `BILLING_SERVER_URL`/`BILLING_API_KEY` and
+  `OS_FLAGS_BASE_URL`/`OS_FLAGS_API_KEY` configure optional external APIs.
+
+Billing and flags are independent server-side clients. Their administrative
+keys never belong in Maple or another public client. An unconfigured optional
+integration can have feature- and account-specific behavior; validate the
+exact path rather than assuming all endpoints fail open or fail closed.
+
+## Development and architecture
+
+This repository is one Rust package and binary, not a Cargo workspace. The main
+areas are:
+
+- `src/main.rs`: configuration, state, middleware, and router assembly.
+- `src/web/`: encrypted HTTP routes, OpenAI-shaped APIs, auth/OAuth, health,
+  web search, and Responses.
+- `src/models/`, `src/db.rs`, and `migrations/`: PostgreSQL persistence and
+  Diesel schema.
+- `src/encrypt.rs`, `src/seed_wrapping.rs`, `src/jwt.rs`, and attestation/session
+  code: cryptographic and identity boundaries.
+- `src/model_config.rs`, `src/provider_routing.rs`, `src/proxy_config.rs`, and
+  `src/provider_client.rs`: model catalog, routing, provider configuration,
+  transport, streaming, retries, and usage.
+- `src/brave.rs` and `src/kagi.rs`: provider-specific web adapters.
+
+Protected routes require OpenSecret attestation/key exchange and encrypted
+sessions. “OpenAI-compatible” describes the decrypted payload shape; raw
+plaintext `curl` is not an end-to-end API test. Use an OpenSecret SDK or Maple
+for protected-route smoke tests.
+
+Persisted encryption has separate key domains. User-private content follows
+the credential-derived user-key path, while server-owned material such as
+OAuth access tokens, project secrets, and password verifiers uses its owning
+enclave/system secret. A ciphertext-format migration must preserve that
+boundary: use a versioned dual-read/new-write transition and lazy authenticated
+rewrite for user-key rows; reserve startup rewrites for data whose owning key
+is available at startup.
+
+Contributor and coding-agent standards live in [`AGENTS.md`](AGENTS.md).
+Task-specific local development, API, provider, security, and validation
+workflows live under [`.agents/skills/`](.agents/skills/).
+
+## Validation
+
+Match the checked-in Rust CI gate while preventing check-only shells from
+starting PostgreSQL, generating `.env`, or changing Linux container settings:
+
+```bash
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c cargo fmt --all -- --check
+
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c \
+  env RUSTFLAGS='-D warnings' \
+  cargo clippy --locked --all-targets --all-features -- -D warnings
+
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c \
+  env RUSTFLAGS='-D warnings' cargo test --locked --all-features
+```
+
+Default CI does not start PostgreSQL or run ignored tests. Database migration,
+AEAD tamper, OAuth database, live provider, encrypted API, and Maple smoke are
+separate evidence tiers. In particular:
+
+- `/health-check` is process liveness and does not query PostgreSQL.
+- `/health-check-extended` checks Tinfoil model-list connectivity only.
+- Ignored database evidence is valid only when the disposable database
+  identity and migrations are verified, the selected tests are listed, no
+  skip marker appears under `--nocapture`, and the expected pass count is
+  asserted.
+- The ignored live Tinfoil test bypasses OpenSecret's public API and therefore
+  does not prove auth, encrypted transport, persistence, routing, or billing.
+
+Do not run every ignored test together. Use
+`.agents/skills/validate-opensecret/` for safe disposable-database commands,
+provider probes, SDK-driven encrypted smoke, and evidence reporting. Add
+`nix flake check --print-build-logs` for changes to Nix, entrypoints, Nitro
+helpers, kernel sources, or security-build invariants.
+
+## Nitro builds and deployment
+
+The named Nix outputs are the supported EIF build path:
+
+```bash
 nix build '.?submodules=1#eif-dev'
-
-# For production
-nix build '.?submodules=1#eif-prod'
-
-# For preview
 nix build '.?submodules=1#eif-preview'
+nix build '.?submodules=1#eif-prod'
 ```
 
-This will create a symlink `result` pointing to the built EIF file.
+EIF construction, PCR comparison, deployment, and live trust verification are
+different evidence. EIF builds require the appropriate Linux/ARM environment;
+current-host checks on macOS do not prove them.
 
-3. Copy the EIF to your AWS parent instance:
-```bash
-# For development
-just scp-eif-to-aws-dev
+Copying an EIF, mutating PCR references or KMS policy, terminating/running an
+enclave, restarting a proxy, or using any `stage-*`/`deploy-*` recipe requires
+explicit operator authorization. Treat a PCR recipe as verification only when
+it compares the built result with a reviewed, checked-in reference through the
+matching workflow.
 
-# For production
-just scp-eif-to-aws-prod
+See [`docs/nitro-deploy.md`](docs/nitro-deploy.md) for infrastructure context.
+Treat its deployment commands as operator procedures, not contributor setup.
 
-# For preview
-just scp-eif-to-aws-preview
-```
+## Contributing
 
-4. Deploy the EIF:
-```bash
-# For development
-just deploy-dev-nix
+Keep changes focused and add regression coverage at the owning boundary. For
+API changes, review encrypted transport, auth context, errors/SSE, persistence,
+published SDKs, and Maple compatibility. For provider changes, keep upstream
+IDs and secrets behind the provider boundary and prove retry safety and usage
+handling.
 
-# For production
-just deploy-prod-nix
-
-# For preview
-just deploy-preview-nix
-```
-
-The deployment process will:
-1. Build the EIF
-2. Copy it to the AWS parent instance
-3. Prompt you to review the PCR values
-4. After confirmation, terminate any existing enclave
-5. Run the new enclave
-6. Restart the socat proxy
-
-### PCR Value Management
-
-The Nix build process generates PCR (Platform Configuration Register) values that are used by AWS KMS for attestation. You can:
-
-1. Copy PCR values to a reference file:
-```bash
-just copy-pcr-dev    # For development
-just copy-pcr-prod   # For production
-just copy-pcr-preview # For preview
-```
-
-2. Verify PCR values match the reference:
-```bash
-just verify-pcr-dev    # For development
-just verify-pcr-prod   # For production
-just verify-pcr-preview # For preview
-```
-
-This ensures the build is reproducible and matches the expected configuration.
-
-## Nitro Enclaves Setup
-
-The project uses AWS Nitro Enclaves and requires two helper artifacts:
-- `libnsm.so` - NSM (Nitro Security Module) library
-- `kmstool_enclave_cli` - KMS tool for key operations
-
-Nix builds both from fixed commits and hashes declared in
-`nix/nitro-bins/upstreams.nix`. The source repositories are:
-- [aws-nitro-enclaves-nsm-api](https://github.com/aws/aws-nitro-enclaves-nsm-api)
-- [aws-nitro-enclaves-sdk-c](https://github.com/aws/aws-nitro-enclaves-sdk-c)
-
-### Building Nitro Binaries
-
-To build the same helper derivation consumed by the EIF:
-
-```bash
-just build-nitro-bins
-```
-
-The build fetches only the reviewed, immutable sources and produces a Nix
-result; it never writes ELF binaries back into the repository. Normal EIF
-builds consume this derivation automatically.
-
-## Building and Deploying with Nix
-
-### Building the EIF
-
-1. Build an explicit EIF target using Nix; its helper closure is built
-   automatically (development shown):
-```bash
-nix build '.?submodules=1#eif-dev'
-```
-
-This will create a symlink `result` pointing to the built EIF file.
-
-### EIF construction contract
-
-The named Nix outputs are the only supported way to assemble the OpenSecret
-application root filesystem and EIF. The parent-instance credential requester
-and logging containers are operational services, not EIF build inputs.
-
-The Nix-based build:
-- Creates a more reproducible build environment
-- Source-builds Nitro helper artifacts from reviewed commits and hashes
-- Integrates with the Monzo aws-nitro-util for EIF creation
-- Preserves the application-facing helper CLI contract
-
-The resulting EIF is deployed with the environment-specific commands above.
-
-## CI/CD Requirements
-
-### GitHub Actions Runner
-
-This project requires a custom GitHub Actions runner with the following specifications:
-
-- Label: `ubuntu-22.04-arm64-4core`
-- Architecture: ARM64
-- Operating System: Ubuntu 22.04
-- Resources: 4 CPU cores
-
-The workflow uses this custom runner for both development and production builds. For more information about setting up custom GitHub Actions runners, see [GitHub's documentation](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/adding-self-hosted-runners).
+Before opening a pull request, run the applicable full gates, test migrations
+against a disposable database when relevant, and inspect `git diff --check`.
+Security reports must separate source-confirmed facts, tests, deployed
+configuration, and live observations.

--- a/README.md
+++ b/README.md
@@ -2,221 +2,120 @@
 
 OpenSecret is the open-source Rust backend for confidential AI applications
 such as [Maple](https://github.com/OpenSecretCloud/Maple). It owns
-authentication, encrypted client sessions, encrypted persistence, model and
-provider routing, usage accounting, and OpenAI-shaped/Responses APIs carried
-inside the OpenSecret encrypted transport.
+authentication, encrypted client sessions and persistence, provider routing,
+usage accounting, and OpenAI-shaped/Responses APIs carried inside the
+OpenSecret encrypted transport.
 
-Production is designed to run inside AWS Nitro Enclaves. A source checkout or
-local build can validate implementation and build invariants, but cannot by
-itself prove the PCRs, KMS/IAM policy, logging configuration, artifact identity,
-or network placement of a deployed environment.
+Production is designed for AWS Nitro Enclaves. A source checkout or local build
+can validate implementation and build invariants, but does not by itself prove
+the artifact, PCR, IAM/KMS policy, logging, or network configuration of a
+deployed environment.
 
-## Local development
+## Local quick start
 
-The Nix flake pins Rust, PostgreSQL, Diesel, native libraries, provider tooling,
-and the repository's submodule dependencies.
+The Nix flake pins the Rust toolchain, PostgreSQL, Diesel, native libraries, and
+provider dependencies.
 
-```bash
+```sh
 git submodule update --init --recursive
 OPENSECRET_DEV_CONTAINERS=0 nix develop
-```
-
-The default shell hook first checks for any PostgreSQL server responding on
-`localhost:$PGPORT`. If one responds, the hook reuses that listener and skips
-initializing this checkout's `.pgdata`, role, and database. Otherwise it starts
-the checkout-local cluster. The hook also creates a gitignored `.env` from
-`.env.sample` when one is absent. On Linux, enabling the container setup
-rewrites user-level container configuration; keep
-`OPENSECRET_DEV_CONTAINERS=0` unless the task intentionally uses those local
-container helpers. For all shell-hook controls, see
-[`docs/dev-shell.md`](docs/dev-shell.md).
-
-SQL migrations are a required, separate step:
-
-```bash
 just diesel-migration-run-local
 ```
 
-Backend startup does not run Diesel schema migrations. `src/migrations.rs`
-contains application-data migration logic and is not a replacement for the
-command above.
+The development shell may reuse a PostgreSQL listener, start `.pgdata`, and
+create `.env` from `.env.sample`. On Linux, container setup also changes
+user-level container configuration unless disabled. See
+[`docs/dev-shell.md`](docs/dev-shell.md) before running check-only commands or
+multiple checkouts.
 
-### Provider credentials
+Backend startup does not run Diesel schema migrations;
+`src/migrations.rs` is separate application-data migration logic.
 
-Tinfoil is a hard runtime dependency. On macOS, the supported local stack also
-uses a native Continuum proxy. Put credentials in gitignored files so they do
-not enter shell history:
+### Provider credentials and macOS stack
+
+Tinfoil runs in-process and requires a credential. The supported macOS local
+stack can also use a native Continuum proxy. Store credentials in these
+gitignored files:
 
 ```text
 .local/secrets/tinfoil_api_key
 .local/secrets/continuum_api_key
 ```
 
-Environment variables `TINFOIL_API_KEY` and `CONTINUUM_API_KEY` override those
-files. Provider credentials are secrets: never commit them, print them in
-diagnostics, or copy them into Maple.
+Build the local proxy once, then run the long-lived processes in separate
+terminals:
 
-Build the local Continuum binary once:
-
-```bash
+```sh
 nix develop -c just build-local-proxies-macos
 ```
 
-Then use separate terminals for the provider proxy and backend:
+Terminal 1:
 
-```bash
+```sh
 nix develop -c just run-continuum-proxy-macos
+```
+
+Terminal 2:
+
+```sh
 nix develop -c just run-local-backend-macos
 ```
 
-The defaults are:
+See [`docs/local-macos-stack.md`](docs/local-macos-stack.md) for topology and
+Maple wiring. There is no local Tinfoil sidecar.
 
-```text
-Continuum proxy   http://127.0.0.1:8092
-OpenSecret API    http://127.0.0.1:3000
-```
+## Configuration and API boundary
 
-The attested Tinfoil client runs inside the OpenSecret process; there is no
-local Tinfoil sidecar or port. See
-[`docs/local-macos-stack.md`](docs/local-macos-stack.md) for the complete local
-topology and provider configuration.
-
-Point Maple's ignored `frontend/.env.local` at this API:
-
-```dotenv
-VITE_OPEN_SECRET_API_URL=http://127.0.0.1:3000
-```
-
-Keep the default Vite origin when testing OAuth or verification callbacks
-unless the callback contract is the feature being changed.
-
-## Configuration
-
-`.env.sample` documents local configuration. The important boundaries are:
-
-- `DATABASE_URL`, `APP_MODE`, `ENCLAVE_SECRET_MOCK`, and `JWT_SECRET` configure
-  local persistence and cryptographic development state.
-- `OPENSECRET_BIND_ADDR` changes the API listener from its default
-  `127.0.0.1:3000`.
-- `OPENAI_API_BASE` selects the default OpenAI-compatible provider. The
-  documented loopback Continuum recipe does not need `OPENAI_API_KEY`.
-  Arbitrary custom bases are credential boundaries: review the exact URL,
-  authentication headers, and forwarding behavior rather than inferring them
-  from the base URL alone.
-- `TINFOIL_API_KEY` is always required.
-- `BRAVE_API_KEY` and `KAGI_API_KEY` enable optional web providers.
-- `BILLING_SERVER_URL`/`BILLING_API_KEY` and
-  `OS_FLAGS_BASE_URL`/`OS_FLAGS_API_KEY` configure optional external APIs.
-
-Billing and flags are independent server-side clients. Their administrative
-keys never belong in Maple or another public client. An unconfigured optional
-integration can have feature- and account-specific behavior; validate the
-exact path rather than assuming all endpoints fail open or fail closed.
-
-## Development and architecture
-
-This repository is one Rust package and binary, not a Cargo workspace. The main
-areas are:
-
-- `src/main.rs`: configuration, state, middleware, and router assembly.
-- `src/web/`: encrypted HTTP routes, OpenAI-shaped APIs, auth/OAuth, health,
-  web search, and Responses.
-- `src/models/`, `src/db.rs`, and `migrations/`: PostgreSQL persistence and
-  Diesel schema.
-- `src/encrypt.rs`, `src/seed_wrapping.rs`, `src/jwt.rs`, and attestation/session
-  code: cryptographic and identity boundaries.
-- `src/model_config.rs`, `src/provider_routing.rs`, `src/proxy_config.rs`, and
-  `src/provider_client.rs`: model catalog, routing, provider configuration,
-  transport, streaming, retries, and usage.
-- `src/brave.rs` and `src/kagi.rs`: provider-specific web adapters.
+`.env.sample` is the configuration inventory. Keep all real credentials in
+ignored files or protected environment variables. Billing and feature flags
+are optional external HTTP APIs whose administrative credentials remain in the
+backend; their server implementations are not part of this repository setup.
 
 Protected routes require OpenSecret attestation/key exchange and encrypted
-sessions. “OpenAI-compatible” describes the decrypted payload shape; raw
-plaintext `curl` is not an end-to-end API test. Use an OpenSecret SDK or Maple
-for protected-route smoke tests.
-
-Persisted encryption has separate key domains. User-private content follows
-the credential-derived user-key path, while server-owned material such as
-OAuth access tokens, project secrets, and password verifiers uses its owning
-enclave/system secret. A ciphertext-format migration must preserve that
-boundary: use a versioned dual-read/new-write transition and lazy authenticated
-rewrite for user-key rows; reserve startup rewrites for data whose owning key
-is available at startup.
+sessions. “OpenAI-shaped” describes decrypted payloads, not a plaintext
+OpenAI-compatible wire endpoint. Use an OpenSecret SDK or Maple for
+protected-route integration tests; plain `curl` is suitable only for public
+health probes.
 
 Contributor and coding-agent standards live in [`AGENTS.md`](AGENTS.md).
-Task-specific local development, API, provider, security, and validation
-workflows live under [`.agents/skills/`](.agents/skills/).
+Task-specific development, API, provider, security, and validation workflows
+live under [`.agents/skills/`](.agents/skills/).
 
 ## Validation
 
-Match the checked-in Rust CI gate while preventing check-only shells from
-starting PostgreSQL, generating `.env`, or changing Linux container settings:
+The Rust CI gate is formatting, strict all-target/all-feature Clippy, and locked
+all-feature tests. Run it through the pinned shell without starting local
+services:
 
-```bash
+```sh
 OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
   nix develop --no-write-lock-file -c cargo fmt --all -- --check
-
 OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c \
-  env RUSTFLAGS='-D warnings' \
+  nix develop --no-write-lock-file -c env RUSTFLAGS='-D warnings' \
   cargo clippy --locked --all-targets --all-features -- -D warnings
-
 OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
-  nix develop --no-write-lock-file -c \
-  env RUSTFLAGS='-D warnings' cargo test --locked --all-features
+  nix develop --no-write-lock-file -c env RUSTFLAGS='-D warnings' \
+  cargo test --locked --all-features
 ```
 
-Default CI does not start PostgreSQL or run ignored tests. Database migration,
-AEAD tamper, OAuth database, live provider, encrypted API, and Maple smoke are
-separate evidence tiers. In particular:
-
-- `/health-check` is process liveness and does not query PostgreSQL.
-- `/health-check-extended` checks Tinfoil model-list connectivity only.
-- Ignored database evidence is valid only when the disposable database
-  identity and migrations are verified, the selected tests are listed, no
-  skip marker appears under `--nocapture`, and the expected pass count is
-  asserted.
-- The ignored live Tinfoil test bypasses OpenSecret's public API and therefore
-  does not prove auth, encrypted transport, persistence, routing, or billing.
-
-Do not run every ignored test together. Use
-`.agents/skills/validate-opensecret/` for safe disposable-database commands,
-provider probes, SDK-driven encrypted smoke, and evidence reporting. Add
-`nix flake check --print-build-logs` for changes to Nix, entrypoints, Nitro
-helpers, kernel sources, or security-build invariants.
+Default CI does not run ignored database or live-provider tests. Use the
+[`validate-opensecret`](.agents/skills/validate-opensecret/SKILL.md) workflow
+for disposable PostgreSQL tests, authorized provider checks, encrypted-client
+smoke tests, and Nix/EIF/PCR evidence. Report those layers separately.
 
 ## Nitro builds and deployment
 
-The named Nix outputs are the supported EIF build path:
+The supported EIF outputs are `eif-dev`, `eif-preview`, and `eif-prod`, built
+with the repository's Nix flake on the appropriate Linux/ARM environment. Build,
+PCR comparison, deployment, and live trust verification are distinct evidence.
 
-```bash
-nix build '.?submodules=1#eif-dev'
-nix build '.?submodules=1#eif-preview'
-nix build '.?submodules=1#eif-prod'
-```
-
-EIF construction, PCR comparison, deployment, and live trust verification are
-different evidence. EIF builds require the appropriate Linux/ARM environment;
-current-host checks on macOS do not prove them.
-
-Copying an EIF, mutating PCR references or KMS policy, terminating/running an
-enclave, restarting a proxy, or using any `stage-*`/`deploy-*` recipe requires
-explicit operator authorization. Treat a PCR recipe as verification only when
-it compares the built result with a reviewed, checked-in reference through the
-matching workflow.
-
-See [`docs/nitro-deploy.md`](docs/nitro-deploy.md) for infrastructure context.
-Treat its deployment commands as operator procedures, not contributor setup.
+See [`docs/nitro-deploy.md`](docs/nitro-deploy.md) for operator procedures.
+Changing PCR references or KMS policy, copying artifacts, starting or stopping
+enclaves, restarting remote services, staging, and deployment require explicit
+authorization for the named environment.
 
 ## Contributing
 
-Keep changes focused and add regression coverage at the owning boundary. For
-API changes, review encrypted transport, auth context, errors/SSE, persistence,
-published SDKs, and Maple compatibility. For provider changes, keep upstream
-IDs and secrets behind the provider boundary and prove retry safety and usage
-handling.
-
-Before opening a pull request, run the applicable full gates, test migrations
-against a disposable database when relevant, and inspect `git diff --check`.
-Security reports must separate source-confirmed facts, tests, deployed
-configuration, and live observations.
+Keep changes focused, add regression coverage at the owning boundary, and
+follow the relevant repository skill. Before opening a pull request, run every
+validation tier reached by the diff and state what remains unverified.

--- a/docs/dev-shell.md
+++ b/docs/dev-shell.md
@@ -1,8 +1,9 @@
 # Development Shell
 
-The default `nix develop` behavior starts a local Postgres instance under
-`.pgdata`, creates a local `.env` if one does not exist, and keeps the historical
-port `5432` default.
+The default `nix develop` behavior checks `localhost:$PGPORT` first. It reuses a
+responding listener; otherwise it starts a local Postgres instance under
+`.pgdata`. It also creates a local `.env` if one does not exist and keeps the
+historical port `5432` default.
 
 For multi-workspace local development, the shell hook can be configured without
 changing the default path for existing developers.
@@ -43,8 +44,27 @@ OPENSECRET_DEV_DATABASE_URL=postgres://opensecret_user:password@localhost:32417/
 nix develop
 ```
 
-These controls are intended for tools such as `opensecret-workspaces`, where
-each feature workspace owns its own runtime state and ports.
+These controls are intended for isolated development environments where each
+checkout owns its runtime state and ports.
+
+## Linux Container Controls
+
+On Linux, the default shell hook also configures user-level Podman/container
+files. Keep that state unchanged when the task does not need the container
+helpers:
+
+```sh
+OPENSECRET_DEV_CONTAINERS=0 nix develop
+```
+
+For a pure check, disable every stateful hook together:
+
+```sh
+OPENSECRET_DEV_POSTGRES=0 \
+OPENSECRET_DEV_ENV=0 \
+OPENSECRET_DEV_CONTAINERS=0 \
+nix develop --no-write-lock-file -c <command>
+```
 
 ## Backend Bind Address
 

--- a/docs/dev-shell.md
+++ b/docs/dev-shell.md
@@ -1,76 +1,30 @@
-# Development Shell
+# Development shell
 
-The default `nix develop` behavior checks `localhost:$PGPORT` first. It reuses a
-responding listener; otherwise it starts a local Postgres instance under
-`.pgdata`. It also creates a local `.env` if one does not exist and keeps the
-historical port `5432` default.
+`nix develop` provides the pinned toolchain and manages optional local state.
+Before starting a cluster, its hook checks `localhost:$PGPORT`; if a server
+responds, that listener is reused even when it does not belong to this
+checkout. Otherwise the hook initializes or starts `$PGDATA`. It creates `.env`
+from `.env.sample` only when `.env` is absent.
 
-For multi-workspace local development, the shell hook can be configured without
-changing the default path for existing developers.
+## Shell-hook controls
 
-## Postgres Controls
+| Variable | Effect |
+| --- | --- |
+| `OPENSECRET_DEV_POSTGRES=0` | Do not inspect, initialize, or start PostgreSQL. |
+| `OPENSECRET_DEV_ENV=0` | Do not create `.env`. |
+| `OPENSECRET_DEV_CONTAINERS=0` | Do not configure Linux user-level container state. |
+| `PGDATA` / `PGSOCKETS` / `PGPORT` | Select local PostgreSQL state, sockets, and listener. |
+| `OPENSECRET_DEV_DATABASE_URL` | Set the database URL written into a newly generated `.env`. |
+| `OPENSECRET_BIND_ADDR` | Select the backend listener instead of `127.0.0.1:3000`. |
 
-Skip shell-hook Postgres management:
-
-```sh
-OPENSECRET_DEV_POSTGRES=0 nix develop
-```
-
-Override the local Postgres state directory and port:
-
-```sh
-PGDATA=/tmp/opensecret-feature-a/pgdata \
-PGPORT=32417 \
-nix develop
-```
-
-The shell hook also respects `PGSOCKETS` when set. If not set, it defaults to
-`$PGDATA/sockets`.
-
-## Environment Controls
-
-Skip shell-hook `.env` generation:
+For a pure check, disable every stateful hook and avoid changing the lockfile:
 
 ```sh
-OPENSECRET_DEV_ENV=0 nix develop
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c cargo fmt --all -- --check
 ```
 
-When `.env` does not exist and generation is enabled, the generated
-`DATABASE_URL` is based on `OPENSECRET_DEV_DATABASE_URL` if set, otherwise on
-the configured `PGPORT`:
-
-```sh
-OPENSECRET_DEV_DATABASE_URL=postgres://opensecret_user:password@localhost:32417/opensecret \
-nix develop
-```
-
-These controls are intended for isolated development environments where each
-checkout owns its runtime state and ports.
-
-## Linux Container Controls
-
-On Linux, the default shell hook also configures user-level Podman/container
-files. Keep that state unchanged when the task does not need the container
-helpers:
-
-```sh
-OPENSECRET_DEV_CONTAINERS=0 nix develop
-```
-
-For a pure check, disable every stateful hook together:
-
-```sh
-OPENSECRET_DEV_POSTGRES=0 \
-OPENSECRET_DEV_ENV=0 \
-OPENSECRET_DEV_CONTAINERS=0 \
-nix develop --no-write-lock-file -c <command>
-```
-
-## Backend Bind Address
-
-The local backend listens on `127.0.0.1:3000` by default. Override it when
-running multiple local backends at once:
-
-```sh
-OPENSECRET_BIND_ADDR=127.0.0.1:31417 cargo run
-```
+For concurrent live checkouts, choose distinct `PGDATA`, `PGSOCKETS`, `PGPORT`,
+`DATABASE_URL`, and backend bind addresses. Verify the database identity before
+running migrations or destructive tests; never assume that a responding port
+belongs to the current checkout.

--- a/docs/local-macos-stack.md
+++ b/docs/local-macos-stack.md
@@ -1,131 +1,63 @@
-# Local macOS Stack
+# Local macOS stack
 
-This runbook is for developing OpenSecret locally on macOS with the native
-Continuum proxy and the in-process Tinfoil Rust SDK. It is intentionally
-separate from the Linux/Nitro enclave deployment path.
-
-## Shape
-
-Run these processes from the OpenSecret checkout:
+This runbook covers OpenSecret with the native Continuum proxy and the
+in-process Tinfoil Rust SDK. It is separate from Linux/Nitro deployment.
 
 ```text
 Continuum proxy   http://127.0.0.1:8092
-OpenSecret API    http://127.0.0.1:3000 (includes the Tinfoil SDK)
-Maple frontend    VITE_OPEN_SECRET_API_URL=http://127.0.0.1:3000
+OpenSecret API    http://127.0.0.1:3000
+Maple             VITE_OPEN_SECRET_API_URL=http://127.0.0.1:3000
 ```
 
-In local mode, OpenSecret reads `.env` through `dotenv`.
+Tinfoil discovery, attestation, TLS pinning, and requests happen inside the
+OpenSecret process; there is no local Tinfoil sidecar or port.
 
-The supported local recipe sets `OPENAI_API_BASE` to the loopback Continuum
-proxy and does not require `OPENAI_API_KEY` for that route. Treat any other
-custom provider base as a credential boundary and inspect current URL/header
-handling before supplying credentials. The local Continuum proxy recipe enables
-Privatemode shared prompt caching at the proxy layer, so callers do not need to
-send a per-request `cache_salt`.
-
-OpenSecret initializes one shared Tinfoil SDK client from `TINFOIL_API_KEY`.
-The SDK verifies enclave attestation, pins TLS to the verified enclave, and
-reuses its connection pool for models, chat, audio, and embeddings requests.
-
-## One-Time Setup
-
-Initialize submodules:
+## One-time setup
 
 ```sh
 git submodule update --init --recursive
-```
-
-Build the macOS-native Continuum proxy binary:
-
-```sh
+install -d -m 700 .local/secrets
+touch .local/secrets/tinfoil_api_key .local/secrets/continuum_api_key
+chmod 600 .local/secrets/tinfoil_api_key .local/secrets/continuum_api_key
 nix develop -c just build-local-proxies-macos
 ```
 
-This writes the generated binary under `.local/bin/`, which is gitignored:
+Populate the credential files without printing their contents. The generated
+proxy binary and secret directory are gitignored local state.
 
-```text
-.local/bin/continuum-proxy-darwin
-```
-
-The checked-in Linux Continuum proxy binary is not replaced.
-
-## Secrets
-
-For local development, store provider keys in gitignored files:
-
-```text
-.local/secrets/continuum_api_key
-.local/secrets/tinfoil_api_key
-```
-
-The run recipes also accept environment variables. The Tinfoil key is read by
-OpenSecret itself, not by a local sidecar:
+Enter `nix develop` once to prepare the local PostgreSQL state and create `.env`
+when absent. Review an existing `.env` rather than replacing it, then run:
 
 ```sh
-CONTINUUM_API_KEY=...
-TINFOIL_API_KEY=...
+just diesel-migration-run-local
 ```
 
-Prefer the gitignored files for day-to-day use so keys do not land in shell history.
+## Run
 
-## Environment
+Use separate terminals.
 
-The usual path is to enter the dev shell once and let its shell hook create
-`.env`:
-
-```sh
-nix develop
-```
-
-When `.env` does not already exist, `nix develop` starts from `.env.sample`,
-fills in the local Postgres URL, and generates local-only secret values.
-
-The `run-local-backend-macos` recipe injects the local Continuum proxy URL and
-direct Tinfoil API key when it starts the backend. If creating `.env` by hand
-and running `cargo run` directly, generate local-only secrets with OpenSSL and
-set these provider values yourself:
-
-```dotenv
-APP_MODE=local
-OPENAI_API_BASE=http://127.0.0.1:8092
-TINFOIL_API_KEY=<your key>
-ENCLAVE_SECRET_MOCK=<openssl rand -hex 32>
-JWT_SECRET=<openssl rand -hex 32>
-```
-
-## Running
-
-Use separate terminals:
+Terminal 1:
 
 ```sh
 nix develop -c just run-continuum-proxy-macos
-nix develop -c just diesel-migration-run-local
+```
+
+Terminal 2:
+
+```sh
 nix develop -c just run-local-backend-macos
 ```
 
-Then point Maple at the local backend from the Maple checkout:
+The backend recipe selects the loopback Continuum base and reads the Tinfoil
+credential. Any other custom provider base is a credential boundary; derive
+URL and header behavior from current source before supplying credentials.
+
+In Maple, set its ignored local configuration to:
 
 ```dotenv
 VITE_OPEN_SECRET_API_URL=http://127.0.0.1:3000
 ```
 
-and run:
-
-```sh
-nix develop -c just dev
-```
-
-That command starts Maple's web-only Research client. To exercise native
-Tauri behavior or Agent Mode, use Maple's desktop workflow instead:
-
-```sh
-nix develop -c just desktop-dev
-```
-
-## Notes
-
-- Production Linux/Nitro and local macOS Continuum proxy launches enable Privatemode shared prompt caching without a fixed prompt cache salt. The cache is shared by requests handled by the same proxy instance and is reset when that proxy restarts.
-- The macOS Continuum proxy binary is a generated local artifact only.
-- There is no local Tinfoil proxy process or port. Tinfoil traffic originates
-  from the OpenSecret process through the SDK's attested, origin-bound client.
-- Device builds, TestFlight, notarization, and production app signing still need Apple developer credentials configured separately.
+Follow the selected Maple revision's own `AGENTS.md` and development or
+validation skill when present. Browser Research and native Agent Mode are
+separate consumers; choose the path that exercises the changed contract.

--- a/docs/local-macos-stack.md
+++ b/docs/local-macos-stack.md
@@ -19,7 +19,8 @@ git submodule update --init --recursive
 install -d -m 700 .local/secrets
 touch .local/secrets/tinfoil_api_key .local/secrets/continuum_api_key
 chmod 600 .local/secrets/tinfoil_api_key .local/secrets/continuum_api_key
-nix develop -c just build-local-proxies-macos
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c just build-local-proxies-macos
 ```
 
 Populate the credential files without printing their contents. The generated
@@ -39,7 +40,8 @@ Use separate terminals.
 Terminal 1:
 
 ```sh
-nix develop -c just run-continuum-proxy-macos
+OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
+  nix develop --no-write-lock-file -c just run-continuum-proxy-macos
 ```
 
 Terminal 2:

--- a/docs/local-macos-stack.md
+++ b/docs/local-macos-stack.md
@@ -16,7 +16,12 @@ Maple frontend    VITE_OPEN_SECRET_API_URL=http://127.0.0.1:3000
 
 In local mode, OpenSecret reads `.env` through `dotenv`.
 
-When `OPENAI_API_BASE` is not `api.openai.com`, OpenSecret treats it as the default Continuum-compatible proxy and does not require `OPENAI_API_KEY` for that route. The local Continuum proxy recipe enables Privatemode shared prompt caching at the proxy layer, so callers do not need to send a per-request `cache_salt`.
+The supported local recipe sets `OPENAI_API_BASE` to the loopback Continuum
+proxy and does not require `OPENAI_API_KEY` for that route. Treat any other
+custom provider base as a credential boundary and inspect current URL/header
+handling before supplying credentials. The local Continuum proxy recipe enables
+Privatemode shared prompt caching at the proxy layer, so callers do not need to
+send a per-request `cache_salt`.
 
 OpenSecret initializes one shared Tinfoil SDK client from `TINFOIL_API_KEY`.
 The SDK verifies enclave attestation, pins TLS to the verified enclave, and
@@ -108,6 +113,13 @@ and run:
 
 ```sh
 nix develop -c just dev
+```
+
+That command starts Maple's web-only Research client. To exercise native
+Tauri behavior or Agent Mode, use Maple's desktop workflow instead:
+
+```sh
+nix develop -c just desktop-dev
 ```
 
 ## Notes

--- a/docs/tinfoil-rust-sdk-parity.md
+++ b/docs/tinfoil-rust-sdk-parity.md
@@ -1,142 +1,49 @@
-# Tinfoil Rust SDK migration parity
+# Tinfoil Rust SDK boundary
 
-This migration removes the localhost Tinfoil Go process and sends Tinfoil
-requests from the OpenSecret backend through the attested `tinfoil-rs` client.
-The public OpenSecret API is unchanged.
+OpenSecret sends Tinfoil requests through the in-process, attested `tinfoil-rs`
+client. The public OpenSecret API remains an encrypted client-to-OpenSecret
+protocol; this document defines only the provider boundary.
 
-## What parity means
+## Compatibility boundary
 
-Literal packets cannot be identical after removing a network hop. TLS record
-bytes are randomized, the HTTP implementation changed, and the Rust client can
-choose different header casing, ordering, HTTP framing, or connection reuse.
-The relevant compatibility boundary is the decrypted HTTP request and response:
+Provider parity concerns decrypted HTTP semantics rather than randomized TLS
+records or implementation-specific framing:
 
-- method, path, and query string;
-- backend-supplied end-to-end request headers, with inbound authorization
-  replaced by the configured Tinfoil bearer token;
-- removal of standard hop-by-hop headers and headers named by `Connection`;
-- exact request body bytes;
-- upstream status, application `Content-Type`, and response body schema;
-- ordered Server-Sent Event payloads, numeric usage, and exactly one terminal
-  `[DONE]` frame.
+- method, path, query, and exact request body;
+- safe end-to-end headers with provider authorization supplied by OpenSecret;
+- upstream status, application content type, and response schema;
+- ordered SSE payloads, numeric usage, and one terminal `[DONE]`.
 
-Library-generated defaults such as `User-Agent`, `Accept-Encoding`, header
-casing/order, and message framing are not part of that boundary. Likewise,
-`Date`, `Server`, the selected `Tinfoil-Enclave`, proof metadata, and
-`Content-Length` versus chunked transfer reflect the live transport or selected
-enclave rather than the OpenSecret API contract. The before and after captures
-retain those headers so the distinction is reviewable; stable JSON/SSE content
-types are asserted automatically.
+Header casing/order, connection reuse, TLS bytes, live enclave metadata,
+generated text, and chunk boundaries are not stable compatibility evidence.
 
-The Rust client intentionally sends directly to an attested enclave over
-origin-bound TLS. The removed Go process accepted localhost HTTP and then used
-ordinary CA-validated TLS for the effective request path. Requests with a
-known byte-vector body may also carry `Content-Length` instead of the previous
-unknown-length framing. Those are transport and security changes, not public
-API changes.
-
-## Before and after evidence
-
-The baseline was captured from the checked-in Go proxy before it was removed.
-The same live Tinfoil credentials, model, prompts, temperature, token limit,
-and streaming options were then exercised through the Rust SDK.
-
-| Contract | Go baseline | Rust SDK result |
-| --- | --- | --- |
-| Tinfoil upstream `GET /v1/models` | HTTP 200, JSON, `object: list`, 14 model IDs | HTTP 200, JSON, same object and exact model-ID set |
-| Non-streaming `POST /v1/chat/completions` | HTTP 200, `chat.completion`, model `glm-5-2`, exact text `parity-ok`, numeric usage | Same status, object, model, exact text, and usage shape |
-| Streaming `POST /v1/chat/completions` | HTTP 200 SSE, ordered `chat.completion.chunk` frames, numeric final usage, one terminal `[DONE]` | Same status/content type, event schema, model, numeric final usage, and one terminal `[DONE]` |
-| OpenSecret extended health check | Tinfoil models reachable through localhost sidecar | Tinfoil models reachable directly; 14 models reported and no sidecar port |
-| Maple paid-user chat | Not applicable to the isolated proxy baseline | Built desktop app, Pro entitlement and 100,000 credits verified; exact GUI responses `maple-sdk-parity-ok` and `maple-sdk-final-ok` before and after the final backend restart |
-
-Both completion request bodies were byte-identical across implementations. The
-non-streaming body SHA-256 was
-`1815c5ecd2c36834c59f7ce354737ad1b5bc2b93f176068c561f451957c6a717`;
-the streaming body SHA-256 was
-`d15a8b974409567cc3fef3d708406dedb99ee5578edeaf05ecc9dca9168120c8`.
-The `GET` had the standard empty-body SHA-256
-`e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`.
-
-Raw Go and Rust response artifacts plus redacted manifests are kept outside the
-repository workspace under `evidence/before/` and `evidence/after/`, so live
-response data is not committed. The manifests record the implementation,
-revision state, target, exact request JSON and hashes, stable response headers,
-and normalized results. Their normalized request sections have no diff. The
-live Rust assertions are executable and fail on a changed contract.
-
-Completion text and streaming chunk boundaries are model-generated and are not
-treated as packet-stable evidence. The same exact non-streaming text was
-observed in both captures. Streaming parity uses the identical request bytes
-and compares response status/content type, ordered event schema, numeric final
-usage, and terminal framing; it does not require an identical number of deltas
-or identical model-generated reasoning.
-
-OpenSecret's public encrypted `/v1/models` response remains its existing static
-catalog. The live upstream models call above exercises the provider boundary
-used by extended health, which is the path that changed in this migration.
-
-## Automated boundary checks
+## Automated evidence
 
 `provider_client::tests::tinfoil_request_matches_contract_at_the_network_boundary`
-uses a real local HTTP listener to inspect the request emitted by the new
-client. It proves the method, path/query, Tinfoil authorization replacement,
-content type, preserved end-to-end header, stripped hop headers, and exact body
-bytes at the receiving socket.
+uses a local listener to verify request method, path/query, header policy, and
+body bytes.
 
 `provider_client::tests::live_tinfoil_models_and_completions_match_the_legacy_api_contract`
-is ignored by default because it requires live credentials and egress. It
-attests a real Tinfoil enclave and checks the models, JSON/SSE content types,
-non-streaming completion, and streaming completion contracts listed above. It
-also checks that the only `[DONE]` is terminal and that the final usage frame
-contains numeric prompt, completion, and total token counts.
+is ignored by default because it requires an approved credential and network
+egress. It exercises live attestation, model discovery, non-streaming response,
+streaming SSE, terminal framing, and numeric usage. Run it only through the
+Tier 3 procedure in
+`.agents/skills/validate-opensecret/SKILL.md`.
 
-Run the live check with either `TINFOIL_API_KEY` or the normal gitignored local
-secret file configured:
+If raw live evidence is needed, keep it outside the repository, use a
+non-secret credential label, and redact authorization and attestation metadata.
+The live test proves that provider and moment only; it does not prove
+OpenSecret auth, encrypted public transport, persistence, Maple, another
+provider, EIF identity, or deployment.
 
-```sh
-nix develop -c cargo test \
-  provider_client::tests::live_tinfoil_models_and_completions_match_the_legacy_api_contract \
-  -- --ignored --exact
-```
+## Trust and lifecycle
 
-Set `TINFOIL_PARITY_EVIDENCE_DIR` to write response bodies, headers, and a
-redacted manifest during that test. `TINFOIL_PARITY_CREDENTIAL_LABEL` records a
-non-secret operator assertion that the same test credential was used for both
-captures; the credential itself and its fingerprint are never written.
+Preserve Tinfoil discovery, attestation, origin-bound TLS, bounded recovery,
+connection reuse, and the no-downgrade rule. Retry only failures known to occur
+before request acceptance; do not replay ambiguous completion requests or
+retain request bodies in shared recovery work.
 
-## Deployment and build boundary
-
-`entrypoint.sh` still decrypts the historical `tinfoil_proxy_*` Secrets Manager
-value, but exports it as `TINFOIL_API_KEY` to the backend instead of launching a
-second binary. The existing OpenSecret startup, five-second wait, VSOCK
-exposure, and traffic-forwarder behavior are otherwise unchanged. Tinfoil
-discovery and attestation retry in a single background loop inside OpenSecret,
-so an outage at that boundary does not prevent login, billing,
-stored-conversation, or non-Tinfoil routes from starting. Tinfoil-dependent
-routes return HTTP 503 until an attested client is ready. Each discovery or
-attestation attempt is bounded to 30 seconds before the background loop backs
-off and retries. The EIF root filesystem no longer contains the Go proxy.
-Existing Tinfoil egress forwarders remain unchanged for this minimal migration.
-
-The shared attested client reuses connections. A typed DNS/TCP/TLS connection
-failure triggers a single-flight router rediscovery and attestation, then one
-retry rebuilt with identical request bytes. Request/body/response/status errors
-are never replayed by the rotation layer, avoiding ambiguous completion POST
-retries. The underlying HTTP implementation may still perform protocol-defined
-safe retries, such as an HTTP/2 stream explicitly rejected before processing.
-Only one request owns a router refresh; concurrent requests fail fast with HTTP
-503 instead of retaining their bodies in a refresh wait queue. Recovery runs in
-an owned task that captures no request body, so a short caller timeout does not
-cancel the shared certificate/router refresh.
-
-The root Nix development shell still includes Go only for the independently
-vendored Continuum proxy build. All Tinfoil-specific Go source, module files,
-build recipes, nested flake, binary artifacts, and root-filesystem wiring are
-removed.
-
-This repository's supported Tinfoil lifecycle is the in-process SDK path
-described above. External orchestration must derive its lifecycle commands from
-the current public recipes.
-
-Before selecting an enclave technology, verify that the pinned SDK implements
-and tests its verifier and that deployment defaults select the same technology.
+When changing enclave technology or SDK revision, verify that the pinned SDK
+supports the selected verifier and that deployment configuration selects the
+same technology. Treat source, local provider tests, EIF/PCR evidence, and live
+deployment evidence as separate claims.

--- a/docs/tinfoil-rust-sdk-parity.md
+++ b/docs/tinfoil-rust-sdk-parity.md
@@ -134,12 +134,9 @@ vendored Continuum proxy build. All Tinfoil-specific Go source, module files,
 build recipes, nested flake, binary artifacts, and root-filesystem wiring are
 removed.
 
-The companion `OpenSecretCloud/opensecret-workspaces` change must merge with
-this backend change. The updated manager intentionally supports only the SDK
-backend. Existing workspaces must stop services with the old manager, then
-rebase both repositories before starting again; the old manager still expects
-the recipes removed here.
+This repository's supported Tinfoil lifecycle is the in-process SDK path
+described above. External orchestration must derive its lifecycle commands from
+the current public recipes.
 
-The released Rust SDK currently verifies AMD SEV-SNP enclaves; its TDX verifier
-is not implemented. This matches the Tinfoil deployment selected by the current
-SDK defaults and is an explicit constraint for future provider changes.
+Before selecting an enclave technology, verify that the pinned SDK implements
+and tests its verifier and that deployment defaults select the same technology.

--- a/src/main.rs
+++ b/src/main.rs
@@ -542,6 +542,37 @@ impl FromStr for AppMode {
     }
 }
 
+fn normalize_optional_env(value: Result<String, env::VarError>) -> Option<String> {
+    value
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+fn optional_env(name: &str) -> Option<String> {
+    normalize_optional_env(env::var(name))
+}
+
+#[cfg(test)]
+mod optional_env_tests {
+    use super::*;
+
+    #[test]
+    fn absent_or_blank_values_are_not_configured() {
+        assert_eq!(normalize_optional_env(Err(env::VarError::NotPresent)), None);
+        assert_eq!(normalize_optional_env(Ok(String::new())), None);
+        assert_eq!(normalize_optional_env(Ok(" \t\n ".to_string())), None);
+    }
+
+    #[test]
+    fn configured_values_are_trimmed() {
+        assert_eq!(
+            normalize_optional_env(Ok("  configured value  ".to_string())),
+            Some("configured value".to_string())
+        );
+    }
+}
+
 #[derive(Clone)]
 pub struct AppState {
     app_mode: AppMode,
@@ -3521,31 +3552,31 @@ async fn main() -> Result<(), Error> {
     let resend_api_key = if app_mode != AppMode::Local {
         retrieve_resend_api_key(aws_credential_manager.clone(), db.clone()).await?
     } else {
-        std::env::var("RESEND_API_KEY").ok()
+        optional_env("RESEND_API_KEY")
     };
 
     let github_client_secret = if app_mode != AppMode::Local {
         retrieve_github_client_secret(aws_credential_manager.clone(), db.clone()).await?
     } else {
-        std::env::var("GITHUB_CLIENT_SECRET").ok()
+        optional_env("GITHUB_CLIENT_SECRET")
     };
 
     let github_client_id = if app_mode != AppMode::Local {
         retrieve_github_client_id(aws_credential_manager.clone(), db.clone()).await?
     } else {
-        std::env::var("GITHUB_CLIENT_ID").ok()
+        optional_env("GITHUB_CLIENT_ID")
     };
 
     let google_client_secret = if app_mode != AppMode::Local {
         retrieve_google_client_secret(aws_credential_manager.clone(), db.clone()).await?
     } else {
-        std::env::var("GOOGLE_CLIENT_SECRET").ok()
+        optional_env("GOOGLE_CLIENT_SECRET")
     };
 
     let google_client_id = if app_mode != AppMode::Local {
         retrieve_google_client_id(aws_credential_manager.clone(), db.clone()).await?
     } else {
-        std::env::var("GOOGLE_CLIENT_ID").ok()
+        optional_env("GOOGLE_CLIENT_ID")
     };
 
     let sqs_queue_maple_events_url = if app_mode != AppMode::Local {
@@ -3589,37 +3620,33 @@ async fn main() -> Result<(), Error> {
         // Get from database if in enclave mode
         retrieve_billing_api_key(aws_credential_manager.clone(), db.clone()).await?
     } else {
-        std::env::var("BILLING_API_KEY").ok()
+        optional_env("BILLING_API_KEY")
     };
 
     let billing_server_url = if app_mode != AppMode::Local {
         // Get from database if in enclave mode
         retrieve_billing_server_url(aws_credential_manager.clone(), db.clone()).await?
     } else {
-        std::env::var("BILLING_SERVER_URL").ok()
+        optional_env("BILLING_SERVER_URL")
     };
 
     let brave_api_key = if app_mode != AppMode::Local {
         // Get from database if in enclave mode
         retrieve_brave_api_key(aws_credential_manager.clone(), db.clone()).await?
     } else {
-        std::env::var("BRAVE_API_KEY")
-            .ok()
-            .filter(|key| !key.trim().is_empty())
+        optional_env("BRAVE_API_KEY")
     };
 
     let kagi_api_key = if app_mode != AppMode::Local {
         retrieve_kagi_api_key(aws_credential_manager.clone(), db.clone()).await?
     } else {
-        std::env::var("KAGI_API_KEY")
-            .ok()
-            .filter(|key| !key.trim().is_empty())
+        optional_env("KAGI_API_KEY")
     };
 
     let os_flags_api_key = if app_mode != AppMode::Local {
         retrieve_os_flags_api_key(aws_credential_manager.clone(), db.clone()).await?
     } else {
-        std::env::var("OS_FLAGS_API_KEY").ok()
+        optional_env("OS_FLAGS_API_KEY")
     };
 
     let os_flags_base_url = if app_mode != AppMode::Local {
@@ -3635,7 +3662,7 @@ async fn main() -> Result<(), Error> {
             }
         }
     } else {
-        std::env::var("OS_FLAGS_BASE_URL").ok()
+        optional_env("OS_FLAGS_BASE_URL")
     };
 
     let app_state = AppStateBuilder::default()


### PR DESCRIPTION
## Summary

- add concise repository-wide agent guidance and five task-specific skills for development, API/provider changes, validation, and security review
- keep durable ownership, security, and compatibility boundaries while routing volatile behavior to current source instead of copying endpoint and provider inventories
- add a guarded disposable-PostgreSQL helper for migration and ignored database test evidence; lock generated schema validation and use a deterministic UTF-8 cluster
- treat blank optional local configuration as absent and keep optional sample values commented out
- scope EIF/PCR parity and reference updates to authorized dev/prod release work; ordinary pull requests distinguish a successful EIF build plus measurement drift from an EIF build failure
- simplify the README and local development docs while keeping billing and feature flags as external API boundaries only

## Testing

- official skill validator for all five skills
- repository-relative Markdown link and documented path/recipe validation
- `bash -n .env.sample`
- `bash -n .agents/skills/validate-opensecret/scripts/disposable_db_tests.sh`
- `shellcheck .agents/skills/validate-opensecret/scripts/disposable_db_tests.sh`
- `cargo fmt --all -- --check`
- strict locked all-target/all-feature Clippy
- locked all-feature Rust test suite: 368 passed, 17 ignored
- disposable DB helper with `--redo-latest`: 14 AEAD/database and 2 OAuth database tests passed, zero skipped, generated schema unchanged, temporary cluster removed
- fresh-context forward tests for setup, API compatibility, migration validation, security review, and the release-only PCR boundary

## Not run

- live-provider test
- Maple browser or native GUI smoke
- authorized dev/prod EIF/PCR release update
- deployment
