### PR TITLE
[routing v2 1/8] Add request-scoped Router v2 rollout gate

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,7 @@ mod aead_db_tamper_tests;
 use apple_signin::AppleJwtVerifier;
 use oauth::{AppleProvider, GithubProvider, GoogleProvider, OAuthManager};
 use provider_client::{ProviderClient, ProviderRequestError};
-use provider_routing::{ProviderPreference, ProviderRouter};
+use provider_routing::{InferenceRoutingMode, ProviderPreference, ProviderRouter};
 use proxy_config::ProxyRouter;
 
 const ENCLAVE_KEY_NAME: &str = "enclave_key";
@@ -155,6 +155,7 @@ const OS_FLAGS_API_KEY_NAME: &str = "os_flags_api_key";
 const OS_FLAGS_BASE_URL_NAME: &str = "os_flags_base_url";
 const MODEL_ALIAS_FLAGS_TIMEOUT_SECS: u64 = 5;
 const PROVIDER_ROUTING_FLAGS_TIMEOUT_SECS: u64 = 5;
+const ROUTING_FLAGS_FAILURE_BACKOFF_SECS: u64 = 30;
 const BILLING_ACCESS_TIMEOUT_SECS: u64 = 5;
 const MAX_ATTESTATION_NONCE_BYTES: usize = 512;
 const MAX_PENDING_ATTESTATIONS: usize = 65_536;
