### PR TITLE
fix: enable local debug logs after crate rename

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -21,3 +21,5 @@ JWT_SECRET=
 # BILLING_API_KEY=
 # OS_FLAGS_BASE_URL=
 # OS_FLAGS_API_KEY=
+# Optional. Unset uses opensecret=debug plus selected framework crates.
+# RUST_LOG=opensecret=debug,sqlx=warn,tower_http=info

--- a/docs/dev-shell.md
+++ b/docs/dev-shell.md
@@ -28,3 +28,11 @@ For concurrent live checkouts, choose distinct `PGDATA`, `PGSOCKETS`, `PGPORT`,
 `DATABASE_URL`, and backend bind addresses. Verify the database identity before
 running migrations or destructive tests; never assume that a responding port
 belongs to the current checkout.
+
+## Logging
+
+`APP_MODE=local` writes line-buffered tracing to stdout so redirected `cargo run`
+logs appear immediately. When `RUST_LOG` is unset the default is
+`opensecret=debug` plus `axum_login`, `tower_sessions`, `sqlx=warn`, and
+`tower_http`. Override `RUST_LOG` to quiet or expand that set. Do not log
+secrets, tokens, decrypted bodies, or raw provider payloads.

--- a/docs/local-macos-stack.md
+++ b/docs/local-macos-stack.md
@@ -50,6 +50,9 @@ Terminal 2:
 nix develop -c just run-local-backend-macos
 ```
 
+Local backend logs are line-buffered on stdout. Follow that terminal, or the
+capturing process's log file (workspace-managed starts use `logs/opensecret.log`).
+
 The backend recipe selects the loopback Continuum base and reads the Tinfoil
 credential. Any other custom provider base is a credential boundary; derive
 URL and header behavior from current source before supplying credentials.

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ use tokio::spawn;
 use tokio::sync::RwLock;
 use tokio::task::{self};
 use tower_http::cors::{Any, CorsLayer};
-use tracing::{debug, error, trace, warn};
+use tracing::{debug, error, info, trace, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use url::Url;
 use uuid::Uuid;
@@ -564,6 +564,32 @@ fn optional_env(name: &str) -> Option<String> {
     normalize_optional_env(env::var(name))
 }
 
+/// Default `RUST_LOG` when unset. The binary crate is `opensecret`; the old
+/// `sg_backend` default matched no events, so local `cargo run` was silent.
+const DEFAULT_RUST_LOG_FILTER: &str =
+    "opensecret=debug,axum_login=debug,tower_sessions=debug,sqlx=warn,tower_http=debug";
+
+fn init_tracing(app_mode: &AppMode) -> Result<(), Error> {
+    let filter = EnvFilter::new(
+        std::env::var("RUST_LOG").unwrap_or_else(|_| DEFAULT_RUST_LOG_FILTER.to_string()),
+    );
+    let fmt = tracing_subscriber::fmt::layer().with_ansi(false);
+    if matches!(app_mode, AppMode::Local) {
+        // File-redirected stdout is block-buffered; local debug needs lines
+        // to appear in workspace / `cargo run` logs immediately.
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(fmt.with_writer(|| std::io::LineWriter::new(std::io::stdout())))
+            .try_init()?;
+    } else {
+        tracing_subscriber::registry()
+            .with(filter)
+            .with(fmt)
+            .try_init()?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod optional_env_tests {
     use super::*;
@@ -580,6 +606,25 @@ mod optional_env_tests {
         assert_eq!(
             normalize_optional_env(Ok("  configured value  ".to_string())),
             Some("configured value".to_string())
+        );
+    }
+}
+
+#[cfg(test)]
+mod default_log_filter_tests {
+    use super::*;
+
+    #[test]
+    fn default_filter_targets_the_opensecret_crate() {
+        assert!(
+            DEFAULT_RUST_LOG_FILTER
+                .split(',')
+                .any(|directive| directive == "opensecret=debug"),
+            "local default must enable opensecret=debug: {DEFAULT_RUST_LOG_FILTER}"
+        );
+        assert!(
+            !DEFAULT_RUST_LOG_FILTER.contains("sg_backend"),
+            "stale sg_backend default hides every local application log: {DEFAULT_RUST_LOG_FILTER}"
         );
     }
 }
@@ -3395,10 +3440,6 @@ async fn retrieve_kagi_api_key(
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    // Add debug logs for entrypoints and exit points
-    tracing::debug!("Starting application");
-
-    // Load .env file
     dotenv::dotenv().ok();
 
     let app_mode = std::env::var("APP_MODE")
@@ -3406,15 +3447,9 @@ async fn main() -> Result<(), Error> {
         .parse::<AppMode>()
         .expect("Invalid APP_MODE");
 
-    tracing_subscriber::registry()
-        .with(EnvFilter::new(std::env::var("RUST_LOG").unwrap_or_else(
-            |_| {
-                "sg_backend=debug,axum_login=debug,tower_sessions=debug,sqlx=warn,tower_http=debug"
-                    .into()
-            },
-        )))
-        .with(tracing_subscriber::fmt::layer().with_ansi(false))
-        .try_init()?;
+    init_tracing(&app_mode)?;
+    info!(app_mode = %app_mode, "OpenSecret logging initialized");
+    debug!("Starting application");
 
     let aws_credential_manager = if app_mode != AppMode::Local {
         Arc::new(RwLock::new(Some(AwsCredentialManager::new())))


### PR DESCRIPTION
## Summary

- default `RUST_LOG` now targets the `opensecret` crate at debug, not the stale `sg_backend` filter that matched no events
- `APP_MODE=local` line-buffers stdout so redirected `cargo run` / workspace `logs/opensecret.log` files show lines immediately
- initialize tracing after dotenv so a `.env` `RUST_LOG` override is honored
- document the default in `.env.sample`, `docs/dev-shell.md`, and `docs/local-macos-stack.md`

Local OpenSecret was silent during a Maple Agent Mode glm-5-2 500 investigation: the crate rename left the default filter pointing at `sg_backend`, and file-redirected stdout stayed block-buffered until process exit. This does not change enclave/deployed logging policy beyond the default filter name and local line buffering.

## Validation

- `cargo test --locked default_log_filter_tests`: passed
- live local stack: after the change, `logs/opensecret.log` showed `OpenSecret logging initialized app_mode=local` and glm-5-2 Tinfoil success/failure lines
- not run: full locked suite, enclave/EIF rebuild