### PR TITLE
Graduate Kimi K3 and DeepSeek model rollouts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,10 +11,7 @@ use crate::encrypt::{
 };
 use crate::jwt::validate_platform_jwt;
 use crate::login_routes::RegisterCredentials;
-use crate::model_config::{
-    model_requires_feature_flag, ModelAliasTargets, ModelFeatureAccess, ModelPlan,
-    PaidModelAliasOverrides,
-};
+use crate::model_config::{ModelAliasTargets, ModelPlan, PaidModelAliasOverrides};
 use crate::models::account_deletion::{AccountDeletionError, NewAccountDeletionRequest};
 use crate::models::email_verification::{EmailVerificationError, NewEmailVerification};
 use crate::models::oauth::{NewUserOAuthConnection, OAuthError};
@@ -154,7 +151,6 @@ const BRAVE_API_KEY_NAME: &str = "brave_api_key";
 const KAGI_API_KEY_NAME: &str = "kagi_api_key";
 const OS_FLAGS_API_KEY_NAME: &str = "os_flags_api_key";
 const OS_FLAGS_BASE_URL_NAME: &str = "os_flags_base_url";
-const MODEL_ACCESS_FLAGS_TIMEOUT_SECS: u64 = 5;
 const MODEL_ALIAS_FLAGS_TIMEOUT_SECS: u64 = 5;
 const BILLING_ACCESS_TIMEOUT_SECS: u64 = 5;
 const MAX_ATTESTATION_NONCE_BYTES: usize = 512;
@@ -1203,56 +1199,6 @@ impl AppState {
                 None
             }
         }
-    }
-
-    /// Load all model-access flags as one snapshot so every model surface uses
-    /// the same os-flags cache key. Missing configuration, missing flags, and
-    /// control-plane failures all preserve the default-off behavior.
-    pub(crate) async fn model_feature_access(&self, user_uuid: Uuid) -> ModelFeatureAccess {
-        let Some(client) = &self.os_flags_client else {
-            trace!(
-                "os-flags client not configured; using default-off model access (user_uuid={})",
-                user_uuid
-            );
-            return ModelFeatureAccess::default();
-        };
-
-        match tokio::time::timeout(
-            Duration::from_secs(MODEL_ACCESS_FLAGS_TIMEOUT_SECS),
-            client.get_user_flags(user_uuid, Some(os_flags::MODEL_ACCESS_FLAG_KEYS)),
-        )
-        .await
-        {
-            Ok(Ok(response)) => ModelFeatureAccess::from_flag_values(&response.flags),
-            Ok(Err(e)) => {
-                warn!(
-                    "os-flags model access check failed (user_uuid={}): {}; using default-off model access",
-                    user_uuid, e
-                );
-                ModelFeatureAccess::default()
-            }
-            Err(_) => {
-                warn!(
-                    "os-flags model access check timed out after {}s (user_uuid={}); using default-off model access",
-                    MODEL_ACCESS_FLAGS_TIMEOUT_SECS, user_uuid
-                );
-                ModelFeatureAccess::default()
-            }
-        }
-    }
-
-    /// Avoid an os-flags lookup for models that cannot be model-access gated.
-    /// Gated requests use the same model-access snapshot as both model-list APIs.
-    pub(crate) async fn model_feature_access_for_request(
-        &self,
-        user_uuid: Uuid,
-        requested_model: &str,
-    ) -> ModelFeatureAccess {
-        if !model_requires_feature_flag(requested_model) {
-            return ModelFeatureAccess::default();
-        }
-
-        self.model_feature_access(user_uuid).await
     }
 
     /// Resolve the automatic model aliases for this user's plan. Paid alias

--- a/src/main.rs
+++ b/src/main.rs
@@ -1201,9 +1201,9 @@ impl AppState {
         }
     }
 