@@ -792,9 +793,66 @@ pub struct AppState {
     sqs_publisher: Option<Arc<SqsEventPublisher>>,
     billing_client: Option<BillingClient>,
     os_flags_client: Option<os_flags::OsFlagsClient>,
+    router_v2_flag_failure_backoff: RoutingFlagsFailureBackoff,
     apple_jwt_verifier: Arc<AppleJwtVerifier>,
     response_executions: web::responses::ResponseExecutionRegistry,
     kagi_client: Option<Arc<crate::kagi::KagiClient>>,
+}
+
+#[derive(Clone, Debug)]
+struct RoutingFlagsFailureBackoff {
+    unavailable_until: Arc<RwLock<Option<tokio::time::Instant>>>,
+    duration: Duration,
+}
+
+impl Default for RoutingFlagsFailureBackoff {
+    fn default() -> Self {
+        Self {
+            unavailable_until: Arc::new(RwLock::new(None)),
+            duration: Duration::from_secs(ROUTING_FLAGS_FAILURE_BACKOFF_SECS),
+        }
+    }
+}
+
+impl RoutingFlagsFailureBackoff {
+    async fn is_active(&self) -> bool {
+        self.unavailable_until
+            .read()
+            .await
+            .is_some_and(|deadline| deadline > tokio::time::Instant::now())
+    }
+
+    async fn record_failure(&self) {
+        *self.unavailable_until.write().await = Some(tokio::time::Instant::now() + self.duration);
+    }
+
+    async fn record_success(&self) {
+        *self.unavailable_until.write().await = None;
+    }
+}
+
+#[cfg(test)]
+mod routing_flags_failure_backoff_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn failure_backoff_opens_closes_and_expires() {
+        let backoff = RoutingFlagsFailureBackoff {
+            unavailable_until: Arc::new(RwLock::new(None)),
+            duration: Duration::from_millis(1),
+        };
+
+        assert!(!backoff.is_active().await);
+        backoff.record_failure().await;
+        assert!(backoff.is_active().await);
+
+        backoff.record_success().await;
+        assert!(!backoff.is_active().await);
+
+        backoff.record_failure().await;
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        assert!(!backoff.is_active().await);
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1133,6 +1191,7 @@ impl AppStateBuilder {
             sqs_publisher,
             billing_client,
             os_flags_client,
+            router_v2_flag_failure_backoff: RoutingFlagsFailureBackoff::default(),
             apple_jwt_verifier,
             response_executions: web::responses::ResponseExecutionRegistry::default(),
             kagi_client,
@@ -1208,6 +1267,76 @@ impl AppState {
         ModelAliasTargets::for_plan_with_overrides(model_plan, overrides)
     }
 
+    /// Resolve the inference router exactly once for an authenticated external
+    /// request. Router v2 is opt-in: absent configuration, a missing or false
+    /// flag, service failure, and timeout all retain the legacy router.
+    pub(crate) async fn inference_routing_mode(&self, user_uuid: Uuid) -> InferenceRoutingMode {
+        let flag_key = os_flags::INFERENCE_ROUTER_V2_FLAG_KEY;
+        let Some(client) = &self.os_flags_client else {
+            trace!(
+                user_uuid = %user_uuid,
+                flag_key,
+                "os-flags client not configured; retaining legacy inference router"
+            );
+            return InferenceRoutingMode::Legacy;
+        };
+        if self.router_v2_flag_failure_backoff.is_active().await {
+            let cached_value = client.get_cached_bool_flag(user_uuid, flag_key).await;
+            let mode = cached_value
+                .flatten()
+                .map(|value| InferenceRoutingMode::from_router_v2_flag(Some(value)))
+                .unwrap_or(InferenceRoutingMode::Legacy);
+            trace!(
+                user_uuid = %user_uuid,
+                flag_key,
+                cache_hit = cached_value.is_some(),
+                routing_mode = ?mode,
+                "os-flags routing checks are in failure backoff; using cached inference-router decision"
+            );
+            return mode;
+        }
+
+        let mode = match tokio::time::timeout(
+            Duration::from_secs(PROVIDER_ROUTING_FLAGS_TIMEOUT_SECS),
+            client.get_bool_flag(user_uuid, flag_key),
+        )
+        .await
+        {
+            Ok(Ok(value)) => {
+                self.router_v2_flag_failure_backoff.record_success().await;
+                InferenceRoutingMode::from_router_v2_flag(value)
+            }
+            Ok(Err(error)) => {
+                self.router_v2_flag_failure_backoff.record_failure().await;
+                warn!(
+                    user_uuid = %user_uuid,
+                    flag_key,
+                    %error,
+                    "os-flags inference-router check failed; retaining legacy router"
+                );
+                InferenceRoutingMode::Legacy
+            }
+            Err(_) => {
+                self.router_v2_flag_failure_backoff.record_failure().await;
+                warn!(
+                    user_uuid = %user_uuid,
+                    flag_key,
+                    timeout_seconds = PROVIDER_ROUTING_FLAGS_TIMEOUT_SECS,
+                    "os-flags inference-router check timed out; retaining legacy router"
+                );
+                InferenceRoutingMode::Legacy
+            }
+        };
+
+        debug!(
+            user_uuid = %user_uuid,
+            flag_key,
+            routing_mode = ?mode,
+            "Resolved request-scoped inference router"
+        );
+        mode
+    }
+
     /// Resolve an explicit provider preference only for models configured for
     /// flag-controlled routing. Missing configuration, flags, failures, and
     /// timeouts retain the model's default provider.
@@ -1228,7 +1357,6 @@ impl AppState {
             );
             return None;
         };
-
         match tokio::time::timeout(
             Duration::from_secs(PROVIDER_ROUTING_FLAGS_TIMEOUT_SECS),
             client.get_bool_flag(user_uuid, flag_key),

--- a/src/model_config.rs
+++ b/src/model_config.rs
@@ -1153,6 +1153,45 @@ mod tests {
     }
 
     #[test]
+    fn test_golden_auto_alias_resolution_matrix_by_plan() {
+        for (plan, selector, expected_target) in [
+            (ModelPlan::Free, AUTO_QUICK_MODEL_ID, QUICK_MODEL_ID),
+            (
+                ModelPlan::Paid,
+                AUTO_QUICK_MODEL_ID,
+                DEEPSEEK_V4_FLASH_MODEL_ID,
+            ),
+            (ModelPlan::Free, AUTO_POWERFUL_MODEL_ID, GLM_5_2_MODEL_ID),
+            (ModelPlan::Paid, AUTO_POWERFUL_MODEL_ID, GLM_5_2_MODEL_ID),
+        ] {
+            let targets = ModelAliasTargets::for_plan(plan);
+            assert_eq!(targets.resolve(selector), expected_target, "plan={plan:?}");
+        }
+    }
+
+    #[test]
+    fn test_golden_explicit_model_resolution_is_plan_invariant() {
+        for plan in [ModelPlan::Free, ModelPlan::Paid] {
+            let targets = ModelAliasTargets::for_plan(plan);
+            for model in [
+                QUICK_MODEL_ID,
+                "kimi-k2-6",
+                KIMI_K3_MODEL_ID,
+                GLM_5_2_MODEL_ID,
+                GLM_5_3_MODEL_ID,
+                GLM_5_3_FLASH_MODEL_ID,
+                DEEPSEEK_V4_FLASH_MODEL_ID,
+            ] {
+                assert_eq!(
+                    targets.resolve(model),
+                    model,
+                    "explicit model changed for plan={plan:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn test_catalog_alias_metadata_tracks_paid_targets() {
         let targets = ModelAliasTargets::for_plan(ModelPlan::Paid);
         let catalog = model_catalog_response(targets);

--- a/src/os_flags.rs
+++ b/src/os_flags.rs
@@ -18,6 +18,7 @@ pub const AGENT_FEATURE_FLAG_KEY: &str = "agent";
 pub const PAID_POWERFUL_GLM_5_3_ALIAS_FLAG_KEY: &str = "model-alias.paid.powerful.glm-5-3";
 pub const PAID_MODEL_ALIAS_FLAG_KEYS: &[&str] = &[PAID_POWERFUL_GLM_5_3_ALIAS_FLAG_KEY];
 pub const GLM_5_3_TINFOIL_FLAG_KEY: &str = "provider-routing.glm-5-3.tinfoil";
+pub const INFERENCE_ROUTER_V2_FLAG_KEY: &str = "inference.router-v2";
 
 #[derive(Debug, thiserror::Error)]
 pub enum OsFlagsError {
@@ -211,6 +212,22 @@ impl OsFlagsClient {
         );
         Ok(value)
     }
+
+    /// Return a cached flag value without contacting os-flags. The outer
+    /// option distinguishes a cache miss from a cached response in which the
+    /// requested flag was absent.
+    pub(crate) async fn get_cached_bool_flag(
+        &self,
+        user_uuid: Uuid,
+        key: &str,
+    ) -> Option<Option<bool>> {
+        let keys = [key];
+        let cache_key = UserFlagsCacheKey::new(user_uuid, Some(&keys));
+        self.cache
+            .get(&cache_key)
+            .await
+            .map(|response| response.flags.get(key).copied())
+    }
 }
 
 impl std::fmt::Debug for OsFlagsClient {
@@ -246,6 +263,76 @@ fn evict_expired(inner: &mut HashMap<UserFlagsCacheKey, UserFlagsCacheEntry>, no
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::{
+        extract::{Path, Query, State},
+        http::StatusCode,
+        response::{IntoResponse, Response},
+        routing::get,
+        Json, Router,
+    };
+    use serde_json::json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::net::TcpListener;
+
+    #[derive(Clone, Default)]
+    struct FlagServerState {
+        calls: Arc<AtomicUsize>,
+    }
+
+    async fn cached_router_flag(
+        Path(user_uuid): Path<Uuid>,
+        Query(query): Query<HashMap<String, String>>,
+        State(state): State<FlagServerState>,
+    ) -> Json<serde_json::Value> {
+        assert_eq!(
+            query.get("keys").map(String::as_str),
+            Some(INFERENCE_ROUTER_V2_FLAG_KEY)
+        );
+        let call = state.calls.fetch_add(1, Ordering::SeqCst);
+        Json(json!({
+            "user_uuid": user_uuid,
+            "flags": { (INFERENCE_ROUTER_V2_FLAG_KEY): call > 0 }
+        }))
+    }
+
+    async fn transient_router_flag_error(
+        Path(user_uuid): Path<Uuid>,
+        Query(query): Query<HashMap<String, String>>,
+        State(state): State<FlagServerState>,
+    ) -> Response {
+        assert_eq!(
+            query.get("keys").map(String::as_str),
+            Some(INFERENCE_ROUTER_V2_FLAG_KEY)
+        );
+        if state.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            return StatusCode::SERVICE_UNAVAILABLE.into_response();
+        }
+
+        Json(json!({
+            "user_uuid": user_uuid,
+            "flags": { (INFERENCE_ROUTER_V2_FLAG_KEY): true }
+        }))
+        .into_response()
+    }
+
+    async fn spawn_flag_server(
+        state: FlagServerState,
+        handler: axum::routing::MethodRouter<FlagServerState>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(
+                listener,
+                Router::new()
+                    .route("/v1/users/:user_uuid/flags", handler)
+                    .with_state(state),
+            )
+            .await
+            .unwrap();
+        });
+        (format!("http://{address}"), server)
+    }
 
     fn response(user_uuid: Uuid) -> UserFlagsResponse {
         UserFlagsResponse {
@@ -285,5 +372,75 @@ mod tests {
 
         tokio::time::sleep(Duration::from_millis(10)).await;
         assert!(cache.get(&key).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn router_v2_flag_is_cached_by_user_including_false() {
+        let state = FlagServerState::default();
+        let calls = state.calls.clone();
+        let (base_url, server) = spawn_flag_server(state, get(cached_router_flag)).await;
+        let client = OsFlagsClient::new(base_url, None).unwrap();
+        let first_user = Uuid::new_v4();
+        let second_user = Uuid::new_v4();
+
+        assert_eq!(
+            client
+                .get_cached_bool_flag(first_user, INFERENCE_ROUTER_V2_FLAG_KEY)
+                .await,
+            None
+        );
+
+        assert_eq!(
+            client
+                .get_bool_flag(first_user, INFERENCE_ROUTER_V2_FLAG_KEY)
+                .await
+                .unwrap(),
+            Some(false)
+        );
+        assert_eq!(
+            client
+                .get_cached_bool_flag(first_user, INFERENCE_ROUTER_V2_FLAG_KEY)
+                .await,
+            Some(Some(false))
+        );
+        assert_eq!(
+            client
+                .get_bool_flag(first_user, INFERENCE_ROUTER_V2_FLAG_KEY)
+                .await
+                .unwrap(),
+            Some(false)
+        );
+        assert_eq!(
+            client
+                .get_bool_flag(second_user, INFERENCE_ROUTER_V2_FLAG_KEY)
+                .await
+                .unwrap(),
+            Some(true)
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn router_v2_flag_errors_are_not_cached() {
+        let state = FlagServerState::default();
+        let calls = state.calls.clone();
+        let (base_url, server) = spawn_flag_server(state, get(transient_router_flag_error)).await;
+        let client = OsFlagsClient::new(base_url, None).unwrap();
+        let user_uuid = Uuid::new_v4();
+
+        assert!(client
+            .get_bool_flag(user_uuid, INFERENCE_ROUTER_V2_FLAG_KEY)
+            .await
+            .is_err());
+        assert_eq!(
+            client
+                .get_bool_flag(user_uuid, INFERENCE_ROUTER_V2_FLAG_KEY)
+                .await
+                .unwrap(),
+            Some(true)
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        server.abort();
     }
 }

--- a/src/provider_routing.rs
+++ b/src/provider_routing.rs
@@ -11,6 +11,26 @@ pub(crate) enum ProviderName {
     Continuum,
 }
 
+/// Selects the completion-routing implementation once at an authenticated
+/// inference entrypoint. The choice is carried through the complete logical
+/// request so feature-flag changes cannot switch routers between provider
+/// turns.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum InferenceRoutingMode {
+    #[default]
+    Legacy,
+    V2,
+}
+
+impl InferenceRoutingMode {
+    pub(crate) const fn from_router_v2_flag(value: Option<bool>) -> Self {
+        match value {
+            Some(true) => Self::V2,
+            Some(false) | None => Self::Legacy,
+        }
+    }
+}
+
 impl ProviderName {
     pub(crate) const fn as_str(self) -> &'static str {
         match self {
@@ -254,6 +274,49 @@ impl ProviderRouter {
         self.fallback_completion_route(proxy_router, requested_model)
     }
 
+    /// Dispatch completion routing through the request-scoped implementation
+    /// selected at the public inference entrypoint. Router v2 intentionally
+    /// delegates to the legacy implementation in this foundation stack; later
+    /// stacks may evolve only the v2 branch while the legacy path stays intact.
+    pub(crate) fn select_completion_route_for_mode(
+        &self,
+        proxy_router: &ProxyRouter,
+        account_uuid: Uuid,
+        requested_model: &str,
+        provider_preference: Option<ProviderPreference>,
+        routing_mode: InferenceRoutingMode,
+    ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
+        match routing_mode {
+            InferenceRoutingMode::Legacy => self.select_completion_route_with_preference(
+                proxy_router,
+                account_uuid,
+                requested_model,
+                provider_preference,
+            ),
+            InferenceRoutingMode::V2 => self.select_completion_route_v2(
+                proxy_router,
+                account_uuid,
+                requested_model,
+                provider_preference,
+            ),
+        }
+    }
+
+    fn select_completion_route_v2(
+        &self,
+        proxy_router: &ProxyRouter,
+        account_uuid: Uuid,
+        requested_model: &str,
+        provider_preference: Option<ProviderPreference>,
+    ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
+        self.select_completion_route_with_preference(
+            proxy_router,
+            account_uuid,
+            requested_model,
+            provider_preference,
+        )
+    }
+
     pub(crate) fn provider_routing_flag_for_completion_model(
         &self,
         requested_model: &str,
@@ -470,7 +533,11 @@ fn proxy_for_provider(proxy_router: &ProxyRouter, provider: ProviderName) -> Opt
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model_config::{ModelAliasTargets, ModelPlan, PaidModelAliasOverrides};
+    use crate::model_config::{
+        ModelAliasTargets, ModelPlan, PaidModelAliasOverrides, AUTO_POWERFUL_MODEL_ID,
+        AUTO_QUICK_MODEL_ID, DEEPSEEK_V4_FLASH_MODEL_ID, GLM_5_2_MODEL_ID, GLM_5_3_FLASH_MODEL_ID,
+        GLM_5_3_MODEL_ID, KIMI_K3_MODEL_ID, QUICK_MODEL_ID,
+    };
     use crate::os_flags::PAID_POWERFUL_GLM_5_3_ALIAS_FLAG_KEY;
     use std::collections::HashMap;
 
@@ -492,6 +559,262 @@ mod tests {
         assert_eq!(stable_account_bucket(uuid_for_bucket(49)), 49);
         assert_eq!(stable_account_bucket(uuid_for_bucket(50)), 50);
         assert_eq!(stable_account_bucket(uuid_for_bucket(99)), 99);
+    }
+
+    #[test]
+    fn router_v2_flag_is_strictly_opt_in() {
+        assert_eq!(
+            InferenceRoutingMode::from_router_v2_flag(Some(true)),
+            InferenceRoutingMode::V2
+        );
+        assert_eq!(
+            InferenceRoutingMode::from_router_v2_flag(Some(false)),
+            InferenceRoutingMode::Legacy
+        );
+        assert_eq!(
+            InferenceRoutingMode::from_router_v2_flag(None),
+            InferenceRoutingMode::Legacy
+        );
+    }
+
+    #[test]
+    fn initial_router_v2_seam_is_route_identical_to_legacy() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        let cases = [
+            (GLM_5_2_MODEL_ID, None),
+            (
+                GLM_5_2_MODEL_ID,
+                Some(ProviderPreference::feature_flag(ProviderName::Continuum)),
+            ),
+            (GLM_5_3_MODEL_ID, None),
+            (
+                GLM_5_3_MODEL_ID,
+                Some(ProviderPreference::feature_flag(ProviderName::Tinfoil)),
+            ),
+            (GLM_5_3_FLASH_MODEL_ID, None),
+            ("kimi-k2-6", None),
+            ("gpt-oss-120b", None),
+        ];
+
+        for (model, preference) in cases {
+            let legacy = router
+                .select_completion_route_for_mode(
+                    &proxy_router,
+                    uuid_for_bucket(73),
+                    model,
+                    preference,
+                    InferenceRoutingMode::Legacy,
+                )
+                .expect("legacy route");
+            let v2 = router
+                .select_completion_route_for_mode(
+                    &proxy_router,
+                    uuid_for_bucket(73),
+                    model,
+                    preference,
+                    InferenceRoutingMode::V2,
+                )
+                .expect("v2 route");
+
+            assert_eq!(
+                legacy.proxy.provider_name, v2.proxy.provider_name,
+                "{model}"
+            );
+            assert_eq!(legacy.proxy.base_url, v2.proxy.base_url, "{model}");
+            assert_eq!(legacy.public_model_id, v2.public_model_id, "{model}");
+            assert_eq!(legacy.provider_model_id, v2.provider_model_id, "{model}");
+            assert_eq!(legacy.response_model_id, v2.response_model_id, "{model}");
+            assert_eq!(legacy.bucket, v2.bucket, "{model}");
+            assert_eq!(legacy.selection_source, v2.selection_source, "{model}");
+        }
+    }
+
+    #[test]
+    fn test_golden_completion_route_matrix_by_selector_plan_and_provider_preference() {
+        #[derive(Clone, Copy)]
+        struct Case {
+            name: &'static str,
+            selector: &'static str,
+            plan: ModelPlan,
+            provider_preference: Option<ProviderPreference>,
+            continuum_available: bool,
+            expected_access: bool,
+            expected_public_model: &'static str,
+            expected_provider: &'static str,
+            expected_provider_model: &'static str,
+            expected_source: ProviderSelectionSource,
+        }
+
+        let cases = [
+            Case {
+                name: "free auto quick",
+                selector: AUTO_QUICK_MODEL_ID,
+                plan: ModelPlan::Free,
+                provider_preference: None,
+                continuum_available: true,
+                expected_access: true,
+                expected_public_model: QUICK_MODEL_ID,
+                expected_provider: "tinfoil",
+                expected_provider_model: QUICK_MODEL_ID,
+                expected_source: ProviderSelectionSource::StaticSplit,
+            },
+            Case {
+                name: "free auto powerful remains unavailable",
+                selector: AUTO_POWERFUL_MODEL_ID,
+                plan: ModelPlan::Free,
+                provider_preference: None,
+                continuum_available: true,
+                expected_access: false,
+                expected_public_model: GLM_5_2_MODEL_ID,
+                expected_provider: "tinfoil",
+                expected_provider_model: GLM_5_2_MODEL_ID,
+                expected_source: ProviderSelectionSource::DefaultProvider,
+            },
+            Case {
+                name: "paid auto quick",
+                selector: AUTO_QUICK_MODEL_ID,
+                plan: ModelPlan::Paid,
+                provider_preference: None,
+                continuum_available: true,
+                expected_access: true,
+                expected_public_model: DEEPSEEK_V4_FLASH_MODEL_ID,
+                expected_provider: "tinfoil",
+                expected_provider_model: DEEPSEEK_V4_FLASH_MODEL_ID,
+                expected_source: ProviderSelectionSource::StaticSplit,
+            },
+            Case {
+                name: "paid auto powerful uses GLM default",
+                selector: AUTO_POWERFUL_MODEL_ID,
+                plan: ModelPlan::Paid,
+                provider_preference: None,
+                continuum_available: true,
+                expected_access: true,
+                expected_public_model: GLM_5_2_MODEL_ID,
+                expected_provider: "tinfoil",
+                expected_provider_model: GLM_5_2_MODEL_ID,
+                expected_source: ProviderSelectionSource::DefaultProvider,
+            },
+            Case {
+                name: "explicit K3 is independent of the auto target",
+                selector: KIMI_K3_MODEL_ID,
+                plan: ModelPlan::Paid,
+                provider_preference: None,
+                continuum_available: true,
+                expected_access: true,
+                expected_public_model: KIMI_K3_MODEL_ID,
+                expected_provider: "tinfoil",
+                expected_provider_model: KIMI_K3_MODEL_ID,
+                expected_source: ProviderSelectionSource::StaticSplit,
+            },
+            Case {
+                name: "explicit GLM default",
+                selector: GLM_5_2_MODEL_ID,
+                plan: ModelPlan::Paid,
+                provider_preference: None,
+                continuum_available: true,
+                expected_access: true,
+                expected_public_model: GLM_5_2_MODEL_ID,
+                expected_provider: "tinfoil",
+                expected_provider_model: GLM_5_2_MODEL_ID,
+                expected_source: ProviderSelectionSource::DefaultProvider,
+            },
+            Case {
+                name: "explicit GLM 5.3 Tinfoil preference",
+                selector: GLM_5_3_MODEL_ID,
+                plan: ModelPlan::Paid,
+                provider_preference: Some(ProviderPreference::feature_flag(ProviderName::Tinfoil)),
+                continuum_available: true,
+                expected_access: true,
+                expected_public_model: GLM_5_3_MODEL_ID,
+                expected_provider: "tinfoil",
+                expected_provider_model: GLM_5_3_MODEL_ID,
+                expected_source: ProviderSelectionSource::FeatureFlag,
+            },
+            Case {
+                name: "explicit GLM 5.3 Continuum preference",
+                selector: GLM_5_3_MODEL_ID,
+                plan: ModelPlan::Paid,
+                provider_preference: Some(ProviderPreference::feature_flag(
+                    ProviderName::Continuum,
+                )),
+                continuum_available: true,
+                expected_access: true,
+                expected_public_model: GLM_5_3_MODEL_ID,
+                expected_provider: "continuum",
+                expected_provider_model: "glm-5.3",
+                expected_source: ProviderSelectionSource::FeatureFlag,
+            },
+            Case {
+                name: "explicit GLM 5.3 Tinfoil preference without a Continuum proxy",
+                selector: GLM_5_3_MODEL_ID,
+                plan: ModelPlan::Paid,
+                provider_preference: Some(ProviderPreference::feature_flag(ProviderName::Tinfoil)),
+                continuum_available: false,
+                expected_access: true,
+                expected_public_model: GLM_5_3_MODEL_ID,
+                expected_provider: "tinfoil",
+                expected_provider_model: GLM_5_3_MODEL_ID,
+                expected_source: ProviderSelectionSource::FeatureFlag,
+            },
+        ];
+
+        let router = ProviderRouter::default();
+        for case in cases {
+            let alias_targets = ModelAliasTargets::for_plan(case.plan);
+            let resolved_model = alias_targets.resolve(case.selector);
+            let access = case.plan.allows_model(resolved_model);
+
+            assert_eq!(access, case.expected_access, "{}", case.name);
+            if !case.expected_access {
+                continue;
+            }
+
+            let proxy_router = if case.continuum_available {
+                proxy_router_with_both_providers()
+            } else {
+                ProxyRouter::new(
+                    "https://api.openai.com".to_string(),
+                    None,
+                    "http://tinfoil.example.com".to_string(),
+                )
+            };
+            let selected = router
+                .select_completion_route_with_preference(
+                    &proxy_router,
+                    uuid_for_bucket(73),
+                    resolved_model,
+                    case.provider_preference,
+                )
+                .unwrap_or_else(|error| panic!("{}: {error:?}", case.name));
+
+            assert_eq!(
+                selected.public_model_id, case.expected_public_model,
+                "{}",
+                case.name
+            );
+            assert_eq!(
+                selected.provider_model_id, case.expected_provider_model,
+                "{}",
+                case.name
+            );
+            assert_eq!(
+                selected.response_model_id, case.expected_public_model,
+                "{}",
+                case.name
+            );
+            assert_eq!(
+                selected.proxy.provider_name, case.expected_provider,
+                "{}",
+                case.name
+            );
+            assert_eq!(
+                selected.selection_source, case.expected_source,
+                "{}",
+                case.name
+            );
+            assert_eq!(selected.bucket, None, "{}", case.name);
+        }
     }
 
     #[test]

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -10,7 +10,7 @@ use crate::provider_cache::{
 use crate::provider_client::{
     ProviderClient, ProviderRequest, ProviderRequestError, ProviderResponse,
 };
-use crate::provider_routing::{ProviderName, ProviderRoutingError};
+use crate::provider_routing::{InferenceRoutingMode, ProviderName, ProviderRoutingError};
 use crate::proxy_config::ProxyConfig;
 use crate::sqs::UsageEvent;
 use crate::web::audio_utils::{merge_transcriptions, AudioSplitter, TINFOIL_MAX_SIZE};
@@ -563,7 +563,7 @@ pub struct BillingContext {
 /// completion implementation used by Chat and Responses.
 pub(crate) struct CompletionExecutionContext<'a> {
     billing: BillingContext,
-    model_plan: ModelPlan,
+    routing: InferenceRoutingContext,
     cache: &'a CompletionCachePolicy,
     response_execution: Option<ResponseExecution>,
     response_execution_guard: Option<ResponseExecutionTaskGuard>,
@@ -572,12 +572,12 @@ pub(crate) struct CompletionExecutionContext<'a> {
 impl<'a> CompletionExecutionContext<'a> {
     pub(crate) const fn new(
         billing: BillingContext,
-        model_plan: ModelPlan,
+        routing: InferenceRoutingContext,
         cache: &'a CompletionCachePolicy,
     ) -> Self {
         Self {
             billing,
-            model_plan,
+            routing,
             cache,
             response_execution: None,
             response_execution_guard: None,
@@ -604,6 +604,33 @@ impl BillingContext {
             auth_method,
             model_name,
         }
+    }
+}
+
+/// Immutable routing policy captured at an authenticated inference entrypoint.
+/// Internal child requests may use a different entitlement plan while retaining
+/// the same Router v1/v2 decision for the parent request's complete lifetime.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct InferenceRoutingContext {
+    model_plan: ModelPlan,
+    mode: InferenceRoutingMode,
+}
+
+impl InferenceRoutingContext {
+    pub(crate) const fn new(model_plan: ModelPlan, mode: InferenceRoutingMode) -> Self {
+        Self { model_plan, mode }
+    }
+
+    pub(crate) const fn with_model_plan(self, model_plan: ModelPlan) -> Self {
+        Self { model_plan, ..self }
+    }
+
+    pub(crate) const fn model_plan(self) -> ModelPlan {
+        self.model_plan
+    }
+
+    pub(crate) const fn mode(self) -> InferenceRoutingMode {
+        self.mode
     }
 }
 
@@ -894,6 +921,8 @@ async fn proxy_openai(
 
     // Create billing context
     let billing_context = BillingContext::new(auth_method, requested_model_name);
+    let routing =
+        InferenceRoutingContext::new(model_plan, state.inference_routing_mode(user.uuid).await);
 
     // Get the completion stream - billing happens automatically inside!
     let completion = get_chat_completion_response(
@@ -901,7 +930,7 @@ async fn proxy_openai(
         &user,
         body,
         &headers,
-        CompletionExecutionContext::new(billing_context, model_plan, &cache_policy),
+        CompletionExecutionContext::new(billing_context, routing, &cache_policy),
     )
     .await?;
 
@@ -1106,11 +1135,12 @@ async fn get_chat_completion_response_with_expected_route(
 ) -> Result<CompletionStream, ApiError> {
     let CompletionExecutionContext {
         mut billing,
-        model_plan,
+        routing,
         cache,
         response_execution,
         response_execution_guard,
     } = execution;
+    let model_plan = routing.model_plan();
     let billing_context = &mut billing;
     let cache_policy = cache;
     let require_provider_done = cache_policy.requires_provider_done();
@@ -1159,11 +1189,12 @@ async fn get_chat_completion_response_with_expected_route(
         .await;
     let selected_route = state
         .provider_router
-        .select_completion_route_with_preference(
+        .select_completion_route_for_mode(
             &state.proxy_router,
             user.uuid,
             &requested_model_name,
             provider_preference,
+            routing.mode(),
         )
         .map_err(|err| match err {
             ProviderRoutingError::UnsupportedModel(model) => {
@@ -1204,7 +1235,8 @@ async fn get_chat_completion_response_with_expected_route(
         || selected_route.public_model_id != selected_route.provider_model_id
     {
         debug!(
-            "Selected completion route: requested_model={}, public_model={}, provider={}, provider_model={}, bucket={:?}, source={:?}",
+            "Selected completion route: routing_mode={:?}, requested_model={}, public_model={}, provider={}, provider_model={}, bucket={:?}, source={:?}",
+            routing.mode(),
             requested_model_name,
             selected_route.public_model_id,
             selected_route.proxy.provider_name,
@@ -3379,6 +3411,67 @@ mod tests {
         assert!(event.is_api_request);
         assert_eq!(event.provider_name, "continuum");
         assert_eq!(event.model_name, "kimi-k2-6");
+    }
+
+    #[test]
+    fn route_identity_is_preserved_in_usage_events() {
+        let usage = CompletionUsage {
+            prompt_tokens: 100,
+            completion_tokens: 20,
+            cached_prompt_tokens: Some(42),
+        };
+
+        for (provider, public_model) in [
+            ("tinfoil", "gpt-oss-120b"),
+            ("tinfoil", "deepseek-v4-flash"),
+            ("tinfoil", "kimi-k3"),
+            ("tinfoil", "glm-5-2"),
+            ("tinfoil", "glm-5-3"),
+            ("tinfoil", "glm-5-3-flash"),
+            ("continuum", "kimi-k2-6"),
+            ("continuum", "glm-5-3"),
+        ] {
+            let event = build_usage_event(
+                Uuid::parse_str("6142db59-fc0c-413d-8792-579fc1457fe2").unwrap(),
+                usage.clone(),
+                BigDecimal::from_str("0.001").unwrap(),
+                false,
+                provider.to_string(),
+                public_model.to_string(),
+            );
+
+            assert_eq!(event.provider_name, provider);
+            assert_eq!(event.model_name, public_model);
+            assert_eq!(event.input_tokens, 100);
+            assert_eq!(event.output_tokens, 20);
+            assert_eq!(event.cached_input_tokens, Some(42));
+        }
+    }
+
+    #[test]
+    fn provider_model_ids_are_canonicalized_in_client_responses() {
+        for (provider_model, public_model) in [
+            ("kimi-k2.6", "kimi-k2-6"),
+            ("glm-5.3", "glm-5-3"),
+            ("kimi-k3", "kimi-k3"),
+            ("glm-5-3-flash", "glm-5-3-flash"),
+        ] {
+            let mut response = json!({
+                "id": "completion-id",
+                "model": provider_model,
+                "choices": [],
+            });
+
+            canonicalize_response_model(&mut response, public_model);
+
+            assert_eq!(response["model"], public_model);
+            assert_eq!(response["id"], "completion-id");
+            assert_eq!(response["choices"], json!([]));
+        }
+
+        let mut response_without_model = json!({"choices": []});
+        canonicalize_response_model(&mut response_without_model, "glm-5-3-flash");
+        assert!(response_without_model.get("model").is_none());
     }
 
     fn stream_usage_chunk(

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -23,7 +23,8 @@ use crate::{
             ensure_completion_model_access, get_chat_completion_response,
             get_chat_completion_response_for_execution,
             get_chat_completion_response_for_expected_route, BillingContext, CompletionCachePolicy,
-            CompletionChunk, CompletionExecutionContext, ServerSelectedCompletionRoute,
+            CompletionChunk, CompletionExecutionContext, InferenceRoutingContext,
+            ServerSelectedCompletionRoute,
         },
         openai_auth::AuthMethod,
         responses::{
@@ -1362,6 +1363,60 @@ mod tests {
             build_model_turn_request(&body, &[json!({"role": "user", "content": "hello"})], false);
 
         assert_eq!(chat_request["model"], crate::model_config::QUICK_MODEL_ID);
+    }
+
+    #[test]
+    fn test_golden_responses_alias_resolution_matrix() {
+        struct Case {
+            name: &'static str,
+            plan: ModelPlan,
+            selector: &'static str,
+            expected_model: &'static str,
+            expected_access: bool,
+        }
+
+        let cases = [
+            Case {
+                name: "free auto quick",
+                plan: ModelPlan::Free,
+                selector: crate::model_config::AUTO_QUICK_MODEL_ID,
+                expected_model: crate::model_config::QUICK_MODEL_ID,
+                expected_access: true,
+            },
+            Case {
+                name: "free auto powerful",
+                plan: ModelPlan::Free,
+                selector: crate::model_config::AUTO_POWERFUL_MODEL_ID,
+                expected_model: crate::model_config::GLM_5_2_MODEL_ID,
+                expected_access: false,
+            },
+            Case {
+                name: "paid auto quick",
+                plan: ModelPlan::Paid,
+                selector: crate::model_config::AUTO_QUICK_MODEL_ID,
+                expected_model: crate::model_config::DEEPSEEK_V4_FLASH_MODEL_ID,
+                expected_access: true,
+            },
+            Case {
+                name: "paid auto powerful",
+                plan: ModelPlan::Paid,
+                selector: crate::model_config::AUTO_POWERFUL_MODEL_ID,
+                expected_model: crate::model_config::GLM_5_2_MODEL_ID,
+                expected_access: true,
+            },
+        ];
+
+        for case in cases {
+            let targets = ModelAliasTargets::for_plan(case.plan);
+            let selected_model = targets.resolve(case.selector);
+
+            assert_eq!(selected_model, case.expected_model, "{}", case.name);
+            let result = resolve_responses_model(selected_model, "tinfoil", case.plan);
+            assert_eq!(result.is_ok(), case.expected_access, "{}", case.name);
+            if case.expected_access {
+                assert_eq!(result.unwrap(), case.expected_model, "{}", case.name);
+            }
+        }
     }
 
     #[test]
@@ -2830,6 +2885,7 @@ struct ResponsesImageDescriptionExecutor<'a> {
     state: &'a Arc<AppState>,
     user: &'a User,
     cache_policy: &'a CompletionCachePolicy,
+    routing: InferenceRoutingContext,
     _access: PaidImageDescriptionAccess,
 }
 
@@ -2867,7 +2923,7 @@ impl ImageDescriptionAttemptExecutor for ResponsesImageDescriptionExecutor<'_> {
             self.user,
             request,
             &headers,
-            CompletionExecutionContext::new(billing_context, ModelPlan::Paid, self.cache_policy),
+            CompletionExecutionContext::new(billing_context, self.routing, self.cache_policy),
             ServerSelectedCompletionRoute {
                 provider_name: candidate.provider.as_str(),
                 provider_model_id: candidate.provider_model_id,
@@ -2914,6 +2970,7 @@ async fn describe_images(
     state: &Arc<AppState>,
     user: &User,
     cache_policy: &CompletionCachePolicy,
+    routing: InferenceRoutingContext,
     access: PaidImageDescriptionAccess,
     images: &[ImageAttachment],
 ) -> Result<Vec<ImageDescriptionToolPair>, ApiError> {
@@ -2921,6 +2978,7 @@ async fn describe_images(
         state,
         user,
         cache_policy,
+        routing,
         _access: access,
     };
     let fallback_policy = RetryNonTerminalImageDescriptionFallbackPolicy;
@@ -3030,6 +3088,7 @@ struct PersistedData {
 /// * `user` - The user who owns the conversation
 /// * `user_key` - User's encryption key for metadata
 /// * `user_content` - The user's first message content
+#[allow(clippy::too_many_arguments)]
 fn spawn_title_generation_task(
     state: Arc<AppState>,
     conversation_id: i64,
@@ -3038,6 +3097,7 @@ fn spawn_title_generation_task(
     user_key: SecretKey,
     user_content: String,
     cache_policy: CompletionCachePolicy,
+    routing: InferenceRoutingContext,
 ) {
     tokio::spawn(async move {
         debug!(
@@ -3079,7 +3139,7 @@ fn spawn_title_generation_task(
             &user,
             title_request,
             &headers,
-            CompletionExecutionContext::new(billing_context, ModelPlan::Free, &cache_policy),
+            CompletionExecutionContext::new(billing_context, routing, &cache_policy),
         )
         .await
         {
@@ -3926,7 +3986,7 @@ async fn stream_one_assistant_turn(
     state: &Arc<AppState>,
     user: &User,
     body: &ResponsesCreateRequest,
-    model_plan: ModelPlan,
+    routing: InferenceRoutingContext,
     headers: &HeaderMap,
     prompt_messages: &[Value],
     tools_enabled: bool,
@@ -3969,7 +4029,7 @@ async fn stream_one_assistant_turn(
         user,
         chat_request.take(),
         headers,
-        CompletionExecutionContext::new(billing_context, model_plan, cache_policy),
+        CompletionExecutionContext::new(billing_context, routing, cache_policy),
         response_execution,
     )
     .await?;
@@ -4223,7 +4283,7 @@ async fn setup_completion_processor(
     state: &Arc<AppState>,
     user: &User,
     body: &ResponsesCreateRequest,
-    model_plan: ModelPlan,
+    routing: InferenceRoutingContext,
     context: &BuiltContext,
     user_key: &SecretKey,
     assistant_message_id: Uuid,
@@ -4235,6 +4295,7 @@ async fn setup_completion_processor(
     response_execution: ResponseExecution,
     cache_policy: &CompletionCachePolicy,
 ) -> Result<crate::models::responses::Response, ApiError> {
+    let model_plan = routing.model_plan();
     let tools_enabled = context.web_search_enabled;
     let mut prompt_messages = Arc::as_ref(&context.prompt_messages).clone();
     let mut prompt_token_estimate = context.total_prompt_tokens;
@@ -4248,7 +4309,7 @@ async fn setup_completion_processor(
                 state,
                 user,
                 body,
-                model_plan,
+                routing,
                 headers,
                 &prompt_messages,
                 tools_enabled,
@@ -4348,6 +4409,8 @@ async fn create_response_stream(
         ModelAliasTargets::for_plan(model_plan)
     };
     let selected_model = alias_targets.resolve(&requested_model).to_string();
+    let routing =
+        InferenceRoutingContext::new(model_plan, state.inference_routing_mode(user.uuid).await);
     let completion_provider = state.proxy_router.get_completion_proxy();
     let resolved_model = resolve_responses_model(
         &selected_model,
@@ -4415,6 +4478,7 @@ async fn create_response_stream(
                 &state,
                 &user,
                 &cache_policy,
+                routing.with_model_plan(ModelPlan::Paid),
                 access,
                 &prepared.image_attachments,
             )
@@ -4551,6 +4615,7 @@ async fn create_response_stream(
             prepared.user_key,
             user_content,
             cache_policy.clone(),
+            routing.with_model_plan(ModelPlan::Free),
         );
     }
 
@@ -4650,7 +4715,7 @@ async fn create_response_stream(
                     &orchestrator_state,
                     &orchestrator_user,
                     &orchestrator_body,
-                    model_plan,
+                    routing,
                     &context_for_completion,
                     &user_key,
                     assistant_message_id,


### PR DESCRIPTION
Router v2 can be enabled for selected users while keeping the legacy router available through the existing feature-flag service. This layer selects the routing implementation once at authenticated Chat Completions or Responses ingress; both implementations still select the same provider route here.

- Only a successful exact `true` for `inference.router-v2` selects Router v2. False, missing, unconfigured, timeout, and lookup-error results select Router v1.
- Carry the immutable routing context through image descriptions, background titles, main inference, and later tool turns. API callers cannot supply the mode or change it mid-execution.
- Preserve the existing ten-minute successful assignment cache. A flag-service failure starts a thirty-second enclave-local lookup backoff; cached assignments remain authoritative and cache misses use legacy defaults. Disabling the flag therefore respects the existing cache lifetime.
- Preserve the legacy selector, public model identity, authorization, billing identity, and independent alias/provider-preference flags. GLM 5.3 and GLM 5.3 Flash remain separate models.

The rebase retains [#343's execution ownership and durable terminal behavior](https://github.com/OpenSecretCloud/opensecret/pull/343) and [#341's encrypted OpenAI-shaped stream errors](https://github.com/OpenSecretCloud/opensecret/pull/341). Router v2 remains default off; merging this layer does not enable a cohort.

Local validation at `cc8e9d98ed5f6f5eaf57cd2aa0aa59d6611dcf31`: direct pinned formatting and warning-denied all-target/all-feature Clippy passed; the full all-feature suite reported **473 passed, 0 failed, 23 ignored**. Independent review of this exact head found no P0/P1 blocker.

Final GitHub snapshot, 2026-09-04 23:32:16 UTC: 9 successful checks, expected production EIF skip, no pending or failed checks. The exact head, master base, and merge-base match; the PR is open, non-draft, mergeable/CLEAN, and zero commits behind. Local tests do not establish deployed flag state or provider behavior.

Stack **1/8**: `master` → **#297** → [#298](https://github.com/OpenSecretCloud/opensecret/pull/298). Final head/base: **cc8e9d98ed5f6f5eaf57cd2aa0aa59d6611dcf31 / efcaa686d7e98b4eed490d27f323abea526d2eb4**.

[Routing walkthrough: rollout gate](https://maple-routing-review.anthony599874.chatgpt.site/#stack-1) · [Ingress and flag source](https://github.com/OpenSecretCloud/opensecret/blob/cc8e9d98ed5f6f5eaf57cd2aa0aa59d6611dcf31/src/main.rs).
