### PR TITLE
Add flag-controlled GLM provider routing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -131,7 +131,7 @@ mod aead_db_tamper_tests;
 use apple_signin::AppleJwtVerifier;
 use oauth::{AppleProvider, GithubProvider, GoogleProvider, OAuthManager};
 use provider_client::{ProviderClient, ProviderRequestError};
-use provider_routing::ProviderRouter;
+use provider_routing::{ProviderName, ProviderPreference, ProviderRouter};
 use proxy_config::ProxyRouter;
 
 const ENCLAVE_KEY_NAME: &str = "enclave_key";
@@ -152,6 +152,7 @@ const KAGI_API_KEY_NAME: &str = "kagi_api_key";
 const OS_FLAGS_API_KEY_NAME: &str = "os_flags_api_key";
 const OS_FLAGS_BASE_URL_NAME: &str = "os_flags_base_url";
 const MODEL_ALIAS_FLAGS_TIMEOUT_SECS: u64 = 5;
+const PROVIDER_ROUTING_FLAGS_TIMEOUT_SECS: u64 = 5;
 const BILLING_ACCESS_TIMEOUT_SECS: u64 = 5;
 const MAX_ATTESTATION_NONCE_BYTES: usize = 512;
 const MAX_PENDING_ATTESTATIONS: usize = 65_536;
@@ -1157,6 +1158,58 @@ impl AppState {
                     user_uuid, flag_key, e
                 );
                 false
+            }
+        }
+    }
+
+    /// Resolve an explicit provider preference only for models configured for
+    /// flag-controlled routing. Missing configuration, flags, failures, and
+    /// timeouts retain the model's default provider.
+    pub(crate) async fn provider_routing_preference(
+        &self,
+        user_uuid: Uuid,
+        requested_model: &str,
+    ) -> Option<ProviderPreference> {
+        let flag_key = self
+            .provider_router
+            .continuum_flag_key_for_completion_model(requested_model)?;
+
+        let Some(client) = &self.os_flags_client else {
+            trace!(
+                "os-flags client not configured; using default provider routing for model {}",
+                requested_model
+            );
+            return None;
+        };
+
+        match tokio::time::timeout(
+            Duration::from_secs(PROVIDER_ROUTING_FLAGS_TIMEOUT_SECS),
+            client.get_bool_flag(user_uuid, flag_key),
+        )
+        .await
+        {
+            Ok(Ok(Some(true))) => Some(ProviderPreference::feature_flag(ProviderName::Continuum)),
+            Ok(Ok(Some(false))) => Some(ProviderPreference::feature_flag(ProviderName::Tinfoil)),
+            Ok(Ok(None)) => {
+                debug!(
+                    "os-flags provider routing flag missing (user_uuid={}, requested_model={}, flag_key={}); using default provider routing",
+                    user_uuid, requested_model, flag_key
+                );
+                None
+            }
+            Ok(Err(e)) => {
+                warn!(
+                    "os-flags provider routing check failed (user_uuid={}, requested_model={}, flag_key={}): {}; using default provider routing",
+                    user_uuid, requested_model, flag_key, e
+                );
+                None
+            }
+            Err(_) => {
+                warn!(
+                    "os-flags provider routing check timed out after {}s (user_uuid={}, requested_model={}, flag_key={}); using default provider routing",
+                    PROVIDER_ROUTING_FLAGS_TIMEOUT_SECS, user_uuid, requested_model, flag_key
+                );
+                None
             }
         }
     }

--- a/src/os_flags.rs
+++ b/src/os_flags.rs
@@ -15,6 +15,7 @@ const USER_FLAGS_CACHE_TTL: Duration = Duration::from_secs(10 * 60);
 // externally configured identifiers.
 #[allow(dead_code)]
 pub const AGENT_FEATURE_FLAG_KEY: &str = "agent";
+pub const GLM_5_2_CONTINUUM_FLAG_KEY: &str = "provider-routing.glm-5-2.continuum";
 pub const KAGI_WEB_SEARCH_FLAG_KEY: &str = "web-search.kagi";
 pub const PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY: &str = "model-alias.paid.powerful.kimi-k3";
 pub const PAID_MODEL_ALIAS_FLAG_KEYS: &[&str] = &[PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY];