-    /// Resolve the automatic model aliases for this user's plan. Paid alias
-    /// overrides are batched and default off on missing configuration, missing
-    /// flags, service failures, or timeouts. Free plans never apply overrides.
+    /// Resolve the automatic model aliases for this user's plan. The paid alias
+    /// override defaults off on missing configuration, a missing flag, service
+    /// failure, or timeout. Free plans never apply the override.
     pub(crate) async fn model_alias_targets(
         &self,
         user_uuid: Uuid,

--- a/src/model_config.rs
+++ b/src/model_config.rs
@@ -1,9 +1,6 @@
 //! Central model-specific configuration and public model catalog.
 
-use crate::os_flags::{
-    KIMI_K3_MODEL_ACCESS_FLAG_KEY, PAID_POWERFUL_GLM_ALIAS_FLAG_KEY,
-    PAID_QUICK_DEEPSEEK_ALIAS_FLAG_KEY,
-};
+use crate::os_flags::{PAID_POWERFUL_GLM_ALIAS_FLAG_KEY, PAID_QUICK_DEEPSEEK_ALIAS_FLAG_KEY};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
@@ -56,7 +53,6 @@ struct ModelConfigEntry {
     listed: bool,
     api_listed: bool,
     enabled: bool,
-    required_feature_flag: Option<&'static str>,
     deprecated: bool,
     sort_order: u16,
     config: ModelConfig,
@@ -91,11 +87,6 @@ struct ModelCatalogMetadata {
     output_modalities: &'static [&'static str],
     parameter_size: Option<&'static str>,
     active_parameter_size: Option<&'static str>,
-}
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct ModelFeatureAccess {
-    kimi_k3: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -195,7 +186,6 @@ impl ModelConfigEntry {
             listed,
             api_listed: listed,
             enabled,
-            required_feature_flag: None,
             deprecated,
             sort_order,
             config: ModelConfig::new(context_window),
@@ -233,7 +223,6 @@ impl ModelConfigEntry {
             listed,
             api_listed: listed,
             enabled,
-            required_feature_flag: None,
             deprecated,
             sort_order,
             config: ModelConfig::with_responses(context_window, responses),
@@ -269,17 +258,11 @@ impl ModelConfigEntry {
             listed: false,
             api_listed: true,
             enabled,
-            required_feature_flag: None,
             deprecated,
             sort_order,
             config: ModelConfig::new(context_window),
             catalog_metadata: None,
         }
-    }
-
-    const fn requiring_feature_flag(mut self, flag_key: &'static str) -> Self {
-        self.required_feature_flag = Some(flag_key);
-        self
     }
 
     const fn with_catalog_provider(
@@ -372,35 +355,6 @@ impl ModelCatalogMetadata {
             parameter_size,
             active_parameter_size,
         }
-    }
-}
-
-impl ModelFeatureAccess {
-    pub(crate) const fn new(kimi_k3: bool) -> Self {
-        Self { kimi_k3 }
-    }
-
-    pub(crate) fn from_flag_values(flags: &HashMap<String, bool>) -> Self {
-        Self::new(
-            flags
-                .get(KIMI_K3_MODEL_ACCESS_FLAG_KEY)
-                .copied()
-                .unwrap_or(false),
-        )
-    }
-
-    fn flag_enabled(self, flag_key: &str) -> bool {
-        match flag_key {
-            KIMI_K3_MODEL_ACCESS_FLAG_KEY => self.kimi_k3,
-            _ => false,
-        }
-    }
-
-    pub(crate) fn allows_model(self, model: &str) -> bool {
-        let canonical = alias_target(model).unwrap_or(model);
-        model_entry(canonical)
-            .and_then(|entry| entry.required_feature_flag)
-            .is_none_or(|flag_key| self.flag_enabled(flag_key))
     }
 }
 
@@ -603,7 +557,6 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
         30,
         256_000,
     )
-    .requiring_feature_flag(KIMI_K3_MODEL_ACCESS_FLAG_KEY)
     .with_catalog_metadata(ModelCatalogMetadata::new(
         &["text", "image"],
         &["text"],
@@ -734,13 +687,6 @@ pub fn resolve_public_model_id(model: &str) -> Option<&'static str> {
         .map(|entry| entry.id)
 }
 
-pub(crate) fn model_requires_feature_flag(model: &str) -> bool {
-    let canonical = alias_target(model).unwrap_or(model);
-    model_entry(canonical)
-        .and_then(|entry| entry.required_feature_flag)
-        .is_some()
-}
-
 pub fn model_config(model: &str) -> ModelConfig {
     let canonical = alias_target(model).unwrap_or(model);
 
@@ -781,22 +727,14 @@ pub fn model_supports_reasoning_history(model: &str) -> bool {
     model_reasoning_history_strategy(model).is_some()
 }
 
-pub(crate) fn model_catalog_response(
-    access: ModelFeatureAccess,
-    alias_targets: ModelAliasTargets,
-) -> Value {
+pub(crate) fn model_catalog_response(alias_targets: ModelAliasTargets) -> Value {
     let data = MODEL_CONFIGS
         .iter()
-        .filter(|entry| entry.listed && access.allows_model(entry.id))
+        .filter(|entry| entry.listed)
         .map(|entry| entry.catalog_json())
         .collect::<Vec<_>>();
     let aliases = MODEL_ALIAS_ENTRIES
         .iter()
-        .filter(|entry| {
-            alias_targets
-                .target_for(entry.id)
-                .is_some_and(|target| access.allows_model(target))
-        })
         .map(|entry| entry.catalog_json(alias_targets))
         .collect::<Vec<_>>();
 
@@ -823,10 +761,10 @@ pub(crate) fn model_catalog_response(
     })
 }
 
-pub fn openai_models_response(access: ModelFeatureAccess) -> Value {
+pub fn openai_models_response() -> Value {
     let mut data = MODEL_CONFIGS
         .iter()
-        .filter(|entry| entry.api_listed && entry.enabled && access.allows_model(entry.id))
+        .filter(|entry| entry.api_listed && entry.enabled)
         .map(|entry| entry.openai_model_json())
         .collect::<Vec<_>>();
 
@@ -873,22 +811,6 @@ pub fn openai_models_response(access: ModelFeatureAccess) -> Value {
         "object": "list",
         "data": data,
     })
-}
-
-pub(crate) fn filter_model_list_response_for_access(
-    response: &mut Value,
-    access: ModelFeatureAccess,
-) {
-    let Some(data) = response.get_mut("data").and_then(Value::as_array_mut) else {
-        return;
-    };
-
-    data.retain(|model| {
-        model
-            .get("id")
-            .and_then(Value::as_str)
-            .is_none_or(|id| access.allows_model(id))
-    });
 }
 
 #[cfg(test)]
@@ -1135,7 +1057,7 @@ mod tests {
             ModelPlan::Paid,
             PaidModelAliasOverrides::from_flag_values(&flags),
         );
-        let catalog = model_catalog_response(ModelFeatureAccess::default(), targets);
+        let catalog = model_catalog_response(targets);
         let aliases = catalog["aliases"].as_array().expect("aliases");
         let quick = aliases
             .iter()
@@ -1185,8 +1107,7 @@ mod tests {
 
     #[test]
     fn test_catalog_hides_api_only_models_and_includes_aliases() {
-        let response =
-            model_catalog_response(ModelFeatureAccess::default(), ModelAliasTargets::default());
+        let response = model_catalog_response(ModelAliasTargets::default());
         let data = response["data"].as_array().expect("catalog data");
         assert!(data.iter().any(|model| model["id"] == QUICK_MODEL_ID));
         assert!(!data
@@ -1203,10 +1124,7 @@ mod tests {
             .any(|alias| alias["id"] == AUTO_POWERFUL_MODEL_ID));
 
         for plan in [ModelPlan::Free, ModelPlan::Paid] {
-            let catalog = model_catalog_response(
-                ModelFeatureAccess::default(),
-                ModelAliasTargets::for_plan(plan),
-            );
+            let catalog = model_catalog_response(ModelAliasTargets::for_plan(plan));
             let aliases = catalog["aliases"].as_array().expect("aliases");
             let quick = aliases
                 .iter()
@@ -1226,7 +1144,7 @@ mod tests {
 
     #[test]
     fn test_openai_models_includes_api_only_models() {
-        let response = openai_models_response(ModelFeatureAccess::default());
+        let response = openai_models_response();
         let data = response["data"].as_array().expect("models data");
 
         assert!(data
@@ -1239,8 +1157,7 @@ mod tests {
 
     #[test]
     fn test_catalog_advertises_voxtral_as_default_speech_model() {
-        let response =
-            model_catalog_response(ModelFeatureAccess::default(), ModelAliasTargets::default());
+        let response = model_catalog_response(ModelAliasTargets::default());
 
         assert_eq!(response["audio"]["speech"]["available"], true);
         assert_eq!(response["audio"]["speech"]["model"], "voxtral-tts");
@@ -1249,8 +1166,7 @@ mod tests {
 
     #[test]
     fn test_catalog_advertises_kimi_through_continuum() {
-        let catalog =
-            model_catalog_response(ModelFeatureAccess::default(), ModelAliasTargets::default());
+        let catalog = model_catalog_response(ModelAliasTargets::default());
         let kimi = catalog_model(&catalog, POWERFUL_MODEL_ID);
 
         assert_eq!(kimi["provider"], "continuum");
@@ -1262,28 +1178,21 @@ mod tests {
     }
 
     #[test]
-    fn test_kimi_visibility_is_default_off_and_deepseek_is_generally_available() {
-        for (access, kimi_visible) in [
-            (ModelFeatureAccess::default(), false),
-            (ModelFeatureAccess::new(true), true),
-        ] {
-            let catalog = model_catalog_response(access, ModelAliasTargets::default());
-            let openai_models = openai_models_response(access);
+    fn test_kimi_k3_and_deepseek_are_generally_listed() {
+        let catalog = model_catalog_response(ModelAliasTargets::default());
+        let openai_models = openai_models_response();
 
-            assert_eq!(has_model(&catalog, "kimi-k3"), kimi_visible);
-            assert!(has_model(&catalog, "deepseek-v4-flash"));
-            assert_eq!(has_model(&openai_models, "kimi-k3"), kimi_visible);
-            assert!(has_model(&openai_models, "deepseek-v4-flash"));
-            assert!(has_model(&catalog, QUICK_MODEL_ID));
-            assert!(has_model(&openai_models, QUICK_MODEL_ID));
+        for model in ["kimi-k3", "deepseek-v4-flash", QUICK_MODEL_ID] {
+            assert!(has_model(&catalog, model));
+            assert!(has_model(&openai_models, model));
         }
     }
 
     #[test]
-    fn test_enriched_catalog_has_only_verified_gated_model_metadata() {
-        let catalog =
-            model_catalog_response(ModelFeatureAccess::new(true), ModelAliasTargets::default());
+    fn test_enriched_catalog_has_verified_new_model_metadata() {
+        let catalog = model_catalog_response(ModelAliasTargets::default());
         let kimi = catalog_model(&catalog, "kimi-k3");
+        assert_eq!(kimi["access"], "pro");
         assert_eq!(kimi["provider_id"], "kimi-k3");
         assert_eq!(kimi["context_window"], 256_000);
         assert_eq!(kimi["input_modalities"], json!(["text", "image"]));
@@ -1296,6 +1205,7 @@ mod tests {
         assert_eq!(kimi["tasks"], json!(["generate", "vision"]));
 
         let deepseek = catalog_model(&catalog, "deepseek-v4-flash");
+        assert_eq!(deepseek["access"], "pro");
         assert_eq!(deepseek["provider_id"], "deepseek-v4-flash");
         assert_eq!(deepseek["context_window"], 800_000);
         assert_eq!(deepseek["input_modalities"], json!(["text"]));
@@ -1307,52 +1217,9 @@ mod tests {
         assert_eq!(deepseek["capabilities"]["tool_use"], true);
         assert_eq!(deepseek["tasks"], json!(["generate"]));
 
-        let minimal = openai_models_response(ModelFeatureAccess::new(true));
+        let minimal = openai_models_response();
         let minimal_kimi = catalog_model(&minimal, "kimi-k3");
         assert!(minimal_kimi.get("input_modalities").is_none());
         assert!(minimal_kimi.get("parameter_size").is_none());
-    }
-
-    #[test]
-    fn test_model_access_snapshot_defaults_missing_flags_off() {
-        let mut flags = HashMap::new();
-        let access = ModelFeatureAccess::from_flag_values(&flags);
-        assert!(!access.allows_model("kimi-k3"));
-        assert!(access.allows_model("deepseek-v4-flash"));
-        assert!(access.allows_model("gpt-oss-120b"));
-
-        flags.insert(KIMI_K3_MODEL_ACCESS_FLAG_KEY.to_string(), true);
-        let access = ModelFeatureAccess::from_flag_values(&flags);
-        assert!(access.allows_model("kimi-k3"));
-        assert!(access.allows_model("deepseek-v4-flash"));
-    }
-
-    #[test]
-    fn test_raw_model_list_filter_hides_only_denied_gated_models() {
-        let mut response = json!({
-            "object": "list",
-            "data": [
-                {"id": "kimi-k3"},
-                {"id": "deepseek-v4-flash"},
-                {"id": "provider-specific-model"},
-                {"object": "model"}
-            ]
-        });
-
-        filter_model_list_response_for_access(&mut response, ModelFeatureAccess::default());
-
-        assert!(!has_model(&response, "kimi-k3"));
-        assert!(has_model(&response, "deepseek-v4-flash"));
-        assert!(has_model(&response, "provider-specific-model"));
-        assert_eq!(response["data"].as_array().expect("data").len(), 3);
-    }
-
-    #[test]
-    fn test_model_feature_flag_requirements_are_exact() {
-        assert!(model_requires_feature_flag("kimi-k3"));
-        assert!(!model_requires_feature_flag("deepseek-v4-flash"));
-        assert!(!model_requires_feature_flag("kimi-k2-6"));
-        assert!(!model_requires_feature_flag("deepseek-v4-flash-0731"));
-        assert!(!model_requires_feature_flag("unknown-model"));
     }
 }

--- a/src/model_config.rs
+++ b/src/model_config.rs
@@ -1,6 +1,6 @@
 //! Central model-specific configuration and public model catalog.
 
-use crate::os_flags::PAID_POWERFUL_GLM_ALIAS_FLAG_KEY;
+use crate::os_flags::PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY;
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
@@ -105,7 +105,7 @@ pub(crate) struct ModelAliasTargets {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct PaidModelAliasOverrides {
-    powerful_glm: bool,
+    powerful_kimi_k3: bool,
 }
 
 pub const DEFAULT_CONTEXT_WINDOW: usize = 64_000;
@@ -115,6 +115,7 @@ pub const AUTO_QUICK_MODEL_ID: &str = "auto:quick";
 pub const AUTO_POWERFUL_MODEL_ID: &str = "auto:powerful";
 pub const QUICK_MODEL_ID: &str = "gpt-oss-120b";
 pub const POWERFUL_MODEL_ID: &str = "kimi-k2-6";
+pub const KIMI_K3_MODEL_ID: &str = "kimi-k3";
 pub const DEEPSEEK_V4_FLASH_MODEL_ID: &str = "deepseek-v4-flash";
 pub const GLM_5_2_MODEL_ID: &str = "glm-5-2";
 
@@ -406,8 +407,8 @@ impl ModelAliasTargets {
             ModelPlan::Free => FREE_MODEL_ALIAS_TARGETS,
             ModelPlan::Paid => Self {
                 quick: PAID_MODEL_ALIAS_TARGETS.quick,
-                powerful: if overrides.powerful_glm {
-                    GLM_5_2_MODEL_ID
+                powerful: if overrides.powerful_kimi_k3 {
+                    KIMI_K3_MODEL_ID
                 } else {
                     PAID_MODEL_ALIAS_TARGETS.powerful
                 },
@@ -435,8 +436,8 @@ impl ModelAliasTargets {
 impl PaidModelAliasOverrides {
     pub(crate) fn from_flag_values(flags: &HashMap<String, bool>) -> Self {
         Self {
-            powerful_glm: flags
-                .get(PAID_POWERFUL_GLM_ALIAS_FLAG_KEY)
+            powerful_kimi_k3: flags
+                .get(PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY)
                 .copied()
                 .unwrap_or(false),
         }
@@ -535,7 +536,7 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
         GEMMA4_RESPONSES_MODEL_CONFIG,
     ),
     ModelConfigEntry::new(
-        "kimi-k3",
+        KIMI_K3_MODEL_ID,
         "Kimi K3",
         "Kimi K3",
         "Multimodal reasoning and tool-use model.",
@@ -998,10 +999,10 @@ mod tests {
     }
 
     #[test]
-    fn test_paid_powerful_alias_override_is_plan_gated() {
+    fn test_paid_powerful_kimi_k3_alias_override_is_plan_gated_and_default_off() {
         for powerful_enabled in [false, true] {
             let flags = HashMap::from([(
-                PAID_POWERFUL_GLM_ALIAS_FLAG_KEY.to_string(),
+                PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY.to_string(),
                 powerful_enabled,
             )]);
             let overrides = PaidModelAliasOverrides::from_flag_values(&flags);
@@ -1018,7 +1019,7 @@ mod tests {
             assert_eq!(
                 paid.resolve(AUTO_POWERFUL_MODEL_ID),
                 if powerful_enabled {
-                    GLM_5_2_MODEL_ID
+                    KIMI_K3_MODEL_ID
                 } else {
                     POWERFUL_MODEL_ID
                 }
@@ -1029,11 +1030,19 @@ mod tests {
             PaidModelAliasOverrides::from_flag_values(&HashMap::new()),
             PaidModelAliasOverrides::default()
         );
+        assert_eq!(
+            PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY,
+            "model-alias.paid.powerful.kimi-k3"
+        );
+        assert_eq!(
+            crate::os_flags::PAID_MODEL_ALIAS_FLAG_KEYS,
+            &[PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY]
+        );
     }
 
     #[test]
     fn test_catalog_alias_metadata_tracks_paid_override_targets() {
-        let flags = HashMap::from([(PAID_POWERFUL_GLM_ALIAS_FLAG_KEY.to_string(), true)]);
+        let flags = HashMap::from([(PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY.to_string(), true)]);
         let targets = ModelAliasTargets::for_plan_with_overrides(
             ModelPlan::Paid,
             PaidModelAliasOverrides::from_flag_values(&flags),
@@ -1052,9 +1061,9 @@ mod tests {
         assert_eq!(quick["target_model"], DEEPSEEK_V4_FLASH_MODEL_ID);
         assert_eq!(quick["access"], "pro");
         assert_eq!(quick["capabilities"]["vision"], false);
-        assert_eq!(powerful["target_model"], GLM_5_2_MODEL_ID);
+        assert_eq!(powerful["target_model"], KIMI_K3_MODEL_ID);
         assert_eq!(powerful["access"], "pro");
-        assert_eq!(powerful["capabilities"]["vision"], false);
+        assert_eq!(powerful["capabilities"]["vision"], true);
     }
 
     #[test]

--- a/src/model_config.rs
+++ b/src/model_config.rs
@@ -527,7 +527,7 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
         "Starter-friendly reasoning and vision model.",
         ModelAccessTier::Starter,
         ModelCapabilities::chat(true, true),
-        &["New", "Reasoning"],
+        &["Reasoning"],
         true,
         true,
         false,
@@ -562,7 +562,7 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
         "Powerful model for deeper thinking and analysis.",
         ModelAccessTier::Pro,
         ModelCapabilities::chat(true, true),
-        &["New", "Reasoning"],
+        &["Reasoning"],
         true,
         true,
         false,
@@ -577,7 +577,7 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
         "Long-horizon pro reasoning model.",
         ModelAccessTier::Pro,
         ModelCapabilities::chat(true, false),
-        &["New", "Reasoning"],
+        &["Reasoning"],
         true,
         true,
         false,
@@ -824,6 +824,22 @@ mod tests {
             .iter()
             .find(|model| model["id"] == model_id)
             .expect("model in catalog")
+    }
+
+    fn model_ids_with_badge(response: &Value, badge: &str) -> Vec<String> {
+        let mut model_ids = response["data"]
+            .as_array()
+            .expect("model list data")
+            .iter()
+            .filter(|model| {
+                model["badges"]
+                    .as_array()
+                    .is_some_and(|badges| badges.iter().any(|value| value == badge))
+            })
+            .filter_map(|model| model["id"].as_str().map(str::to_owned))
+            .collect::<Vec<_>>();
+        model_ids.sort_unstable();
+        model_ids
     }
 
     #[test]
@@ -1197,6 +1213,23 @@ mod tests {
             assert!(has_model(&catalog, model));
             assert!(has_model(&openai_models, model));
         }
+    }
+
+    #[test]
+    fn test_only_kimi_k3_and_deepseek_have_new_badges() {
+        let expected = vec![
+            DEEPSEEK_V4_FLASH_MODEL_ID.to_string(),
+            KIMI_K3_MODEL_ID.to_string(),
+        ];
+
+        assert_eq!(
+            model_ids_with_badge(&model_catalog_response(ModelAliasTargets::default()), "New"),
+            expected
+        );
+        assert_eq!(
+            model_ids_with_badge(&openai_models_response(), "New"),
+            expected
+        );
     }
 
     #[test]

--- a/src/model_config.rs
+++ b/src/model_config.rs
@@ -1,6 +1,6 @@
 //! Central model-specific configuration and public model catalog.
 
-use crate::os_flags::{PAID_POWERFUL_GLM_ALIAS_FLAG_KEY, PAID_QUICK_DEEPSEEK_ALIAS_FLAG_KEY};
+use crate::os_flags::PAID_POWERFUL_GLM_ALIAS_FLAG_KEY;
 use serde_json::{json, Value};
 use std::collections::HashMap;
 
@@ -105,7 +105,6 @@ pub(crate) struct ModelAliasTargets {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct PaidModelAliasOverrides {
-    quick_deepseek: bool,
     powerful_glm: bool,
 }
 
@@ -125,7 +124,7 @@ const FREE_MODEL_ALIAS_TARGETS: ModelAliasTargets = ModelAliasTargets {
 };
 
 const PAID_MODEL_ALIAS_TARGETS: ModelAliasTargets = ModelAliasTargets {
-    quick: QUICK_MODEL_ID,
+    quick: DEEPSEEK_V4_FLASH_MODEL_ID,
     powerful: POWERFUL_MODEL_ID,
 };
 
@@ -406,11 +405,7 @@ impl ModelAliasTargets {
         match plan {
             ModelPlan::Free => FREE_MODEL_ALIAS_TARGETS,
             ModelPlan::Paid => Self {
-                quick: if overrides.quick_deepseek {
-                    DEEPSEEK_V4_FLASH_MODEL_ID
-                } else {
-                    PAID_MODEL_ALIAS_TARGETS.quick
-                },
+                quick: PAID_MODEL_ALIAS_TARGETS.quick,
                 powerful: if overrides.powerful_glm {
                     GLM_5_2_MODEL_ID
                 } else {
@@ -440,10 +435,6 @@ impl ModelAliasTargets {
 impl PaidModelAliasOverrides {
     pub(crate) fn from_flag_values(flags: &HashMap<String, bool>) -> Self {
         Self {
-            quick_deepseek: flags
-                .get(PAID_QUICK_DEEPSEEK_ALIAS_FLAG_KEY)
-                .copied()
-                .unwrap_or(false),
             powerful_glm: flags
                 .get(PAID_POWERFUL_GLM_ALIAS_FLAG_KEY)
                 .copied()
@@ -660,8 +651,8 @@ fn alias_target(model: &str) -> Option<&'static str> {
     ModelAliasTargets::default().target_for(model)
 }
 
-pub(crate) fn is_auto_model_alias(model: &str) -> bool {
-    matches!(model, AUTO_QUICK_MODEL_ID | AUTO_POWERFUL_MODEL_ID)
+pub(crate) fn model_alias_requires_flag_lookup(model: &str) -> bool {
+    model == AUTO_POWERFUL_MODEL_ID
 }
 
 fn model_entry(model: &str) -> Option<ModelConfigEntry> {
@@ -993,29 +984,26 @@ mod tests {
 
     #[test]
     fn test_model_alias_targets_are_selected_by_plan() {
-        for plan in [ModelPlan::Free, ModelPlan::Paid] {
-            let targets = ModelAliasTargets::for_plan(plan);
-            assert_eq!(targets.resolve(AUTO_QUICK_MODEL_ID), QUICK_MODEL_ID);
-            assert_eq!(targets.resolve(AUTO_POWERFUL_MODEL_ID), POWERFUL_MODEL_ID);
-            assert_eq!(targets.resolve("glm-5-2"), "glm-5-2");
-        }
+        let free = ModelAliasTargets::for_plan(ModelPlan::Free);
+        assert_eq!(free.resolve(AUTO_QUICK_MODEL_ID), QUICK_MODEL_ID);
+        assert_eq!(free.resolve(AUTO_POWERFUL_MODEL_ID), POWERFUL_MODEL_ID);
+
+        let paid = ModelAliasTargets::for_plan(ModelPlan::Paid);
+        assert_eq!(
+            paid.resolve(AUTO_QUICK_MODEL_ID),
+            DEEPSEEK_V4_FLASH_MODEL_ID
+        );
+        assert_eq!(paid.resolve(AUTO_POWERFUL_MODEL_ID), POWERFUL_MODEL_ID);
+        assert_eq!(paid.resolve("glm-5-2"), "glm-5-2");
     }
 
     #[test]
-    fn test_paid_model_alias_overrides_are_plan_gated_and_independent() {
-        for (quick_enabled, powerful_enabled) in
-            [(false, false), (true, false), (false, true), (true, true)]
-        {
-            let flags = HashMap::from([
-                (
-                    PAID_QUICK_DEEPSEEK_ALIAS_FLAG_KEY.to_string(),
-                    quick_enabled,
-                ),
-                (
-                    PAID_POWERFUL_GLM_ALIAS_FLAG_KEY.to_string(),
-                    powerful_enabled,
-                ),
-            ]);
+    fn test_paid_powerful_alias_override_is_plan_gated() {
+        for powerful_enabled in [false, true] {
+            let flags = HashMap::from([(
+                PAID_POWERFUL_GLM_ALIAS_FLAG_KEY.to_string(),
+                powerful_enabled,
+            )]);
             let overrides = PaidModelAliasOverrides::from_flag_values(&flags);
 
             let free = ModelAliasTargets::for_plan_with_overrides(ModelPlan::Free, overrides);
@@ -1025,11 +1013,7 @@ mod tests {
             let paid = ModelAliasTargets::for_plan_with_overrides(ModelPlan::Paid, overrides);
             assert_eq!(
                 paid.resolve(AUTO_QUICK_MODEL_ID),
-                if quick_enabled {
-                    DEEPSEEK_V4_FLASH_MODEL_ID
-                } else {
-                    QUICK_MODEL_ID
-                }
+                DEEPSEEK_V4_FLASH_MODEL_ID
             );
             assert_eq!(
                 paid.resolve(AUTO_POWERFUL_MODEL_ID),
@@ -1049,10 +1033,7 @@ mod tests {
 
     #[test]
     fn test_catalog_alias_metadata_tracks_paid_override_targets() {
-        let flags = HashMap::from([
-            (PAID_QUICK_DEEPSEEK_ALIAS_FLAG_KEY.to_string(), true),
-            (PAID_POWERFUL_GLM_ALIAS_FLAG_KEY.to_string(), true),
-        ]);
+        let flags = HashMap::from([(PAID_POWERFUL_GLM_ALIAS_FLAG_KEY.to_string(), true)]);
         let targets = ModelAliasTargets::for_plan_with_overrides(
             ModelPlan::Paid,
             PaidModelAliasOverrides::from_flag_values(&flags),
@@ -1123,7 +1104,10 @@ mod tests {
             .iter()
             .any(|alias| alias["id"] == AUTO_POWERFUL_MODEL_ID));
 
-        for plan in [ModelPlan::Free, ModelPlan::Paid] {
+        for (plan, expected_quick, expected_quick_access) in [
+            (ModelPlan::Free, QUICK_MODEL_ID, "free"),
+            (ModelPlan::Paid, DEEPSEEK_V4_FLASH_MODEL_ID, "pro"),
+        ] {
             let catalog = model_catalog_response(ModelAliasTargets::for_plan(plan));
             let aliases = catalog["aliases"].as_array().expect("aliases");
             let quick = aliases
@@ -1135,10 +1119,28 @@ mod tests {
                 .find(|alias| alias["id"] == AUTO_POWERFUL_MODEL_ID)
                 .expect("powerful alias");
 
-            assert_eq!(quick["target_model"], QUICK_MODEL_ID);
-            assert_eq!(quick["access"], "free");
+            assert_eq!(quick["target_model"], expected_quick);
+            assert_eq!(quick["access"], expected_quick_access);
             assert_eq!(powerful["target_model"], POWERFUL_MODEL_ID);
             assert_eq!(powerful["access"], "pro");
+        }
+    }
+
+    #[test]
+    fn test_only_powerful_alias_requires_flag_lookup() {
+        assert!(model_alias_requires_flag_lookup(AUTO_POWERFUL_MODEL_ID));
+        for model in [
+            AUTO_QUICK_MODEL_ID,
+            QUICK_MODEL_ID,
+            POWERFUL_MODEL_ID,
+            "kimi-k3",
+            DEEPSEEK_V4_FLASH_MODEL_ID,
+            GLM_5_2_MODEL_ID,
+        ] {
+            assert!(
+                !model_alias_requires_flag_lookup(model),
+                "direct/static model should not require flags: {model}"
+            );
         }
     }
 

--- a/src/os_flags.rs
+++ b/src/os_flags.rs
@@ -16,8 +16,8 @@ const USER_FLAGS_CACHE_TTL: Duration = Duration::from_secs(10 * 60);
 #[allow(dead_code)]
 pub const AGENT_FEATURE_FLAG_KEY: &str = "agent";
 pub const KAGI_WEB_SEARCH_FLAG_KEY: &str = "web-search.kagi";
-pub const PAID_POWERFUL_GLM_ALIAS_FLAG_KEY: &str = "model-alias.paid.powerful.glm-5-2";
-pub const PAID_MODEL_ALIAS_FLAG_KEYS: &[&str] = &[PAID_POWERFUL_GLM_ALIAS_FLAG_KEY];
+pub const PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY: &str = "model-alias.paid.powerful.kimi-k3";
+pub const PAID_MODEL_ALIAS_FLAG_KEYS: &[&str] = &[PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY];
 
 #[derive(Debug, thiserror::Error)]
 pub enum OsFlagsError {

--- a/src/os_flags.rs
+++ b/src/os_flags.rs
@@ -16,12 +16,8 @@ const USER_FLAGS_CACHE_TTL: Duration = Duration::from_secs(10 * 60);
 #[allow(dead_code)]
 pub const AGENT_FEATURE_FLAG_KEY: &str = "agent";
 pub const KAGI_WEB_SEARCH_FLAG_KEY: &str = "web-search.kagi";
-pub const PAID_QUICK_DEEPSEEK_ALIAS_FLAG_KEY: &str = "model-alias.paid.quick.deepseek-v4-flash";
 pub const PAID_POWERFUL_GLM_ALIAS_FLAG_KEY: &str = "model-alias.paid.powerful.glm-5-2";
-pub const PAID_MODEL_ALIAS_FLAG_KEYS: &[&str] = &[
-    PAID_QUICK_DEEPSEEK_ALIAS_FLAG_KEY,
-    PAID_POWERFUL_GLM_ALIAS_FLAG_KEY,
-];
+pub const PAID_MODEL_ALIAS_FLAG_KEYS: &[&str] = &[PAID_POWERFUL_GLM_ALIAS_FLAG_KEY];
 
 #[derive(Debug, thiserror::Error)]
 pub enum OsFlagsError {

--- a/src/os_flags.rs
+++ b/src/os_flags.rs
@@ -16,8 +16,6 @@ const USER_FLAGS_CACHE_TTL: Duration = Duration::from_secs(10 * 60);
 #[allow(dead_code)]
 pub const AGENT_FEATURE_FLAG_KEY: &str = "agent";
 pub const KAGI_WEB_SEARCH_FLAG_KEY: &str = "web-search.kagi";
-pub const KIMI_K3_MODEL_ACCESS_FLAG_KEY: &str = "model-access.kimi-k3";
-pub const MODEL_ACCESS_FLAG_KEYS: &[&str] = &[KIMI_K3_MODEL_ACCESS_FLAG_KEY];
 pub const PAID_QUICK_DEEPSEEK_ALIAS_FLAG_KEY: &str = "model-alias.paid.quick.deepseek-v4-flash";
 pub const PAID_POWERFUL_GLM_ALIAS_FLAG_KEY: &str = "model-alias.paid.powerful.glm-5-2";
 pub const PAID_MODEL_ALIAS_FLAG_KEYS: &[&str] = &[

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -1,6 +1,6 @@
 use crate::model_config::{
-    filter_model_list_response_for_access, is_auto_model_alias, model_catalog_response,
-    openai_models_response, ModelAliasTargets, ModelFeatureAccess, ModelPlan,
+    is_auto_model_alias, model_catalog_response, openai_models_response, ModelAliasTargets,
+    ModelPlan,
 };
 use crate::models::token_usage::NewTokenUsage;
 use crate::models::users::User;
@@ -825,21 +825,10 @@ async fn proxy_openai(
     // Create billing context
     let billing_context = BillingContext::new(auth_method, requested_model_name);
 
-    let model_access = state
-        .model_feature_access_for_request(user.uuid, &model_name)
-        .await;
-
     // Get the completion stream - billing happens automatically inside!
-    let completion = get_chat_completion_response(
-        &state,
-        &user,
-        body,
-        &headers,
-        billing_context,
-        model_access,
-        model_plan,
-    )
-    .await?;
+    let completion =
+        get_chat_completion_response(&state, &user, body, &headers, billing_context, model_plan)
+            .await?;
 
     debug!(
         "Received completion from provider: {} (streaming: {})",
@@ -917,7 +906,6 @@ pub async fn get_chat_completion_response(
     body: Value,
     headers: &HeaderMap,
     mut billing_context: BillingContext,
-    model_access: ModelFeatureAccess,
     model_plan: ModelPlan,
 ) -> Result<CompletionStream, ApiError> {
     if body.is_null() || body.as_object().is_none_or(|obj| obj.is_empty()) {
@@ -948,7 +936,7 @@ pub async fn get_chat_completion_response(
         })?
         .to_string();
 
-    ensure_completion_model_access(&requested_model_name, model_access, model_plan)?;
+    ensure_completion_model_access(&requested_model_name, model_plan)?;
 
     let selected_route = state
         .provider_router
@@ -1264,14 +1252,8 @@ pub async fn get_chat_completion_response(
 
 pub(crate) fn ensure_completion_model_access(
     model_name: &str,
-    model_access: ModelFeatureAccess,
     model_plan: ModelPlan,
 ) -> Result<(), ApiError> {
-    if !model_access.allows_model(model_name) {
-        error!("Unsupported completion model requested: {}", model_name);
-        return Err(ApiError::BadRequest);
-    }
-
     if !model_plan.allows_model(model_name) {
         error!(
             "Paid completion model requested without entitlement: {}",
@@ -1595,17 +1577,13 @@ async fn proxy_models(
     axum::Extension(session_id): axum::Extension<Uuid>,
     user: Option<axum::Extension<User>>,
 ) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
-    let model_access = match user {
-        Some(axum::Extension(user)) => state.model_feature_access(user.uuid).await,
-        None => ModelFeatureAccess::default(),
-    };
+    let _ = user;
     let proxy_config = state.proxy_router.get_completion_proxy();
-    let mut models_response = if proxy_config.provider_name == "tinfoil" {
-        openai_models_response(model_access)
+    let models_response = if proxy_config.provider_name == "tinfoil" {
+        openai_models_response()
     } else {
         fetch_provider_models(&state.provider_client, &proxy_config).await?
     };
-    filter_model_list_response_for_access(&mut models_response, model_access);
     encrypt_response(&state, &session_id, &models_response).await
 }
 
@@ -1663,15 +1641,12 @@ async fn proxy_model_catalog(
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(_body): axum::Extension<()>,
 ) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
-    let (model_access, billing_access) = tokio::join!(
-        state.model_feature_access(user.uuid),
-        state.chat_billing_access(user.uuid, false)
-    );
+    let billing_access = state.chat_billing_access(user.uuid, false).await;
     let model_plan = ModelPlan::from_is_paid(
         billing_access.is_some_and(crate::billing::ChatBillingAccess::is_paid),
     );
     let alias_targets = state.model_alias_targets(user.uuid, model_plan).await;
-    let catalog_response = model_catalog_response(model_access, alias_targets);
+    let catalog_response = model_catalog_response(alias_targets);
     encrypt_response(&state, &session_id, &catalog_response).await
 }
 
@@ -2466,111 +2441,33 @@ mod tests {
     use super::*;
 
     #[test]
-    fn completion_model_access_enforces_feature_and_plan_gates() {
+    fn completion_model_access_enforces_plan_gates() {
         assert!(matches!(
-            ensure_completion_model_access(
-                "kimi-k3",
-                ModelFeatureAccess::default(),
-                ModelPlan::Paid
-            ),
-            Err(ApiError::BadRequest)
-        ));
-        assert!(matches!(
-            ensure_completion_model_access(
-                "kimi-k3",
-                ModelFeatureAccess::new(true),
-                ModelPlan::Free
-            ),
+            ensure_completion_model_access("kimi-k3", ModelPlan::Free),
             Err(ApiError::ModelNotAvailableOnPlan)
         ));
-        assert!(ensure_completion_model_access(
-            "kimi-k3",
-            ModelFeatureAccess::new(true),
-            ModelPlan::Paid
-        )
-        .is_ok());
+        assert!(ensure_completion_model_access("kimi-k3", ModelPlan::Paid).is_ok());
         assert!(matches!(
-            ensure_completion_model_access(
-                "deepseek-v4-flash",
-                ModelFeatureAccess::default(),
-                ModelPlan::Free
-            ),
+            ensure_completion_model_access("deepseek-v4-flash", ModelPlan::Free),
             Err(ApiError::ModelNotAvailableOnPlan)
         ));
-        assert!(ensure_completion_model_access(
-            "deepseek-v4-flash",
-            ModelFeatureAccess::default(),
-            ModelPlan::Paid
-        )
-        .is_ok());
+        assert!(ensure_completion_model_access("deepseek-v4-flash", ModelPlan::Paid).is_ok());
         assert!(matches!(
-            ensure_completion_model_access(
-                "glm-5-2",
-                ModelFeatureAccess::default(),
-                ModelPlan::Free
-            ),
+            ensure_completion_model_access("glm-5-2", ModelPlan::Free),
             Err(ApiError::ModelNotAvailableOnPlan)
         ));
-        assert!(ensure_completion_model_access(
-            "glm-5-2",
-            ModelFeatureAccess::default(),
-            ModelPlan::Paid
-        )
-        .is_ok());
+        assert!(ensure_completion_model_access("glm-5-2", ModelPlan::Paid).is_ok());
         assert!(matches!(
             ensure_completion_model_access(
                 crate::model_config::AUTO_POWERFUL_MODEL_ID,
-                ModelFeatureAccess::default(),
                 ModelPlan::Free
             ),
             Err(ApiError::ModelNotAvailableOnPlan)
         ));
-        // The feature gate does not replace normal model validation. Ungated and
-        // unknown IDs continue to the existing provider-routing validation path.
-        assert!(ensure_completion_model_access(
-            "gpt-oss-120b",
-            ModelFeatureAccess::default(),
-            ModelPlan::Free
-        )
-        .is_ok());
-        assert!(ensure_completion_model_access(
-            "not-a-real-model",
-            ModelFeatureAccess::default(),
-            ModelPlan::Free
-        )
-        .is_ok());
-    }
-
-    #[test]
-    fn provider_model_response_filter_hides_only_gated_models() {
-        fn visible_ids(access: ModelFeatureAccess) -> Vec<String> {
-            let mut response = json!({
-                "object": "list",
-                "data": [
-                    {"id": "gpt-oss-120b", "object": "model"},
-                    {"id": "kimi-k3", "object": "model"},
-                    {"id": "deepseek-v4-flash", "object": "model"},
-                    {"object": "model"}
-                ]
-            });
-            filter_model_list_response_for_access(&mut response, access);
-            response["data"]
-                .as_array()
-                .unwrap()
-                .iter()
-                .filter_map(|model| model.get("id").and_then(Value::as_str))
-                .map(str::to_owned)
-                .collect()
-        }
-
-        assert_eq!(
-            visible_ids(ModelFeatureAccess::default()),
-            ["gpt-oss-120b", "deepseek-v4-flash"]
-        );
-        assert_eq!(
-            visible_ids(ModelFeatureAccess::new(true)),
-            ["gpt-oss-120b", "kimi-k3", "deepseek-v4-flash"]
-        );
+        // Plan access does not replace normal model validation. Unknown IDs
+        // continue to the existing provider-routing validation path.
+        assert!(ensure_completion_model_access("gpt-oss-120b", ModelPlan::Free).is_ok());
+        assert!(ensure_completion_model_access("not-a-real-model", ModelPlan::Free).is_ok());
     }
 
     fn tts_request(payload: Value) -> TTSRequest {

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -1,6 +1,6 @@
 use crate::model_config::{
-    is_auto_model_alias, model_catalog_response, openai_models_response, ModelAliasTargets,
-    ModelPlan,
+    model_alias_requires_flag_lookup, model_catalog_response, openai_models_response,
+    ModelAliasTargets, ModelPlan,
 };
 use crate::models::token_usage::NewTokenUsage;
 use crate::models::users::User;
@@ -806,7 +806,7 @@ async fn proxy_openai(
         })?
         .to_string();
 
-    let alias_targets = if is_auto_model_alias(&requested_model_name) {
+    let alias_targets = if model_alias_requires_flag_lookup(&requested_model_name) {
         state.model_alias_targets(user.uuid, model_plan).await
     } else {
         ModelAliasTargets::for_plan(model_plan)

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -8,8 +8,8 @@ use crate::{
     jwt::AuthContext,
     model_config::{
         is_auto_model_alias, model_config, model_reasoning_history_strategy,
-        resolve_public_model_id, ModelAliasTargets, ModelFeatureAccess, ModelPlan,
-        ReasoningHistoryStrategy, ResponsesModelConfig, SamplingConfig,
+        resolve_public_model_id, ModelAliasTargets, ModelPlan, ReasoningHistoryStrategy,
+        ResponsesModelConfig, SamplingConfig,
     },
     models::responses::{NewUserMessage, ResponseStatus, ResponsesError},
     models::users::User,
@@ -134,10 +134,9 @@ fn resolve_responses_sampling(body: &ResponsesCreateRequest) -> SamplingConfig {
 fn resolve_responses_model(
     requested_model: &str,
     completion_provider_name: &str,
-    model_access: ModelFeatureAccess,
     model_plan: ModelPlan,
 ) -> Result<String, ApiError> {
-    ensure_completion_model_access(requested_model, model_access, model_plan)?;
+    ensure_completion_model_access(requested_model, model_plan)?;
 
     match resolve_public_model_id(requested_model) {
         Some(model) => Ok(model.to_string()),
@@ -476,7 +475,7 @@ mod tests {
     };
     use crate::web::responses::tools::{self, WebSearchProvider};
     use crate::{
-        model_config::{ModelAliasTargets, ModelFeatureAccess, ModelPlan},
+        model_config::{ModelAliasTargets, ModelPlan},
         ApiError,
     };
     use chrono::{TimeZone, Utc};
@@ -645,85 +644,37 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_responses_models_enforces_feature_and_plan_gates() {
-        assert!(matches!(
-            resolve_responses_model(
-                "kimi-k3",
-                "tinfoil",
-                ModelFeatureAccess::default(),
-                ModelPlan::Paid
-            ),
-            Err(ApiError::BadRequest)
-        ));
+    fn test_resolve_responses_models_enforces_plan_gates() {
         assert_eq!(
-            resolve_responses_model(
-                "kimi-k3",
-                "tinfoil",
-                ModelFeatureAccess::new(true),
-                ModelPlan::Paid
-            )
-            .unwrap(),
+            resolve_responses_model("kimi-k3", "tinfoil", ModelPlan::Paid).unwrap(),
             "kimi-k3"
         );
         assert!(matches!(
-            resolve_responses_model(
-                "kimi-k3",
-                "tinfoil",
-                ModelFeatureAccess::new(true),
-                ModelPlan::Free
-            ),
+            resolve_responses_model("kimi-k3", "tinfoil", ModelPlan::Free),
             Err(ApiError::ModelNotAvailableOnPlan)
         ));
         assert!(matches!(
-            resolve_responses_model(
-                "glm-5-2",
-                "tinfoil",
-                ModelFeatureAccess::default(),
-                ModelPlan::Free
-            ),
+            resolve_responses_model("glm-5-2", "tinfoil", ModelPlan::Free),
             Err(ApiError::ModelNotAvailableOnPlan)
         ));
         assert_eq!(
-            resolve_responses_model(
-                "glm-5-2",
-                "tinfoil",
-                ModelFeatureAccess::default(),
-                ModelPlan::Paid
-            )
-            .unwrap(),
+            resolve_responses_model("glm-5-2", "tinfoil", ModelPlan::Paid).unwrap(),
             "glm-5-2"
         );
         assert!(matches!(
-            resolve_responses_model(
-                "deepseek-v4-flash",
-                "tinfoil",
-                ModelFeatureAccess::default(),
-                ModelPlan::Free
-            ),
+            resolve_responses_model("deepseek-v4-flash", "tinfoil", ModelPlan::Free),
             Err(ApiError::ModelNotAvailableOnPlan)
         ));
         assert_eq!(
-            resolve_responses_model(
-                "deepseek-v4-flash",
-                "tinfoil",
-                ModelFeatureAccess::default(),
-                ModelPlan::Paid
-            )
-            .unwrap(),
+            resolve_responses_model("deepseek-v4-flash", "tinfoil", ModelPlan::Paid).unwrap(),
             "deepseek-v4-flash"
         );
     }
 
     #[test]
-    fn test_resolve_responses_model_allows_ungated_model_by_default() {
+    fn test_resolve_responses_model_allows_free_model() {
         assert_eq!(
-            resolve_responses_model(
-                "llama3-3-70b",
-                "tinfoil",
-                ModelFeatureAccess::default(),
-                ModelPlan::Free
-            )
-            .unwrap(),
+            resolve_responses_model("llama3-3-70b", "tinfoil", ModelPlan::Free).unwrap(),
             "llama3-3-70b"
         );
     }
@@ -2151,7 +2102,6 @@ async fn spawn_title_generation_task(
             title_request,
             &headers,
             billing_context,
-            ModelFeatureAccess::default(),
             ModelPlan::Free,
         )
         .await
@@ -2841,7 +2791,6 @@ async fn stream_one_assistant_turn(
     state: &Arc<AppState>,
     user: &User,
     body: &ResponsesCreateRequest,
-    model_access: ModelFeatureAccess,
     model_plan: ModelPlan,
     headers: &HeaderMap,
     prompt_messages: &[Value],
@@ -2892,7 +2841,6 @@ async fn stream_one_assistant_turn(
         chat_request.take(),
         headers,
         billing_context,
-        model_access,
         model_plan,
     )
     .await?;
@@ -3150,7 +3098,6 @@ async fn setup_completion_processor(
     state: &Arc<AppState>,
     user: &User,
     body: &ResponsesCreateRequest,
-    model_access: ModelFeatureAccess,
     model_plan: ModelPlan,
     context: &BuiltContext,
     prepared: &PreparedRequest,
@@ -3174,7 +3121,6 @@ async fn setup_completion_processor(
                 state,
                 user,
                 body,
-                model_access,
                 model_plan,
                 headers,
                 &prompt_messages,
@@ -3313,13 +3259,9 @@ async fn create_response_stream(
     };
     let selected_model = alias_targets.resolve(&requested_model).to_string();
     let completion_provider = state.proxy_router.get_completion_proxy();
-    let model_access = state
-        .model_feature_access_for_request(user.uuid, &selected_model)
-        .await;
     let resolved_model = resolve_responses_model(
         &selected_model,
         &completion_provider.provider_name,
-        model_access,
         model_plan,
     )?;
     if requested_model != resolved_model {
@@ -3542,7 +3484,6 @@ async fn create_response_stream(
                         &orchestrator_state,
                         &orchestrator_user,
                         &orchestrator_body,
-                        model_access,
                         model_plan,
                         &context_for_completion,
                         &prepared_for_completion,

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -734,7 +734,7 @@ mod tests {
 
         let overrides =
             crate::model_config::PaidModelAliasOverrides::from_flag_values(&HashMap::from([(
-                crate::os_flags::PAID_POWERFUL_GLM_ALIAS_FLAG_KEY.to_string(),
+                crate::os_flags::PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY.to_string(),
                 true,
             )]));
         let targets = ModelAliasTargets::for_plan_with_overrides(ModelPlan::Paid, overrides);
@@ -761,14 +761,14 @@ mod tests {
         );
         assert_eq!(
             paid_powerful_request["model"],
-            crate::model_config::GLM_5_2_MODEL_ID
+            crate::model_config::KIMI_K3_MODEL_ID
         );
         assert_eq!(
-            paid_powerful_request["chat_template_kwargs"]["clear_thinking"],
-            false
+            paid_powerful_request["chat_template_kwargs"]["preserve_thinking"],
+            true
         );
         assert!(paid_powerful_request["chat_template_kwargs"]
-            .get("preserve_thinking")
+            .get("clear_thinking")
             .is_none());
     }
 

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -7,7 +7,7 @@ use crate::{
     encrypt::{decrypt_content, decrypt_string, encrypt_with_key},
     jwt::AuthContext,
     model_config::{
-        is_auto_model_alias, model_config, model_reasoning_history_strategy,
+        model_alias_requires_flag_lookup, model_config, model_reasoning_history_strategy,
         resolve_public_model_id, ModelAliasTargets, ModelPlan, ReasoningHistoryStrategy,
         ResponsesModelConfig, SamplingConfig,
     },
@@ -733,16 +733,10 @@ mod tests {
         );
 
         let overrides =
-            crate::model_config::PaidModelAliasOverrides::from_flag_values(&HashMap::from([
-                (
-                    crate::os_flags::PAID_QUICK_DEEPSEEK_ALIAS_FLAG_KEY.to_string(),
-                    true,
-                ),
-                (
-                    crate::os_flags::PAID_POWERFUL_GLM_ALIAS_FLAG_KEY.to_string(),
-                    true,
-                ),
-            ]));
+            crate::model_config::PaidModelAliasOverrides::from_flag_values(&HashMap::from([(
+                crate::os_flags::PAID_POWERFUL_GLM_ALIAS_FLAG_KEY.to_string(),
+                true,
+            )]));
         let targets = ModelAliasTargets::for_plan_with_overrides(ModelPlan::Paid, overrides);
         let paid_quick =
             responses_request_for_model(targets.resolve(crate::model_config::AUTO_QUICK_MODEL_ID));
@@ -3252,7 +3246,7 @@ async fn create_response_stream(
         );
         return Err(ApiError::Unauthorized);
     }
-    let alias_targets = if is_auto_model_alias(&requested_model) {
+    let alias_targets = if model_alias_requires_flag_lookup(&requested_model) {
         state.model_alias_targets(user.uuid, model_plan).await
     } else {
         ModelAliasTargets::for_plan(model_plan)


### PR DESCRIPTION
## Summary

- Make Kimi K3 generally visible as a locked Pro model and available to every paid user, removing its model-access flag and all flag-off paths.
- Make DeepSeek V4 Flash the unconditional paid Quick target while keeping Free Quick on GPT-OSS and removing the old paid Quick flag lookup.
- Replace the abandoned GLM 5.2 Powerful rollout with the default-off model-alias.paid.powerful.kimi-k3 flag. Paid Powerful remains Kimi K2.6 when missing/off and becomes K3 when on.
- Keep the New badge only on Kimi K3 and DeepSeek V4 Flash. Direct GLM selection remains supported. Agent Mode is unchanged.

## Behavior matrix

| Plan | K3 Powerful flag | Quick | Powerful | Direct K3 / DeepSeek |
| --- | --- | --- | --- | --- |
| Free | missing, off, or on | GPT-OSS | Kimi K2.6 target, plan-locked | 403 |
| Paid | missing or off | DeepSeek V4 Flash | Kimi K2.6 | allowed |
| Paid | on | DeepSeek V4 Flash | Kimi K3 | allowed |

## Validation

- cargo fmt --all -- --check
- RUSTFLAGS=-D warnings cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-features: 389 passed, 17 ignored
- Every commit independently compiled and passed its model-config suite: 20, 21, 21, and 22 tests
- Managed workspace smoke passed for OpenSecret, migrations, Continuum model listing, Tinfoil SDK model listing, billing, and os-flags
- Encrypted local Free/Pro matrix passed with the new flag missing, off, and on. It covered both model catalogs, exact New badges, alias targets, and Free Chat/Responses 403s.
- No successful paid completion was invoked; validation did not incur model inference traffic.

## Rollout notes

- Provision model-alias.paid.powerful.kimi-k3 as default-off before rollout.
- Keep the retired K3-access and DeepSeek-Quick flags enabled until older server instances have drained.
- Ensure model-alias.paid.powerful.glm-5-2 is off before a mixed-version rollout so older instances cannot continue selecting GLM, then archive the retired flags after the deployment is fully drained.