### PR TITLE
ci: enforce locked dependency resolution

### DIFF
--- a/.agents/skills/develop-opensecret/SKILL.md
+++ b/.agents/skills/develop-opensecret/SKILL.md
@@ -23,7 +23,7 @@ authorizes the exact action and environment.
 ## Enter the toolchain deliberately
 
 ```sh
-OPENSECRET_DEV_CONTAINERS=0 nix develop
+OPENSECRET_DEV_CONTAINERS=0 nix develop --no-update-lock-file
 ```
 
 The shell may reuse a PostgreSQL listener, start `.pgdata`, and create `.env`
@@ -38,7 +38,7 @@ database.
 Run SQL migrations before starting the backend:
 
 ```sh
-OPENSECRET_DEV_CONTAINERS=0 nix develop -c just diesel-migration-run-local
+OPENSECRET_DEV_CONTAINERS=0 nix develop --no-update-lock-file -c just diesel-migration-run-local
 ```
 
 `src/migrations.rs` is application-data migration logic, not the Diesel runner.
@@ -46,7 +46,7 @@ For a schema change, create a new reversible migration and let Diesel regenerate
 `src/models/schema.rs`:
 
 ```sh
-OPENSECRET_DEV_CONTAINERS=0 nix develop -c \
+OPENSECRET_DEV_CONTAINERS=0 nix develop --no-update-lock-file -c \
   just diesel-migration-generate add_user_preferences
 ```
 

--- a/.agents/skills/validate-opensecret/SKILL.md
+++ b/.agents/skills/validate-opensecret/SKILL.md
@@ -21,7 +21,7 @@ applicable tiers. A higher tier supplements rather than replaces lower tiers.
 | Authorized dev or prod publish/deployment | Tier 5 release EIF/PCR evidence on the supported Linux/ARM64 builder. |
 
 Keep credentials and user data out of commands, logs, fixtures, and tracked
-files. Never blanket-run `cargo test -- --ignored`: ignored tests mix
+files. Never blanket-run `cargo test --locked -- --ignored`: ignored tests mix
 disposable-database mutation with a credentialed live-provider test.
 
 ## Tier 0: iterate narrowly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         id: build-dev
         run: |
           set -euo pipefail
-          nix build .?submodules=1#eif-dev
+          nix build --no-update-lock-file .?submodules=1#eif-dev
           echo "Build completed successfully"
 
       # Verify PCR values match the reference
@@ -114,7 +114,7 @@ jobs:
         id: build-prod
         run: |
           set -euo pipefail
-          nix build .?submodules=1#eif-prod
+          nix build --no-update-lock-file .?submodules=1#eif-prod
           echo "Build completed successfully"
 
       # Verify PCR values match the reference

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -24,4 +24,4 @@ jobs:
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check bans
-          arguments: --all-features
+          arguments: --all-features --locked

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ container setup changes user-level state unless disabled. See
 
 ```sh
 git submodule update --init --recursive
-OPENSECRET_DEV_CONTAINERS=0 nix develop
+OPENSECRET_DEV_CONTAINERS=0 nix develop --no-update-lock-file
 just diesel-migration-run-local
 ```
 

--- a/docs/local-macos-stack.md
+++ b/docs/local-macos-stack.md
@@ -47,7 +47,7 @@ OPENSECRET_DEV_POSTGRES=0 OPENSECRET_DEV_ENV=0 OPENSECRET_DEV_CONTAINERS=0 \
 Terminal 2:
 
 ```sh
-nix develop -c just run-local-backend-macos
+nix develop --no-update-lock-file -c just run-local-backend-macos
 ```
 
 Local backend logs are line-buffered on stdout. Follow that terminal, or the

--- a/docs/nitro-deploy.md
+++ b/docs/nitro-deploy.md
@@ -167,13 +167,13 @@ just build-nitro-bins
 2. Build the EIF for your target environment:
 ```bash
 # For development
-nix build '.?submodules=1#eif-dev'
+nix build --no-update-lock-file '.?submodules=1#eif-dev'
 
 # For production
-nix build '.?submodules=1#eif-prod'
+nix build --no-update-lock-file '.?submodules=1#eif-prod'
 
 # For preview
-nix build '.?submodules=1#eif-preview'
+nix build --no-update-lock-file '.?submodules=1#eif-preview'
 ```
 
 This will create a symlink `result` pointing to the built EIF file.

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ default:
 
 # Build the pinned NSM and KMS helper sources with Nix
 build-nitro-bins:
