### PR TITLE
docs: point client guidance to Maple SDK

### DIFF
--- a/.agents/skills/change-opensecret-api/SKILL.md
+++ b/.agents/skills/change-opensecret-api/SKILL.md
@@ -85,11 +85,13 @@ at those points.
 
 ## Coordinate pinned consumers
 
-Resolve OpenSecret SDK and Maple checkouts independently. Search each available
-repository from its own root, without hiding errors, and follow its checked-in
-`AGENTS.md` and applicable skills when present. If a consumer checkout is
-unavailable, report compatibility as unverified rather than claiming there are
-no consumers.
+Resolve one current Maple checkout: the OpenSecret SDK source is under its
+`sdk/` directory, while the Maple application consumers remain under
+`frontend/`. Search from the Maple root without hiding errors and follow its
+checked-in `AGENTS.md` and applicable skills. If a Maple checkout or an affected
+consumer is unavailable, report compatibility as unverified rather than
+falling back to the retired standalone SDK repository or claiming there are no
+consumers.
 
 Maple's browser Research path uses Responses/Conversations through the
 TypeScript client, while native Agent Mode uses chat completions through the
@@ -97,12 +99,16 @@ Rust client. A semantic change intended for both is two protocol integrations,
 not one shared wire-field edit. Trace request construction, provider handoff,
 persistence, and usage in each affected path.
 
-Use the versions pinned by the selected Maple revision. Update SDK types,
-custom-fetch adaptation, native transport allowlists, call sites, mocks, and
-fixtures only where the contract reaches them. Test old-client/new-server and
-new-client/old-server behavior. Prefer server-first rollout for compatible
-additions; use an explicit capability/version gate when either direction cannot
-interoperate.
+Use the SDK source and application dependency resolutions recorded by the
+selected Maple revision. `frontend/package.json` is authoritative for whether
+the browser client consumes a published TypeScript version or the in-tree
+`file:../sdk` package. The native client continues to consume the published
+Rust crate pinned in `frontend/src-tauri/Cargo.toml` until the proxy and Rust
+consumers switch together. Update SDK types, custom-fetch adaptation, native
+transport allowlists, call sites, mocks, and fixtures only where the contract
+reaches them. Test old-client/new-server and new-client/old-server behavior.
+Prefer server-first rollout for compatible additions; use an explicit
+capability/version gate when either direction cannot interoperate.
 
 ## Validate the changed boundary
 

--- a/.agents/skills/develop-opensecret/SKILL.md
+++ b/.agents/skills/develop-opensecret/SKILL.md
@@ -65,8 +65,9 @@ Billing and feature flags are optional external HTTP API boundaries. Configure
 their URLs and backend-only credentials only when the task exercises their
 public outcomes; do not pull their server implementations into this setup.
 
-Plain `curl` is suitable for health probes, not protected-route proof. Use a
-pinned OpenSecret SDK or Maple for authenticated encrypted smoke tests.
+Plain `curl` is suitable for health probes, not protected-route proof. Use the
+SDK under a selected Maple checkout's `sdk/` directory or the corresponding
+pinned Maple application client for authenticated encrypted smoke tests.
 
 ## Follow ownership
 

--- a/.agents/skills/review-opensecret-security/SKILL.md
+++ b/.agents/skills/review-opensecret-security/SKILL.md
@@ -102,8 +102,12 @@ Apply these OpenSecret-specific invariants:
   Safe metadata is bounded and allowlisted.
 - A changed ciphertext format needs explicit versioning, compatibility,
   rollback, and access to the owning key; ordinary startup lacks user keys.
-- Shared protocol changes require coordinated testing of pinned SDKs and
-  affected Maple paths.
+- Shared protocol changes require coordinated review of the SDK source under a
+  selected Maple checkout's `sdk/` directory and the dependency actually
+  resolved by each affected Maple application path. Treat
+  `frontend/package.json` as authoritative for the TypeScript client; the Rust
+  client remains on its published crate until the coordinated proxy/Rust
+  switch.
 
 Use `$change-opensecret-api` or `$change-opensecret-provider` for the detailed
 contract procedure rather than duplicating it here.

--- a/.agents/skills/validate-opensecret/SKILL.md
+++ b/.agents/skills/validate-opensecret/SKILL.md
@@ -130,7 +130,8 @@ The first is process liveness; the second checks Tinfoil model connectivity.
 Neither proves PostgreSQL, auth, encryption, persistence, routing, billing,
 flags, or a user flow.
 
-Exercise protected routes through a pinned OpenSecret SDK or Maple:
+Exercise protected routes through the SDK under a selected Maple checkout's
+`sdk/` directory or through the corresponding pinned Maple application client:
 
 1. Start an isolated migrated backend with the authorized external services.
 2. Exercise the exact changed success and failure paths with route-appropriate
@@ -141,10 +142,14 @@ Exercise protected routes through a pinned OpenSecret SDK or Maple:
 5. Inspect bounded logs for accidental sensitive content.
 
 In the selected Maple revision, follow its checked-in `AGENTS.md` and matching
-validation skill when present. Otherwise derive commands from that revision's
-repository-native docs and build metadata. Test browser Research and native
-Agent paths independently when both consume the change. An unavailable client
-checkout leaves that layer unverified.
+SDK or application validation skill when present. Otherwise derive commands
+from that revision's repository-native docs and build metadata. Read
+`frontend/package.json` to determine whether the browser client consumes a
+published TypeScript version or the in-tree `file:../sdk` package. The native
+path remains on the Rust crate pinned in `frontend/src-tauri/Cargo.toml` until
+the coordinated proxy/Rust switch. Test browser Research and native Agent paths
+independently when both consume the change. An unavailable client checkout
+leaves that layer unverified.
 
 Configure billing or feature-flag API URLs/keys only when their public backend
 outcome is in scope. Treat them as external HTTP dependencies and test the


### PR DESCRIPTION
## Summary

- replace the obsolete independent OpenSecret-SDK checkout guidance with Maple/`sdk/`
- use `frontend/package.json` as the source of truth for published versus in-tree TypeScript consumption
- record that native Maple remains on the published Rust crate until the coordinated proxy/Rust switch
- align development, API-change, validation, and security-review guidance with those boundaries

Provider guidance was audited and remains accurate without changes. The wording is intentionally valid both before and after Maple PR #850 and does not stack on that branch.

## Validation

- all four changed skills passed `quick_validate.py`
- `git diff --check`