### PR TITLE
Add precise recovery signals for expired sessions and access tokens

### DIFF
--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -596,10 +596,11 @@ pub async fn validate_jwt(
 
     tracing::trace!("Validating JWT");
 
-    let claims = match validate_token(&token, &data, USER_ACCESS) {
-        Ok(claims) => claims,
-        Err(_) => return ApiError::InvalidJwt.into_response(),
-    };
+    let (claims, access_token_expired) =
+        match validate_access_token_for_auth(&token, &data, USER_ACCESS) {
+            Ok(validation) => validation,
+            Err(_) => return ApiError::InvalidJwt.into_response(),
+        };
 
     let auth_context = match AuthContext::from_claims(&claims) {
         Ok(auth_context) => auth_context,
@@ -635,6 +636,10 @@ pub async fn validate_jwt(
         return ApiError::InvalidJwt.into_response();
     }
 
+    if access_token_expired {
+        return ApiError::AccessTokenExpired.into_response();
+    }
+
     req.extensions_mut().insert(auth_context);
     req.extensions_mut().insert(user);
     next.run(req).await
@@ -657,10 +662,11 @@ pub async fn validate_platform_jwt(
 
     tracing::trace!("Validating platform JWT");
 
-    let claims = match validate_token(&token, &data, PLATFORM_ACCESS) {
-        Ok(claims) => claims,
-        Err(_) => return ApiError::InvalidJwt.into_response(),
-    };
+    let (claims, access_token_expired) =
+        match validate_access_token_for_auth(&token, &data, PLATFORM_ACCESS) {
+            Ok(validation) => validation,
+            Err(_) => return ApiError::InvalidJwt.into_response(),
+        };
 
     let platform_user_id: Uuid = match Uuid::parse_str(&claims.sub) {
         Ok(uuid) => uuid,
@@ -678,6 +684,10 @@ pub async fn validate_platform_jwt(
         }
     };
 
+    if access_token_expired {
+        return ApiError::AccessTokenExpired.into_response();
+    }
+
     req.extensions_mut().insert(platform_user);
     next.run(req).await
 }
@@ -687,9 +697,46 @@ pub(crate) fn validate_token(
     data: &AppState,
     expected_audience: &str,
 ) -> Result<CustomClaims, ApiError> {
+    validate_token_with_keys(original_token, &data.config.jwt_keys, expected_audience)
+}
+
+pub(crate) fn validate_access_token_for_auth(
+    original_token: &str,
+    data: &AppState,
+    expected_audience: &str,
+) -> Result<(CustomClaims, bool), ApiError> {
+    if !is_access_token_audience(expected_audience) {
+        return Err(ApiError::InvalidJwt);
+    }
+    validate_token_with_keys_for_auth(original_token, &data.config.jwt_keys, expected_audience)
+}
+
+fn validate_token_with_keys(
+    original_token: &str,
+    jwt_keys: &JwtKeys,
+    expected_audience: &str,
+) -> Result<CustomClaims, ApiError> {
+    let (claims, access_token_expired) =
+        validate_token_with_keys_for_auth(original_token, jwt_keys, expected_audience)?;
+    if access_token_expired {
+        Err(ApiError::AccessTokenExpired)
+    } else {
+        Ok(claims)
+    }
+}
+
+fn is_access_token_audience(audience: &str) -> bool {
+    audience == USER_ACCESS || audience == PLATFORM_ACCESS
+}
+
+fn validate_token_with_keys_for_auth(
+    original_token: &str,
+    jwt_keys: &JwtKeys,
+    expected_audience: &str,
+) -> Result<(CustomClaims, bool), ApiError> {
     // Try ES256K first
-    let es256k = Es256k::<Sha256>::new(data.config.jwt_keys.secp.clone());
-    let public_key = data.config.jwt_keys.public_key();
+    let es256k = Es256k::<Sha256>::new(jwt_keys.secp.clone());
+    let public_key = jwt_keys.public_key();
 
     tracing::trace!("Attempting to validate ES256K token");
 
@@ -703,49 +750,187 @@ pub(crate) fn validate_token(
     };
 
     // Deserialize claims first
-    let token: Token<CustomClaims> = match es256k.validator(&public_key).validate(&parsed_token) {
-        Ok(token) => {
-            tracing::trace!("ES256K signature validation successful");
+    let (token, access_token_expired): (Token<CustomClaims>, bool) =
+        match es256k.validator(&public_key).validate(&parsed_token) {
+            Ok(token) => {
+                tracing::trace!("ES256K signature validation successful");
 
-            // Only validate expiration, not maturity
-            let time_options = TimeOptions::default();
-            if let Err(e) = token.claims().validate_expiration(&time_options) {
-                tracing::error!("Token expired: {:?}", e);
-                return Err(ApiError::InvalidJwt);
-            }
-
-            // Validate audience with proper type annotation
-            let claims: &Claims<CustomClaims> = token.claims();
-            if let Some(audience) = &claims.custom.aud {
-                if audience != expected_audience {
-                    tracing::error!(
-                        "Invalid audience: got {}, expected {}",
-                        audience,
-                        expected_audience
-                    );
+                // Validate the audience before classifying expiration. This ensures
+                // an expired token for another audience is never a refresh signal.
+                let claims: &Claims<CustomClaims> = token.claims();
+                if let Some(audience) = &claims.custom.aud {
+                    if audience != expected_audience {
+                        tracing::error!(
+                            "Invalid audience: got {}, expected {}",
+                            audience,
+                            expected_audience
+                        );
+                        return Err(ApiError::InvalidJwt);
+                    }
+                } else {
+                    tracing::error!("Missing audience in token, expected {}", expected_audience);
                     return Err(ApiError::InvalidJwt);
                 }
-            } else {
-                tracing::error!("Missing audience in token, expected {}", expected_audience);
+
+                // Only validate expiration, not maturity. Access-token expiry is
+                // carried to the authentication middleware so identity and auth
+                // binding checks still run before a refresh signal is emitted.
+                let time_options = TimeOptions::default();
+                let access_token_expired = match token.claims().validate_expiration(&time_options) {
+                    Ok(_) => false,
+                    Err(jwt_compact::ValidationError::Expired)
+                        if is_access_token_audience(expected_audience) =>
+                    {
+                        true
+                    }
+                    Err(e) => {
+                        tracing::error!("Token expiration validation failed: {:?}", e);
+                        return Err(ApiError::InvalidJwt);
+                    }
+                };
+
+                (token, access_token_expired)
+            }
+            Err(e) => {
+                tracing::debug!("ES256K validation failed: {:?}", e);
                 return Err(ApiError::InvalidJwt);
             }
+        };
 
-            token
-        }
-        Err(e) => {
-            tracing::debug!("ES256K validation failed: {:?}", e);
-            return Err(ApiError::InvalidJwt);
-        }
-    };
-
-    // Return the claims
-    Ok(token.claims().custom.clone())
+    Ok((token.claims().custom.clone(), access_token_expired))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use jsonwebtoken::{decode as jwt_decode, DecodingKey, Validation};
+
+    fn test_keys(byte: u8) -> JwtKeys {
+        JwtKeys::new(vec![byte; 32]).unwrap()
+    }
+
+    fn signed_test_token(
+        keys: &JwtKeys,
+        audience: &str,
+        expiration: Option<chrono::DateTime<Utc>>,
+    ) -> String {
+        signed_test_token_with_auth_binding(
+            keys,
+            audience,
+            expiration,
+            Some(URL_SAFE_NO_PAD.encode([7u8; 32])),
+        )
+    }
+
+    fn signed_test_token_with_auth_binding(
+        keys: &JwtKeys,
+        audience: &str,
+        expiration: Option<chrono::DateTime<Utc>>,
+        auth_binding: Option<String>,
+    ) -> String {
+        let now = Utc::now();
+        let mut claims = Claims::new(CustomClaims {
+            sub: Uuid::nil().to_string(),
+            aud: Some(audience.to_string()),
+            azp: None,
+            role: None,
+            token_format: Some(USER_TOKEN_FORMAT_V2),
+            auth_method: Some(AuthMethod::Password.as_str().to_string()),
+            project_id: Some(1),
+            auth_binding,
+        });
+        claims.issued_at = Some(now - Duration::minutes(2));
+        claims.not_before = Some(now - Duration::minutes(2));
+        claims.expiration = expiration;
+
+        Es256k::<Sha256>::new(keys.secp.clone())
+            .token(
+                &Header::empty().with_token_type("JWT"),
+                &claims,
+                &keys.signing_key,
+            )
+            .unwrap()
+    }
+
+    #[test]
+    fn expired_user_access_token_is_recoverable_only_after_signature_and_audience_validation() {
+        let trusted_keys = test_keys(1);
+        let other_keys = test_keys(2);
+        let expired = Utc::now() - Duration::minutes(1);
+
+        let expired_access = signed_test_token(&trusted_keys, USER_ACCESS, Some(expired));
+        assert!(matches!(
+            validate_token_with_keys(&expired_access, &trusted_keys, USER_ACCESS),
+            Err(ApiError::AccessTokenExpired)
+        ));
+
+        let wrong_audience = signed_test_token(&trusted_keys, USER_REFRESH, Some(expired));
+        assert!(matches!(
+            validate_token_with_keys(&wrong_audience, &trusted_keys, USER_ACCESS),
+            Err(ApiError::InvalidJwt)
+        ));
+
+        let wrong_signature = signed_test_token(&other_keys, USER_ACCESS, Some(expired));
+        assert!(matches!(
+            validate_token_with_keys(&wrong_signature, &trusted_keys, USER_ACCESS),
+            Err(ApiError::InvalidJwt)
+        ));
+    }
+
+    #[test]
+    fn expired_access_tokens_are_recoverable_but_refresh_tokens_are_not() {
+        let keys = test_keys(3);
+        let expired = Utc::now() - Duration::minutes(1);
+
+        let refresh = signed_test_token(&keys, USER_REFRESH, Some(expired));
+        assert!(matches!(
+            validate_token_with_keys(&refresh, &keys, USER_REFRESH),
+            Err(ApiError::InvalidJwt)
+        ));
+
+        let platform_access = signed_test_token(&keys, PLATFORM_ACCESS, Some(expired));
+        assert!(matches!(
+            validate_token_with_keys(&platform_access, &keys, PLATFORM_ACCESS),
+            Err(ApiError::AccessTokenExpired)
+        ));
+    }
+
+    #[test]
+    fn expired_access_claims_are_available_for_auth_binding_validation() {
+        let keys = test_keys(5);
+        let malformed_binding = URL_SAFE_NO_PAD.encode([7u8; 31]);
+        let token = signed_test_token_with_auth_binding(
+            &keys,
+            USER_ACCESS,
+            Some(Utc::now() - Duration::minutes(1)),
+            Some(malformed_binding),
+        );
+
+        let (claims, access_token_expired) =
+            validate_token_with_keys_for_auth(&token, &keys, USER_ACCESS).unwrap();
+        assert!(access_token_expired);
+        assert!(matches!(
+            AuthContext::from_claims(&claims),
+            Err(ApiError::InvalidJwt)
+        ));
+    }
+
+    #[test]
+    fn valid_access_and_malformed_tokens_do_not_report_expiration() {
+        let keys = test_keys(4);
+        let valid = signed_test_token(&keys, USER_ACCESS, Some(Utc::now() + Duration::minutes(5)));
+        let missing_expiration = signed_test_token(&keys, USER_ACCESS, None);
+
+        assert!(validate_token_with_keys(&valid, &keys, USER_ACCESS).is_ok());
+        assert!(matches!(
+            validate_token_with_keys(&missing_expiration, &keys, USER_ACCESS),
+            Err(ApiError::InvalidJwt)
+        ));
+        assert!(matches!(
+            validate_token_with_keys("not-a-jwt", &keys, USER_ACCESS),
+            Err(ApiError::InvalidJwt)
+        ));
+    }
 
     #[test]
     fn test_jsonwebtoken_hs256_round_trip() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,12 @@ use crate::{
 };
 use crate::{encrypt::create_new_encryption_key, jwt::validate_jwt};
 use aws_credentials::{AwsCredentialManager, AwsCredentials};
-use axum::{http::StatusCode, middleware::from_fn_with_state, response::IntoResponse, Json};
+use axum::{
+    http::{HeaderName, HeaderValue, StatusCode},
+    middleware::{from_fn, from_fn_with_state, Next},
+    response::{IntoResponse, Response},
+    Json,
+};
 use base64::engine::general_purpose;
 use base64::Engine as _;
 use chacha20poly1305::aead::Aead;
@@ -157,6 +162,12 @@ const MAX_PENDING_ATTESTATIONS: usize = 65_536;
 const PENDING_ATTESTATION_TTL: Duration = Duration::from_secs(5 * 60);
 const MAX_ENCRYPTION_SESSIONS: usize = 2_097_152;
 const ENCRYPTION_SESSION_IDLE_TTL: Duration = Duration::from_secs(65 * 60);
+
+pub(crate) const ERROR_CONTRACT_HEADER: &str = "x-opensecret-error-contract";
+pub(crate) const ERROR_CODE_HEADER: &str = "x-opensecret-error-code";
+const ERROR_CONTRACT_VERSION: &str = "1";
+const SESSION_NOT_FOUND_ERROR_CODE: &str = "session_not_found";
+const ACCESS_TOKEN_EXPIRED_ERROR_CODE: &str = "access_token_expired";
 
 type PendingAttestationKey = [u8; 32];
 pub(crate) type SessionLease = CacheLease<SessionState>;
@@ -352,6 +363,9 @@ pub enum ApiError {
     #[error("Invalid JWT")]
     InvalidJwt,
 
+    #[error("Invalid JWT")]
+    AccessTokenExpired,
+
     #[error("Internal server error")]
     InternalServerError,
 
@@ -360,6 +374,9 @@ pub enum ApiError {
 
     #[error("Bad Request")]
     BadRequest,
+
+    #[error("Bad Request")]
+    SessionNotFound,
 
     #[error("Conflict")]
     Conflict,
@@ -418,13 +435,15 @@ pub enum ApiError {
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> axum::response::Response {
-        let status = match self {
+        let status = match &self {
             ApiError::InvalidUsernameOrPassword => StatusCode::UNAUTHORIZED,
             ApiError::InvalidJwt => StatusCode::UNAUTHORIZED,
+            ApiError::AccessTokenExpired => StatusCode::UNAUTHORIZED,
             ApiError::Unauthorized => StatusCode::UNAUTHORIZED,
             ApiError::InternalServerError => StatusCode::INTERNAL_SERVER_ERROR,
             ApiError::ServiceUnavailable => StatusCode::SERVICE_UNAVAILABLE,
             ApiError::BadRequest => StatusCode::BAD_REQUEST,
+            ApiError::SessionNotFound => StatusCode::BAD_REQUEST,
             ApiError::Conflict => StatusCode::CONFLICT,
             ApiError::InvalidInviteCode => StatusCode::UNAUTHORIZED,
             ApiError::RefreshFailed => StatusCode::UNAUTHORIZED,
@@ -443,15 +462,39 @@ impl IntoResponse for ApiError {
             ApiError::PayloadTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
             ApiError::TooManyRequests => StatusCode::TOO_MANY_REQUESTS,
         };
-        (
+        let error_code = match &self {
+            ApiError::SessionNotFound => Some(SESSION_NOT_FOUND_ERROR_CODE),
+            ApiError::AccessTokenExpired => Some(ACCESS_TOKEN_EXPIRED_ERROR_CODE),
+            _ => None,
+        };
+        let mut response = (
             status,
             Json(ErrorResponse {
                 status: status.as_u16(),
                 message: self.to_string(),
             }),
         )
-            .into_response()
+            .into_response();
+        response.headers_mut().insert(
+            ERROR_CONTRACT_HEADER,
+            HeaderValue::from_static(ERROR_CONTRACT_VERSION),
+        );
+        if let Some(error_code) = error_code {
+            response
+                .headers_mut()
+                .insert(ERROR_CODE_HEADER, HeaderValue::from_static(error_code));
+        }
+        response
     }
+}
+
+async fn add_error_contract_header(request: axum::extract::Request, next: Next) -> Response {
+    let mut response = next.run(request).await;
+    response.headers_mut().insert(
+        ERROR_CONTRACT_HEADER,
+        HeaderValue::from_static(ERROR_CONTRACT_VERSION),
+    );
+    response
 }
 
 impl From<ProviderRequestError> for ApiError {
@@ -482,6 +525,78 @@ impl From<DBError> for ApiError {
 pub struct ErrorResponse {
     status: u16,
     message: String,
+}
+
+#[cfg(test)]
+mod api_error_contract_tests {
+    use super::*;
+
+    async fn assert_error_response(
+        error: ApiError,
+        expected_status: StatusCode,
+        expected_body: &[u8],
+        expected_code: Option<&str>,
+    ) {
+        let response = error.into_response();
+
+        assert_eq!(response.status(), expected_status);
+        assert_eq!(
+            response.headers().get(ERROR_CONTRACT_HEADER).unwrap(),
+            ERROR_CONTRACT_VERSION
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(ERROR_CODE_HEADER)
+                .map(|value| value.to_str().unwrap()),
+            expected_code
+        );
+
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(body.as_ref(), expected_body);
+    }
+
+    #[tokio::test]
+    async fn session_not_found_adds_code_without_changing_legacy_response() {
+        assert_error_response(
+            ApiError::SessionNotFound,
+            StatusCode::BAD_REQUEST,
+            br#"{"status":400,"message":"Bad Request"}"#,
+            Some(SESSION_NOT_FOUND_ERROR_CODE),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn access_token_expired_adds_code_without_changing_legacy_response() {
+        assert_error_response(
+            ApiError::AccessTokenExpired,
+            StatusCode::UNAUTHORIZED,
+            br#"{"status":401,"message":"Invalid JWT"}"#,
+            Some(ACCESS_TOKEN_EXPIRED_ERROR_CODE),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn generic_bad_request_and_invalid_jwt_are_not_recoverable() {
+        assert_error_response(
+            ApiError::BadRequest,
+            StatusCode::BAD_REQUEST,
+            br#"{"status":400,"message":"Bad Request"}"#,
+            None,
+        )
+        .await;
+        assert_error_response(
+            ApiError::InvalidJwt,
+            StatusCode::UNAUTHORIZED,
+            br#"{"status":401,"message":"Invalid JWT"}"#,
+            None,
+        )
+        .await;
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1867,7 +1982,7 @@ impl AppState {
         }
     }
 
-    pub(crate) async fn acquire_session(
+    pub(crate) async fn acquire_request_session(
         &self,
         session_id: &Uuid,
     ) -> Result<SessionLease, ApiError> {
@@ -1875,7 +1990,7 @@ impl AppState {
             .lock()
             .await
             .acquire(session_id)
-            .ok_or(ApiError::BadRequest)
+            .ok_or(ApiError::SessionNotFound)
     }
 
     pub(crate) async fn touch_session(&self, session_id: &Uuid) -> Result<(), ApiError> {
@@ -3795,6 +3910,11 @@ async fn main() -> Result<(), Error> {
         .allow_methods(Any)
         // allow all headers
         .allow_headers(Any)
+        // expose the machine-readable recovery contract to browser SDKs
+        .expose_headers([
+            HeaderName::from_static(ERROR_CONTRACT_HEADER),
+            HeaderName::from_static(ERROR_CODE_HEADER),
+        ])
         // allow requests from any origin
         .allow_origin(Any);
 
@@ -3839,7 +3959,8 @@ async fn main() -> Result<(), Error> {
             platform_routes(app_state.clone())
                 .route_layer(from_fn_with_state(app_state.clone(), validate_platform_jwt)),
         )
-        .layer(cors);
+        .layer(cors)
+        .layer(from_fn(add_error_contract_header));
 
     let bind_addr =
         std::env::var("OPENSECRET_BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".to_string());

--- a/src/security_invariants.rs
+++ b/src/security_invariants.rs
@@ -212,6 +212,40 @@ fn models_route_allows_optional_identity_but_requires_session_e2ee() {
 }
 
 #[test]
+fn openai_auth_remains_outside_session_decryption() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let main_source = fs::read_to_string(manifest_dir.join("src/main.rs"))
+        .expect("main source should be readable");
+    let openai_source = fs::read_to_string(manifest_dir.join("src/web/openai.rs"))
+        .expect("OpenAI route source should be readable");
+
+    // `route_layer` is applied when the completed OpenAI router is composed
+    // into the application, so it wraps the route-local decryption layers.
+    // This order lets a request with both an expired access token and a stale
+    // session receive the access-token refresh signal first.
+    assert!(
+        main_source.contains(
+            "openai_routes(app_state.clone())\n                .route_layer(from_fn_with_state(app_state.clone(), validate_openai_auth))"
+        ),
+        "OpenAI routes must apply authentication outside route-local middleware"
+    );
+
+    let router_body = extract_function_body(&openai_source, "pub fn router");
+    let chat_route_start = router_body
+        .find("\"/v1/chat/completions\"")
+        .expect("chat completions route should exist");
+    let next_route_start = router_body[chat_route_start + 1..]
+        .find(".route(")
+        .map(|index| chat_route_start + 1 + index)
+        .unwrap_or(router_body.len());
+    let chat_route = &router_body[chat_route_start..next_route_start];
+    assert!(
+        chat_route.contains("decrypt_request::<Value>"),
+        "chat completions must retain route-local session decryption"
+    );
+}
+
+#[test]
 fn web_routes_remain_jwt_authenticated_and_e2ee_wrapped() {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let main_source = fs::read_to_string(manifest_dir.join("src/main.rs"))
@@ -260,6 +294,7 @@ fn user_jwt_middleware_requires_active_seed_wrap_before_request_extensions() {
             "AuthContext::from_claims(&claims)",
             "if user.project_id != auth_context.project_id",
             "verify_seed_wrap_for_auth_context(&user, &auth_context)",
+            "if access_token_expired",
             "req.extensions_mut().insert(auth_context)",
             "req.extensions_mut().insert(user)",
         ],
@@ -291,6 +326,7 @@ fn openai_jwt_fallback_inserts_signed_auth_context_but_api_keys_do_not() {
             "AuthContext::from_claims(&claims)",
             "if user.project_id != auth_context.project_id",
             "verify_seed_wrap_for_auth_context(&user, &auth_context)",
+            "if access_token_expired",
             "req.extensions_mut().insert(auth_context)",
             "req.extensions_mut().insert(user)",
             "req.extensions_mut().insert(AuthMethod::Jwt)",
@@ -744,6 +780,23 @@ fn password_credential_lifecycle_rewraps_seed_and_reissues_tokens() {
             && !main_contents.contains("convert_guest_to_email_and_seed_wrap")
             && !db_contents.contains("update_user_and_seed_wrap"),
         "guest conversion is intentionally unsupported; do not reintroduce it without revisiting the seed-wrap lifecycle"
+    );
+}
+
+#[test]
+fn platform_access_expiry_is_signaled_only_after_user_validation() {
+    let jwt_source = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/jwt.rs");
+    let contents = fs::read_to_string(&jwt_source).expect("JWT source should be readable");
+    let middleware_body = extract_function_body(&contents, "pub async fn validate_platform_jwt");
+
+    assert_patterns_in_order(
+        middleware_body,
+        &[
+            "Uuid::parse_str(&claims.sub)",
+            "get_platform_user_by_uuid(platform_user_id)",
+            "if access_token_expired",
+            "req.extensions_mut().insert(platform_user)",
+        ],
     );
 }
 

--- a/src/web/encryption_middleware.rs
+++ b/src/web/encryption_middleware.rs
@@ -47,6 +47,14 @@ fn skips_encrypted_body<T: 'static>(method: &Method) -> bool {
         || std::any::TypeId::of::<T>() == std::any::TypeId::of::<()>()
 }
 
+fn parse_session_id(headers: &HeaderMap) -> Result<Uuid, ApiError> {
+    headers
+        .get("x-session-id")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| Uuid::parse_str(value).ok())
+        .ok_or(ApiError::BadRequest)
+}
+
 async fn forward_bodyless_request<T, Resource, SessionCheck, RunNext, RunNextFuture>(
     session_check: SessionCheck,
     session_id: Uuid,
@@ -79,11 +87,7 @@ pub async fn decrypt_request<T>(
 where
     T: DeserializeOwned + Send + Sync + Clone + 'static,
 {
-    let session_id = headers
-        .get("x-session-id")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| Uuid::parse_str(v).ok())
-        .ok_or(ApiError::BadRequest)?;
+    let session_id = parse_session_id(&headers)?;
 
     // Skip body processing for GET, DELETE, or when T is ().
     if skips_encrypted_body::<T>(request.method()) {
@@ -91,7 +95,7 @@ where
         // Reject an unknown session before a handler can perform side effects.
         return forward_bodyless_request::<T, _, _, _, _>(
             async {
-                let session_lease = state.acquire_session(&session_id).await?;
+                let session_lease = state.acquire_request_session(&session_id).await?;
                 state.touch_session(&session_id).await?;
                 Ok(session_lease)
             },
@@ -112,7 +116,7 @@ where
 
     // Pin only after the request body has arrived. A slow or abandoned
     // upload therefore cannot retain a session indefinitely.
-    let session_lease = state.acquire_session(&session_id).await?;
+    let session_lease = state.acquire_request_session(&session_id).await?;
     let decrypted_data = state
         .decrypt_session_data(&session_id, &session_lease, &encrypted_request.encrypted)
         .await
@@ -206,13 +210,27 @@ mod tests {
         assert!(!skips_encrypted_body::<serde_json::Value>(&Method::POST));
     }
 
+    #[test]
+    fn missing_and_malformed_session_headers_are_generic_bad_requests() {
+        for headers in [HeaderMap::new(), {
+            let mut headers = HeaderMap::new();
+            headers.insert("x-session-id", HeaderValue::from_static("not-a-uuid"));
+            headers
+        }] {
+            let error = parse_session_id(&headers).unwrap_err();
+            let response = error.into_response();
+            assert_eq!(response.status(), axum::http::StatusCode::BAD_REQUEST);
+            assert!(response.headers().get(crate::ERROR_CODE_HEADER).is_none());
+        }
+    }
+
     #[tokio::test]
     async fn failed_session_check_never_calls_next() {
         let calls = Arc::new(AtomicUsize::new(0));
         let observed_calls = calls.clone();
 
         let result = forward_bodyless_request::<(), _, _, _, _>(
-            ready(Err::<(), ApiError>(ApiError::BadRequest)),
+            ready(Err::<(), ApiError>(ApiError::SessionNotFound)),
             Uuid::new_v4(),
             Request::builder()
                 .method(Method::POST)
@@ -232,6 +250,10 @@ mod tests {
         };
         let response = error.into_response();
         assert_eq!(response.status(), axum::http::StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response.headers().get(crate::ERROR_CODE_HEADER).unwrap(),
+            "session_not_found"
+        );
         let body = axum::body::to_bytes(response.into_body(), 1024)
             .await
             .unwrap();

--- a/src/web/openai_auth.rs
+++ b/src/web/openai_auth.rs
@@ -1,4 +1,4 @@
-use crate::jwt::{validate_token, AuthContext, USER_ACCESS};
+use crate::jwt::{validate_access_token_for_auth, AuthContext, USER_ACCESS};
 use crate::ApiError;
 use axum::{
     body::Body,
@@ -72,10 +72,11 @@ pub async fn validate_openai_auth(
         None => return ApiError::InvalidJwt.into_response(),
     };
 
-    let claims = match validate_token(&token, &data, USER_ACCESS) {
-        Ok(claims) => claims,
-        Err(_) => return ApiError::InvalidJwt.into_response(),
-    };
+    let (claims, access_token_expired) =
+        match validate_access_token_for_auth(&token, &data, USER_ACCESS) {
+            Ok(validation) => validation,
+            Err(_) => return ApiError::InvalidJwt.into_response(),
+        };
 
     let auth_context = match AuthContext::from_claims(&claims) {
         Ok(auth_context) => auth_context,
@@ -109,6 +110,10 @@ pub async fn validate_openai_auth(
             e
         );
         return ApiError::InvalidJwt.into_response();
+    }
+
+    if access_token_expired {
+        return ApiError::AccessTokenExpired.into_response();
     }
 
     req.extensions_mut().insert(auth_context);


### PR DESCRIPTION
## Summary

- Preserve the existing HTTP status codes and JSON error bodies.
- Add a versioned response-header contract so clients can distinguish two recoverable cases:
  - `400` + `session_not_found` for a valid session ID that no longer exists.
  - `401` + `access_token_expired` for a fully validated but expired access token.
- Leave malformed sessions, invalid JWTs, refresh-token expiry, provider errors, and other ordinary failures unclassified.
- Expose the new headers through CORS.

## Backward compatibility

The headers are additive: existing clients continue to receive the same `400 Bad Request` and `401 Invalid JWT` responses and can keep their current re-attestation and refresh behavior.

This branch is rebased on #282 and preserves its optional-auth `/v1/models` behavior. Both independent security invariants are retained.

## Testing

- `cargo test --locked --all-features` — 385 passed, 17 ignored
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- Live probes for recoverable, malformed, and generic error cases
- Unedited packaged Maple Chat and Agent smoke tests after restarting the upgraded server