-    nix build .#nitro-bins
+    nix build --no-update-lock-file .#nitro-bins
 
 ### Credential Requester Commands ###
 
@@ -170,7 +170,7 @@ update-continuum-proxy-version version:
 
 # Build continuum-proxy from source using Nix (produces statically linked binary)
 build-continuum-proxy:
-    nix build ./privatemode-public#privatemode-proxy.bin -o continuum-proxy-build
+    nix build --no-update-lock-file ./privatemode-public#privatemode-proxy.bin -o continuum-proxy-build
     chmod u+w continuum-proxy || true
     cp continuum-proxy-build/bin/privatemode-proxy continuum-proxy
     chmod +x continuum-proxy
@@ -187,7 +187,7 @@ update-continuum-proxy version="v1.39.1":
 ### Local macOS Proxy Commands ###
 
 # Build the macOS-native Continuum proxy binary under .local/bin.
-# Run from a Nix dev shell, for example: nix develop -c just build-local-proxies-macos
+# Run from a Nix dev shell, for example: nix develop --no-update-lock-file -c just build-local-proxies-macos
 build-local-proxies-macos: build-continuum-proxy-macos
 
 # Build a macOS-native Continuum proxy without replacing the checked-in Linux binary.
@@ -218,7 +218,7 @@ run-continuum-proxy-macos:
     port="${CONTINUUM_PROXY_PORT:-8092}"
     workspace="${CONTINUUM_PROXY_WORKSPACE:-.local/continuum}"
     if [ ! -x "$bin" ]; then
-        echo "$bin is missing. Run: nix develop -c just build-continuum-proxy-macos" >&2
+        echo "$bin is missing. Run: nix develop --no-update-lock-file -c just build-continuum-proxy-macos" >&2
         exit 1
     fi
     api_key="${CONTINUUM_API_KEY:-}"
@@ -249,7 +249,7 @@ run-local-backend-macos:
     APP_MODE="${APP_MODE:-local}" \
         OPENAI_API_BASE="${OPENAI_API_BASE:-http://127.0.0.1:8092}" \
         TINFOIL_API_KEY="$tinfoil_api_key" \
-        exec cargo run
+        exec cargo run --locked
 
 ### Enclave Management ###
 
@@ -317,32 +317,32 @@ run-stage-preview: terminate-enclave-preview run-eif-preview restart-socat-previ
 
 # Build EIF for development environment
 build-eif-dev:
-    nix build '.?submodules=1#eif-dev'
+    nix build --no-update-lock-file '.?submodules=1#eif-dev'
     echo "EIF build completed. PCR:"
     cat result/pcr.json
 
 # Build EIF for production environment
 build-eif-prod:
-    nix build '.?submodules=1#eif-prod'
+    nix build --no-update-lock-file '.?submodules=1#eif-prod'
     echo "EIF build completed. PCR:"
     cat result/pcr.json
 
 # Build EIF for preview environment
 build-eif-preview:
-    nix build '.?submodules=1#eif-preview'
+    nix build --no-update-lock-file '.?submodules=1#eif-preview'
     echo "EIF build completed. PCR:"
     cat result/pcr.json
 
 # Build EIF for development environment
 copy-pcr-dev:
-    nix build '.?submodules=1#eif-dev'
+    nix build --no-update-lock-file '.?submodules=1#eif-dev'
     echo "EIF build completed. PCR:"
     cat result/pcr.json
     cp -f result/pcr.json ./pcrDev.json
 
 # Build EIF for production environment
 copy-pcr-prod:
-    nix build '.?submodules=1#eif-prod'
+    nix build --no-update-lock-file '.?submodules=1#eif-prod'
     echo "EIF build completed. PCR:"
     cat result/pcr.json
     cp -f result/pcr.json ./pcrProd.json


### PR DESCRIPTION
## Summary
- require Cargo.lock for dependency-resolving Cargo commands across CI, local recipes, deployment docs, and supply-chain checks
- prevent routine Nix commands from updating flake.lock
- retain existing no-write lockfile validation where it is already stronger

## Validation
- `cargo metadata --locked --format-version 1`
- `cargo deny --all-features --locked check bans`
- `nix flake check --no-update-lock-file --no-build`
- repository-wide command inventory and `git diff --check`