### PR TITLE
Allow model selection before sign-in

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,12 +22,12 @@ use crate::models::password_reset::NewPasswordResetRequest;
 use crate::models::platform_password_reset::NewPlatformPasswordResetRequest;
 use crate::models::platform_users::PlatformUser;
 use crate::sqs::SqsEventPublisher;
-use crate::web::openai_auth::validate_openai_auth;
+use crate::web::openai_auth::{validate_openai_auth, validate_optional_openai_auth};
 use crate::web::platform_login_routes;
 use crate::web::{
     conversation_projects_routes, conversations_routes, health_routes_with_state,
-    instructions_routes, login_routes, oauth_routes, openai_routes, protected_routes,
-    responses_routes, web_routes,
+    instructions_routes, login_routes, oauth_routes, openai_models_routes, openai_routes,
+    protected_routes, responses_routes, web_routes,
 };
 use crate::{attestation_routes::SessionState, web::platform_routes};
 use bounded_ttl_cache::BoundedTtlCache;
@@ -3800,6 +3800,12 @@ async fn main() -> Result<(), Error> {
         .merge(
             openai_routes(app_state.clone())
                 .route_layer(from_fn_with_state(app_state.clone(), validate_openai_auth)),
+        )
+        .merge(
+            openai_models_routes(app_state.clone()).route_layer(from_fn_with_state(
+                app_state.clone(),
+                validate_optional_openai_auth,
+            )),
         )
         .merge(
             responses_routes(app_state.clone())

--- a/src/security_invariants.rs
+++ b/src/security_invariants.rs
@@ -176,6 +176,42 @@ fn openai_compatible_routes_do_not_request_user_storage_keys() {
 }
 
 #[test]
+fn models_route_allows_optional_identity_but_requires_session_e2ee() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let main_source = fs::read_to_string(manifest_dir.join("src/main.rs"))
+        .expect("main source should be readable");
+    let openai_source = fs::read_to_string(manifest_dir.join("src/web/openai.rs"))
+        .expect("OpenAI route source should be readable");
+
+    assert!(
+        main_source.contains("openai_models_routes(app_state.clone()).route_layer")
+            && main_source.contains("validate_optional_openai_auth"),
+        "the models route must use its dedicated optional-identity middleware"
+    );
+
+    let router_body = extract_function_body(&openai_source, "pub fn models_router");
+    assert!(
+        router_body.contains("\"/v1/models\"")
+            && router_body.contains("decrypt_request::<()>")
+            && !router_body.contains("decrypt_models_request"),
+        "the models route must validate a live encryption session for every request"
+    );
+
+    let handler_body = extract_function_body(&openai_source, "async fn proxy_models");
+    assert!(
+        openai_source.contains(
+            "async fn proxy_models(\n    State(state): State<Arc<AppState>>,\n    axum::Extension(session_id): axum::Extension<Uuid>,\n    user: Option<axum::Extension<User>>"
+        )
+            && handler_body.contains("encrypt_response(&state, &session_id, &models_response)"),
+        "the models handler must require session E2EE while allowing optional identity"
+    );
+    assert!(
+        !handler_body.contains("Json(models_response)"),
+        "the models handler must not return a successful plaintext response"
+    );
+}
+
+#[test]
 fn web_routes_remain_jwt_authenticated_and_e2ee_wrapped() {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let main_source = fs::read_to_string(manifest_dir.join("src/main.rs"))

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod web_safety;
 pub use health_routes::router_with_state as health_routes_with_state;
 pub use login_routes::router as login_routes;
 pub use oauth_routes::router as oauth_routes;
+pub use openai::models_router as openai_models_routes;
 pub use openai::router as openai_routes;
 pub use platform::router as platform_routes;
 pub use protected_routes::router as protected_routes;

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -725,13 +725,6 @@ pub fn router(app_state: Arc<AppState>) -> Router<()> {
             )),
         )
         .route(
-            "/v1/models",
-            get(proxy_models).layer(axum::middleware::from_fn_with_state(
-                app_state.clone(),
-                decrypt_request::<()>,
-            )),
-        )
-        .route(
             "/v1/models/catalog",
             get(proxy_model_catalog).layer(axum::middleware::from_fn_with_state(
                 app_state.clone(),
@@ -757,6 +750,18 @@ pub fn router(app_state: Arc<AppState>) -> Router<()> {
             post(proxy_embeddings).layer(axum::middleware::from_fn_with_state(
                 app_state.clone(),
                 decrypt_request::<EmbeddingRequest>,
+            )),
+        )
+        .with_state(app_state)
+}
+
+pub fn models_router(app_state: Arc<AppState>) -> Router<()> {
+    Router::new()
+        .route(
+            "/v1/models",
+            get(proxy_models).layer(axum::middleware::from_fn_with_state(
+                app_state.clone(),
+                decrypt_request::<()>,
             )),
         )
         .with_state(app_state)
@@ -1587,13 +1592,13 @@ async fn encrypt_sse_event(
 
 async fn proxy_models(
     State(state): State<Arc<AppState>>,
-    _headers: HeaderMap,
     axum::Extension(session_id): axum::Extension<Uuid>,
-    axum::Extension(user): axum::Extension<User>,
-    axum::Extension(_auth_method): axum::Extension<AuthMethod>,
-    axum::Extension(_body): axum::Extension<()>,
+    user: Option<axum::Extension<User>>,
 ) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
-    let model_access = state.model_feature_access(user.uuid).await;
+    let model_access = match user {
+        Some(axum::Extension(user)) => state.model_feature_access(user.uuid).await,
+        None => ModelFeatureAccess::default(),
+    };
     let proxy_config = state.proxy_router.get_completion_proxy();
     let mut models_response = if proxy_config.provider_name == "tinfoil" {
         openai_models_response(model_access)

--- a/src/web/openai_auth.rs
+++ b/src/web/openai_auth.rs
@@ -116,3 +116,18 @@ pub async fn validate_openai_auth(
     req.extensions_mut().insert(AuthMethod::Jwt);
     next.run(req).await
 }
+
+/// Authenticate the dedicated models route when current OpenAI credentials
+/// are present. The route's attested encryption session is validated
+/// independently by its encryption middleware.
+pub async fn validate_optional_openai_auth(
+    state: State<Arc<crate::AppState>>,
+    req: Request<Body>,
+    next: Next,
+) -> Response {
+    if !req.headers().contains_key(header::AUTHORIZATION) {
+        return next.run(req).await;
+    }
+
+    validate_openai_auth(state, req, next).await
+}


### PR DESCRIPTION
Third-party integrations often require users to select a model during setup, before they can complete an OpenSecret sign-in.

Return the public model list as plaintext when no authorization header is present. Preserve encrypted responses for authenticated clients.