### PR TITLE
Security: modernize Rust dependencies and enforce daily audits

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,9 +1,11 @@
-name: Rust supply-chain denylist
+name: Rust supply-chain checks
 
 on:
   pull_request:
   push:
     branches: [master]
+  schedule:
+    - cron: "17 6 * * *"
   workflow_dispatch:
 
 permissions:
@@ -11,7 +13,7 @@ permissions:
 
 jobs:
   cargo-deny:
-    name: Known malicious crates
+    name: RustSec advisories and malicious crates
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -20,8 +22,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check incident denylist
+      - name: Check RustSec advisories and incident denylist
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
-          command: check bans
+          command: check advisories bans
           arguments: --all-features --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4377,9 +4377,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spinning_top"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
  "futures",
  "getrandom 0.3.4",
  "rand 0.9.5",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "secrecy",
  "serde",
  "serde_json",
@@ -503,9 +503,9 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.4.18",
+ "h2",
  "http 1.1.0",
- "hyper 1.7.0",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
@@ -650,7 +650,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -734,12 +734,6 @@ dependencies = [
  "bitcoin-internals 0.3.0",
  "bitcoin_hashes 0.14.0",
 ]
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -1059,13 +1053,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -1083,7 +1088,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2002,8 +2007,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2045,25 +2053,6 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -2182,6 +2171,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "hpke"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65d16b699dd1a1fa2d851c970b0c971b388eeeb40f744252b8de48860980c8f"
+dependencies = [
+ "aead",
+ "aes-gcm",
+ "chacha20poly1305",
+ "digest 0.10.7",
+ "generic-array",
+ "hkdf",
+ "hmac",
+ "p256",
+ "rand_core 0.9.5",
+ "sha2 0.10.8",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,30 +2270,6 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.7",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
@@ -2292,7 +2278,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.18",
+ "h2",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
@@ -2312,26 +2298,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.1.0",
- "hyper 1.7.0",
+ "hyper",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.30",
- "native-tls",
- "tokio",
- "tokio-native-tls",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2342,7 +2316,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2363,12 +2337,12 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.7.0",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2766,6 +2740,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3013,16 +2993,16 @@ dependencies = [
 
 [[package]]
 name = "oauth2"
-version = "4.4.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.15",
- "http 0.2.12",
+ "http 1.1.0",
  "rand 0.8.6",
- "reqwest 0.11.27",
+ "reqwest 0.12.23",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -3087,8 +3067,6 @@ dependencies = [
  "hkdf",
  "hmac",
  "http-body 1.0.1",
- "hyper 0.14.30",
- "hyper-tls 0.5.0",
  "jsonwebtoken",
  "jwt-compact",
  "lazy_static",
@@ -3102,8 +3080,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rcgen",
  "regex",
- "reqwest 0.11.27",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "resend-rs",
  "rustls",
  "secp256k1",
@@ -3238,7 +3215,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3493,6 +3470,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.3",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash 2.1.3",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3546,6 +3579,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3581,6 +3625,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3671,46 +3730,6 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.30",
- "hyper-tls 0.5.0",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
- "tokio",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
@@ -3721,14 +3740,17 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
- "hyper-tls 0.6.0",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3736,6 +3758,7 @@ dependencies = [
  "sync_wrapper 1.0.1",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower 0.5.2",
  "tower-http 0.6.11",
  "tower-service",
@@ -3743,23 +3766,24 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.4.18",
+ "h2",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -3796,7 +3820,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.1.0",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "serde",
  "thiserror 2.0.18",
  "tower-service",
@@ -3868,6 +3892,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3927,20 +3957,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -4345,16 +4367,6 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
@@ -4473,27 +4485,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4568,7 +4559,7 @@ dependencies = [
  "fancy-regex",
  "lazy_static",
  "parking_lot",
- "rustc-hash",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]
@@ -4604,8 +4595,8 @@ dependencies = [
 
 [[package]]
 name = "tinfoil"
-version = "0.1.0"
-source = "git+https://github.com/tinfoilsh/tinfoil-rs?tag=v0.1.3#13057691ac15217d5f658221e39554ee9003a3fe"
+version = "0.2.0"
+source = "git+https://github.com/tinfoilsh/tinfoil-rs?tag=v0.2.0#91e8aef8fbc34129b68de8667ece5bd9ef7b7110"
 dependencies = [
  "async-openai",
  "async-stream",
@@ -4628,7 +4619,7 @@ dependencies = [
  "p384",
  "pem",
  "regex",
- "reqwest 0.13.3",
+ "reqwest 0.13.4",
  "reqwest-middleware",
  "rsa",
  "rustls",
@@ -4638,12 +4629,37 @@ dependencies = [
  "sha2 0.10.8",
  "thiserror 2.0.18",
  "time",
+ "tinfoil-ehbp",
  "tls_codec",
  "tokio",
  "tokio-rustls",
  "tower 0.5.2",
  "webpki-roots",
  "x509-cert",
+]
+
+[[package]]
+name = "tinfoil-ehbp"
+version = "0.3.1"
+source = "git+https://github.com/tinfoilsh/encrypted-http-body-protocol?rev=93cc1fa1ad61e19f9a34fb23cb5b5d5635d3edb0#93cc1fa1ad61e19f9a34fb23cb5b5d5635d3edb0"
+dependencies = [
+ "aes-gcm",
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "hex",
+ "hkdf",
+ "hpke",
+ "http 1.1.0",
+ "http-body-util",
+ "rand 0.9.5",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "thiserror 1.0.63",
+ "url",
+ "zeroize",
 ]
 
 [[package]]
@@ -4704,7 +4720,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.0",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5197,6 +5213,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-root-certs"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5236,7 +5262,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5251,7 +5277,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5262,20 +5288,11 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5284,7 +5301,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5298,40 +5315,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -5341,21 +5337,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5371,21 +5355,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5395,37 +5367,15 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "argon2"
@@ -503,7 +503,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.4.13",
+ "h2 0.4.18",
  "http 1.1.0",
  "hyper 1.7.0",
  "hyper-rustls",
@@ -1340,8 +1340,18 @@ version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.10",
+ "darling_macro 0.20.10",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -1359,12 +1369,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.10",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.106",
 ]
@@ -1459,7 +1494,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.10",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -1477,15 +1512,16 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.2.3"
+version = "2.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e13bab2796f412722112327f3e575601a3e9cdcbe426f0d30dbf43f3f5dc71"
+checksum = "29fe29a87fb84c631ffb3ba21798c4b1f3a964701ba78f0dce4bf8668562ec88"
 dependencies = [
  "bigdecimal",
  "bitflags 2.13.0",
  "byteorder",
  "chrono",
  "diesel_derives",
+ "downcast-rs",
  "itoa",
  "num-bigint",
  "num-integer",
@@ -1510,9 +1546,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.2.2"
+version = "2.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ff2be1e7312c858b2ef974f5c7089833ae57b5311b334b30923af58e5718d8"
+checksum = "d1817b7f4279b947fc4cafddec12b0e5f8727141706561ce3ac94a60bddd1cf5"
 dependencies = [
  "diesel_table_macro_syntax",
  "dsl_auto_type",
@@ -1523,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_table_macro_syntax"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
+checksum = "fe2444076b48641147115697648dc743c2c00b61adade0f01ce67133c7babe8c"
 dependencies = [
  "syn 2.0.106",
 ]
@@ -1591,12 +1627,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
-name = "dsl_auto_type"
-version = "0.1.2"
+name = "downcast-rs"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d9abe6314103864cc2d8901b7ae224e0ab1a103a0a416661b4097b0779b607"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
+name = "dsl_auto_type"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd122633e4bef06db27737f21d3738fb89c8f6d5360d6d9d7635dda142a7757e"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "either",
  "heck 0.5.0",
  "proc-macro2",
@@ -2026,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2250,7 +2292,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2 0.4.18",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
@@ -3713,7 +3755,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
+ "h2 0.4.18",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -5000,7 +5042,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
 dependencies = [
- "darling",
+ "darling 0.20.10",
  "once_cell",
  "proc-macro-error2",
  "proc-macro2",
@@ -5194,7 +5236,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "1.0.63"
 async-trait = "0.1.81"
 jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
 jwt-compact = { version = "0.9.0-beta.1", features = ["es256k"] }
-diesel = { version = "=2.2.3", features = [
+diesel = { version = "=2.3.10", features = [
     "postgres",
     "postgres_backend",
     "r2d2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,8 @@ hkdf = "0.12.4"
 generic-array = "0.14"
 cbc = "0.1.2"
 secp256k1 = { version = "0.29.0", features = ["rand"] }
-hyper = { version = "0.14", features = ["full"] }
-hyper-tls = "0.5.0"
 http-body = "1.0"
-reqwest = { version = "0.11", features = ["json"] }
-reqwest-tinfoil = { package = "reqwest", version = "=0.13.3", default-features = false, features = ["gzip", "http2", "json", "rustls-no-provider", "stream"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["form", "gzip", "http2", "json", "query", "rustls-no-provider", "stream"] }
 futures = "0.3.30"
 uuid = { version = "1.10.0", features = ["v4", "serde"] }
 tokio-stream = "0.1"
@@ -65,7 +62,7 @@ yasna = "0.5"
 rcgen = { version = "0.13.1", features = ["crypto"] }
 chacha20poly1305 = "0.10.1"
 getrandom = "0.2.15"
-oauth2 = { version = "4.4.2", default-features = false, features = ["reqwest", "native-tls"] }
+oauth2 = { version = "5.0.0", default-features = false, features = ["reqwest", "rustls-tls"] }
 url = "2.5.2"
 bigdecimal = { version = "0.4.5", features = ["serde"] }
 aws-config = "1.8.0"
@@ -81,7 +78,7 @@ tiktoken-rs = "0.5"
 once_cell = "1.19"
 pulldown-cmark = { version = "0.13.0", default-features = false }
 pulldown-cmark-to-cmark = "22.0.0"
-tinfoil = { git = "https://github.com/tinfoilsh/tinfoil-rs", tag = "v0.1.3" }
+tinfoil = { git = "https://github.com/tinfoilsh/tinfoil-rs", tag = "v0.2.0" }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 
 [dev-dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -4,7 +4,6 @@
 unmaintained = "none"
 ignore = [
     { id = "RUSTSEC-2023-0071", reason = "No patched rsa release; Tinfoil uses RSA public-key verification only, while the advisory affects private-key operations" },
-    { id = "RUSTSEC-2026-0258", reason = "The remaining h2 0.3 dependency comes from the legacy Hyper 0.14 provider transport; h2 has no patched 0.3 release" },
 ]
 
 [bans]

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,15 @@
+[advisories]
+# Vulnerability and unsoundness advisories are blocking. Unmaintained-package
+# notices are tracked separately because they often require API migrations.
+unmaintained = "none"
+ignore = [
+    { id = "RUSTSEC-2023-0071", reason = "No patched rsa release; Tinfoil uses RSA public-key verification only, while the advisory affects private-key operations" },
+    { id = "RUSTSEC-2026-0258", reason = "The remaining h2 0.3 dependency comes from the legacy Hyper 0.14 provider transport; h2 has no patched 0.3 release" },
+]
+
 [bans]
 # Emergency supply-chain containment for the August 2026 crates.io campaign.
-# Keep this check focused on known malicious packages; broader policy and
-# locked dependency enforcement are intentionally separate follow-up work.
+# Keep these explicit package bans alongside the blocking RustSec checks.
 multiple-versions = "allow"
 wildcards = "allow"
 deny = [

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,7 @@
 [advisories]
 # Vulnerability and unsoundness advisories are blocking. Unmaintained-package
 # notices are tracked separately because they often require API migrations.
+unsound = "all"
 unmaintained = "none"
 ignore = [
     { id = "RUSTSEC-2023-0071", reason = "No patched rsa release; Tinfoil uses RSA public-key verification only, while the advisory affects private-key operations" },

--- a/docs/nitro-deploy.md
+++ b/docs/nitro-deploy.md
@@ -1089,7 +1089,7 @@ sudo vim /etc/nitro_enclaves/vsock-proxy.yaml
 Add these lines:
 ```
 - {address: github-proxy.tinfoil.sh, port: 443}
-# Retained unchanged by this minimal migration; tinfoil-rs v0.1.3 embeds its trust root.
+# Retained unchanged by this migration; tinfoil-rs v0.2.0 embeds its trust root.
 - {address: tuf-repo-cdn.sigstore.dev, port: 443}
 - {address: kds-proxy.tinfoil.sh, port: 443}
 - {address: atc.tinfoil.sh, port: 443}

--- a/flake.nix
+++ b/flake.nix
@@ -486,7 +486,8 @@
           cargoLock = {
             lockFile = ./Cargo.lock;
             outputHashes = {
-              "tinfoil-0.1.0" = "sha256-ViCg20dzw61r1k740xQpyJjfBthv6yXHzBAhxH7OC8Y=";
+              "tinfoil-0.2.0" = "sha256-+J/9OtgO8kNba9UoWEmGuzpTxPKVV8VuSl05mNe8Kpw=";
+              "tinfoil-ehbp-0.3.1" = "sha256-BSSob5uyIIOw/Zr5aZFTU0GOM5imxk7KoZ5g+I4+s70=";
             };
           };
           nativeBuildInputs = [

--- a/flake.nix
+++ b/flake.nix
@@ -501,6 +501,7 @@
             pkgs.zlib
             pkgs.postgresql
           ];
+          SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
           LIBPQ_LIB_DIR = "${pkgs.postgresql.lib}/lib";
         };
 

--- a/src/apple_signin.rs
+++ b/src/apple_signin.rs
@@ -125,7 +125,7 @@ pub struct AppleJwtVerifier {
 impl AppleJwtVerifier {
     pub fn new() -> Self {
         Self {
-            http_client: Client::new(),
+            http_client: crate::http_client::client(),
             jwks_cache: Arc::new(RwLock::new(AppleJwksCache {
                 keys: HashMap::new(),
                 last_updated: chrono::Utc::now() - chrono::Duration::hours(2), // Force initial fetch

--- a/src/billing.rs
+++ b/src/billing.rs
@@ -84,7 +84,7 @@ pub struct BillingClient {
 impl BillingClient {
     pub fn new(api_key: String, base_url: String) -> Self {
         Self {
-            client: Client::new(),
+            client: crate::http_client::client(),
             api_key,
             base_url,
         }

--- a/src/brave.rs
+++ b/src/brave.rs
@@ -29,7 +29,7 @@ pub struct BraveClient {
 impl BraveClient {
     /// Create a new Brave client with the given API key
     pub fn new(api_key: String) -> Result<Self, BraveError> {
-        let client = reqwest::Client::builder()
+        let client = crate::http_client::client_builder()
             .timeout(REQUEST_TIMEOUT)
             .connect_timeout(CONNECT_TIMEOUT)
             .pool_max_idle_per_host(100)

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -1,0 +1,32 @@
+/// Install the process-wide Rustls provider before constructing any Reqwest
+/// client. Tinfoil pins Ring across platforms, so OpenSecret selects the same
+/// provider for its other Rustls clients instead of depending on construction
+/// order.
+pub(crate) fn install_ring_crypto_provider() -> Result<(), ()> {
+    if rustls::crypto::CryptoProvider::get_default().is_some() {
+        return Ok(());
+    }
+
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .map(|_| ())
+        // Another thread may have installed a provider between the check and
+        // install. A configured provider satisfies Reqwest's requirement.
+        .or_else(|_| {
+            rustls::crypto::CryptoProvider::get_default()
+                .is_some()
+                .then_some(())
+                .ok_or(())
+        })
+}
+
+pub(crate) fn client_builder() -> reqwest::ClientBuilder {
+    install_ring_crypto_provider().expect("failed to configure a Rustls crypto provider");
+    reqwest::Client::builder()
+}
+
+pub(crate) fn client() -> reqwest::Client {
+    client_builder()
+        .build()
+        .expect("failed to build the default HTTP client")
+}

--- a/src/kagi.rs
+++ b/src/kagi.rs
@@ -178,7 +178,7 @@ impl KagiClient {
         }
 
         let base_url = Url::parse(&format!("{}/", base_url.trim_end_matches('/')))?;
-        let client = reqwest::Client::builder()
+        let client = crate::http_client::client_builder()
             .connect_timeout(CONNECT_TIMEOUT)
             .timeout(KAGI_REQUEST_TIMEOUT)
             .pool_max_idle_per_host(100)

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,7 @@ mod crypto_property_tests;
 mod db;
 mod email;
 mod encrypt;
+mod http_client;
 mod jwt;
 mod kagi;
 mod kv;
@@ -227,6 +228,9 @@ pub enum Error {
 
     #[error(transparent)]
     TryInit(#[from] tracing_subscriber::util::TryInitError),
+
+    #[error("failed to install the required Ring crypto provider")]
+    CryptoProvider,
 
     #[error("Database error: {0}")]
     DatabaseError(#[from] DBError),
@@ -3441,6 +3445,7 @@ async fn retrieve_kagi_api_key(
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     dotenv::dotenv().ok();
+    http_client::install_ring_crypto_provider().map_err(|_| Error::CryptoProvider)?;
 
     let app_mode = std::env::var("APP_MODE")
         .unwrap_or_else(|_| "local".to_string())

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -3,7 +3,8 @@ use crate::models::oauth::NewOAuthProvider;
 use crate::Error;
 use async_trait::async_trait;
 use oauth2::{
-    basic::BasicClient, AuthUrl, ClientId, ClientSecret, CsrfToken, RedirectUrl, Scope, TokenUrl,
+    basic::BasicClient as OAuthBasicClient, AuthUrl, ClientId, ClientSecret, CsrfToken,
+    EndpointNotSet, EndpointSet, RedirectUrl, Scope, TokenUrl,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -18,6 +19,9 @@ use uuid::Uuid;
 const OAUTH_STATE_TTL: Duration = Duration::from_secs(10 * 60);
 // This limit applies independently to each configured provider.
 const OAUTH_STATE_CAPACITY: usize = 4_096;
+
+pub type BasicClient =
+    OAuthBasicClient<EndpointSet, EndpointNotSet, EndpointNotSet, EndpointNotSet, EndpointSet>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OAuthState {
@@ -165,16 +169,14 @@ impl GithubProvider {
         let token_url = TokenUrl::new(self.token_url.clone())
             .map_err(|e| Error::OAuthError(format!("Invalid token URL: {}", e)))?;
 
-        Ok(BasicClient::new(
-            ClientId::new(client_id),
-            Some(ClientSecret::new(client_secret)),
-            auth_url,
-            Some(token_url),
-        )
-        .set_redirect_uri(
-            RedirectUrl::new(redirect_url)
-                .map_err(|e| Error::OAuthError(format!("Invalid redirect URL: {}", e)))?,
-        ))
+        Ok(OAuthBasicClient::new(ClientId::new(client_id))
+            .set_client_secret(ClientSecret::new(client_secret))
+            .set_auth_uri(auth_url)
+            .set_token_uri(token_url)
+            .set_redirect_uri(
+                RedirectUrl::new(redirect_url)
+                    .map_err(|e| Error::OAuthError(format!("Invalid redirect URL: {}", e)))?,
+            ))
     }
 
     pub async fn generate_authorize_url(&self, client: &BasicClient) -> (String, CsrfToken) {
@@ -271,16 +273,14 @@ impl GoogleProvider {
         let token_url = TokenUrl::new(self.token_url.clone())
             .map_err(|e| Error::OAuthError(format!("Invalid token URL: {}", e)))?;
 
-        Ok(BasicClient::new(
-            ClientId::new(client_id),
-            Some(ClientSecret::new(client_secret)),
-            auth_url,
-            Some(token_url),
-        )
-        .set_redirect_uri(
-            RedirectUrl::new(redirect_url)
-                .map_err(|e| Error::OAuthError(format!("Invalid redirect URL: {}", e)))?,
-        ))
+        Ok(OAuthBasicClient::new(ClientId::new(client_id))
+            .set_client_secret(ClientSecret::new(client_secret))
+            .set_auth_uri(auth_url)
+            .set_token_uri(token_url)
+            .set_redirect_uri(
+                RedirectUrl::new(redirect_url)
+                    .map_err(|e| Error::OAuthError(format!("Invalid redirect URL: {}", e)))?,
+            ))
     }
 
     pub async fn generate_authorize_url(&self, client: &BasicClient) -> (String, CsrfToken) {
@@ -379,16 +379,14 @@ impl AppleProvider {
         let token_url = TokenUrl::new(self.token_url.clone())
             .map_err(|e| Error::OAuthError(format!("Invalid token URL: {}", e)))?;
 
-        Ok(BasicClient::new(
-            ClientId::new(client_id),
-            Some(ClientSecret::new(client_secret)),
-            auth_url,
-            Some(token_url),
-        )
-        .set_redirect_uri(
-            RedirectUrl::new(redirect_url)
-                .map_err(|e| Error::OAuthError(format!("Invalid redirect URL: {}", e)))?,
-        ))
+        Ok(OAuthBasicClient::new(ClientId::new(client_id))
+            .set_client_secret(ClientSecret::new(client_secret))
+            .set_auth_uri(auth_url)
+            .set_token_uri(token_url)
+            .set_redirect_uri(
+                RedirectUrl::new(redirect_url)
+                    .map_err(|e| Error::OAuthError(format!("Invalid redirect URL: {}", e)))?,
+            ))
     }
 
     pub async fn generate_authorize_url(&self, client: &BasicClient) -> (String, CsrfToken) {

--- a/src/os_flags.rs
+++ b/src/os_flags.rs
@@ -132,7 +132,7 @@ impl OsFlagsClient {
         let base_url = format!("{}/", base_url.trim_end_matches('/'));
         let base_url = Url::parse(&base_url)?;
 
-        let client = reqwest::Client::builder()
+        let client = crate::http_client::client_builder()
             .timeout(REQUEST_TIMEOUT)
             .connect_timeout(CONNECT_TIMEOUT)
             .pool_max_idle_per_host(100)

--- a/src/provider_client.rs
+++ b/src/provider_client.rs
@@ -3,21 +3,17 @@ use crate::proxy_config::ProxyConfig;
 use axum::http::{header, HeaderMap, HeaderName, HeaderValue};
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
-use hyper::client::HttpConnector;
-use hyper::header::{HeaderName as HyperHeaderName, HeaderValue as HyperHeaderValue};
-use hyper::{Body as HyperBody, Client as HyperClient, Request as HyperRequest};
-use hyper_tls::HttpsConnector;
-use reqwest_tinfoil::{Method, Request as ReqwestRequest};
+use reqwest::{Method, Request as ReqwestRequest};
 use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
-type StandardHttpClient = HyperClient<HttpsConnector<HttpConnector>, HyperBody>;
+type StandardHttpClient = reqwest::Client;
 type TinfoilRefreshTask = JoinHandle<Result<SecureClientSnapshot, ProviderRequestError>>;
 
 const TINFOIL_INITIAL_RETRY_DELAY: Duration = Duration::from_secs(1);
@@ -28,7 +24,7 @@ const TINFOIL_UNINITIALIZED_BASE_URL: &str = "https://in-process.tinfoil.invalid
 #[derive(Debug, thiserror::Error)]
 pub enum ProviderClientError {
     #[error("failed to build provider HTTP client: {0}")]
-    Client(#[from] reqwest_tinfoil::Error),
+    Client(#[from] reqwest::Error),
 
     #[error("failed to install the required Ring crypto provider")]
     CryptoProvider,
@@ -52,8 +48,8 @@ pub enum ProviderRequestError {
 }
 
 pub enum ProviderResponse {
-    Tinfoil(reqwest_tinfoil::Response),
-    Standard(hyper::Response<HyperBody>),
+    Tinfoil(reqwest::Response),
+    Standard(reqwest::Response),
 }
 
 #[derive(Clone)]
@@ -132,9 +128,7 @@ impl ProviderResponse {
     pub async fn bytes(self) -> Result<Bytes, String> {
         match self {
             Self::Tinfoil(response) => response.bytes().await.map_err(|error| error.to_string()),
-            Self::Standard(response) => hyper::body::to_bytes(response.into_body())
-                .await
-                .map_err(|error| error.to_string()),
+            Self::Standard(response) => response.bytes().await.map_err(|error| error.to_string()),
         }
     }
 
@@ -149,7 +143,7 @@ impl ProviderResponse {
             ),
             Self::Standard(response) => Box::pin(
                 response
-                    .into_body()
+                    .bytes_stream()
                     .map(|result| result.map_err(|e| e.to_string())),
             ),
         }
@@ -208,7 +202,7 @@ enum TinfoilAttempt {
     Secure(SecureClientSnapshot),
     #[cfg(test)]
     Plain {
-        client: reqwest_tinfoil::Client,
+        client: reqwest::Client,
         base_url: String,
         api_key: String,
     },
@@ -219,7 +213,7 @@ enum TinfoilTransport {
     Secure(Arc<SecureTinfoilTransport>),
     #[cfg(test)]
     Plain {
-        client: reqwest_tinfoil::Client,
+        client: reqwest::Client,
         base_url: String,
         api_key: String,
     },
@@ -513,7 +507,8 @@ pub struct ProviderClient {
 
 impl ProviderClient {
     pub async fn new(tinfoil_api_key: String) -> Result<Self, ProviderClientError> {
-        install_crypto_provider()?;
+        crate::http_client::install_ring_crypto_provider()
+            .map_err(|_| ProviderClientError::CryptoProvider)?;
 
         let secure_transport = Arc::new(SecureTinfoilTransport {
             api_key: tinfoil_api_key,
@@ -528,13 +523,14 @@ impl ProviderClient {
 
         Ok(Self {
             tinfoil: TinfoilTransport::Secure(secure_transport),
-            standard: standard_http_client(),
+            standard: standard_http_client()?,
         })
     }
 
     #[cfg(test)]
     fn uninitialized_for_test() -> Result<Self, ProviderClientError> {
-        install_crypto_provider()?;
+        crate::http_client::install_ring_crypto_provider()
+            .map_err(|_| ProviderClientError::CryptoProvider)?;
 
         Ok(Self {
             tinfoil: TinfoilTransport::Secure(Arc::new(SecureTinfoilTransport {
@@ -548,13 +544,14 @@ impl ProviderClient {
                 // without creating a real discovery request.
                 initialization_started: AtomicBool::new(true),
             })),
-            standard: standard_http_client(),
+            standard: standard_http_client()?,
         })
     }
 
     #[cfg(test)]
     pub fn for_test(base_url: String) -> Result<Self, ProviderClientError> {
-        install_crypto_provider()?;
+        crate::http_client::install_ring_crypto_provider()
+            .map_err(|_| ProviderClientError::CryptoProvider)?;
         let client = test_http_client()?;
 
         Ok(Self {
@@ -563,7 +560,7 @@ impl ProviderClient {
                 base_url,
                 api_key: "test-tinfoil-key".to_string(),
             },
-            standard: standard_http_client(),
+            standard: standard_http_client()?,
         })
     }
 
@@ -697,7 +694,7 @@ impl ProviderClient {
             base_url.trim_end_matches('/'),
             path.trim_start_matches('/')
         );
-        let url = reqwest_tinfoil::Url::parse(&url)
+        let url = reqwest::Url::parse(&url)
             .map_err(|error| ProviderRequestError::Build(error.to_string()))?;
         let mut request = ReqwestRequest::new(method, url);
 
@@ -744,32 +741,33 @@ impl ProviderClient {
             provider.base_url.trim_end_matches('/'),
             path.trim_start_matches('/')
         );
-        let mut request = HyperRequest::builder().method(method.as_str()).uri(url);
+        let url = reqwest::Url::parse(&url)
+            .map_err(|error| ProviderRequestError::Build(error.to_string()))?;
+        let mut request = ReqwestRequest::new(method, url);
 
+        if let Some(headers) = source_headers {
+            *request.headers_mut() = forwarded_headers(headers);
+        }
         if let Some(content_type) = content_type {
-            request = request.header("Content-Type", content_type);
+            let content_type = HeaderValue::from_str(content_type)
+                .map_err(|error| ProviderRequestError::Build(error.to_string()))?;
+            request
+                .headers_mut()
+                .insert(header::CONTENT_TYPE, content_type);
         }
         if let Some(api_key) = provider.api_key.as_deref().filter(|key| !key.is_empty()) {
-            request = request.header("Authorization", format!("Bearer {api_key}"));
+            let mut authorization = HeaderValue::from_str(&format!("Bearer {api_key}"))
+                .map_err(|error| ProviderRequestError::Build(error.to_string()))?;
+            authorization.set_sensitive(true);
+            request
+                .headers_mut()
+                .insert(header::AUTHORIZATION, authorization);
         }
-        if let Some(headers) = source_headers {
-            let skipped = skipped_forward_headers(headers);
-            for (name, value) in headers {
-                if !skipped.contains(name) {
-                    if let (Ok(name), Ok(value)) = (
-                        HyperHeaderName::from_bytes(name.as_ref()),
-                        HyperHeaderValue::from_bytes(value.as_bytes()),
-                    ) {
-                        request = request.header(name, value);
-                    }
-                }
-            }
+        if let Some(body) = body {
+            *request.body_mut() = Some(body.into());
         }
 
-        let request = request
-            .body(body.map(HyperBody::from).unwrap_or_else(HyperBody::empty))
-            .map_err(|error| ProviderRequestError::Build(error.to_string()))?;
-        let response = tokio::time::timeout(response_start_timeout, self.standard.request(request))
+        let response = tokio::time::timeout(response_start_timeout, self.standard.execute(request))
             .await
             .map_err(|_| ProviderRequestError::Timeout(response_start_timeout))?
             .map_err(|error| ProviderRequestError::Send(error.to_string()))?;
@@ -778,39 +776,22 @@ impl ProviderClient {
 }
 
 #[cfg(test)]
-fn test_http_client() -> Result<reqwest_tinfoil::Client, reqwest_tinfoil::Error> {
-    reqwest_tinfoil::Client::builder()
+fn test_http_client() -> Result<reqwest::Client, reqwest::Error> {
+    crate::http_client::client_builder()
         // Plain transport exists only for loopback contract tests. Supplying an
         // empty trust store keeps client construction independent of host CA
         // files while ensuring an accidental HTTPS test request trusts no CA.
-        .tls_certs_only(std::iter::empty::<reqwest_tinfoil::Certificate>())
+        .tls_certs_only(std::iter::empty::<reqwest::Certificate>())
         .pool_idle_timeout(Duration::from_secs(30))
         .pool_max_idle_per_host(10)
         .build()
 }
 
-fn standard_http_client() -> StandardHttpClient {
-    HyperClient::builder()
+fn standard_http_client() -> Result<StandardHttpClient, reqwest::Error> {
+    crate::http_client::client_builder()
         .pool_idle_timeout(Duration::from_secs(30))
         .pool_max_idle_per_host(10)
-        .build::<_, HyperBody>(HttpsConnector::new())
-}
-
-fn install_crypto_provider() -> Result<(), ProviderClientError> {
-    static INSTALLATION: OnceLock<Result<(), ()>> = OnceLock::new();
-
-    if INSTALLATION
-        .get_or_init(|| {
-            rustls::crypto::ring::default_provider()
-                .install_default()
-                .map_err(|_| ())
-        })
-        .is_err()
-    {
-        Err(ProviderClientError::CryptoProvider)
-    } else {
-        Ok(())
-    }
+        .build()
 }
 
 fn skipped_forward_headers(source: &HeaderMap) -> HashSet<HeaderName> {
@@ -970,10 +951,11 @@ mod tests {
 
     #[test]
     fn provider_response_exposes_the_upstream_content_type() {
-        let response = hyper::Response::builder()
+        let response = axum::http::Response::builder()
             .header("content-type", "audio/flac")
-            .body(HyperBody::empty())
-            .unwrap();
+            .body(reqwest::Body::default())
+            .unwrap()
+            .into();
 
         assert_eq!(
             ProviderResponse::Standard(response).content_type(),
@@ -1618,7 +1600,7 @@ mod tests {
             .unwrap_or("unknown");
         let manifest = json!({
             "captured_at_unix_seconds": captured_at_unix_seconds,
-            "implementation": "tinfoil-rs v0.1.3 (in-process)",
+            "implementation": "tinfoil-rs v0.2.0 (in-process)",
             "revision": revision,
             "working_tree": working_tree_status,
             "credential_label": credential_label,

--- a/src/provider_client.rs
+++ b/src/provider_client.rs
@@ -743,31 +743,25 @@ impl ProviderClient {
         );
         let url = reqwest::Url::parse(&url)
             .map_err(|error| ProviderRequestError::Build(error.to_string()))?;
-        let mut request = ReqwestRequest::new(method, url);
+        let mut headers = source_headers.map(forwarded_headers).unwrap_or_default();
 
-        if let Some(headers) = source_headers {
-            *request.headers_mut() = forwarded_headers(headers);
-        }
         if let Some(content_type) = content_type {
             let content_type = HeaderValue::from_str(content_type)
                 .map_err(|error| ProviderRequestError::Build(error.to_string()))?;
-            request
-                .headers_mut()
-                .insert(header::CONTENT_TYPE, content_type);
+            headers.insert(header::CONTENT_TYPE, content_type);
         }
         if let Some(api_key) = provider.api_key.as_deref().filter(|key| !key.is_empty()) {
             let mut authorization = HeaderValue::from_str(&format!("Bearer {api_key}"))
                 .map_err(|error| ProviderRequestError::Build(error.to_string()))?;
             authorization.set_sensitive(true);
-            request
-                .headers_mut()
-                .insert(header::AUTHORIZATION, authorization);
+            headers.insert(header::AUTHORIZATION, authorization);
         }
+        let mut request = self.standard.request(method, url).headers(headers);
         if let Some(body) = body {
-            *request.body_mut() = Some(body.into());
+            request = request.body(body);
         }
 
-        let response = tokio::time::timeout(response_start_timeout, self.standard.execute(request))
+        let response = tokio::time::timeout(response_start_timeout, request.send())
             .await
             .map_err(|_| ProviderRequestError::Timeout(response_start_timeout))?
             .map_err(|error| ProviderRequestError::Send(error.to_string()))?;

--- a/src/provider_client.rs
+++ b/src/provider_client.rs
@@ -783,6 +783,13 @@ fn test_http_client() -> Result<reqwest::Client, reqwest::Error> {
 
 fn standard_http_client() -> Result<StandardHttpClient, reqwest::Error> {
     crate::http_client::client_builder()
+        // Provider responses are untrusted. In particular, following a 307 or
+        // 308 could replay a prompt or audio body to an arbitrary Location.
+        .redirect(reqwest::redirect::Policy::none())
+        // Preserve the previous direct-connection behavior. The enclave's
+        // plaintext loopback provider traffic must not be rerouted by inherited
+        // HTTP_PROXY/HTTPS_PROXY/ALL_PROXY environment variables.
+        .no_proxy()
         .pool_idle_timeout(Duration::from_secs(30))
         .pool_max_idle_per_host(10)
         .build()
@@ -1212,6 +1219,77 @@ mod tests {
 
         assert!(response.is_success());
         assert_eq!(response.bytes().await.unwrap(), "standard-provider-ok");
+    }
+
+    #[tokio::test]
+    async fn standard_provider_redirect_does_not_replay_request() {
+        let (target_tx, mut target_rx) = mpsc::channel(1);
+        let target_app = Router::new().route(
+            "/redirect-target",
+            any(move |body: Bytes| {
+                let target_tx = target_tx.clone();
+                async move {
+                    target_tx.send(body).await.unwrap();
+                    StatusCode::OK
+                }
+            }),
+        );
+        let target_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let target_address = target_listener.local_addr().unwrap();
+        let target_server =
+            tokio::spawn(async move { axum::serve(target_listener, target_app).await.unwrap() });
+
+        let redirect_location = format!("http://{target_address}/redirect-target");
+        let redirect_app = Router::new().route(
+            "/v1/chat/completions",
+            any(move || {
+                let redirect_location = redirect_location.clone();
+                async move {
+                    (
+                        StatusCode::TEMPORARY_REDIRECT,
+                        [(header::LOCATION, redirect_location)],
+                    )
+                }
+            }),
+        );
+        let redirect_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let redirect_address = redirect_listener.local_addr().unwrap();
+        let redirect_server =
+            tokio::spawn(
+                async move { axum::serve(redirect_listener, redirect_app).await.unwrap() },
+            );
+
+        let client = ProviderClient::uninitialized_for_test().unwrap();
+        let provider = ProxyConfig {
+            base_url: format!("http://{redirect_address}"),
+            api_key: None,
+            provider_name: ProviderName::Continuum.as_str().to_string(),
+        };
+        let body = Bytes::from_static(br#"{"model":"glm-5-2"}"#);
+
+        let response = client
+            .send(
+                &provider,
+                ProviderRequest::new(Method::POST, "/v1/chat/completions", Duration::from_secs(5))
+                    .content_type("application/json")
+                    .body(body),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status_code(),
+            StatusCode::TEMPORARY_REDIRECT.as_u16()
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), target_rx.recv())
+                .await
+                .is_err(),
+            "the redirect target must never receive the provider request body"
+        );
+
+        redirect_server.abort();
+        target_server.abort();
     }
 
     #[tokio::test]

--- a/src/web/health_routes.rs
+++ b/src/web/health_routes.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use axum::{http::StatusCode, Router};
 use axum::{routing::get, Json};
-use reqwest_tinfoil::Method;
+use reqwest::Method;
 use serde::Serialize;
 use std::sync::Arc;
 use std::time::Duration;

--- a/src/web/oauth_routes.rs
+++ b/src/web/oauth_routes.rs
@@ -2,7 +2,7 @@ use crate::apple_signin::{generate_apple_client_secret, validate_apple_native_to
 #[cfg(test)]
 use crate::models::oauth::NewUserOAuthConnection;
 use crate::models::oauth::UserOAuthConnection;
-use crate::oauth::OAuthState;
+use crate::oauth::{BasicClient, OAuthState};
 use crate::web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse};
 use crate::web::login_routes::handle_new_user_registration;
 use crate::web::platform::common::{
@@ -28,8 +28,7 @@ use axum::{
 use base64::Engine as _;
 use oauth2::TokenResponse;
 use oauth2::{
-    basic::{BasicClient, BasicTokenType},
-    AuthorizationCode, EmptyExtraTokenFields, StandardTokenResponse,
+    basic::BasicTokenType, AuthorizationCode, EmptyExtraTokenFields, StandardTokenResponse,
 };
 use reqwest::header::AUTHORIZATION;
 use secp256k1::SecretKey;
@@ -549,7 +548,7 @@ pub async fn oauth_callback(
         let token_url = "https://appleid.apple.com/auth/token";
 
         // Let's try a custom approach matching your successful Postman request
-        let client = reqwest::Client::new();
+        let client = crate::http_client::client();
 
         // Get the parameters from the OAuth client
         let client_id = oauth_client.client_id().as_str();
@@ -643,7 +642,7 @@ pub async fn oauth_callback(
         })?;
 
         let redirect_uri = oauth_client
-            .redirect_url()
+            .redirect_uri()
             .ok_or_else(|| {
                 error!("OAuth redirect URL not configured");
                 ApiError::InternalServerError
@@ -737,9 +736,18 @@ pub async fn oauth_callback(
         (token, Some(id_token))
     } else {
         // For other providers, use the standard OAuth client
+        let http_client = oauth2::reqwest::ClientBuilder::new()
+            // OAuth token endpoints must not follow redirects: doing so could
+            // send client credentials to an attacker-controlled destination.
+            .redirect(oauth2::reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|e| {
+                error!("Failed to build OAuth HTTP client: {:?}", e);
+                ApiError::InternalServerError
+            })?;
         let token = oauth_client
             .exchange_code(AuthorizationCode::new(callback_request.code.clone()))
-            .request_async(oauth2::reqwest::async_http_client)
+            .request_async(&http_client)
             .await
             .map_err(|e| {
                 error!("Failed to exchange code for access token: {:?}", e);
@@ -902,7 +910,7 @@ async fn fetch_github_user(
     access_token: &str,
     github_provider: &GithubProvider,
 ) -> Result<GithubUser, ApiError> {
-    let client = reqwest::Client::new();
+    let client = crate::http_client::client();
     let user_url = &github_provider.user_info_url;
 
     debug!("Sending request to GitHub API: {}", user_url);
@@ -1016,7 +1024,7 @@ async fn fetch_google_user(
     access_token: &str,
     google_provider: &GoogleProvider,
 ) -> Result<GoogleUser, ApiError> {
-    let client = reqwest::Client::new();
+    let client = crate::http_client::client();
     let user_url = &google_provider.user_info_url;
 
     debug!("Sending request to Google API: {}", user_url);

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -26,7 +26,7 @@ use base64::{engine::general_purpose, Engine as _};
 use bigdecimal::BigDecimal;
 use chrono::Utc;
 use futures::StreamExt;
-use reqwest_tinfoil::Method;
+use reqwest::Method;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;


### PR DESCRIPTION
## Summary

- upgrades Tinfoil from v0.1.3 to v0.2.0
- replaces the legacy Hyper 0.14 / Reqwest 0.11 provider transport with Reqwest 0.13
- upgrades oauth2 from 4.4 to 5.0 while preserving no-redirect token exchange
- selects the Ring Rustls provider before any shared HTTP client is constructed
- removes the RUSTSEC-2026-0258 exception; the graph now resolves only patched h2 0.4.18
- replaces the yanked spin 0.9.8 release with 0.9.9
- upgrades other patch-compatible RustSec-affected dependencies
- makes vulnerability and unsoundness advisories blocking in cargo-deny
- keeps the August 2026 malicious-crate denylist active and adds a staggered daily scan

## Remaining exception

- RUSTSEC-2023-0071: no patched rsa release exists; this path performs AMD certificate public-key verification only and never private-key operations

## Validation

- cargo fmt --all -- --check
- RUSTFLAGS=-D warnings cargo clippy --locked --all-targets --all-features -- -D warnings
- RUSTFLAGS=-D warnings cargo test --locked --all-features (373 passed, 17 ignored)
- cargo deny --all-features --locked check advisories bans
- focused provider tests (15 passed, 1 live credentialed test ignored)
- focused OAuth state tests (7 passed)

The credentialed live Tinfoil test was not run. EIF PCR changes remain a release-only follow-up and are not updated in this PR.