### PR TITLE
[routing v2 3/8] Add explicit provider registry and shadow planner

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1,5 +1,5 @@
 use crate::model_config::{ModelPlan, AUTO_POWERFUL_MODEL_ID, AUTO_QUICK_MODEL_ID};
-use crate::provider_routing::{ProviderName, ProviderSelectionSource};
+use crate::provider_registry::{ProviderId, RouteSelectionSource};
 use std::fmt;
 use std::time::Duration;
 use uuid::Uuid;
@@ -105,22 +105,22 @@ impl InferenceIntent {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RouteIdentity {
-    pub(crate) provider: ProviderName,
+    pub(crate) provider: ProviderId,
     pub(crate) public_model_id: String,
     pub(crate) provider_model_id: String,
     pub(crate) response_model_id: String,
-    pub(crate) selection_source: ProviderSelectionSource,
+    pub(crate) selection_source: RouteSelectionSource,
     pub(crate) bucket: Option<u8>,
 }
 
 impl RouteIdentity {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        provider: ProviderName,
+        provider: ProviderId,
         public_model_id: impl Into<String>,
         provider_model_id: impl Into<String>,
         response_model_id: impl Into<String>,
-        selection_source: ProviderSelectionSource,
+        selection_source: RouteSelectionSource,
         bucket: Option<u8>,
     ) -> Self {
         Self {
@@ -143,7 +143,7 @@ impl RouteIdentity {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct RouteKey {
-    pub(crate) provider: ProviderName,
+    pub(crate) provider: ProviderId,
     pub(crate) provider_model_id: String,
 }
 
@@ -300,11 +300,11 @@ mod tests {
 
     fn route() -> RouteIdentity {
         RouteIdentity::new(
-            ProviderName::Tinfoil,
+            ProviderId::Tinfoil,
             "kimi-k3",
             "kimi-k3",
             "kimi-k3",
-            ProviderSelectionSource::StaticSplit,
+            RouteSelectionSource::StaticSplit,
             None,
         )
     }
@@ -371,18 +371,18 @@ mod tests {
     #[test]
     fn route_key_uses_typed_provider_and_upstream_model() {
         let route = RouteIdentity::new(
-            ProviderName::Continuum,
+            ProviderId::Continuum,
             "glm-5-3",
             "glm-5.3",
             "glm-5-3",
-            ProviderSelectionSource::FeatureFlag,
+            RouteSelectionSource::FeatureFlag,
             None,
         );
 
         assert_eq!(
             route.route_key(),
             RouteKey {
-                provider: ProviderName::Continuum,
+                provider: ProviderId::Continuum,
                 provider_model_id: "glm-5.3".to_string(),
             }
         );

--- a/src/inference_planning.rs
+++ b/src/inference_planning.rs
@@ -1,0 +1,474 @@
+//! Deterministic, credential-free completion route planning.
+//!
+//! The plan produced here is shadow-only. It describes route identity and
+//! ordered same-model candidates, but it cannot name or invoke an executable
+//! provider endpoint.
+
+use crate::inference::{InferenceIntent, RouteIdentity};
+use crate::provider_registry::{
+    ProviderId, ProviderRegistry, RouteSelectionSource, SHADOW_ROUTING_POLICY_VERSION,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProviderPreference {
+    provider: ProviderId,
+    source: RouteSelectionSource,
+}
+
+impl ProviderPreference {
+    pub(crate) const fn feature_flag(provider: ProviderId) -> Self {
+        Self {
+            provider,
+            source: RouteSelectionSource::FeatureFlag,
+        }
+    }
+
+    pub(crate) const fn default_provider(provider: ProviderId) -> Self {
+        Self {
+            provider,
+            source: RouteSelectionSource::DefaultProvider,
+        }
+    }
+
+    pub(crate) const fn provider(self) -> ProviderId {
+        self.provider
+    }
+
+    pub(crate) const fn source(self) -> RouteSelectionSource {
+        self.source
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct ConfiguredProviders {
+    tinfoil: bool,
+    continuum: bool,
+}
+
+impl ConfiguredProviders {
+    pub(crate) const fn none() -> Self {
+        Self {
+            tinfoil: false,
+            continuum: false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn all() -> Self {
+        Self {
+            tinfoil: true,
+            continuum: true,
+        }
+    }
+
+    pub(crate) fn with_provider(mut self, provider: ProviderId) -> Self {
+        match provider {
+            ProviderId::Tinfoil => self.tinfoil = true,
+            ProviderId::Continuum => self.continuum = true,
+        }
+        self
+    }
+
+    pub(crate) const fn contains(self, provider: ProviderId) -> bool {
+        match provider {
+            ProviderId::Tinfoil => self.tinfoil,
+            ProviderId::Continuum => self.continuum,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RoutePlanningInput<'a> {
+    pub(crate) intent: &'a InferenceIntent,
+    pub(crate) configured_providers: ConfiguredProviders,
+    pub(crate) provider_preference: Option<ProviderPreference>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RouteCandidate {
+    pub(crate) provider: ProviderId,
+    pub(crate) public_model_id: String,
+    pub(crate) provider_model_id: String,
+    pub(crate) response_model_id: String,
+    pub(crate) effective_weight: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PlanDecision {
+    FixedRoute,
+    StaticBucket,
+    DefaultProvider,
+    FeatureFlagPreference,
+    PreferredProviderUnavailable,
+    DefaultProviderUnavailable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CandidateScope {
+    SamePublicModelOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RoutePlan {
+    pub(crate) selected: RouteIdentity,
+    pub(crate) eligible_routes: Vec<RouteCandidate>,
+    pub(crate) decision: PlanDecision,
+    pub(crate) candidate_scope: CandidateScope,
+    pub(crate) policy_version: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RoutePlanningError {
+    UnsupportedModel(String),
+    NoEligibleRoute(String),
+}
+
+#[derive(Debug, Clone)]
+struct EligibleRoute {
+    candidate: RouteCandidate,
+}
+
+pub(crate) fn plan_completion_route(
+    registry: &ProviderRegistry,
+    input: RoutePlanningInput<'_>,
+) -> Result<RoutePlan, RoutePlanningError> {
+    let public_model_id = input.intent.public_model_id.as_str();
+    let model = registry
+        .completion_model(public_model_id)
+        .ok_or_else(|| RoutePlanningError::UnsupportedModel(public_model_id.to_string()))?;
+
+    let eligible_routes = model
+        .routes
+        .iter()
+        .filter_map(|route| {
+            if !route.enabled || route.weight == 0 {
+                return None;
+            }
+            let provider = registry.provider(route.provider)?;
+            if !provider.enabled
+                || provider.weight == 0
+                || !input.configured_providers.contains(route.provider)
+            {
+                return None;
+            }
+
+            Some(EligibleRoute {
+                candidate: RouteCandidate {
+                    provider: route.provider,
+                    public_model_id: model.public_model_id.to_string(),
+                    provider_model_id: route.provider_model_id.to_string(),
+                    response_model_id: route.response_model_id.to_string(),
+                    effective_weight: u32::from(provider.weight) * u32::from(route.weight),
+                },
+            })
+        })
+        .collect::<Vec<_>>();
+
+    if eligible_routes.is_empty() {
+        return Err(RoutePlanningError::NoEligibleRoute(
+            model.public_model_id.to_string(),
+        ));
+    }
+
+    if let Some(preference) = input.provider_preference {
+        if let Some(route) = eligible_routes
+            .iter()
+            .find(|route| route.candidate.provider == preference.provider())
+        {
+            return Ok(build_plan(
+                route,
+                &eligible_routes,
+                preference.source(),
+                None,
+                PlanDecision::FeatureFlagPreference,
+            ));
+        }
+    }
+
+    if let Some(default_provider) = model.default_provider {
+        if let Some(route) = eligible_routes
+            .iter()
+            .find(|route| route.candidate.provider == default_provider)
+        {
+            let (source, decision) = if input.provider_preference.is_some() {
+                (
+                    RouteSelectionSource::Fallback,
+                    PlanDecision::PreferredProviderUnavailable,
+                )
+            } else {
+                (
+                    RouteSelectionSource::DefaultProvider,
+                    PlanDecision::DefaultProvider,
+                )
+            };
+            return Ok(build_plan(route, &eligible_routes, source, None, decision));
+        }
+    }
+
+    let fallback_source = if input.provider_preference.is_some() || model.default_provider.is_some()
+    {
+        RouteSelectionSource::Fallback
+    } else {
+        RouteSelectionSource::StaticSplit
+    };
+    let missing_preference_decision = if input.provider_preference.is_some() {
+        Some(PlanDecision::PreferredProviderUnavailable)
+    } else if model.default_provider.is_some() {
+        Some(PlanDecision::DefaultProviderUnavailable)
+    } else {
+        None
+    };
+
+    if eligible_routes.len() == 1 {
+        return Ok(build_plan(
+            &eligible_routes[0],
+            &eligible_routes,
+            fallback_source,
+            None,
+            missing_preference_decision.unwrap_or(PlanDecision::FixedRoute),
+        ));
+    }
+
+    let bucket = stable_account_bucket(input.intent.account_uuid);
+    let selected = select_weighted_route(bucket, &eligible_routes)
+        .ok_or_else(|| RoutePlanningError::NoEligibleRoute(model.public_model_id.to_string()))?;
+    Ok(build_plan(
+        selected,
+        &eligible_routes,
+        fallback_source,
+        Some(bucket),
+        missing_preference_decision.unwrap_or(PlanDecision::StaticBucket),
+    ))
+}
+
+fn build_plan(
+    selected: &EligibleRoute,
+    eligible_routes: &[EligibleRoute],
+    selection_source: RouteSelectionSource,
+    bucket: Option<u8>,
+    decision: PlanDecision,
+) -> RoutePlan {
+    let selected = &selected.candidate;
+    RoutePlan {
+        selected: RouteIdentity::new(
+            selected.provider,
+            selected.public_model_id.clone(),
+            selected.provider_model_id.clone(),
+            selected.response_model_id.clone(),
+            selection_source,
+            bucket,
+        ),
+        eligible_routes: eligible_routes
+            .iter()
+            .map(|route| route.candidate.clone())
+            .collect(),
+        decision,
+        candidate_scope: CandidateScope::SamePublicModelOnly,
+        policy_version: SHADOW_ROUTING_POLICY_VERSION,
+    }
+}
+
+fn select_weighted_route(bucket: u8, routes: &[EligibleRoute]) -> Option<&EligibleRoute> {
+    let total_weight = routes
+        .iter()
+        .map(|route| route.candidate.effective_weight)
+        .sum::<u32>();
+    if total_weight == 0 {
+        return None;
+    }
+
+    let mut cumulative = 0u32;
+    for (index, route) in routes.iter().enumerate() {
+        let bucket_span = if index == routes.len() - 1 {
+            100u32.saturating_sub(cumulative)
+        } else {
+            (route.candidate.effective_weight * 100) / total_weight
+        };
+        cumulative = cumulative.saturating_add(bucket_span);
+
+        if u32::from(bucket) < cumulative || index == routes.len() - 1 {
+            return Some(route);
+        }
+    }
+    None
+}
+
+fn stable_account_bucket(account_uuid: uuid::Uuid) -> u8 {
+    (u128::from_be_bytes(*account_uuid.as_bytes()) % 100) as u8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model_config::{
+        ModelPlan, AUTO_POWERFUL_MODEL_ID, GLM_5_2_MODEL_ID, GLM_5_3_FLASH_MODEL_ID,
+        GLM_5_3_MODEL_ID,
+    };
+    use crate::provider_registry::{ProviderId, PROVIDER_REGISTRY};
+    use uuid::Uuid;
+
+    fn intent(requested_model: &str, public_model: &str) -> InferenceIntent {
+        InferenceIntent::new(
+            Uuid::from_u128(73),
+            requested_model,
+            public_model,
+            ModelPlan::Paid,
+            crate::inference::InferenceSurface::Responses,
+            crate::inference::WorkloadClass::Interactive,
+        )
+    }
+
+    #[test]
+    fn planner_uses_resolved_public_model_without_resolving_auto_again() {
+        let intent = intent(AUTO_POWERFUL_MODEL_ID, GLM_5_2_MODEL_ID);
+        let plan = plan_completion_route(
+            &PROVIDER_REGISTRY,
+            RoutePlanningInput {
+                intent: &intent,
+                configured_providers: ConfiguredProviders::all(),
+                provider_preference: None,
+            },
+        )
+        .expect("shadow route");
+
+        assert_eq!(intent.requested_model_id, AUTO_POWERFUL_MODEL_ID);
+        assert_eq!(plan.selected.public_model_id, GLM_5_2_MODEL_ID);
+        assert_eq!(plan.selected.provider_model_id, GLM_5_2_MODEL_ID);
+        assert_eq!(plan.selected.provider, ProviderId::Tinfoil);
+        assert_eq!(plan.selected.bucket, None);
+        assert_eq!(plan.decision, PlanDecision::DefaultProvider);
+    }
+
+    #[test]
+    fn alias_resolved_glm_5_3_honors_the_tinfoil_provider_preference() {
+        let intent = intent(AUTO_POWERFUL_MODEL_ID, GLM_5_3_MODEL_ID);
+        let plan = plan_completion_route(
+            &PROVIDER_REGISTRY,
+            RoutePlanningInput {
+                intent: &intent,
+                configured_providers: ConfiguredProviders::all(),
+                provider_preference: Some(ProviderPreference::feature_flag(ProviderId::Tinfoil)),
+            },
+        )
+        .expect("GLM 5.3 Tinfoil plan");
+
+        assert_eq!(intent.requested_model_id, AUTO_POWERFUL_MODEL_ID);
+        assert_eq!(intent.public_model_id, GLM_5_3_MODEL_ID);
+        assert_eq!(plan.selected.provider, ProviderId::Tinfoil);
+        assert_eq!(plan.selected.provider_model_id, GLM_5_3_MODEL_ID);
+        assert_eq!(plan.eligible_routes.len(), 2);
+        assert!(plan
+            .eligible_routes
+            .iter()
+            .all(|route| route.public_model_id == GLM_5_3_MODEL_ID));
+    }
+
+    #[test]
+    fn planner_is_deterministic_and_candidates_never_cross_public_models() {
+        let intent = intent(GLM_5_3_MODEL_ID, GLM_5_3_MODEL_ID);
+        let input = RoutePlanningInput {
+            intent: &intent,
+            configured_providers: ConfiguredProviders::all(),
+            provider_preference: Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
+        };
+
+        let first = plan_completion_route(&PROVIDER_REGISTRY, input).expect("first plan");
+        let second = plan_completion_route(&PROVIDER_REGISTRY, input).expect("second plan");
+        assert_eq!(first, second);
+        assert_eq!(first.candidate_scope, CandidateScope::SamePublicModelOnly);
+        assert!(first
+            .eligible_routes
+            .iter()
+            .all(|route| route.public_model_id == intent.public_model_id));
+        assert_eq!(
+            first
+                .eligible_routes
+                .iter()
+                .map(|route| (route.provider, route.provider_model_id.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                (ProviderId::Continuum, "glm-5.3"),
+                (ProviderId::Tinfoil, GLM_5_3_MODEL_ID),
+            ]
+        );
+    }
+
+    #[test]
+    fn unavailable_preference_falls_back_without_authorizing_another_model() {
+        let intent = intent(GLM_5_3_MODEL_ID, GLM_5_3_MODEL_ID);
+        let configured = ConfiguredProviders::none().with_provider(ProviderId::Tinfoil);
+        let plan = plan_completion_route(
+            &PROVIDER_REGISTRY,
+            RoutePlanningInput {
+                intent: &intent,
+                configured_providers: configured,
+                provider_preference: Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
+            },
+        )
+        .expect("Tinfoil fallback plan");
+
+        assert_eq!(plan.selected.provider, ProviderId::Tinfoil);
+        assert_eq!(plan.selected.public_model_id, GLM_5_3_MODEL_ID);
+        assert_eq!(
+            plan.selected.selection_source,
+            RouteSelectionSource::Fallback
+        );
+        assert_eq!(plan.decision, PlanDecision::PreferredProviderUnavailable);
+        assert_eq!(plan.eligible_routes.len(), 1);
+    }
+
+    #[test]
+    fn flash_is_a_distinct_tinfoil_only_model_not_a_glm_5_3_fallback() {
+        let intent = intent(GLM_5_3_FLASH_MODEL_ID, GLM_5_3_FLASH_MODEL_ID);
+        let plan = plan_completion_route(
+            &PROVIDER_REGISTRY,
+            RoutePlanningInput {
+                intent: &intent,
+                configured_providers: ConfiguredProviders::all(),
+                provider_preference: None,
+            },
+        )
+        .expect("Flash route");
+
+        assert_eq!(plan.selected.provider, ProviderId::Tinfoil);
+        assert_eq!(plan.selected.public_model_id, GLM_5_3_FLASH_MODEL_ID);
+        assert_eq!(plan.selected.provider_model_id, GLM_5_3_FLASH_MODEL_ID);
+        assert_eq!(plan.eligible_routes.len(), 1);
+        assert!(plan
+            .eligible_routes
+            .iter()
+            .all(|route| route.public_model_id == GLM_5_3_FLASH_MODEL_ID));
+    }
+
+    #[test]
+    fn planner_fails_closed_for_unknown_and_unconfigured_models() {
+        let unknown = intent("unknown-model", "unknown-model");
+        assert_eq!(
+            plan_completion_route(
+                &PROVIDER_REGISTRY,
+                RoutePlanningInput {
+                    intent: &unknown,
+                    configured_providers: ConfiguredProviders::all(),
+                    provider_preference: None,
+                },
+            ),
+            Err(RoutePlanningError::UnsupportedModel(
+                "unknown-model".to_string()
+            ))
+        );
+
+        let kimi = intent("kimi-k2-6", "kimi-k2-6");
+        let tinfoil_only = ConfiguredProviders::none().with_provider(ProviderId::Tinfoil);
+        assert_eq!(
+            plan_completion_route(
+                &PROVIDER_REGISTRY,
+                RoutePlanningInput {
+                    intent: &kimi,
+                    configured_providers: tinfoil_only,
+                    provider_preference: None,
+                },
+            ),
+            Err(RoutePlanningError::NoEligibleRoute("kimi-k2-6".to_string()))
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,7 @@ mod email;
 mod encrypt;
 mod http_client;
 mod inference;
+mod inference_planning;
 mod jwt;
 mod kagi;
 mod kv;
@@ -117,6 +118,7 @@ mod private_key;
 #[allow(dead_code)] // Used by the dormant Transport V2 core in this stack layer.
 mod provider_cache;
 mod provider_client;
+mod provider_registry;
 mod provider_routing;
 mod proxy_config;
 mod secret_cache_maintenance;
@@ -133,9 +135,10 @@ mod web;
 mod aead_db_tamper_tests;
 
 use apple_signin::AppleJwtVerifier;
+use inference_planning::ProviderPreference;
 use oauth::{AppleProvider, GithubProvider, GoogleProvider, OAuthManager};
 use provider_client::{ProviderClient, ProviderRequestError};
-use provider_routing::{InferenceRoutingMode, ProviderPreference, ProviderRouter};
+use provider_routing::{InferenceRoutingMode, ProviderRouter};
 use proxy_config::ProxyRouter;
 
 const ENCLAVE_KEY_NAME: &str = "enclave_key";

--- a/src/model_config.rs
+++ b/src/model_config.rs
@@ -119,6 +119,7 @@ pub const GLM_5_3_MODEL_ID: &str = "glm-5-3";
 pub const GLM_5_3_FLASH_MODEL_ID: &str = "glm-5-3-flash";
 pub const POWERFUL_MODEL_ID: &str = GLM_5_2_MODEL_ID;
 pub const KIMI_K3_MODEL_ID: &str = "kimi-k3";
+pub const KIMI_K2_6_MODEL_ID: &str = "kimi-k2-6";
 pub const DEEPSEEK_V4_FLASH_MODEL_ID: &str = "deepseek-v4-flash";
 
 const FREE_MODEL_ALIAS_TARGETS: ModelAliasTargets = ModelAliasTargets {
@@ -699,6 +700,14 @@ fn model_entry(model: &str) -> Option<ModelConfigEntry> {
         .iter()
         .find(|entry| entry.id == model)
         .copied()
+}
+
+#[cfg(test)]
+pub(crate) fn enabled_api_completion_model_ids() -> impl Iterator<Item = &'static str> {
+    MODEL_CONFIGS
+        .iter()
+        .filter(|entry| entry.api_listed && entry.enabled && entry.capabilities.chat)
+        .map(|entry| entry.id)
 }
 
 pub fn resolve_completion_model_id(model: &str) -> Option<&'static str> {

--- a/src/provider_client.rs
+++ b/src/provider_client.rs
@@ -1,4 +1,4 @@
-use crate::provider_routing::ProviderName;
+use crate::provider_registry::ProviderId;
 use crate::proxy_config::ProxyConfig;
 use axum::http::{header, HeaderMap, HeaderName, HeaderValue};
 use bytes::Bytes;
@@ -624,7 +624,7 @@ impl ProviderClient {
         provider: &ProxyConfig,
         request: ProviderRequest<'_>,
     ) -> ProviderSendTrace {
-        if provider.provider_name != ProviderName::Tinfoil.as_str() {
+        if provider.provider_name != ProviderId::Tinfoil.as_str() {
             return ProviderSendTrace::terminal(self.send_standard(provider, request).await);
         }
 
@@ -745,7 +745,7 @@ impl ProviderClient {
         request: ProviderRequest<'_>,
         attempt: &TinfoilAttempt,
     ) -> Result<ReqwestRequest, ProviderRequestError> {
-        debug_assert_eq!(provider.provider_name, ProviderName::Tinfoil.as_str());
+        debug_assert_eq!(provider.provider_name, ProviderId::Tinfoil.as_str());
         let ProviderRequest {
             method,
             path,
@@ -940,7 +940,7 @@ mod tests {
         ProxyConfig {
             base_url: "http://ignored.invalid".to_string(),
             api_key: None,
-            provider_name: ProviderName::Tinfoil.as_str().to_string(),
+            provider_name: ProviderId::Tinfoil.as_str().to_string(),
         }
     }
 
@@ -1281,7 +1281,7 @@ mod tests {
         let provider = ProxyConfig {
             base_url: format!("http://{address}"),
             api_key: None,
-            provider_name: ProviderName::Continuum.as_str().to_string(),
+            provider_name: ProviderId::Continuum.as_str().to_string(),
         };
 
         let response = client
@@ -1339,7 +1339,7 @@ mod tests {
         let provider = ProxyConfig {
             base_url: format!("http://{redirect_address}"),
             api_key: None,
-            provider_name: ProviderName::Continuum.as_str().to_string(),
+            provider_name: ProviderId::Continuum.as_str().to_string(),
         };
         let body = Bytes::from_static(br#"{"model":"glm-5-2"}"#);
 
@@ -1388,7 +1388,7 @@ mod tests {
         let provider = ProxyConfig {
             base_url: format!("http://{address}"),
             api_key: Some("provider-key".to_string()),
-            provider_name: ProviderName::Continuum.as_str().to_string(),
+            provider_name: ProviderId::Continuum.as_str().to_string(),
         };
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -1592,7 +1592,7 @@ mod tests {
             // the enclave selected and attested by the SDK.
             base_url: client.tinfoil_base_url(),
             api_key: None,
-            provider_name: ProviderName::Tinfoil.as_str().to_string(),
+            provider_name: ProviderId::Tinfoil.as_str().to_string(),
         };
 
         let initialization_deadline = tokio::time::Instant::now() + Duration::from_secs(30);

--- a/src/provider_registry.rs
+++ b/src/provider_registry.rs
@@ -1,0 +1,418 @@
+//! Credential-free provider topology for completion routing.
+//!
+//! This registry is intentionally independent from the legacy execution
+//! router. Stack 3 exercises it in shadow mode so the topology and planner can
+//! be validated before either is allowed to select an executable proxy.
+
+use crate::model_config::{
+    DEEPSEEK_V4_FLASH_MODEL_ID, GLM_5_2_MODEL_ID, GLM_5_3_FLASH_MODEL_ID, GLM_5_3_MODEL_ID,
+    KIMI_K2_6_MODEL_ID, KIMI_K3_MODEL_ID, QUICK_MODEL_ID,
+};
+
+pub(crate) const SHADOW_ROUTING_POLICY_VERSION: &str = "routing-v2-shadow-v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum ProviderId {
+    Tinfoil,
+    Continuum,
+}
+
+impl ProviderId {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Tinfoil => "tinfoil",
+            Self::Continuum => "continuum",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RouteSelectionSource {
+    StaticSplit,
+    FeatureFlag,
+    DefaultProvider,
+    Fallback,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProviderSpec {
+    pub(crate) id: ProviderId,
+    pub(crate) weight: u16,
+    pub(crate) enabled: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ModelRouteSpec {
+    pub(crate) provider: ProviderId,
+    pub(crate) provider_model_id: &'static str,
+    pub(crate) response_model_id: &'static str,
+    pub(crate) weight: u16,
+    pub(crate) enabled: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CompletionModelSpec {
+    pub(crate) public_model_id: &'static str,
+    pub(crate) routes: &'static [ModelRouteSpec],
+    pub(crate) default_provider: Option<ProviderId>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ProviderRegistry {
+    providers: &'static [ProviderSpec],
+    completion_models: &'static [CompletionModelSpec],
+}
+
+impl ProviderRegistry {
+    pub(crate) fn provider(&self, id: ProviderId) -> Option<&ProviderSpec> {
+        self.providers.iter().find(|provider| provider.id == id)
+    }
+
+    pub(crate) fn providers(&self) -> &'static [ProviderSpec] {
+        self.providers
+    }
+
+    pub(crate) fn completion_model(&self, public_model_id: &str) -> Option<&CompletionModelSpec> {
+        self.completion_models
+            .iter()
+            .find(|model| model.public_model_id == public_model_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn completion_models(&self) -> &'static [CompletionModelSpec] {
+        self.completion_models
+    }
+}
+
+const PROVIDERS: &[ProviderSpec] = &[
+    ProviderSpec {
+        id: ProviderId::Tinfoil,
+        weight: 70,
+        enabled: true,
+    },
+    ProviderSpec {
+        id: ProviderId::Continuum,
+        weight: 30,
+        enabled: true,
+    },
+];
+
+const GPT_OSS_120B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
+    provider: ProviderId::Tinfoil,
+    provider_model_id: QUICK_MODEL_ID,
+    response_model_id: QUICK_MODEL_ID,
+    weight: 100,
+    enabled: true,
+}];
+
+const GEMMA4_31B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
+    provider: ProviderId::Tinfoil,
+    provider_model_id: "gemma4-31b",
+    response_model_id: "gemma4-31b",
+    weight: 100,
+    enabled: true,
+}];
+
+const KIMI_K3_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
+    provider: ProviderId::Tinfoil,
+    provider_model_id: KIMI_K3_MODEL_ID,
+    response_model_id: KIMI_K3_MODEL_ID,
+    weight: 100,
+    enabled: true,
+}];
+
+const KIMI_K2_6_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
+    provider: ProviderId::Continuum,
+    provider_model_id: "kimi-k2.6",
+    response_model_id: KIMI_K2_6_MODEL_ID,
+    weight: 100,
+    enabled: true,
+}];
+
+const GLM_5_2_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
+    provider: ProviderId::Tinfoil,
+    provider_model_id: GLM_5_2_MODEL_ID,
+    response_model_id: GLM_5_2_MODEL_ID,
+    weight: 100,
+    enabled: true,
+}];
+
+const GLM_5_3_ROUTES: &[ModelRouteSpec] = &[
+    ModelRouteSpec {
+        provider: ProviderId::Continuum,
+        provider_model_id: "glm-5.3",
+        response_model_id: GLM_5_3_MODEL_ID,
+        weight: 100,
+        enabled: true,
+    },
+    ModelRouteSpec {
+        provider: ProviderId::Tinfoil,
+        provider_model_id: GLM_5_3_MODEL_ID,
+        response_model_id: GLM_5_3_MODEL_ID,
+        weight: 100,
+        enabled: true,
+    },
+];
+
+const GLM_5_3_FLASH_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
+    provider: ProviderId::Tinfoil,
+    provider_model_id: GLM_5_3_FLASH_MODEL_ID,
+    response_model_id: GLM_5_3_FLASH_MODEL_ID,
+    weight: 100,
+    enabled: true,
+}];
+
+const DEEPSEEK_V4_FLASH_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
+    provider: ProviderId::Tinfoil,
+    provider_model_id: DEEPSEEK_V4_FLASH_MODEL_ID,
+    response_model_id: DEEPSEEK_V4_FLASH_MODEL_ID,
+    weight: 100,
+    enabled: true,
+}];
+
+const LLAMA3_3_70B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
+    provider: ProviderId::Tinfoil,
+    provider_model_id: "llama3-3-70b",
+    response_model_id: "llama3-3-70b",
+    weight: 100,
+    enabled: true,
+}];
+
+const GPT_OSS_SAFEGUARD_120B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
+    provider: ProviderId::Tinfoil,
+    provider_model_id: "gpt-oss-safeguard-120b",
+    response_model_id: "gpt-oss-safeguard-120b",
+    weight: 100,
+    enabled: true,
+}];
+
+const COMPLETION_MODELS: &[CompletionModelSpec] = &[
+    CompletionModelSpec {
+        public_model_id: QUICK_MODEL_ID,
+        routes: GPT_OSS_120B_ROUTES,
+        default_provider: None,
+    },
+    CompletionModelSpec {
+        public_model_id: "gemma4-31b",
+        routes: GEMMA4_31B_ROUTES,
+        default_provider: None,
+    },
+    CompletionModelSpec {
+        public_model_id: KIMI_K3_MODEL_ID,
+        routes: KIMI_K3_ROUTES,
+        default_provider: None,
+    },
+    CompletionModelSpec {
+        public_model_id: KIMI_K2_6_MODEL_ID,
+        routes: KIMI_K2_6_ROUTES,
+        default_provider: Some(ProviderId::Continuum),
+    },
+    CompletionModelSpec {
+        public_model_id: GLM_5_2_MODEL_ID,
+        routes: GLM_5_2_ROUTES,
+        default_provider: Some(ProviderId::Tinfoil),
+    },
+    CompletionModelSpec {
+        public_model_id: GLM_5_3_MODEL_ID,
+        routes: GLM_5_3_ROUTES,
+        default_provider: Some(ProviderId::Continuum),
+    },
+    CompletionModelSpec {
+        public_model_id: GLM_5_3_FLASH_MODEL_ID,
+        routes: GLM_5_3_FLASH_ROUTES,
+        default_provider: None,
+    },
+    CompletionModelSpec {
+        public_model_id: DEEPSEEK_V4_FLASH_MODEL_ID,
+        routes: DEEPSEEK_V4_FLASH_ROUTES,
+        default_provider: None,
+    },
+    CompletionModelSpec {
+        public_model_id: "llama3-3-70b",
+        routes: LLAMA3_3_70B_ROUTES,
+        default_provider: None,
+    },
+    CompletionModelSpec {
+        public_model_id: "gpt-oss-safeguard-120b",
+        routes: GPT_OSS_SAFEGUARD_120B_ROUTES,
+        default_provider: None,
+    },
+];
+
+pub(crate) static PROVIDER_REGISTRY: ProviderRegistry = ProviderRegistry {
+    providers: PROVIDERS,
+    completion_models: COMPLETION_MODELS,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model_config::{
+        enabled_api_completion_model_ids, AUTO_POWERFUL_MODEL_ID, AUTO_QUICK_MODEL_ID,
+    };
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn registry_is_structurally_valid_and_deterministic() {
+        let registry = &PROVIDER_REGISTRY;
+        let provider_ids = registry
+            .providers()
+            .iter()
+            .map(|provider| provider.id)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(provider_ids.len(), registry.providers().len());
+
+        let model_ids = registry
+            .completion_models()
+            .iter()
+            .map(|model| model.public_model_id)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(model_ids.len(), registry.completion_models().len());
+
+        for model in registry.completion_models() {
+            assert!(!model.public_model_id.trim().is_empty());
+            assert!(!model.routes.is_empty(), "{}", model.public_model_id);
+            assert_ne!(model.public_model_id, AUTO_QUICK_MODEL_ID);
+            assert_ne!(model.public_model_id, AUTO_POWERFUL_MODEL_ID);
+
+            let mut route_providers = BTreeSet::new();
+            for route in model.routes {
+                assert!(registry.provider(route.provider).is_some());
+                assert!(route_providers.insert(route.provider));
+                assert!(!route.provider_model_id.trim().is_empty());
+                assert!(!route.response_model_id.trim().is_empty());
+                assert_eq!(route.response_model_id, model.public_model_id);
+            }
+
+            if let Some(default_provider) = model.default_provider {
+                assert!(model
+                    .routes
+                    .iter()
+                    .any(|route| route.provider == default_provider));
+            }
+        }
+
+        let ordered_model_ids = registry
+            .completion_models()
+            .iter()
+            .map(|model| model.public_model_id)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ordered_model_ids,
+            vec![
+                QUICK_MODEL_ID,
+                "gemma4-31b",
+                KIMI_K3_MODEL_ID,
+                KIMI_K2_6_MODEL_ID,
+                GLM_5_2_MODEL_ID,
+                GLM_5_3_MODEL_ID,
+                GLM_5_3_FLASH_MODEL_ID,
+                DEEPSEEK_V4_FLASH_MODEL_ID,
+                "llama3-3-70b",
+                "gpt-oss-safeguard-120b",
+            ]
+        );
+    }
+
+    #[test]
+    fn registry_covers_exactly_enabled_api_completion_models() {
+        let expected = enabled_api_completion_model_ids().collect::<BTreeSet<_>>();
+        let registered = PROVIDER_REGISTRY
+            .completion_models()
+            .iter()
+            .map(|model| model.public_model_id)
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(registered, expected);
+    }
+
+    #[test]
+    fn registry_pins_every_provider_model_translation() {
+        let routes = PROVIDER_REGISTRY
+            .completion_models()
+            .iter()
+            .flat_map(|model| {
+                model.routes.iter().map(move |route| {
+                    (
+                        model.public_model_id,
+                        route.provider,
+                        route.provider_model_id,
+                        route.response_model_id,
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            routes,
+            vec![
+                (
+                    QUICK_MODEL_ID,
+                    ProviderId::Tinfoil,
+                    QUICK_MODEL_ID,
+                    QUICK_MODEL_ID
+                ),
+                (
+                    "gemma4-31b",
+                    ProviderId::Tinfoil,
+                    "gemma4-31b",
+                    "gemma4-31b"
+                ),
+                (
+                    KIMI_K3_MODEL_ID,
+                    ProviderId::Tinfoil,
+                    KIMI_K3_MODEL_ID,
+                    KIMI_K3_MODEL_ID
+                ),
+                (
+                    KIMI_K2_6_MODEL_ID,
+                    ProviderId::Continuum,
+                    "kimi-k2.6",
+                    KIMI_K2_6_MODEL_ID
+                ),
+                (
+                    GLM_5_2_MODEL_ID,
+                    ProviderId::Tinfoil,
+                    GLM_5_2_MODEL_ID,
+                    GLM_5_2_MODEL_ID
+                ),
+                (
+                    GLM_5_3_MODEL_ID,
+                    ProviderId::Continuum,
+                    "glm-5.3",
+                    GLM_5_3_MODEL_ID
+                ),
+                (
+                    GLM_5_3_MODEL_ID,
+                    ProviderId::Tinfoil,
+                    GLM_5_3_MODEL_ID,
+                    GLM_5_3_MODEL_ID
+                ),
+                (
+                    GLM_5_3_FLASH_MODEL_ID,
+                    ProviderId::Tinfoil,
+                    GLM_5_3_FLASH_MODEL_ID,
+                    GLM_5_3_FLASH_MODEL_ID
+                ),
+                (
+                    DEEPSEEK_V4_FLASH_MODEL_ID,
+                    ProviderId::Tinfoil,
+                    DEEPSEEK_V4_FLASH_MODEL_ID,
+                    DEEPSEEK_V4_FLASH_MODEL_ID
+                ),
+                (
+                    "llama3-3-70b",
+                    ProviderId::Tinfoil,
+                    "llama3-3-70b",
+                    "llama3-3-70b"
+                ),
+                (
+                    "gpt-oss-safeguard-120b",
+                    ProviderId::Tinfoil,
+                    "gpt-oss-safeguard-120b",
+                    "gpt-oss-safeguard-120b"
+                ),
+            ]
+        );
+    }
+}

--- a/src/provider_routing.rs
+++ b/src/provider_routing.rs
@@ -1,16 +1,17 @@
-use crate::inference::RouteIdentity;
+use crate::inference::{InferenceIntent, RouteIdentity};
+use crate::inference_planning::{
+    plan_completion_route, ConfiguredProviders, ProviderPreference, RoutePlan, RoutePlanningError,
+    RoutePlanningInput,
+};
 use crate::model_config::{
     resolve_completion_model_id, resolve_public_model_id, GLM_5_2_MODEL_ID, GLM_5_3_MODEL_ID,
 };
 use crate::os_flags::GLM_5_3_TINFOIL_FLAG_KEY;
+use crate::provider_registry::{
+    ProviderId, ProviderRegistry, RouteSelectionSource, PROVIDER_REGISTRY,
+};
 use crate::proxy_config::{canonicalize_tinfoil_model, ProxyConfig, ProxyRouter};
 use uuid::Uuid;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) enum ProviderName {
-    Tinfoil,
-    Continuum,
-}
 
 /// Selects the completion-routing implementation once at an authenticated
 /// inference entrypoint. The choice is carried through the complete logical
@@ -31,56 +32,16 @@ impl InferenceRoutingMode {
         }
     }
 }
-
-impl ProviderName {
-    pub(crate) const fn as_str(self) -> &'static str {
-        match self {
-            Self::Tinfoil => "tinfoil",
-            Self::Continuum => "continuum",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ProviderSelectionSource {
-    StaticSplit,
-    FeatureFlag,
-    DefaultProvider,
-    Fallback,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct ProviderPreference {
-    provider: ProviderName,
-    source: ProviderSelectionSource,
-}
-
-impl ProviderPreference {
-    pub(crate) const fn feature_flag(provider: ProviderName) -> Self {
-        Self {
-            provider,
-            source: ProviderSelectionSource::FeatureFlag,
-        }
-    }
-
-    const fn default_provider(provider: ProviderName) -> Self {
-        Self {
-            provider,
-            source: ProviderSelectionSource::DefaultProvider,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy)]
 struct ProviderConfig {
-    provider: ProviderName,
+    provider: ProviderId,
     weight: u16,
     enabled: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
 struct ModelProviderRoute {
-    provider: ProviderName,
+    provider: ProviderId,
     provider_model_id: &'static str,
     weight: u16,
     enabled: bool,
@@ -92,14 +53,14 @@ struct ModelRoutingConfig {
     public_model_id: &'static str,
     routes: &'static [ModelProviderRoute],
     provider_flag: Option<ProviderRoutingFlag>,
-    default_provider: Option<ProviderName>,
+    default_provider: Option<ProviderId>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ProviderRoutingFlag {
     key: &'static str,
-    enabled_provider: ProviderName,
-    disabled_provider: ProviderName,
+    enabled_provider: ProviderId,
+    disabled_provider: ProviderId,
 }
 
 impl ProviderRoutingFlag {
@@ -124,13 +85,13 @@ struct ProviderRoutingConfig {
 
 #[derive(Debug, Clone)]
 pub(crate) struct SelectedProviderRoute {
-    pub(crate) provider: ProviderName,
+    pub(crate) provider: ProviderId,
     pub(crate) proxy: ProxyConfig,
     pub(crate) public_model_id: String,
     pub(crate) provider_model_id: String,
     pub(crate) response_model_id: String,
     pub(crate) bucket: Option<u8>,
-    pub(crate) selection_source: ProviderSelectionSource,
+    pub(crate) selection_source: RouteSelectionSource,
 }
 
 impl SelectedProviderRoute {
@@ -152,14 +113,37 @@ pub(crate) enum ProviderRoutingError {
     NoEligibleRoute(String),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CredentialFreeRouteOutcome {
+    Selected(RouteIdentity),
+    UnsupportedModel,
+    NoEligibleRoute,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ShadowRouteComparison {
+    Match {
+        outcome: CredentialFreeRouteOutcome,
+        decision: Option<crate::inference_planning::PlanDecision>,
+        candidate_count: usize,
+    },
+    Mismatch {
+        active: CredentialFreeRouteOutcome,
+        shadow: CredentialFreeRouteOutcome,
+        decision: Option<crate::inference_planning::PlanDecision>,
+        candidate_count: usize,
+    },
+}
+
 #[derive(Debug)]
 pub(crate) struct ProviderRouter {
     config: &'static ProviderRoutingConfig,
+    registry: &'static ProviderRegistry,
 }
 
 #[derive(Debug, Clone)]
 struct EligibleRoute {
-    provider: ProviderName,
+    provider: ProviderId,
     proxy: ProxyConfig,
     provider_model_id: &'static str,
     effective_weight: u32,
@@ -167,19 +151,19 @@ struct EligibleRoute {
 
 const PROVIDERS: &[ProviderConfig] = &[
     ProviderConfig {
-        provider: ProviderName::Tinfoil,
+        provider: ProviderId::Tinfoil,
         weight: 70,
         enabled: true,
     },
     ProviderConfig {
-        provider: ProviderName::Continuum,
+        provider: ProviderId::Continuum,
         weight: 30,
         enabled: true,
     },
 ];
 
 const KIMI_K2_6_ROUTES: &[ModelProviderRoute] = &[ModelProviderRoute {
-    provider: ProviderName::Continuum,
+    provider: ProviderId::Continuum,
     provider_model_id: "kimi-k2.6",
     weight: 100,
     enabled: true,
@@ -187,7 +171,7 @@ const KIMI_K2_6_ROUTES: &[ModelProviderRoute] = &[ModelProviderRoute {
 }];
 
 const GLM_5_2_ROUTES: &[ModelProviderRoute] = &[ModelProviderRoute {
-    provider: ProviderName::Tinfoil,
+    provider: ProviderId::Tinfoil,
     provider_model_id: GLM_5_2_MODEL_ID,
     weight: 100,
     enabled: true,
@@ -196,17 +180,17 @@ const GLM_5_2_ROUTES: &[ModelProviderRoute] = &[ModelProviderRoute {
 
 const GLM_5_3_ROUTES: &[ModelProviderRoute] = &[
     ModelProviderRoute {
-        provider: ProviderName::Continuum,
+        provider: ProviderId::Continuum,
         provider_model_id: "glm-5.3",
         weight: 100,
         enabled: true,
         requires_explicit_preference: false,
     },
     ModelProviderRoute {
-        // Staged for Tinfoil's in-progress launch. Keep this route out of
-        // automatic fallback until the live catalog publishes the model and
-        // billing rates have been added.
-        provider: ProviderName::Tinfoil,
+        // Preserve the current Router v1 rollout fence. Router v2's separate
+        // registry treats the now-GA Tinfoil route as a normal same-model
+        // candidate without changing behavior for the feature-flag-off cohort.
+        provider: ProviderId::Tinfoil,
         provider_model_id: GLM_5_3_MODEL_ID,
         weight: 100,
         enabled: true,
@@ -219,23 +203,23 @@ const MODEL_ROUTES: &[ModelRoutingConfig] = &[
         public_model_id: "kimi-k2-6",
         routes: KIMI_K2_6_ROUTES,
         provider_flag: None,
-        default_provider: Some(ProviderName::Continuum),
+        default_provider: Some(ProviderId::Continuum),
     },
     ModelRoutingConfig {
         public_model_id: GLM_5_2_MODEL_ID,
         routes: GLM_5_2_ROUTES,
         provider_flag: None,
-        default_provider: Some(ProviderName::Tinfoil),
+        default_provider: Some(ProviderId::Tinfoil),
     },
     ModelRoutingConfig {
         public_model_id: GLM_5_3_MODEL_ID,
         routes: GLM_5_3_ROUTES,
         provider_flag: Some(ProviderRoutingFlag {
             key: GLM_5_3_TINFOIL_FLAG_KEY,
-            enabled_provider: ProviderName::Tinfoil,
-            disabled_provider: ProviderName::Continuum,
+            enabled_provider: ProviderId::Tinfoil,
+            disabled_provider: ProviderId::Continuum,
         }),
-        default_provider: Some(ProviderName::Continuum),
+        default_provider: Some(ProviderId::Continuum),
     },
 ];
 
@@ -248,6 +232,7 @@ impl Default for ProviderRouter {
     fn default() -> Self {
         Self {
             config: &DEFAULT_PROVIDER_ROUTING_CONFIG,
+            registry: &PROVIDER_REGISTRY,
         }
     }
 }
@@ -332,6 +317,33 @@ impl ProviderRouter {
         )
     }
 
+    pub(crate) fn shadow_completion_plan(
+        &self,
+        proxy_router: &ProxyRouter,
+        intent: &InferenceIntent,
+        provider_preference: Option<ProviderPreference>,
+    ) -> Result<RoutePlan, RoutePlanningError> {
+        let configured_providers = self.registry.providers().iter().fold(
+            ConfiguredProviders::none(),
+            |configured, provider| {
+                if proxy_for_provider(proxy_router, provider.id).is_some() {
+                    configured.with_provider(provider.id)
+                } else {
+                    configured
+                }
+            },
+        );
+
+        plan_completion_route(
+            self.registry,
+            RoutePlanningInput {
+                intent,
+                configured_providers,
+                provider_preference,
+            },
+        )
+    }
+
     pub(crate) fn provider_routing_flag_for_completion_model(
         &self,
         requested_model: &str,
@@ -355,7 +367,7 @@ impl ProviderRouter {
             }
             if route.requires_explicit_preference
                 && provider_preference
-                    .is_none_or(|preference| preference.provider != route.provider)
+                    .is_none_or(|preference| preference.provider() != route.provider)
             {
                 continue;
             }
@@ -392,18 +404,18 @@ impl ProviderRouter {
         let provider_preference_route = provider_preference.and_then(|preference| {
             eligible_routes
                 .iter()
-                .find(|route| route.provider == preference.provider)
-                .map(|route| (route, preference.source))
+                .find(|route| route.provider == preference.provider())
+                .map(|route| (route, preference.source()))
         });
         let default_preference_route = default_preference.and_then(|preference| {
             eligible_routes
                 .iter()
-                .find(|route| route.provider == preference.provider)
+                .find(|route| route.provider == preference.provider())
                 .map(|route| {
                     let source = if provider_preference.is_some() {
-                        ProviderSelectionSource::Fallback
+                        RouteSelectionSource::Fallback
                     } else {
-                        preference.source
+                        preference.source()
                     };
                     (route, source)
                 })
@@ -422,9 +434,9 @@ impl ProviderRouter {
                 selected.route,
                 Some(selected.bucket),
                 if provider_preference.is_some() || default_preference.is_some() {
-                    ProviderSelectionSource::Fallback
+                    RouteSelectionSource::Fallback
                 } else {
-                    ProviderSelectionSource::StaticSplit
+                    RouteSelectionSource::StaticSplit
                 },
             )
         };
@@ -448,7 +460,7 @@ impl ProviderRouter {
         let proxy = proxy_router.get_completion_proxy();
         let resolved_public_model_id =
             resolve_public_model_id(requested_model).map(ToOwned::to_owned);
-        let provider_model_id = if proxy.provider_name == ProviderName::Tinfoil.as_str() {
+        let provider_model_id = if proxy.provider_name == ProviderId::Tinfoil.as_str() {
             resolve_completion_model_id(requested_model)
                 .ok_or_else(|| ProviderRoutingError::UnsupportedModel(requested_model.into()))?
                 .to_string()
@@ -460,24 +472,24 @@ impl ProviderRouter {
 
         let public_model_id = resolved_public_model_id.unwrap_or_else(|| provider_model_id.clone());
 
-        let response_model_id = if proxy.provider_name == ProviderName::Tinfoil.as_str() {
+        let response_model_id = if proxy.provider_name == ProviderId::Tinfoil.as_str() {
             canonicalize_tinfoil_model(&provider_model_id)
         } else {
             public_model_id.clone()
         };
 
         Ok(SelectedProviderRoute {
-            provider: ProviderName::Tinfoil,
+            provider: ProviderId::Tinfoil,
             proxy,
             public_model_id,
             provider_model_id,
             response_model_id,
             bucket: None,
-            selection_source: ProviderSelectionSource::StaticSplit,
+            selection_source: RouteSelectionSource::StaticSplit,
         })
     }
 
-    fn provider_config(&self, provider: ProviderName) -> Option<&ProviderConfig> {
+    fn provider_config(&self, provider: ProviderId) -> Option<&ProviderConfig> {
         self.config
             .providers
             .iter()
@@ -489,6 +501,49 @@ impl ProviderRouter {
             .models
             .iter()
             .find(|config| config.public_model_id == public_model_id)
+    }
+}
+
+pub(crate) fn compare_shadow_route(
+    active: &Result<SelectedProviderRoute, ProviderRoutingError>,
+    shadow: &Result<RoutePlan, RoutePlanningError>,
+) -> ShadowRouteComparison {
+    let active_outcome = match active {
+        Ok(route) => CredentialFreeRouteOutcome::Selected(route.identity()),
+        Err(ProviderRoutingError::UnsupportedModel(_)) => {
+            CredentialFreeRouteOutcome::UnsupportedModel
+        }
+        Err(ProviderRoutingError::NoEligibleRoute(_)) => {
+            CredentialFreeRouteOutcome::NoEligibleRoute
+        }
+    };
+    let (shadow_outcome, decision, candidate_count) = match shadow {
+        Ok(plan) => (
+            CredentialFreeRouteOutcome::Selected(plan.selected.clone()),
+            Some(plan.decision),
+            plan.eligible_routes.len(),
+        ),
+        Err(RoutePlanningError::UnsupportedModel(_)) => {
+            (CredentialFreeRouteOutcome::UnsupportedModel, None, 0)
+        }
+        Err(RoutePlanningError::NoEligibleRoute(_)) => {
+            (CredentialFreeRouteOutcome::NoEligibleRoute, None, 0)
+        }
+    };
+
+    if active_outcome == shadow_outcome {
+        ShadowRouteComparison::Match {
+            outcome: active_outcome,
+            decision,
+            candidate_count,
+        }
+    } else {
+        ShadowRouteComparison::Mismatch {
+            active: active_outcome,
+            shadow: shadow_outcome,
+            decision,
+            candidate_count,
+        }
     }
 }
 
@@ -537,12 +592,12 @@ fn stable_account_bucket(account_uuid: Uuid) -> u8 {
     (u128::from_be_bytes(*account_uuid.as_bytes()) % 100) as u8
 }
 
-fn proxy_for_provider(proxy_router: &ProxyRouter, provider: ProviderName) -> Option<ProxyConfig> {
+fn proxy_for_provider(proxy_router: &ProxyRouter, provider: ProviderId) -> Option<ProxyConfig> {
     match provider {
-        ProviderName::Tinfoil => Some(proxy_router.get_tinfoil_proxy()),
-        ProviderName::Continuum => {
+        ProviderId::Tinfoil => Some(proxy_router.get_tinfoil_proxy()),
+        ProviderId::Continuum => {
             let proxy = proxy_router.get_default_proxy();
-            (proxy.provider_name == ProviderName::Continuum.as_str()).then_some(proxy)
+            (proxy.provider_name == ProviderId::Continuum.as_str()).then_some(proxy)
         }
     }
 }
@@ -550,6 +605,7 @@ fn proxy_for_provider(proxy_router: &ProxyRouter, provider: ProviderName) -> Opt
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::inference::{InferenceSurface, WorkloadClass};
     use crate::model_config::{
         ModelAliasTargets, ModelPlan, PaidModelAliasOverrides, AUTO_POWERFUL_MODEL_ID,
         AUTO_QUICK_MODEL_ID, DEEPSEEK_V4_FLASH_MODEL_ID, GLM_5_2_MODEL_ID, GLM_5_3_FLASH_MODEL_ID,
@@ -602,12 +658,12 @@ mod tests {
             (GLM_5_2_MODEL_ID, None),
             (
                 GLM_5_2_MODEL_ID,
-                Some(ProviderPreference::feature_flag(ProviderName::Continuum)),
+                Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
             ),
             (GLM_5_3_MODEL_ID, None),
             (
                 GLM_5_3_MODEL_ID,
-                Some(ProviderPreference::feature_flag(ProviderName::Tinfoil)),
+                Some(ProviderPreference::feature_flag(ProviderId::Tinfoil)),
             ),
             (GLM_5_3_FLASH_MODEL_ID, None),
             ("kimi-k2-6", None),
@@ -660,7 +716,7 @@ mod tests {
             expected_public_model: &'static str,
             expected_provider: &'static str,
             expected_provider_model: &'static str,
-            expected_source: ProviderSelectionSource,
+            expected_source: RouteSelectionSource,
         }
 
         let cases = [
@@ -674,7 +730,7 @@ mod tests {
                 expected_public_model: QUICK_MODEL_ID,
                 expected_provider: "tinfoil",
                 expected_provider_model: QUICK_MODEL_ID,
-                expected_source: ProviderSelectionSource::StaticSplit,
+                expected_source: RouteSelectionSource::StaticSplit,
             },
             Case {
                 name: "free auto powerful remains unavailable",
@@ -686,7 +742,7 @@ mod tests {
                 expected_public_model: GLM_5_2_MODEL_ID,
                 expected_provider: "tinfoil",
                 expected_provider_model: GLM_5_2_MODEL_ID,
-                expected_source: ProviderSelectionSource::DefaultProvider,
+                expected_source: RouteSelectionSource::DefaultProvider,
             },
             Case {
                 name: "paid auto quick",
@@ -698,7 +754,7 @@ mod tests {
                 expected_public_model: DEEPSEEK_V4_FLASH_MODEL_ID,
                 expected_provider: "tinfoil",
                 expected_provider_model: DEEPSEEK_V4_FLASH_MODEL_ID,
-                expected_source: ProviderSelectionSource::StaticSplit,
+                expected_source: RouteSelectionSource::StaticSplit,
             },
             Case {
                 name: "paid auto powerful uses GLM default",
@@ -710,7 +766,7 @@ mod tests {
                 expected_public_model: GLM_5_2_MODEL_ID,
                 expected_provider: "tinfoil",
                 expected_provider_model: GLM_5_2_MODEL_ID,
-                expected_source: ProviderSelectionSource::DefaultProvider,
+                expected_source: RouteSelectionSource::DefaultProvider,
             },
             Case {
                 name: "explicit K3 is independent of the auto target",
@@ -722,7 +778,7 @@ mod tests {
                 expected_public_model: KIMI_K3_MODEL_ID,
                 expected_provider: "tinfoil",
                 expected_provider_model: KIMI_K3_MODEL_ID,
-                expected_source: ProviderSelectionSource::StaticSplit,
+                expected_source: RouteSelectionSource::StaticSplit,
             },
             Case {
                 name: "explicit GLM default",
@@ -734,45 +790,43 @@ mod tests {
                 expected_public_model: GLM_5_2_MODEL_ID,
                 expected_provider: "tinfoil",
                 expected_provider_model: GLM_5_2_MODEL_ID,
-                expected_source: ProviderSelectionSource::DefaultProvider,
+                expected_source: RouteSelectionSource::DefaultProvider,
             },
             Case {
                 name: "explicit GLM 5.3 Tinfoil preference",
                 selector: GLM_5_3_MODEL_ID,
                 plan: ModelPlan::Paid,
-                provider_preference: Some(ProviderPreference::feature_flag(ProviderName::Tinfoil)),
+                provider_preference: Some(ProviderPreference::feature_flag(ProviderId::Tinfoil)),
                 continuum_available: true,
                 expected_access: true,
                 expected_public_model: GLM_5_3_MODEL_ID,
                 expected_provider: "tinfoil",
                 expected_provider_model: GLM_5_3_MODEL_ID,
-                expected_source: ProviderSelectionSource::FeatureFlag,
+                expected_source: RouteSelectionSource::FeatureFlag,
             },
             Case {
                 name: "explicit GLM 5.3 Continuum preference",
                 selector: GLM_5_3_MODEL_ID,
                 plan: ModelPlan::Paid,
-                provider_preference: Some(ProviderPreference::feature_flag(
-                    ProviderName::Continuum,
-                )),
+                provider_preference: Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
                 continuum_available: true,
                 expected_access: true,
                 expected_public_model: GLM_5_3_MODEL_ID,
                 expected_provider: "continuum",
                 expected_provider_model: "glm-5.3",
-                expected_source: ProviderSelectionSource::FeatureFlag,
+                expected_source: RouteSelectionSource::FeatureFlag,
             },
             Case {
                 name: "explicit GLM 5.3 Tinfoil preference without a Continuum proxy",
                 selector: GLM_5_3_MODEL_ID,
                 plan: ModelPlan::Paid,
-                provider_preference: Some(ProviderPreference::feature_flag(ProviderName::Tinfoil)),
+                provider_preference: Some(ProviderPreference::feature_flag(ProviderId::Tinfoil)),
                 continuum_available: false,
                 expected_access: true,
                 expected_public_model: GLM_5_3_MODEL_ID,
                 expected_provider: "tinfoil",
                 expected_provider_model: GLM_5_3_MODEL_ID,
-                expected_source: ProviderSelectionSource::FeatureFlag,
+                expected_source: RouteSelectionSource::FeatureFlag,
             },
         ];
 
@@ -831,6 +885,125 @@ mod tests {
                 case.name
             );
             assert_eq!(selected.bucket, None, "{}", case.name);
+
+            let intent = InferenceIntent::new(
+                uuid_for_bucket(73),
+                case.selector,
+                resolved_model,
+                case.plan,
+                InferenceSurface::ChatCompletions,
+                WorkloadClass::Interactive,
+            );
+            let active = Ok(selected.clone());
+            let shadow =
+                router.shadow_completion_plan(&proxy_router, &intent, case.provider_preference);
+            assert!(
+                matches!(
+                    compare_shadow_route(&active, &shadow),
+                    ShadowRouteComparison::Match { .. }
+                ),
+                "{}: active={active:?}, shadow={shadow:?}",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn shadow_planner_matches_legacy_except_for_the_router_v2_glm_5_3_ga_fallback() {
+        let router = ProviderRouter::default();
+        let both = proxy_router_with_both_providers();
+        let tinfoil_only = ProxyRouter::new(
+            "https://api.openai.com".to_string(),
+            None,
+            "http://tinfoil.example.com".to_string(),
+        );
+
+        for proxy_router in [&both, &tinfoil_only] {
+            for model in PROVIDER_REGISTRY.completion_models() {
+                for bucket in [0, 29, 30, 69, 70, 99] {
+                    let account_uuid = uuid_for_bucket(bucket);
+                    let intent = InferenceIntent::new(
+                        account_uuid,
+                        model.public_model_id,
+                        model.public_model_id,
+                        ModelPlan::Paid,
+                        InferenceSurface::Responses,
+                        WorkloadClass::Interactive,
+                    );
+                    let active = router.select_completion_route_with_preference(
+                        proxy_router,
+                        account_uuid,
+                        model.public_model_id,
+                        None,
+                    );
+                    let shadow = router.shadow_completion_plan(proxy_router, &intent, None);
+                    let comparison = compare_shadow_route(&active, &shadow);
+                    let is_router_v2_only_glm_fallback = model.public_model_id == GLM_5_3_MODEL_ID
+                        && proxy_for_provider(proxy_router, ProviderId::Continuum).is_none();
+
+                    if is_router_v2_only_glm_fallback {
+                        assert!(
+                            matches!(
+                                comparison,
+                                ShadowRouteComparison::Mismatch {
+                                    active: CredentialFreeRouteOutcome::NoEligibleRoute,
+                                    shadow: CredentialFreeRouteOutcome::Selected(RouteIdentity {
+                                        provider: ProviderId::Tinfoil,
+                                        ..
+                                    }),
+                                    ..
+                                }
+                            ),
+                            "model={}, bucket={bucket}, active={active:?}, shadow={shadow:?}",
+                            model.public_model_id
+                        );
+                    } else {
+                        assert!(
+                            matches!(comparison, ShadowRouteComparison::Match { .. }),
+                            "model={}, bucket={bucket}, active={active:?}, shadow={shadow:?}",
+                            model.public_model_id
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn shadow_planner_matches_legacy_error_classes_for_unknown_models() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+
+        for model in [
+            "unknown-model",
+            "kimi-k-3",
+            "kimi-k3-latest",
+            "deepseek-v4-flash-0731",
+        ] {
+            let account_uuid = uuid_for_bucket(50);
+            let intent = InferenceIntent::new(
+                account_uuid,
+                model,
+                model,
+                ModelPlan::Paid,
+                InferenceSurface::ChatCompletions,
+                WorkloadClass::Interactive,
+            );
+            let active = router.select_completion_route_with_preference(
+                &proxy_router,
+                account_uuid,
+                model,
+                None,
+            );
+            let shadow = router.shadow_completion_plan(&proxy_router, &intent, None);
+
+            assert!(matches!(
+                compare_shadow_route(&active, &shadow),
+                ShadowRouteComparison::Match {
+                    outcome: CredentialFreeRouteOutcome::UnsupportedModel,
+                    ..
+                }
+            ));
         }
     }
 
@@ -851,7 +1024,7 @@ mod tests {
             assert_eq!(selected.bucket, None);
             assert_eq!(
                 selected.selection_source,
-                ProviderSelectionSource::DefaultProvider
+                RouteSelectionSource::DefaultProvider
             );
         }
     }
@@ -888,11 +1061,11 @@ mod tests {
             .expect("GLM 5.3 provider flag");
 
         assert_eq!(flag.key(), GLM_5_3_TINFOIL_FLAG_KEY);
-        assert_eq!(flag.preference_for(true).provider, ProviderName::Tinfoil);
-        assert_eq!(flag.preference_for(false).provider, ProviderName::Continuum);
+        assert_eq!(flag.preference_for(true).provider(), ProviderId::Tinfoil);
+        assert_eq!(flag.preference_for(false).provider(), ProviderId::Continuum);
         assert_eq!(
-            flag.preference_for(true).source,
-            ProviderSelectionSource::FeatureFlag
+            flag.preference_for(true).source(),
+            RouteSelectionSource::FeatureFlag
         );
     }
 
@@ -906,7 +1079,7 @@ mod tests {
                 &proxy_router,
                 uuid_for_bucket(1),
                 GLM_5_2_MODEL_ID,
-                Some(ProviderPreference::feature_flag(ProviderName::Continuum)),
+                Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
             )
             .expect("route");
 
@@ -915,7 +1088,7 @@ mod tests {
         assert_eq!(selected.provider_model_id, GLM_5_2_MODEL_ID);
         assert_eq!(selected.response_model_id, GLM_5_2_MODEL_ID);
         assert_eq!(selected.bucket, None);
-        assert_eq!(selected.selection_source, ProviderSelectionSource::Fallback);
+        assert_eq!(selected.selection_source, RouteSelectionSource::Fallback);
     }
 
     #[test]
@@ -928,17 +1101,14 @@ mod tests {
                 &proxy_router,
                 uuid_for_bucket(99),
                 GLM_5_2_MODEL_ID,
-                Some(ProviderPreference::feature_flag(ProviderName::Tinfoil)),
+                Some(ProviderPreference::feature_flag(ProviderId::Tinfoil)),
             )
             .expect("route");
 
         assert_eq!(selected.proxy.provider_name, "tinfoil");
         assert_eq!(selected.provider_model_id, GLM_5_2_MODEL_ID);
         assert_eq!(selected.bucket, None);
-        assert_eq!(
-            selected.selection_source,
-            ProviderSelectionSource::FeatureFlag
-        );
+        assert_eq!(selected.selection_source, RouteSelectionSource::FeatureFlag);
     }
 
     #[test]
@@ -955,14 +1125,14 @@ mod tests {
                 &tinfoil_only,
                 uuid_for_bucket(70),
                 GLM_5_2_MODEL_ID,
-                Some(ProviderPreference::feature_flag(ProviderName::Continuum)),
+                Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
             )
             .expect("route");
 
         assert_eq!(selected.proxy.provider_name, "tinfoil");
         assert_eq!(selected.provider_model_id, GLM_5_2_MODEL_ID);
         assert_eq!(selected.bucket, None);
-        assert_eq!(selected.selection_source, ProviderSelectionSource::Fallback);
+        assert_eq!(selected.selection_source, RouteSelectionSource::Fallback);
     }
 
     #[test]
@@ -982,7 +1152,7 @@ mod tests {
             assert_eq!(selected.bucket, None);
             assert_eq!(
                 selected.selection_source,
-                ProviderSelectionSource::DefaultProvider
+                RouteSelectionSource::DefaultProvider
             );
         }
     }
@@ -1003,7 +1173,7 @@ mod tests {
         assert_eq!(selected.bucket, None);
         assert_eq!(
             selected.selection_source,
-            ProviderSelectionSource::DefaultProvider
+            RouteSelectionSource::DefaultProvider
         );
     }
 
@@ -1029,10 +1199,7 @@ mod tests {
         assert_eq!(selected.provider_model_id, GLM_5_3_MODEL_ID);
         assert_eq!(selected.response_model_id, GLM_5_3_MODEL_ID);
         assert_eq!(selected.bucket, None);
-        assert_eq!(
-            selected.selection_source,
-            ProviderSelectionSource::FeatureFlag
-        );
+        assert_eq!(selected.selection_source, RouteSelectionSource::FeatureFlag);
 
         let selected = router
             .select_completion_route_with_preference(
@@ -1045,10 +1212,7 @@ mod tests {
 
         assert_eq!(selected.proxy.provider_name, "continuum");
         assert_eq!(selected.provider_model_id, "glm-5.3");
-        assert_eq!(
-            selected.selection_source,
-            ProviderSelectionSource::FeatureFlag
-        );
+        assert_eq!(selected.selection_source, RouteSelectionSource::FeatureFlag);
     }
 
     #[test]
@@ -1071,7 +1235,7 @@ mod tests {
         assert_eq!(selected.bucket, None);
         assert_eq!(
             selected.selection_source,
-            ProviderSelectionSource::DefaultProvider
+            RouteSelectionSource::DefaultProvider
         );
     }
 
@@ -1100,7 +1264,7 @@ mod tests {
         assert_eq!(selected.bucket, None);
         assert_eq!(
             selected.selection_source,
-            ProviderSelectionSource::DefaultProvider
+            RouteSelectionSource::DefaultProvider
         );
     }
 

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -3,6 +3,7 @@ use crate::inference::{
     CompletionEvidence, InferenceAttempt, InferenceExecution, InferenceIntent, InferenceSurface,
     ReplaySafety, WorkloadClass,
 };
+use crate::inference_planning::{RoutePlan, RoutePlanningError};
 use crate::model_config::{
     model_alias_requires_flag_lookup, model_catalog_response, openai_models_response,
     ModelAliasTargets, ModelPlan,
@@ -16,8 +17,10 @@ use crate::provider_client::{
     ProviderClient, ProviderRequest, ProviderRequestError, ProviderResponse, ProviderSendTrace,
     UpstreamProviderError,
 };
+use crate::provider_registry::{ProviderId, SHADOW_ROUTING_POLICY_VERSION};
 use crate::provider_routing::{
-    InferenceRoutingMode, ProviderName, ProviderRoutingError, SelectedProviderRoute,
+    compare_shadow_route, InferenceRoutingMode, ProviderRoutingError, SelectedProviderRoute,
+    ShadowRouteComparison,
 };
 use crate::proxy_config::ProxyConfig;
 use crate::sqs::UsageEvent;
@@ -1650,6 +1653,40 @@ async fn proxy_openai(
     Ok(Sse::new(stream).into_response())
 }
 
+fn retain_active_route_after_shadow_observation(
+    intent: &InferenceIntent,
+    active: Result<SelectedProviderRoute, ProviderRoutingError>,
+    shadow: Result<RoutePlan, RoutePlanningError>,
+) -> Result<SelectedProviderRoute, ProviderRoutingError> {
+    let comparison = compare_shadow_route(&active, &shadow);
+    let policy_version = shadow
+        .as_ref()
+        .map(|plan| plan.policy_version)
+        .unwrap_or(SHADOW_ROUTING_POLICY_VERSION);
+    let candidate_scope = shadow.as_ref().ok().map(|plan| plan.candidate_scope);
+
+    match &comparison {
+        ShadowRouteComparison::Match { .. } => debug!(
+            "Shadow route matched active route: request_id={}, public_model={}, policy_version={}, candidate_scope={:?}, comparison={:?}",
+            intent.request_id,
+            intent.public_model_id,
+            policy_version,
+            candidate_scope,
+            comparison
+        ),
+        ShadowRouteComparison::Mismatch { .. } => warn!(
+            "Shadow route differed from active route; retaining active route: request_id={}, public_model={}, policy_version={}, candidate_scope={:?}, comparison={:?}",
+            intent.request_id,
+            intent.public_model_id,
+            policy_version,
+            candidate_scope,
+            comparison
+        ),
+    }
+
+    active
+}
+
 pub(crate) async fn prepare_completion_request(
     state: &Arc<AppState>,
     user: &User,
@@ -1669,25 +1706,34 @@ pub(crate) async fn prepare_completion_request(
     let provider_preference = state
         .provider_routing_preference(user.uuid, &intent.public_model_id)
         .await;
-    let route = state
-        .provider_router
-        .select_completion_route_for_mode(
-            &state.proxy_router,
-            user.uuid,
-            &intent.public_model_id,
-            provider_preference,
-            routing.mode(),
-        )
-        .map_err(|err| match err {
-            ProviderRoutingError::UnsupportedModel(model) => {
-                error!("Unsupported completion model requested: {}", model);
-                ApiError::BadRequest
-            }
-            ProviderRoutingError::NoEligibleRoute(model) => {
-                error!("No eligible provider route for completion model: {}", model);
-                ApiError::InternalServerError
-            }
-        })?;
+    let active = state.provider_router.select_completion_route_for_mode(
+        &state.proxy_router,
+        user.uuid,
+        &intent.public_model_id,
+        provider_preference,
+        routing.mode(),
+    );
+    let selected = match routing.mode() {
+        InferenceRoutingMode::Legacy => active,
+        InferenceRoutingMode::V2 => {
+            let shadow = state.provider_router.shadow_completion_plan(
+                &state.proxy_router,
+                &intent,
+                provider_preference,
+            );
+            retain_active_route_after_shadow_observation(&intent, active, shadow)
+        }
+    };
+    let route = selected.map_err(|err| match err {
+        ProviderRoutingError::UnsupportedModel(model) => {
+            error!("Unsupported completion model requested: {}", model);
+            ApiError::BadRequest
+        }
+        ProviderRoutingError::NoEligibleRoute(model) => {
+            error!("No eligible provider route for completion model: {}", model);
+            ApiError::InternalServerError
+        }
+    })?;
 
     debug!(
         "Pinned inference route: request_id={}, routing_mode={:?}, selection_mode={:?}, auto={}, surface={:?}, workload={:?}, requested_model={}, public_model={}, provider={}, provider_model={}, bucket={:?}, source={:?}",
@@ -1794,7 +1840,7 @@ pub(crate) async fn get_chat_completion_response_for_expected_route(
             CompletionExecutionError::Request(ApiError::ServiceUnavailable)
         })?;
 
-    let continuum_cache_salt = (route.provider_name == ProviderName::Continuum.as_str())
+    let continuum_cache_salt = (route.provider_name == ProviderId::Continuum.as_str())
         .then(|| format!("server-selected-{}", Uuid::new_v4().simple()));
     get_chat_completion_response_with_options(
         state,
@@ -2257,7 +2303,7 @@ fn apply_provider_managed_request_fields(
         .remove(PROVIDER_MANAGED_USER_CACHE_SECRET_FIELD)
         .is_some();
 
-    if provider_name == ProviderName::Tinfoil.as_str() {
+    if provider_name == ProviderId::Tinfoil.as_str() {
         let user_cache_secret = match cache_policy {
             CompletionCachePolicy::LegacyV1 => tinfoil_user_cache_secret(user_uuid),
             CompletionCachePolicy::BoundV2(namespace) => namespace.tinfoil_user_cache_secret(),
@@ -2279,7 +2325,7 @@ fn apply_server_selected_cache_isolation(
     provider_name: &str,
     continuum_cache_salt: Option<&str>,
 ) -> Result<(), ApiError> {
-    if provider_name != ProviderName::Continuum.as_str() {
+    if provider_name != ProviderId::Continuum.as_str() {
         return Ok(());
     }
 
@@ -3498,7 +3544,7 @@ mod tests {
         let proxy = ProxyConfig {
             base_url,
             api_key: None,
-            provider_name: ProviderName::Tinfoil.as_str().to_string(),
+            provider_name: ProviderId::Tinfoil.as_str().to_string(),
         };
         let trace = try_provider(
             &client,
@@ -3576,7 +3622,7 @@ mod tests {
                 WorkloadClass::Interactive,
             ),
             route: SelectedProviderRoute {
-                provider: ProviderName::Tinfoil,
+                provider: ProviderId::Tinfoil,
                 proxy: ProxyConfig {
                     base_url: "http://tinfoil.example.com".to_string(),
                     api_key: None,
@@ -3586,7 +3632,7 @@ mod tests {
                 provider_model_id: "glm-5-2".to_string(),
                 response_model_id: "glm-5-2".to_string(),
                 bucket: None,
-                selection_source: crate::provider_routing::ProviderSelectionSource::DefaultProvider,
+                selection_source: crate::provider_registry::RouteSelectionSource::DefaultProvider,
             },
             routing_mode: InferenceRoutingMode::V2,
         }
@@ -3993,7 +4039,7 @@ mod tests {
         let proxy = ProxyConfig {
             base_url,
             api_key: None,
-            provider_name: ProviderName::Tinfoil.as_str().to_string(),
+            provider_name: ProviderId::Tinfoil.as_str().to_string(),
         };
         let trace = try_provider(
             &client,
@@ -4061,6 +4107,64 @@ mod tests {
         );
         assert!(pinned.intent().selection_mode.is_auto());
         assert_eq!(pinned.routing_mode(), InferenceRoutingMode::V2);
+    }
+
+    #[test]
+    fn shadow_mismatch_or_error_never_changes_the_active_route() {
+        use crate::inference_planning::{CandidateScope, PlanDecision};
+
+        let mut pinned = pinned_test_completion();
+        pinned.route.proxy.base_url = "https://active-route.example".to_string();
+        pinned.route.proxy.api_key = Some("sentinel-active-api-key".to_string());
+        let active = pinned.route.clone();
+        let shadow = RoutePlan {
+            selected: crate::inference::RouteIdentity::new(
+                ProviderId::Continuum,
+                "glm-5-2",
+                "shadow-provider-model",
+                "glm-5-2",
+                crate::provider_registry::RouteSelectionSource::Fallback,
+                Some(73),
+            ),
+            eligible_routes: Vec::new(),
+            decision: PlanDecision::PreferredProviderUnavailable,
+            candidate_scope: CandidateScope::SamePublicModelOnly,
+            policy_version: SHADOW_ROUTING_POLICY_VERSION,
+        };
+
+        let comparison = compare_shadow_route(&Ok(active.clone()), &Ok(shadow.clone()));
+        let comparison_debug = format!("{comparison:?}");
+        assert!(!comparison_debug.contains("active-route.example"));
+        assert!(!comparison_debug.contains("sentinel-active-api-key"));
+
+        let retained = retain_active_route_after_shadow_observation(
+            pinned.intent(),
+            Ok(active.clone()),
+            Ok(shadow.clone()),
+        )
+        .expect("shadow mismatch must retain active route");
+        assert_eq!(retained.identity(), active.identity());
+        assert_eq!(retained.proxy, active.proxy);
+
+        let retained = retain_active_route_after_shadow_observation(
+            pinned.intent(),
+            Ok(active.clone()),
+            Err(RoutePlanningError::NoEligibleRoute("glm-5-2".to_string())),
+        )
+        .expect("shadow error must retain active route");
+        assert_eq!(retained.identity(), active.identity());
+        assert_eq!(retained.proxy, active.proxy);
+
+        let active_error = ProviderRoutingError::NoEligibleRoute("glm-5-2".to_string());
+        let result = retain_active_route_after_shadow_observation(
+            pinned.intent(),
+            Err(active_error.clone()),
+            Ok(shadow),
+        );
+        assert_eq!(
+            result.expect_err("shadow success cannot rescue active failure"),
+            active_error
+        );
     }
 
     #[test]
@@ -4598,7 +4702,7 @@ mod tests {
 
         apply_provider_managed_request_fields(
             &mut body,
-            ProviderName::Tinfoil.as_str(),
+            ProviderId::Tinfoil.as_str(),
             user_uuid,
             &CompletionCachePolicy::LegacyV1,
         );
@@ -4625,7 +4729,7 @@ mod tests {
 
         apply_provider_managed_request_fields(
             &mut body,
-            ProviderName::Tinfoil.as_str(),
+            ProviderId::Tinfoil.as_str(),
             user_uuid,
             &CompletionCachePolicy::BoundV2(namespace),
         );
@@ -4650,7 +4754,7 @@ mod tests {
 
         apply_provider_managed_request_fields(
             &mut body,
-            ProviderName::Continuum.as_str(),
+            ProviderId::Continuum.as_str(),
             Uuid::from_u128(42),
             &CompletionCachePolicy::LegacyV1,
         );
@@ -4669,7 +4773,7 @@ mod tests {
 
         apply_provider_managed_request_fields(
             &mut body,
-            ProviderName::Continuum.as_str(),
+            ProviderId::Continuum.as_str(),
             user_uuid,
             &CompletionCachePolicy::LegacyV1,
         );
@@ -4678,7 +4782,7 @@ mod tests {
         let server_salt = format!("server-selected-{}", Uuid::new_v4().simple());
         apply_server_selected_cache_isolation(
             &mut body,
-            ProviderName::Continuum.as_str(),
+            ProviderId::Continuum.as_str(),
             Some(&server_salt),
         )
         .expect("server-selected Continuum salt should be accepted");


### PR DESCRIPTION
Router v2 gains a deterministic shadow planner backed by an explicit provider registry. The planner compares its proposed route with the active legacy selection without changing the executed request.

- Keep credentials outside the registry and model public identity separately from provider-specific names.
- Resolve aliases before planning and restrict every candidate to the resulting public model. A planner mismatch or error cannot change, rescue, or retry the active route at this layer.
- Represent standard GLM 5.3 as Continuum `glm-5.3` and Tinfoil `glm-5-3`. GLM 5.3 Flash remains the separate Tinfoil-only `glm-5-3-flash` model; GLM 5.2 also remains Tinfoil-only.
- Run planning/comparison only for Router-v2 requests. Flag-off returns through the compiled legacy selector before registry planning, preserving its selection precedence and public errors.

Router v2 remains default off. The stack retains the execution ownership, cancellation/deletion quiescence, and durable terminal behavior inherited from [#343](https://github.com/OpenSecretCloud/opensecret/pull/343) through its parent layers.

Local validation at `6429fca03df4f60c4c4cd66d2594cc81758d90a2`: direct pinned formatting and warning-denied all-target/all-feature Clippy passed; the full all-feature suite reported **505 passed, 0 failed, 23 ignored**. Registry/catalog, public-model separation, provider translation, deterministic precedence, and shadow-inertness tests passed. Independent review of this exact head found no P0/P1 blocker.

Final GitHub snapshot, 2026-09-04 23:32:16 UTC: RustSec passed, the only attached check; none are pending or failed. The exact head, parent base, and merge-base match; the PR is open, non-draft, mergeable/CLEAN, and zero commits behind.

Stack **3/8**: [#298](https://github.com/OpenSecretCloud/opensecret/pull/298) → **#299** → [#300](https://github.com/OpenSecretCloud/opensecret/pull/300). Final head/base: **6429fca03df4f60c4c4cd66d2594cc81758d90a2 / 29254f3b4a8b0de7f432a88a5ee8c537b4f3162e**.

[Routing walkthrough: registry and shadow planning](https://maple-routing-review.anthony599874.chatgpt.site/#stack-3) · [Provider registry](https://github.com/OpenSecretCloud/opensecret/blob/6429fca03df4f60c4c4cd66d2594cc81758d90a2/src/provider_registry.rs) · [Planner](https://github.com/OpenSecretCloud/opensecret/blob/6429fca03df4f60c4c4cd66d2594cc81758d90a2/src/inference_planning.rs).