--- a/src/provider_routing.rs
+++ b/src/provider_routing.rs
@@ -1,4 +1,5 @@
-use crate::model_config::{resolve_completion_model_id, resolve_public_model_id};
+use crate::model_config::{resolve_completion_model_id, resolve_public_model_id, GLM_5_2_MODEL_ID};
+use crate::os_flags::GLM_5_2_CONTINUUM_FLAG_KEY;
 use crate::proxy_config::{canonicalize_tinfoil_model, ProxyConfig, ProxyRouter};
 use uuid::Uuid;
 
@@ -20,8 +21,31 @@ impl ProviderName {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ProviderSelectionSource {
     StaticSplit,
+    FeatureFlag,
     DefaultProvider,
     Fallback,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProviderPreference {
+    provider: ProviderName,
+    source: ProviderSelectionSource,
+}
+
+impl ProviderPreference {
+    pub(crate) const fn feature_flag(provider: ProviderName) -> Self {
+        Self {
+            provider,
+            source: ProviderSelectionSource::FeatureFlag,
+        }
+    }
+
+    const fn default_provider(provider: ProviderName) -> Self {
+        Self {
+            provider,
+            source: ProviderSelectionSource::DefaultProvider,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -43,6 +67,7 @@ struct ModelProviderRoute {
 struct ModelRoutingConfig {
     public_model_id: &'static str,
     routes: &'static [ModelProviderRoute],
+    continuum_flag_key: Option<&'static str>,
     default_provider: Option<ProviderName>,
 }
 
@@ -101,11 +126,35 @@ const KIMI_K2_6_ROUTES: &[ModelProviderRoute] = &[ModelProviderRoute {
     enabled: true,
 }];
 
-const MODEL_ROUTES: &[ModelRoutingConfig] = &[ModelRoutingConfig {
-    public_model_id: "kimi-k2-6",
-    routes: KIMI_K2_6_ROUTES,
-    default_provider: Some(ProviderName::Continuum),
-}];
+const GLM_5_2_ROUTES: &[ModelProviderRoute] = &[
+    ModelProviderRoute {
+        provider: ProviderName::Tinfoil,
+        provider_model_id: GLM_5_2_MODEL_ID,
+        weight: 100,
+        enabled: true,
+    },
+    ModelProviderRoute {
+        provider: ProviderName::Continuum,
+        provider_model_id: "glm-5.2",
+        weight: 100,
+        enabled: true,
+    },
+];
+
+const MODEL_ROUTES: &[ModelRoutingConfig] = &[
+    ModelRoutingConfig {
+        public_model_id: "kimi-k2-6",
+        routes: KIMI_K2_6_ROUTES,
+        continuum_flag_key: None,
+        default_provider: Some(ProviderName::Continuum),
+    },
+    ModelRoutingConfig {
+        public_model_id: GLM_5_2_MODEL_ID,
+        routes: GLM_5_2_ROUTES,
+        continuum_flag_key: Some(GLM_5_2_CONTINUUM_FLAG_KEY),
+        default_provider: Some(ProviderName::Tinfoil),
+    },
+];
 
 static DEFAULT_PROVIDER_ROUTING_CONFIG: ProviderRoutingConfig = ProviderRoutingConfig {
     providers: PROVIDERS,
@@ -121,19 +170,48 @@ impl Default for ProviderRouter {
 }
 
 impl ProviderRouter {
+    #[cfg(test)]
     pub(crate) fn select_completion_route(
         &self,
         proxy_router: &ProxyRouter,
         account_uuid: Uuid,
         requested_model: &str,
     ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
+        self.select_completion_route_with_preference(
+            proxy_router,
+            account_uuid,
+            requested_model,
+            None,
+        )
+    }
+
+    pub(crate) fn select_completion_route_with_preference(
+        &self,
+        proxy_router: &ProxyRouter,
+        account_uuid: Uuid,
+        requested_model: &str,
+        provider_preference: Option<ProviderPreference>,
+    ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
         if let Some(public_model_id) = resolve_public_model_id(requested_model) {
             if let Some(model_config) = self.model_config(public_model_id) {
-                return self.select_configured_route(proxy_router, account_uuid, model_config);
+                return self.select_configured_route(
+                    proxy_router,
+                    account_uuid,
+                    model_config,
+                    provider_preference,
+                );
             }
         }
 
         self.fallback_completion_route(proxy_router, requested_model)
+    }
+
+    pub(crate) fn continuum_flag_key_for_completion_model(
+        &self,
+        requested_model: &str,
+    ) -> Option<&'static str> {
+        let public_model_id = resolve_public_model_id(requested_model)?;
+        self.model_config(public_model_id)?.continuum_flag_key
     }
 
     fn select_configured_route(
@@ -141,6 +219,7 @@ impl ProviderRouter {
         proxy_router: &ProxyRouter,
         account_uuid: Uuid,
         model_config: &ModelRoutingConfig,
+        provider_preference: Option<ProviderPreference>,
     ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
         let mut eligible_routes = Vec::new();
 
@@ -174,14 +253,34 @@ impl ProviderRouter {
             ));
         }
 
-        let preferred_route = model_config.default_provider.and_then(|provider| {
+        let default_preference = model_config
+            .default_provider
+            .map(ProviderPreference::default_provider);
+
+        let provider_preference_route = provider_preference.and_then(|preference| {
             eligible_routes
                 .iter()
-                .find(|route| route.provider == provider)
+                .find(|route| route.provider == preference.provider)
+                .map(|route| (route, preference.source))
+        });
+        let default_preference_route = default_preference.and_then(|preference| {
+            eligible_routes
+                .iter()
+                .find(|route| route.provider == preference.provider)
+                .map(|route| {
+                    let source = if provider_preference.is_some() {
+                        ProviderSelectionSource::Fallback
+                    } else {
+                        preference.source
+                    };
+                    (route, source)
+                })
         });
 
-        let (selected, bucket, selection_source) = if let Some(route) = preferred_route {
-            (route, None, ProviderSelectionSource::DefaultProvider)
+        let preferred_route = provider_preference_route.or(default_preference_route);
+
+        let (selected, bucket, selection_source) = if let Some((route, source)) = preferred_route {
+            (route, None, source)
         } else {
             let selected =
                 select_weighted_route(account_uuid, &eligible_routes).ok_or_else(|| {
@@ -190,7 +289,7 @@ impl ProviderRouter {
             (
                 selected.route,
                 Some(selected.bucket),
-                if model_config.default_provider.is_some() {
+                if provider_preference.is_some() || default_preference.is_some() {
                     ProviderSelectionSource::Fallback
                 } else {
                     ProviderSelectionSource::StaticSplit
@@ -336,6 +435,118 @@ mod tests {
         assert_eq!(stable_account_bucket(uuid_for_bucket(49)), 49);
         assert_eq!(stable_account_bucket(uuid_for_bucket(50)), 50);
         assert_eq!(stable_account_bucket(uuid_for_bucket(99)), 99);
+    }
+
+    #[test]
+    fn test_glm_defaults_to_tinfoil_without_feature_flag_preference() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+
+        for bucket in [0, 29, 30, 69, 70, 99] {
+            let selected = router
+                .select_completion_route(&proxy_router, uuid_for_bucket(bucket), GLM_5_2_MODEL_ID)
+                .expect("route");
+
+            assert_eq!(selected.proxy.provider_name, "tinfoil");
+            assert_eq!(selected.public_model_id, GLM_5_2_MODEL_ID);
+            assert_eq!(selected.provider_model_id, GLM_5_2_MODEL_ID);
+            assert_eq!(selected.response_model_id, GLM_5_2_MODEL_ID);
+            assert_eq!(selected.bucket, None);
+            assert_eq!(
+                selected.selection_source,
+                ProviderSelectionSource::DefaultProvider
+            );
+        }
+    }
+
+    #[test]
+    fn test_glm_routing_flag_key_does_not_apply_to_kimi_or_other_models() {
+        let router = ProviderRouter::default();
+
+        assert_eq!(
+            router.continuum_flag_key_for_completion_model(GLM_5_2_MODEL_ID),
+            Some(GLM_5_2_CONTINUUM_FLAG_KEY)
+        );
+        assert_eq!(
+            router.continuum_flag_key_for_completion_model("kimi-k2-6"),
+            None
+        );
+        assert_eq!(
+            router.continuum_flag_key_for_completion_model("gpt-oss-120b"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_glm_true_feature_flag_selects_continuum_model_id() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+
+        let selected = router
+            .select_completion_route_with_preference(
+                &proxy_router,
+                uuid_for_bucket(1),
+                GLM_5_2_MODEL_ID,
+                Some(ProviderPreference::feature_flag(ProviderName::Continuum)),
+            )
+            .expect("route");
+
+        assert_eq!(selected.proxy.provider_name, "continuum");
+        assert_eq!(selected.public_model_id, GLM_5_2_MODEL_ID);
+        assert_eq!(selected.provider_model_id, "glm-5.2");
+        assert_eq!(selected.response_model_id, GLM_5_2_MODEL_ID);
+        assert_eq!(selected.bucket, None);
+        assert_eq!(
+            selected.selection_source,
+            ProviderSelectionSource::FeatureFlag
+        );
+    }
+
+    #[test]
+    fn test_glm_false_feature_flag_selects_tinfoil_model_id() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+
+        let selected = router
+            .select_completion_route_with_preference(
+                &proxy_router,
+                uuid_for_bucket(99),
+                GLM_5_2_MODEL_ID,
+                Some(ProviderPreference::feature_flag(ProviderName::Tinfoil)),
+            )
+            .expect("route");
+
+        assert_eq!(selected.proxy.provider_name, "tinfoil");
+        assert_eq!(selected.provider_model_id, GLM_5_2_MODEL_ID);
+        assert_eq!(selected.bucket, None);
+        assert_eq!(
+            selected.selection_source,
+            ProviderSelectionSource::FeatureFlag
+        );
+    }
+
+    #[test]
+    fn test_glm_continuum_preference_falls_back_to_tinfoil_when_unavailable() {
+        let router = ProviderRouter::default();
+        let tinfoil_only = ProxyRouter::new(
+            "https://api.openai.com".to_string(),
+            None,
+            "http://tinfoil.example.com".to_string(),
+        );
+
+        let selected = router
+            .select_completion_route_with_preference(
+                &tinfoil_only,
+                uuid_for_bucket(70),
+                GLM_5_2_MODEL_ID,
+                Some(ProviderPreference::feature_flag(ProviderName::Continuum)),
+            )
+            .expect("route");
+
+        assert_eq!(selected.proxy.provider_name, "tinfoil");
+        assert_eq!(selected.provider_model_id, GLM_5_2_MODEL_ID);
+        assert_eq!(selected.bucket, None);
+        assert_eq!(selected.selection_source, ProviderSelectionSource::Fallback);
     }
 
     #[test]

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -938,9 +938,17 @@ pub async fn get_chat_completion_response(
 
     ensure_completion_model_access(&requested_model_name, model_plan)?;
 
+    let provider_preference = state
+        .provider_routing_preference(user.uuid, &requested_model_name)
+        .await;
     let selected_route = state
         .provider_router
-        .select_completion_route(&state.proxy_router, user.uuid, &requested_model_name)
+        .select_completion_route_with_preference(
+            &state.proxy_router,
+            user.uuid,
+            &requested_model_name,
+            provider_preference,
+        )
         .map_err(|err| match err {
             ProviderRoutingError::UnsupportedModel(model) => {
                 error!("Unsupported completion model requested: {}", model);


### PR DESCRIPTION
## Summary

- restore the proven os-flags provider preference path for GLM 5.2
- keep Tinfoil as the default using upstream model ID `glm-5-2`
- route flag-enabled users to PrivateMode/Continuum using upstream model ID `glm-5.2`
- leave Kimi K2.6 Continuum-only and all other model routing unchanged

## Rollout behavior

The flag key is `provider-routing.glm-5-2.continuum`.

- `true`: route GLM 5.2 to PrivateMode/Continuum
- `false`: route GLM 5.2 to Tinfoil
- missing flag, missing os-flags configuration, lookup failure, or 5-second timeout: use the Tinfoil default
- unavailable Continuum configuration: fall back to the eligible Tinfoil route

This preserves os-flags sticky percentage rollout behavior, including manually moving from 0% to 100% Continuum. It does not add automatic request retries or failover after a provider call starts.

## Billing and API compatibility

- the public and billing model ID remains `glm-5-2`
- provider usage attribution records the provider that actually served the request
- customer-visible pricing and credits are unchanged
- no new credentials or public API surface are introduced

## Validation

- `cargo fmt --all -- --check`
- `env RUSTFLAGS=-D warnings cargo clippy --locked --all-targets --all-features -- -D warnings`
- `env RUSTFLAGS=-D warnings cargo test --locked --all-features` (394 passed, 17 ignored)
- focused provider routing suite (16 passed)

Live provider inference was not run; the PrivateMode upstream ID was verified from its current public deployment source.