### PR TITLE
ci: skip PCR comparison on pull requests

### DIFF
--- a/.agents/skills/review-opensecret-security/SKILL.md
+++ b/.agents/skills/review-opensecret-security/SKILL.md
@@ -123,10 +123,13 @@ Load `$validate-opensecret` and run the tiers reached by the diff. Report local,
 database, provider, client, build/artifact, and live evidence separately.
 
 Local artifact builds and read-only PCR comparison are validation when in
-scope. Require explicit authorization for PCR reference/history mutation,
-signing, KMS/IAM changes, shared or remote migrations, artifact transfer,
-enclave or remote-service lifecycle, secret writes, staging, deployment, or
-release actions. Inspect recipes before deciding whether they are read-only.
+scope. A green pull-request EIF build is not PCR evidence; GitHub Actions
+skips PCR comparison on pull requests and still verifies on master and
+`workflow_dispatch`. Require explicit authorization for PCR
+reference/history mutation, signing, KMS/IAM changes, shared or remote
+migrations, artifact transfer, enclave or remote-service lifecycle, secret
+writes, staging, deployment, or release actions. Inspect recipes before
+deciding whether they are read-only.
 
 ## Report the review
 

--- a/.agents/skills/validate-opensecret/SKILL.md
+++ b/.agents/skills/validate-opensecret/SKILL.md
@@ -161,11 +161,14 @@ nix build --no-link --no-write-lock-file .#default
 ```
 
 EIF construction, PCR comparison, and reference/history updates are
-release-only work. Ordinary development and pull-request completion do not run
-or block on the all-PR PCR comparison. If CI successfully builds an EIF and
-then fails only because compiled inputs changed its measurements, report
-deferred release work and do not copy or sign CI values to make it green. Treat
-an EIF build failure separately.
+release-only work. The Nix Reproducible Builds workflow builds the
+development EIF on pull requests but skips PCR comparison there. Master
+pushes and `workflow_dispatch` still compare against checked-in
+references. Ordinary pull-request completion does not update PCR
+references. If a master or release build succeeds and then fails only
+PCR comparison, treat that as deferred release work and do not copy or
+sign CI values just to make the job green. Treat an EIF build failure
+separately.
 
 Immediately before an authorized dev or prod publish/deployment, use the
 supported Linux/ARM64 release builder and the operator runbook in

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,9 +50,10 @@ jobs:
           nix build --no-update-lock-file .?submodules=1#eif-dev
           echo "Build completed successfully"
 
-      # Verify PCR values match the reference
+      # PCR comparison is a master/deployment gate, not a pull-request gate.
       - name: Verify dev PCR
         id: verify-dev
+        if: github.event_name != 'pull_request'
         run: |
           set -euo pipefail
           if [ ! -f "./pcrDev.json" ]; then
@@ -117,9 +118,10 @@ jobs:
           nix build --no-update-lock-file .?submodules=1#eif-prod
           echo "Build completed successfully"
 
-      # Verify PCR values match the reference
+      # PCR comparison is a master/deployment gate, not a pull-request gate.
       - name: Verify prod PCR
         id: verify-prod
+        if: github.event_name != 'pull_request'
         run: |
           set -euo pipefail
           if [ ! -f "./pcrProd.json" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,10 +137,11 @@ or skipped tests, configured external services, and every unverified layer.
 ## Operator authority
 
 EIF/PCR parity is a release and deployment gate, not an ordinary development
-or pull-request gate. If CI successfully builds an EIF and then fails only the
-PCR comparison after compiled inputs changed, record deferred release work;
-do not update references merely to make CI green. Treat an EIF build failure
-separately.
+or pull-request gate. GitHub Actions still builds the development EIF on
+pull requests, but skips PCR comparison there. Master pushes and
+`workflow_dispatch` still verify PCR values against the checked-in
+references. Do not update PCR references as part of ordinary pull-request
+work. Treat an EIF build failure separately from PCR mismatch.
 
 Before publishing or deploying an authorized dev or prod EIF, build it on the
 supported Linux/ARM64 release builder, intentionally review its measurements,

--- a/README.md
+++ b/README.md
@@ -85,10 +85,13 @@ The supported EIF outputs are `eif-dev`, `eif-preview`, and `eif-prod`, built
 with the repository's Nix flake on the appropriate Linux/ARM environment. Build,
 PCR comparison, deployment, and live trust verification are distinct evidence.
 
-Routine pull requests do not require EIF/PCR parity. Before an authorized dev
-or prod publish/deployment, use the supported Linux/ARM64 release builder to
-review and deliberately update/verify the target measurements; never update
-checked-in PCRs solely to clear ordinary pull-request CI.
+Routine pull requests do not require EIF/PCR parity. The Nix Reproducible
+Builds workflow still builds the development EIF on pull requests, but skips
+PCR comparison there. Master pushes and manual `workflow_dispatch` still
+verify PCR values against the checked-in references. Before an authorized
+dev or prod publish/deployment, use the supported Linux/ARM64 release
+builder to review and deliberately update/verify the target measurements;
+never update checked-in PCRs solely to clear ordinary pull-request CI.
 
 See [`docs/nitro-deploy.md`](docs/nitro-deploy.md) for operator procedures.
 Changing PCR references or KMS policy, copying artifacts, starting or stopping


### PR DESCRIPTION
## Summary
- Skip PCR verification in the Nix Reproducible Builds workflow on pull requests. Dev (and prod, if it ever runs on a PR) still build the EIF; PCR comparison remains on `master` pushes and `workflow_dispatch`.
- Ordinary PR work no longer needs a PCR file update. Those checks stay as a pre-deploy gate on master.
- Update README, AGENTS.md, and the validate/security skills so they describe the actual GitHub Actions behavior instead of the old "CI fails PCR on every PR" advice.

## Test plan
- [ ] Confirm this PR's Nix Reproducible Builds **dev** job still builds the EIF and **skips** "Verify dev PCR".
- [ ] Confirm the prod job still does not run on pull requests.
- [ ] After merge, confirm a `master` push still runs "Verify dev PCR" and "Verify prod PCR".