### PR TITLE
[routing v2 4/8] Stabilize capacity and Responses execution

### DIFF
--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -24,7 +24,11 @@ use crate::{
     },
     private_key::generate_twelve_word_seed,
     seed_wrapping::{password_reset_code_mac, CredentialKind},
-    web::responses::{handlers::StorageMessage, storage_task, StorageTaskOutcome},
+    web::responses::{
+        handlers::{ResponseTerminal, StorageMessage},
+        storage::StorageTaskOutcome,
+        storage_task,
+    },
     AppMode, AppState, AppStateBuilder, Error,
 };
 use chrono::Utc;
@@ -32,7 +36,7 @@ use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
 use password_auth::generate_hash;
 use secp256k1::SecretKey;
 use std::sync::Arc;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{mpsc, oneshot, RwLock};
 use uuid::Uuid;
 
 fn test_credential(label: &str) -> &'static str {
@@ -1426,9 +1430,11 @@ async fn db_response_storage_completion_acknowledges_durable_assistant() {
     let user_key = SecretKey::from_slice(&[7u8; 32]).expect("test key should be valid");
     let decryption_key = user_key;
     let (storage_tx, storage_rx) = mpsc::channel(8);
+    let (terminal_tx, mut terminal_rx) = oneshot::channel();
     let storage_handle = tokio::spawn(storage_task(
         storage_rx,
         None,
+        Some(terminal_tx),
         app_state.db.clone(),
         response.id,
         response_uuid,
@@ -1459,16 +1465,18 @@ async fn db_response_storage_completion_acknowledges_durable_assistant() {
         .await
         .expect("queue assistant completion");
     storage_tx
-        .send(StorageMessage::ResponseDone {
+        .send(StorageMessage::Terminal(ResponseTerminal::Completed {
             finish_reason: "stop".to_string(),
-        })
+        }))
         .await
         .expect("queue response completion");
 
-    assert_eq!(
-        storage_handle.await.expect("join storage task"),
-        StorageTaskOutcome::Completed
-    );
+    let terminal = (&mut terminal_rx)
+        .await
+        .expect("terminal sender should finish")
+        .expect("terminal persistence should succeed")
+        .expect("response still exists");
+    assert_eq!(terminal.status(), ResponseStatus::Completed);
     let persisted_response = app_state
         .db
         .get_response_by_uuid_and_user(response_uuid, user.uuid)
@@ -1492,71 +1500,101 @@ async fn db_response_storage_completion_acknowledges_durable_assistant() {
     .expect("assistant ciphertext should decrypt");
     assert_eq!(plaintext, assistant_text.as_bytes());
 
+    assert_eq!(
+        storage_handle.await.expect("join storage task"),
+        StorageTaskOutcome::Completed
+    );
     let _ = app_state.db.delete_user(&user);
 }
 
 #[tokio::test]
 #[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
-async fn db_response_storage_completion_yields_to_committed_cancellation() {
+async fn db_response_storage_terminal_yields_to_committed_authoritative_status() {
     let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
         eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
         return;
     };
 
     let app_state = build_local_test_app_state(database_url).await;
-    let project = first_active_project(&app_state);
-    let marker = Uuid::new_v4();
-    let user = create_response_transaction_test_user(
-        &app_state,
-        project.id,
-        marker,
-        "storage-cancellation-race",
-    );
-    let conversation_id = insert_response_transaction_test_conversation(&app_state, user.uuid);
-    let response_uuid = Uuid::new_v4();
-    let response = app_state
-        .db
-        .create_response(response_transaction_test_response(
+    for (persisted_status, requested, expected_outcome) in [
+        (
+            ResponseStatus::Cancelled,
+            ResponseTerminal::Completed {
+                finish_reason: "stop".to_string(),
+            },
+            StorageTaskOutcome::Cancelled,
+        ),
+        (
+            ResponseStatus::Completed,
+            ResponseTerminal::Cancelled,
+            StorageTaskOutcome::Completed,
+        ),
+    ] {
+        let project = first_active_project(&app_state);
+        let marker = Uuid::new_v4();
+        let user = create_response_transaction_test_user(
+            &app_state,
+            project.id,
+            marker,
+            "storage-cancellation-race",
+        );
+        let conversation_id = insert_response_transaction_test_conversation(&app_state, user.uuid);
+        let response_uuid = Uuid::new_v4();
+        let response = app_state
+            .db
+            .create_response(response_transaction_test_response(
+                response_uuid,
+                user.uuid,
+                conversation_id,
+            ))
+            .expect("response should insert");
+        app_state
+            .db
+            .update_response_status_if_current(
+                response.id,
+                ResponseStatus::InProgress,
+                persisted_status,
+                Some(Utc::now()),
+            )
+            .expect("competing terminal should commit");
+        let user_key = SecretKey::from_slice(&[8u8; 32]).expect("test key should be valid");
+        let (storage_tx, storage_rx) = mpsc::channel(2);
+        let (terminal_tx, mut terminal_rx) = oneshot::channel();
+        let storage_handle = tokio::spawn(storage_task(
+            storage_rx,
+            None,
+            Some(terminal_tx),
+            app_state.db.clone(),
+            response.id,
             response_uuid,
-            user.uuid,
+            Utc::now(),
             conversation_id,
-        ))
-        .expect("response should insert");
-    app_state
-        .db
-        .cancel_response(response_uuid, user.uuid)
-        .expect("cancellation should commit before its broadcast");
-    let user_key = SecretKey::from_slice(&[8u8; 32]).expect("test key should be valid");
-    let (storage_tx, storage_rx) = mpsc::channel(2);
-    let storage_handle = tokio::spawn(storage_task(
-        storage_rx,
-        None,
-        app_state.db.clone(),
-        response.id,
-        response_uuid,
-        Utc::now(),
-        conversation_id,
-        user.uuid,
-        user_key,
-    ));
-    storage_tx
-        .send(StorageMessage::ResponseDone {
-            finish_reason: "stop".to_string(),
-        })
-        .await
-        .expect("queue racing response completion");
+            user.uuid,
+            user_key,
+        ));
+        storage_tx
+            .send(StorageMessage::Terminal(requested))
+            .await
+            .expect("queue racing response completion");
 
-    assert_eq!(
-        storage_handle.await.expect("join storage task"),
-        StorageTaskOutcome::Cancelled
-    );
-    let persisted_response = app_state
-        .db
-        .get_response_by_uuid_and_user(response_uuid, user.uuid)
-        .expect("cancelled response should be readable");
-    assert_eq!(persisted_response.status, ResponseStatus::Cancelled);
+        let terminal = (&mut terminal_rx)
+            .await
+            .expect("terminal sender should finish")
+            .expect("terminal persistence should succeed")
+            .expect("response still exists");
+        assert_eq!(terminal.status(), persisted_status);
+        let persisted_response = app_state
+            .db
+            .get_response_by_uuid_and_user(response_uuid, user.uuid)
+            .expect("cancelled response should be readable");
+        assert_eq!(persisted_response.status, persisted_status);
 
-    let _ = app_state.db.delete_user(&user);
+        assert_eq!(
+            storage_handle.await.expect("join storage task"),
+            expected_outcome
+        );
+        let _ = app_state.db.delete_user(&user);
+    }
 }
 
 #[tokio::test]
@@ -1590,9 +1628,11 @@ async fn db_response_storage_write_failure_never_acknowledges_completion() {
     let assistant_item_id = Uuid::new_v4();
     let user_key = SecretKey::from_slice(&[9u8; 32]).expect("test key should be valid");
     let (storage_tx, storage_rx) = mpsc::channel(8);
+    let (terminal_tx, mut terminal_rx) = oneshot::channel();
     let storage_handle = tokio::spawn(storage_task(
         storage_rx,
         None,
+        Some(terminal_tx),
         app_state.db.clone(),
         response.id,
         response_uuid,
@@ -1622,21 +1662,27 @@ async fn db_response_storage_write_failure_never_acknowledges_completion() {
         .await
         .expect("queue assistant completion");
     storage_tx
-        .send(StorageMessage::ResponseDone {
+        .send(StorageMessage::Terminal(ResponseTerminal::Completed {
             finish_reason: "stop".to_string(),
-        })
+        }))
         .await
         .expect("queue response completion");
 
-    assert_eq!(
-        storage_handle.await.expect("join storage task"),
-        StorageTaskOutcome::Failed
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(250), &mut terminal_rx)
+            .await
+            .is_err(),
+        "failed item persistence must not acknowledge a terminal"
+    );
+    assert!(
+        !storage_handle.is_finished(),
+        "storage must retain ownership while cleanup retries"
     );
     let persisted_response = app_state
         .db
         .get_response_by_uuid_and_user(response_uuid, user.uuid)
-        .expect("failed response should be readable");
-    assert_eq!(persisted_response.status, ResponseStatus::Failed);
+        .expect("unfinished response should be readable");
+    assert_eq!(persisted_response.status, ResponseStatus::InProgress);
     assert!(
         app_state
             .db
@@ -1646,6 +1692,24 @@ async fn db_response_storage_write_failure_never_acknowledges_completion() {
         "failed assistant write must not produce a false durable item"
     );
 
+    // Deleting this disposable row lets the retrying worker establish that no
+    // terminal can be published, without pretending the failed write succeeded.
+    app_state
+        .db
+        .delete_response(response_uuid, user.uuid)
+        .expect("delete test response");
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_secs(2), terminal_rx)
+            .await
+            .expect("storage should notice deletion")
+            .expect("terminal sender")
+            .expect("deletion is authoritative")
+            .is_none()
+    );
+    assert_eq!(
+        storage_handle.await.expect("join storage task"),
+        StorageTaskOutcome::Failed
+    );
     let _ = app_state.db.delete_user(&user);
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -682,6 +682,7 @@ pub trait DBConnection {
         -> Result<(), DBError>;
     fn get_user_message(&self, id: i64, user_id: Uuid) -> Result<UserMessage, DBError>;
     fn get_user_message_by_uuid(&self, uuid: Uuid, user_id: Uuid) -> Result<UserMessage, DBError>;
+    fn user_message_uuid_exists(&self, uuid: Uuid) -> Result<bool, DBError>;
 
     // Assistant messages
     fn create_assistant_message(
@@ -703,6 +704,8 @@ pub trait DBConnection {
 
     // Reasoning items
     fn create_reasoning_item(&self, new_item: NewReasoningItem) -> Result<ReasoningItem, DBError>;
+    fn get_reasoning_item_by_uuid(&self, item_uuid: Uuid)
+        -> Result<Option<ReasoningItem>, DBError>;
     fn update_reasoning_item(
         &self,
         item_uuid: Uuid,
@@ -715,6 +718,7 @@ pub trait DBConnection {
     fn create_tool_call(&self, new_call: NewToolCall) -> Result<ToolCall, DBError>;
     fn get_tool_call_by_uuid(&self, uuid: Uuid, user_id: Uuid) -> Result<ToolCall, DBError>;
     fn create_tool_output(&self, new_output: NewToolOutput) -> Result<ToolOutput, DBError>;
+    fn get_tool_output_by_uuid(&self, uuid: Uuid, user_id: Uuid) -> Result<ToolOutput, DBError>;
 
     // Context reconstruction
     fn get_conversation_context_messages(
@@ -2836,6 +2840,11 @@ impl DBConnection for PostgresConnection {
         UserMessage::get_by_uuid_and_user(conn, uuid, user_id).map_err(DBError::from)
     }
 
+    fn user_message_uuid_exists(&self, uuid: Uuid) -> Result<bool, DBError> {
+        let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
+        UserMessage::uuid_exists(conn, uuid).map_err(DBError::from)
+    }
+
     // Assistant messages
     fn create_assistant_message(
         &self,
@@ -2885,6 +2894,14 @@ impl DBConnection for PostgresConnection {
         new_item.insert(conn).map_err(DBError::from)
     }
 
+    fn get_reasoning_item_by_uuid(
+        &self,
+        item_uuid: Uuid,
+    ) -> Result<Option<ReasoningItem>, DBError> {
+        let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
+        ReasoningItem::get_by_uuid(conn, item_uuid).map_err(DBError::from)
+    }
+
     fn update_reasoning_item(
         &self,
         item_uuid: Uuid,
@@ -2911,6 +2928,11 @@ impl DBConnection for PostgresConnection {
     fn create_tool_output(&self, new_output: NewToolOutput) -> Result<ToolOutput, DBError> {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         new_output.insert(conn).map_err(DBError::from)
+    }
+
+    fn get_tool_output_by_uuid(&self, uuid: Uuid, user_id: Uuid) -> Result<ToolOutput, DBError> {
+        let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
+        ToolOutput::get_by_uuid(conn, uuid, user_id).map_err(DBError::from)
     }
 
     // Context reconstruction

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -194,6 +194,7 @@ pub(crate) enum AttemptFailureKind {
     Transport,
     ResponseStartTimeout,
     HttpStatus,
+    CapacityRejected,
     ResponseBody,
     InvalidResponse,
     UpstreamResponseError,

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ use crate::{
 use crate::{encrypt::create_new_encryption_key, jwt::validate_jwt};
 use aws_credentials::{AwsCredentialManager, AwsCredentials};
 use axum::{
-    http::{HeaderName, HeaderValue, StatusCode},
+    http::{header, HeaderName, HeaderValue, StatusCode},
     middleware::{from_fn, from_fn_with_state, Next},
     response::{IntoResponse, Response},
     Json, Router,
@@ -72,12 +72,13 @@ use secp256k1::SecretKey;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
+use std::collections::HashSet;
 use std::env;
 use std::fmt;
 use std::io::Write;
 use std::num::NonZeroUsize;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 use subtle::ConstantTimeEq;
 use tokio::spawn;
@@ -169,10 +170,13 @@ const ENCRYPTION_SESSION_IDLE_TTL: Duration = Duration::from_secs(65 * 60);
 
 pub(crate) const ERROR_CONTRACT_HEADER: &str = "x-opensecret-error-contract";
 pub(crate) const ERROR_CODE_HEADER: &str = "x-opensecret-error-code";
-const ERROR_CONTRACT_VERSION: &str = "1";
+pub(crate) const CLIENT_REPLAY_HEADER: &str = "x-opensecret-client-replay";
+pub(crate) const ERROR_CONTRACT_VERSION: &str = "1";
 const SESSION_NOT_FOUND_ERROR_CODE: &str = "session_not_found";
 const ACCESS_TOKEN_EXPIRED_ERROR_CODE: &str = "access_token_expired";
 const IMAGE_DESCRIPTION_UNAVAILABLE_ERROR_CODE: &str = "image_description_unavailable";
+pub(crate) const INFERENCE_CAPACITY_ERROR_CODE: &str = "inference_capacity";
+const CLIENT_REPLAY_SAFE: &str = "safe";
 
 type PendingAttestationKey = [u8; 32];
 pub(crate) type SessionLease = CacheLease<SessionState>;
@@ -379,6 +383,12 @@ pub enum ApiError {
 
     #[error("Upstream provider temporarily unavailable")]
     ImageDescriptionUnavailable,
+    #[error("Inference capacity is temporarily unavailable")]
+    InferenceCapacity {
+        status: StatusCode,
+        retry_after: Option<Duration>,
+        client_replay_safe: bool,
+    },
 
     #[error("Bad Request")]
     BadRequest,
@@ -441,6 +451,18 @@ pub enum ApiError {
     TooManyRequests,
 }
 
+impl ApiError {
+    pub(crate) fn with_client_replay_safe(mut self) -> Self {
+        if let Self::InferenceCapacity {
+            client_replay_safe, ..
+        } = &mut self
+        {
+            *client_replay_safe = true;
+        }
+        self
+    }
+}
+
 impl IntoResponse for ApiError {
     fn into_response(self) -> axum::response::Response {
         let status = match &self {
@@ -451,6 +473,7 @@ impl IntoResponse for ApiError {
             ApiError::InternalServerError => StatusCode::INTERNAL_SERVER_ERROR,
             ApiError::ServiceUnavailable => StatusCode::SERVICE_UNAVAILABLE,
             ApiError::ImageDescriptionUnavailable => StatusCode::SERVICE_UNAVAILABLE,
+            ApiError::InferenceCapacity { status, .. } => *status,
             ApiError::BadRequest => StatusCode::BAD_REQUEST,
             ApiError::SessionNotFound => StatusCode::BAD_REQUEST,
             ApiError::Conflict => StatusCode::CONFLICT,
@@ -475,6 +498,7 @@ impl IntoResponse for ApiError {
             ApiError::SessionNotFound => Some(SESSION_NOT_FOUND_ERROR_CODE),
             ApiError::AccessTokenExpired => Some(ACCESS_TOKEN_EXPIRED_ERROR_CODE),
             ApiError::ImageDescriptionUnavailable => Some(IMAGE_DESCRIPTION_UNAVAILABLE_ERROR_CODE),
+            ApiError::InferenceCapacity { .. } => Some(INFERENCE_CAPACITY_ERROR_CODE),
             _ => None,
         };
         let mut response = (
@@ -493,6 +517,24 @@ impl IntoResponse for ApiError {
             response
                 .headers_mut()
                 .insert(ERROR_CODE_HEADER, HeaderValue::from_static(error_code));
+        }
+        if let ApiError::InferenceCapacity {
+            retry_after,
+            client_replay_safe,
+            ..
+        } = self
+        {
+            if client_replay_safe {
+                response.headers_mut().insert(
+                    CLIENT_REPLAY_HEADER,
+                    HeaderValue::from_static(CLIENT_REPLAY_SAFE),
+                );
+            }
+            if let Some(retry_after) = retry_after {
+                if let Ok(value) = HeaderValue::from_str(&retry_after.as_secs().to_string()) {
+                    response.headers_mut().insert(header::RETRY_AFTER, value);
+                }
+            }
         }
         response
     }
@@ -630,6 +672,42 @@ mod api_error_contract_tests {
             None,
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn inference_capacity_contract_is_sanitized_and_replay_is_explicit() {
+        let response = ApiError::InferenceCapacity {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            retry_after: Some(Duration::from_secs(9)),
+            client_replay_safe: true,
+        }
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(response.headers()[ERROR_CONTRACT_HEADER], "1");
+        assert_eq!(
+            response.headers()[ERROR_CODE_HEADER],
+            INFERENCE_CAPACITY_ERROR_CODE
+        );
+        assert_eq!(response.headers()[CLIENT_REPLAY_HEADER], "safe");
+        assert_eq!(response.headers()[header::RETRY_AFTER], "9");
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(
+            body.as_ref(),
+            br#"{"status":429,"message":"Inference capacity is temporarily unavailable"}"#
+        );
+
+        let response = ApiError::InferenceCapacity {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            retry_after: None,
+            client_replay_safe: false,
+        }
+        .into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert!(response.headers().get(CLIENT_REPLAY_HEADER).is_none());
+        assert!(response.headers().get(header::RETRY_AFTER).is_none());
     }
 }
 
@@ -800,9 +878,107 @@ pub struct AppState {
     billing_client: Option<BillingClient>,
     os_flags_client: Option<os_flags::OsFlagsClient>,
     router_v2_flag_failure_backoff: RoutingFlagsFailureBackoff,
+    responses_message_reservations: ResponseMessageReservations,
     apple_jwt_verifier: Arc<AppleJwtVerifier>,
     response_executions: web::responses::ResponseExecutionRegistry,
     kagi_client: Option<Arc<crate::kagi::KagiClient>>,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct ResponseMessageReservations {
+    active: Arc<StdMutex<HashSet<Uuid>>>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ResponseMessageReservationError {
+    AlreadyReserved,
+    Unavailable,
+}
+
+pub(crate) struct ResponseMessageReservation {
+    message_uuid: Uuid,
+    active: Arc<StdMutex<HashSet<Uuid>>>,
+}
+
+impl ResponseMessageReservations {
+    pub(crate) fn try_reserve(
+        &self,
+        message_uuid: Uuid,
+    ) -> Result<ResponseMessageReservation, ResponseMessageReservationError> {
+        let mut active = self
+            .active
+            .lock()
+            .map_err(|_| ResponseMessageReservationError::Unavailable)?;
+        if !active.insert(message_uuid) {
+            return Err(ResponseMessageReservationError::AlreadyReserved);
+        }
+        drop(active);
+
+        Ok(ResponseMessageReservation {
+            message_uuid,
+            active: self.active.clone(),
+        })
+    }
+}
+
+impl Drop for ResponseMessageReservation {
+    fn drop(&mut self) {
+        let mut active = self
+            .active
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        active.remove(&self.message_uuid);
+    }
+}
+
+#[cfg(test)]
+mod response_message_reservations_tests {
+    use super::*;
+    use std::sync::mpsc;
+    use std::thread;
+
+    #[test]
+    fn one_enclave_allows_only_one_active_request_per_message_uuid() {
+        let reservations = ResponseMessageReservations::default();
+        let message_uuid = Uuid::new_v4();
+        let first = reservations
+            .try_reserve(message_uuid)
+            .expect("first request reserves the message UUID");
+
+        assert!(matches!(
+            reservations.try_reserve(message_uuid),
+            Err(ResponseMessageReservationError::AlreadyReserved)
+        ));
+
+        drop(first);
+        assert!(reservations.try_reserve(message_uuid).is_ok());
+    }
+
+    #[test]
+    fn concurrent_duplicate_cannot_begin_while_the_owner_is_active() {
+        let reservations = ResponseMessageReservations::default();
+        let message_uuid = Uuid::new_v4();
+        let owner_reservations = reservations.clone();
+        let (owner_ready_tx, owner_ready_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let owner = thread::spawn(move || {
+            let _reservation = owner_reservations
+                .try_reserve(message_uuid)
+                .expect("owner reserves the message UUID");
+            owner_ready_tx.send(()).expect("signal owner readiness");
+            release_rx.recv().expect("wait for release");
+        });
+
+        owner_ready_rx.recv().expect("owner becomes ready");
+        assert!(matches!(
+            reservations.try_reserve(message_uuid),
+            Err(ResponseMessageReservationError::AlreadyReserved)
+        ));
+
+        release_tx.send(()).expect("release owner");
+        owner.join().expect("owner thread exits");
+        assert!(reservations.try_reserve(message_uuid).is_ok());
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -1198,6 +1374,7 @@ impl AppStateBuilder {
             billing_client,
             os_flags_client,
             router_v2_flag_failure_backoff: RoutingFlagsFailureBackoff::default(),
+            responses_message_reservations: ResponseMessageReservations::default(),
             apple_jwt_verifier,
             response_executions: web::responses::ResponseExecutionRegistry::default(),
             kagi_client,
@@ -4036,6 +4213,8 @@ async fn main() -> Result<(), Error> {
         .expose_headers([
             HeaderName::from_static(ERROR_CONTRACT_HEADER),
             HeaderName::from_static(ERROR_CODE_HEADER),
+            HeaderName::from_static(CLIENT_REPLAY_HEADER),
+            header::RETRY_AFTER,
         ])
         // allow requests from any origin
         .allow_origin(Any);

--- a/src/model_config.rs
+++ b/src/model_config.rs
@@ -521,7 +521,7 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
         true,
         false,
         10,
-        128_000,
+        131_072,
     ),
     ModelConfigEntry::with_responses(
         "gemma4-31b",
@@ -535,7 +535,7 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
         true,
         false,
         20,
-        256_000,
+        262_144,
         GEMMA4_RESPONSES_MODEL_CONFIG,
     ),
     ModelConfigEntry::new(
@@ -570,7 +570,7 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
         true,
         false,
         30,
-        256_000,
+        262_144,
     )
     .with_catalog_metadata(ModelCatalogMetadata::new(
         &["text", "image"],
@@ -590,7 +590,7 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
         true,
         false,
         40,
-        256_000,
+        262_144,
     )
     .with_catalog_provider("continuum", "kimi-k2.6"),
     ModelConfigEntry::new(
@@ -605,7 +605,8 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
         true,
         false,
         50,
-        256_000,
+        // Shared window: Continuum supports 262,144; Tinfoil supports 1,048,576.
+        262_144,
     )
     .with_catalog_provider("continuum", "glm-5.3")
     .with_catalog_metadata(ModelCatalogMetadata::new(&["text"], &["text"], None, None)),
@@ -621,7 +622,7 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
         true,
         false,
         60,
-        256_000,
+        393_216,
     ),
     ModelConfigEntry::new(
         DEEPSEEK_V4_FLASH_MODEL_ID,
@@ -635,7 +636,7 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
         true,
         false,
         70,
-        800_000,
+        1_048_576,
     )
     .with_catalog_metadata(ModelCatalogMetadata::new(
         &["text"],
@@ -655,7 +656,7 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
         true,
         false,
         80,
-        128_000,
+        131_072,
     ),
     ModelConfigEntry::api_only(
         "gpt-oss-safeguard-120b",
@@ -668,7 +669,7 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
         true,
         false,
         900,
-        131_000,
+        131_072,
     ),
 ];
 
@@ -893,18 +894,18 @@ mod tests {
 
     #[test]
     fn test_model_context_window_known_models() {
-        assert_eq!(model_context_window("llama3-3-70b"), 128_000);
-        assert_eq!(model_context_window("gpt-oss-120b"), 128_000);
-        assert_eq!(model_context_window("gpt-oss-safeguard-120b"), 131_000);
-        assert_eq!(model_context_window("kimi-k2-6"), 256_000);
-        assert_eq!(model_context_window("gemma4-31b"), 256_000);
-        assert_eq!(model_context_window("glm-5-2"), 256_000);
-        assert_eq!(model_context_window("glm-5-3"), 256_000);
+        assert_eq!(model_context_window("llama3-3-70b"), 131_072);
+        assert_eq!(model_context_window("gpt-oss-120b"), 131_072);
+        assert_eq!(model_context_window("gpt-oss-safeguard-120b"), 131_072);
+        assert_eq!(model_context_window("kimi-k2-6"), 262_144);
+        assert_eq!(model_context_window("gemma4-31b"), 262_144);
+        assert_eq!(model_context_window("glm-5-2"), 393_216);
+        assert_eq!(model_context_window("glm-5-3"), 262_144);
         assert_eq!(model_context_window("glm-5-3-flash"), 1_048_576);
-        assert_eq!(model_context_window("kimi-k3"), 256_000);
-        assert_eq!(model_context_window("deepseek-v4-flash"), 800_000);
-        assert_eq!(model_context_window(AUTO_QUICK_MODEL_ID), 128_000);
-        assert_eq!(model_context_window(AUTO_POWERFUL_MODEL_ID), 256_000);
+        assert_eq!(model_context_window("kimi-k3"), 262_144);
+        assert_eq!(model_context_window("deepseek-v4-flash"), 1_048_576);
+        assert_eq!(model_context_window(AUTO_QUICK_MODEL_ID), 131_072);
+        assert_eq!(model_context_window(AUTO_POWERFUL_MODEL_ID), 393_216);
     }
 
     #[test]
@@ -1013,7 +1014,7 @@ mod tests {
 
     #[test]
     fn test_model_config_prefix_matching() {
-        assert_eq!(model_context_window("llama3-3-70b-instruct"), 128_000);
+        assert_eq!(model_context_window("llama3-3-70b-instruct"), 131_072);
         assert_eq!(
             model_context_window("unknown-r1-70b-instruct"),
             DEFAULT_CONTEXT_WINDOW
@@ -1333,7 +1334,7 @@ mod tests {
         assert_eq!(glm["provider"], "continuum");
         assert_eq!(glm["provider_id"], "glm-5.3");
         assert_eq!(glm["access"], "pro");
-        assert_eq!(glm["context_window"], 256_000);
+        assert_eq!(glm["context_window"], 262_144);
         assert_eq!(glm["input_modalities"], json!(["text"]));
         assert_eq!(glm["output_modalities"], json!(["text"]));
         assert_eq!(glm["capabilities"]["vision"], false);
@@ -1416,7 +1417,7 @@ mod tests {
         let kimi = catalog_model(&catalog, "kimi-k3");
         assert_eq!(kimi["access"], "pro");
         assert_eq!(kimi["provider_id"], "kimi-k3");
-        assert_eq!(kimi["context_window"], 256_000);
+        assert_eq!(kimi["context_window"], 262_144);
         assert_eq!(kimi["input_modalities"], json!(["text", "image"]));
         assert_eq!(kimi["output_modalities"], json!(["text"]));
         assert_eq!(kimi["parameter_size"], "2.8T");
@@ -1429,7 +1430,7 @@ mod tests {
         let deepseek = catalog_model(&catalog, "deepseek-v4-flash");
         assert_eq!(deepseek["access"], "pro");
         assert_eq!(deepseek["provider_id"], "deepseek-v4-flash");
-        assert_eq!(deepseek["context_window"], 800_000);
+        assert_eq!(deepseek["context_window"], 1_048_576);
         assert_eq!(deepseek["input_modalities"], json!(["text"]));
         assert_eq!(deepseek["output_modalities"], json!(["text"]));
         assert_eq!(deepseek["parameter_size"], "284B");

--- a/src/models/responses.rs
+++ b/src/models/responses.rs
@@ -908,6 +908,14 @@ pub struct NewUserMessage {
 }
 
 impl UserMessage {
+    pub fn uuid_exists(conn: &mut PgConnection, uuid: Uuid) -> Result<bool, ResponsesError> {
+        diesel::select(diesel::dsl::exists(
+            user_messages::table.filter(user_messages::uuid.eq(uuid)),
+        ))
+        .get_result(conn)
+        .map_err(ResponsesError::DatabaseError)
+    }
+
     pub fn get_by_id_and_user(
         conn: &mut PgConnection,
         id: i64,
@@ -1070,6 +1078,23 @@ pub struct NewToolOutput {
     pub created_at: DateTime<Utc>,
 }
 
+impl ToolOutput {
+    pub fn get_by_uuid(
+        conn: &mut PgConnection,
+        uuid: Uuid,
+        user_id: Uuid,
+    ) -> Result<ToolOutput, ResponsesError> {
+        tool_outputs::table
+            .filter(tool_outputs::uuid.eq(uuid))
+            .filter(tool_outputs::user_id.eq(user_id))
+            .first::<ToolOutput>(conn)
+            .map_err(|e| match e {
+                diesel::result::Error::NotFound => ResponsesError::ToolOutputNotFound,
+                _ => ResponsesError::DatabaseError(e),
+            })
+    }
+}
+
 impl NewToolOutput {
     pub fn insert(&self, conn: &mut PgConnection) -> Result<ToolOutput, ResponsesError> {
         diesel::insert_into(tool_outputs::table)
@@ -1184,6 +1209,17 @@ pub struct NewReasoningItem {
 }
 
 impl ReasoningItem {
+    pub fn get_by_uuid(
+        conn: &mut PgConnection,
+        item_uuid: Uuid,
+    ) -> Result<Option<ReasoningItem>, ResponsesError> {
+        reasoning_items::table
+            .filter(reasoning_items::uuid.eq(item_uuid))
+            .first::<ReasoningItem>(conn)
+            .optional()
+            .map_err(ResponsesError::DatabaseError)
+    }
+
     pub fn update(
         conn: &mut PgConnection,
         item_uuid: Uuid,

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -46,18 +46,18 @@ mod tests {
 
     #[test]
     fn test_model_max_ctx_known_models() {
-        assert_eq!(model_max_ctx("llama3-3-70b"), 128_000);
-        assert_eq!(model_max_ctx("gpt-oss-120b"), 128_000);
-        assert_eq!(model_max_ctx("gpt-oss-safeguard-120b"), 131_000);
-        assert_eq!(model_max_ctx("kimi-k2-6"), 256_000);
-        assert_eq!(model_max_ctx("gemma4-31b"), 256_000);
-        assert_eq!(model_max_ctx("glm-5-2"), 256_000);
-        assert_eq!(model_max_ctx("glm-5-3"), 256_000);
+        assert_eq!(model_max_ctx("llama3-3-70b"), 131_072);
+        assert_eq!(model_max_ctx("gpt-oss-120b"), 131_072);
+        assert_eq!(model_max_ctx("gpt-oss-safeguard-120b"), 131_072);
+        assert_eq!(model_max_ctx("kimi-k2-6"), 262_144);
+        assert_eq!(model_max_ctx("gemma4-31b"), 262_144);
+        assert_eq!(model_max_ctx("glm-5-2"), 393_216);
+        assert_eq!(model_max_ctx("glm-5-3"), 262_144);
         assert_eq!(model_max_ctx("glm-5-3-flash"), 1_048_576);
-        assert_eq!(model_max_ctx("kimi-k3"), 256_000);
-        assert_eq!(model_max_ctx("deepseek-v4-flash"), 800_000);
-        assert_eq!(model_max_ctx("auto:quick"), 128_000);
-        assert_eq!(model_max_ctx("auto:powerful"), 256_000);
+        assert_eq!(model_max_ctx("kimi-k3"), 262_144);
+        assert_eq!(model_max_ctx("deepseek-v4-flash"), 1_048_576);
+        assert_eq!(model_max_ctx("auto:quick"), 131_072);
+        assert_eq!(model_max_ctx("auto:powerful"), 393_216);
     }
 
     #[test]
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     fn test_model_max_ctx_prefix_matching() {
-        assert_eq!(model_max_ctx("llama3-3-70b-instruct"), 128_000);
+        assert_eq!(model_max_ctx("llama3-3-70b-instruct"), 131_072);
         assert_eq!(model_max_ctx("unknown-r1-70b-instruct"), 64_000);
     }
 }

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -867,7 +867,20 @@ impl CompletionExecutionError {
     }
 
     pub(crate) fn into_pre_persistence_api_error(self) -> ApiError {
-        self.into_api_error().with_client_replay_safe()
+        let replay_safe = match &self {
+            Self::Request(_) => true,
+            Self::Attempt {
+                terminal: AttemptTerminal::Failed { failure, .. },
+                ..
+            } => failure.replay_safety == ReplaySafety::ProvenPreAcceptance,
+            Self::Attempt { .. } => false,
+        };
+        let error = self.into_api_error();
+        if replay_safe {
+            error.with_client_replay_safe()
+        } else {
+            error
+        }
     }
 }
 
@@ -988,11 +1001,7 @@ fn attempt_failure_from_provider_error(error: &ProviderRequestError) -> AttemptF
                     AttemptFailureKind::HttpStatus
                 },
                 AttemptStage::AwaitingResponse,
-                if is_capacity_rejection {
-                    ReplaySafety::ProvenPreAcceptance
-                } else {
-                    ReplaySafety::NotProvenPreAcceptance
-                },
+                ReplaySafety::NotProvenPreAcceptance,
             )
             .with_upstream_response(
                 upstream.status,
@@ -1604,7 +1613,7 @@ async fn proxy_openai(
         &pinned_completion,
     )
     .await
-    .map_err(CompletionExecutionError::into_api_error)?;
+    .map_err(CompletionExecutionError::into_pre_persistence_api_error)?;
 
     debug!(
         "Received completion stream: request_id={}, execution_id={}, attempt_id={}, provider={}, streaming={}",
@@ -3933,7 +3942,7 @@ mod tests {
         let failure = attempt_failure_from_provider_error(&error);
         assert_eq!(failure.kind, AttemptFailureKind::CapacityRejected);
         assert_eq!(failure.stage, AttemptStage::AwaitingResponse);
-        assert_eq!(failure.replay_safety, ReplaySafety::ProvenPreAcceptance);
+        assert_eq!(failure.replay_safety, ReplaySafety::NotProvenPreAcceptance);
         assert_eq!(failure.status, Some(429));
         assert_eq!(failure.retry_after, Some(Duration::from_secs(17)));
         assert_eq!(
@@ -4008,7 +4017,7 @@ mod tests {
             assert!(!error.to_string().contains("private capacity detail"));
             let failure = attempt_failure_from_provider_error(&error);
             assert_eq!(failure.kind, AttemptFailureKind::CapacityRejected);
-            assert_eq!(failure.replay_safety, ReplaySafety::ProvenPreAcceptance);
+            assert_eq!(failure.replay_safety, ReplaySafety::NotProvenPreAcceptance);
             assert_eq!(failure.status, Some(status));
             assert_eq!(failure.retry_after, Some(Duration::from_secs(11)));
             assert!(matches!(
@@ -4020,6 +4029,54 @@ mod tests {
                 }
             ));
         }
+    }
+
+    #[tokio::test]
+    async fn upstream_capacity_failure_does_not_claim_client_replay_safety() {
+        let provider_error = ProviderRequestError::Upstream(UpstreamProviderError {
+            status: 429,
+            retry_after: Some(Duration::from_secs(7)),
+            upstream_request_id: None,
+        });
+        let failure = attempt_failure_from_provider_error(&provider_error);
+        let pinned = pinned_test_completion();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let response = failed_completion_execution(
+            attempt,
+            failure.clone(),
+            public_completion_error(&provider_error, &failure),
+        )
+        .into_pre_persistence_api_error()
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert!(response
+            .headers()
+            .get(crate::CLIENT_REPLAY_HEADER)
+            .is_none());
+        assert_eq!(response.headers()[crate::ERROR_CONTRACT_HEADER], "1");
+        assert_eq!(
+            response.headers()[crate::ERROR_CODE_HEADER],
+            crate::INFERENCE_CAPACITY_ERROR_CODE
+        );
+        assert_eq!(response.headers()[header::RETRY_AFTER], "7");
+    }
+
+    #[test]
+    fn local_pre_send_capacity_failure_marks_client_replay_safe() {
+        let response = CompletionExecutionError::from(ApiError::InferenceCapacity {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            retry_after: Some(Duration::from_secs(3)),
+            client_replay_safe: false,
+        })
+        .into_pre_persistence_api_error()
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response.headers()[crate::CLIENT_REPLAY_HEADER], "safe");
+        assert_eq!(response.headers()[header::RETRY_AFTER], "3");
     }
 
     #[tokio::test]
@@ -4211,6 +4268,7 @@ mod tests {
                 &tx,
                 Duration::from_secs(30),
                 None,
+                false,
             ),
         )
         .await
@@ -4258,6 +4316,7 @@ mod tests {
                 &tx,
                 Duration::from_secs(30),
                 Some(&execution),
+                false,
             ),
         )
         .await
@@ -4494,7 +4553,7 @@ mod tests {
         });
         let failure = attempt_failure_from_provider_error(&upstream);
         assert_eq!(failure.kind, AttemptFailureKind::CapacityRejected);
-        assert_eq!(failure.replay_safety, ReplaySafety::ProvenPreAcceptance);
+        assert_eq!(failure.replay_safety, ReplaySafety::NotProvenPreAcceptance);
         assert_eq!(failure.status, Some(429));
         assert_eq!(failure.retry_after, Some(Duration::from_secs(60)));
         assert_eq!(failure.upstream_request_id.as_deref(), Some("request-123"));
@@ -4629,7 +4688,7 @@ mod tests {
     }
 
     #[test]
-    fn capacity_statuses_are_explicit_rejections_and_529_is_normalized() {
+    fn capacity_statuses_are_normalized_without_claiming_replay_safety() {
         for (upstream_status, public_status) in [
             (429, StatusCode::TOO_MANY_REQUESTS),
             (503, StatusCode::SERVICE_UNAVAILABLE),
@@ -4642,7 +4701,7 @@ mod tests {
             });
             let failure = attempt_failure_from_provider_error(&provider_error);
             assert_eq!(failure.kind, AttemptFailureKind::CapacityRejected);
-            assert_eq!(failure.replay_safety, ReplaySafety::ProvenPreAcceptance);
+            assert_eq!(failure.replay_safety, ReplaySafety::NotProvenPreAcceptance);
             assert_eq!(failure.status, Some(upstream_status));
             assert!(matches!(
                 public_completion_error(&provider_error, &failure),

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -31,7 +31,7 @@ use crate::web::encryption_middleware::{
 use crate::web::openai_auth::AuthMethod;
 use crate::web::responses::{ResponseExecution, ResponseExecutionTaskGuard};
 use crate::{ApiError, AppState};
-use axum::http::{header, HeaderMap, HeaderName};
+use axum::http::{header, HeaderMap, HeaderName, StatusCode};
 use axum::{
     body::Body,
     extract::State,
@@ -724,7 +724,7 @@ impl StreamUsageAccumulator {
                     .is_some_and(|tokens| tokens < previous.completion_tokens)
             {
                 warn!(
-                    "Streaming usage totals regressed: previous_prompt_tokens={}, previous_completion_tokens={}, observed_prompt_tokens={:?}, observed_completion_tokens={:?}; using the latest explicit provider values",
+                    "Streaming usage totals regressed: previous_prompt_tokens={}, previous_completion_tokens={}, observed_prompt_tokens={:?}, observed_completion_tokens={:?}; preserving the highest cumulative totals",
                     previous.prompt_tokens,
                     previous.completion_tokens,
                     observed.prompt_tokens,
@@ -733,19 +733,31 @@ impl StreamUsageAccumulator {
             }
         }
 
+        let prompt_tokens = observed
+            .prompt_tokens
+            .map(|tokens| {
+                self.latest_usage
+                    .as_ref()
+                    .map_or(tokens, |usage| tokens.max(usage.prompt_tokens))
+            })
+            .or_else(|| self.latest_usage.as_ref().map(|usage| usage.prompt_tokens))
+            .unwrap_or(0);
+        let completion_tokens = observed
+            .completion_tokens
+            .map(|tokens| {
+                self.latest_usage
+                    .as_ref()
+                    .map_or(tokens, |usage| tokens.max(usage.completion_tokens))
+            })
+            .or_else(|| {
+                self.latest_usage
+                    .as_ref()
+                    .map(|usage| usage.completion_tokens)
+            })
+            .unwrap_or(0);
         self.latest_usage = Some(CompletionUsage {
-            prompt_tokens: observed
-                .prompt_tokens
-                .or_else(|| self.latest_usage.as_ref().map(|usage| usage.prompt_tokens))
-                .unwrap_or(0),
-            completion_tokens: observed
-                .completion_tokens
-                .or_else(|| {
-                    self.latest_usage
-                        .as_ref()
-                        .map(|usage| usage.completion_tokens)
-                })
-                .unwrap_or(0),
+            prompt_tokens,
+            completion_tokens,
             cached_prompt_tokens: observed.cached_prompt_tokens.or_else(|| {
                 self.latest_usage
                     .as_ref()
@@ -852,6 +864,10 @@ impl CompletionExecutionError {
                 public_error
             }
         }
+    }
+
+    pub(crate) fn into_pre_persistence_api_error(self) -> ApiError {
+        self.into_api_error().with_client_replay_safe()
     }
 }
 
@@ -963,17 +979,52 @@ fn attempt_failure_from_provider_error(error: &ProviderRequestError) -> AttemptF
             AttemptStage::AwaitingResponse,
             ReplaySafety::NotProvenPreAcceptance,
         ),
-        ProviderRequestError::Upstream(upstream) => AttemptFailure::new(
-            AttemptFailureKind::HttpStatus,
-            AttemptStage::AwaitingResponse,
-            ReplaySafety::NotProvenPreAcceptance,
-        )
-        .with_upstream_response(
-            upstream.status,
-            upstream.retry_after,
-            upstream.upstream_request_id.clone(),
-        ),
+        ProviderRequestError::Upstream(upstream) => {
+            let is_capacity_rejection = public_capacity_status(upstream.status).is_some();
+            AttemptFailure::new(
+                if is_capacity_rejection {
+                    AttemptFailureKind::CapacityRejected
+                } else {
+                    AttemptFailureKind::HttpStatus
+                },
+                AttemptStage::AwaitingResponse,
+                if is_capacity_rejection {
+                    ReplaySafety::ProvenPreAcceptance
+                } else {
+                    ReplaySafety::NotProvenPreAcceptance
+                },
+            )
+            .with_upstream_response(
+                upstream.status,
+                upstream.retry_after,
+                upstream.upstream_request_id.clone(),
+            )
+        }
     }
+}
+
+fn public_capacity_status(upstream_status: u16) -> Option<StatusCode> {
+    match upstream_status {
+        429 => Some(StatusCode::TOO_MANY_REQUESTS),
+        503 | 529 => Some(StatusCode::SERVICE_UNAVAILABLE),
+        _ => None,
+    }
+}
+
+fn public_completion_error(error: &ProviderRequestError, failure: &AttemptFailure) -> ApiError {
+    if failure.kind == AttemptFailureKind::CapacityRejected {
+        let status = failure
+            .status
+            .and_then(public_capacity_status)
+            .expect("capacity failure must carry a supported upstream status");
+        return ApiError::InferenceCapacity {
+            status,
+            retry_after: failure.retry_after,
+            client_replay_safe: false,
+        };
+    }
+
+    ApiError::from(error.clone())
 }
 
 fn terminalize_recovered_provider_failures(
@@ -1205,6 +1256,21 @@ async fn read_non_streaming_completion_response(
     Ok(response_json)
 }
 
+async fn completion_consumer_cancelled(
+    tx_consumer: &mpsc::Sender<CompletionChunk>,
+    response_execution: Option<&ResponseExecution>,
+) {
+    if let Some(execution) = response_execution {
+        tokio::select! {
+            biased;
+            _ = execution.cancelled() => {}
+            _ = tx_consumer.closed() => {}
+        }
+    } else {
+        tx_consumer.closed().await;
+    }
+}
+
 async fn process_completion_stream(
     response: ProviderResponse,
     response_model_id: &str,
@@ -1219,31 +1285,24 @@ async fn process_completion_stream(
     let mut usage_accumulator = StreamUsageAccumulator::default();
 
     loop {
-        let next_chunk = timeout(chunk_timeout, body_stream.next());
-        tokio::pin!(next_chunk);
-        let next_chunk = if let Some(execution) = response_execution {
-            tokio::select! {
-                biased;
-                _ = execution.cancelled() => {
-                    return finish_stream_processing(
-                        &mut usage_accumulator,
-                        StreamUsageFinalization::ConsumerDropped,
-                        AttemptTerminal::Failed {
-                            attempt,
-                            failure: AttemptFailure::new(
-                                AttemptFailureKind::ConsumerDropped,
-                                AttemptStage::Stream,
-                                ReplaySafety::NotProvenPreAcceptance,
-                            ),
-                        },
-                    );
-                }
-                result = &mut next_chunk => result,
+        let next_chunk = tokio::select! {
+            biased;
+            _ = completion_consumer_cancelled(tx_consumer, response_execution) => {
+                return finish_stream_processing(
+                    &mut usage_accumulator,
+                    StreamUsageFinalization::ConsumerDropped,
+                    AttemptTerminal::Failed {
+                        attempt,
+                        failure: AttemptFailure::new(
+                            AttemptFailureKind::ConsumerDropped,
+                            AttemptStage::Stream,
+                            ReplaySafety::NotProvenPreAcceptance,
+                        ),
+                    },
+                );
             }
-        } else {
-            next_chunk.await
+            result = timeout(chunk_timeout, body_stream.next()) => result,
         };
-
         match next_chunk {
             Ok(Some(Ok(bytes))) => {
                 buffer.extend_from_slice(bytes.as_ref());
@@ -1303,11 +1362,12 @@ async fn process_completion_stream(
                     usage_accumulator.observe(&json);
                     canonicalize_response_model(&mut json, response_model_id);
 
-                    if tx_consumer
-                        .send(CompletionChunk::StreamChunk(json))
-                        .await
-                        .is_err()
-                    {
+                    let sent = tokio::select! {
+                        biased;
+                        _ = completion_consumer_cancelled(tx_consumer, response_execution) => false,
+                        result = tx_consumer.send(CompletionChunk::StreamChunk(json)) => result.is_ok(),
+                    };
+                    if !sent {
                         return finish_stream_processing(
                             &mut usage_accumulator,
                             StreamUsageFinalization::ConsumerDropped,
@@ -1758,16 +1818,34 @@ pub(crate) async fn prepare_completion_request(
     })
 }
 
-/// Executes one model turn against a route pinned for the logical inference request.
-/// Billing remains internal until the usage-settlement stack separates the recorder.
-pub(crate) async fn get_chat_completion_response(
+/// A provider response whose HTTP success status has been observed, but whose
+/// body has not yet been consumed. Responses holds this value only across its
+/// persistence boundary so a capacity rejection can still be returned as an
+/// ordinary HTTP error without committing conversation state.
+pub(crate) struct StartedCompletion {
+    response: Option<ProviderResponse>,
+    successful_provider: String,
+    attempt: InferenceAttempt,
+    response_model_id: String,
+    is_streaming: bool,
+    billing_context: BillingContext,
+    non_streaming_body_limit: Option<usize>,
+    require_provider_done: bool,
+    terminal_guard: Option<AttemptTerminalGuard>,
+    response_execution: Option<ResponseExecution>,
+    response_execution_guard: Option<ResponseExecutionTaskGuard>,
+}
+
+/// Starts one model turn against a route pinned for the logical inference
+/// request and returns immediately after a successful provider response start.
+pub(crate) async fn start_chat_completion_response(
     state: &Arc<AppState>,
     user: &User,
     body: Value,
     headers: &HeaderMap,
     execution: CompletionExecutionContext<'_>,
     pinned: &PinnedCompletionRequest,
-) -> Result<CompletionStream, CompletionExecutionError> {
+) -> Result<StartedCompletion, CompletionExecutionError> {
     get_chat_completion_response_with_options(
         state,
         user,
@@ -1780,9 +1858,9 @@ pub(crate) async fn get_chat_completion_response(
     .await
 }
 
-/// Responses-only completion entry point with process-local task ownership.
-/// Ordinary Chat Completions retain their existing independent lifecycle.
-pub(crate) async fn get_chat_completion_response_for_execution(
+/// Starts a Responses provider turn with process-local task ownership that
+/// remains held across the persistence boundary and subsequent processing.
+pub(crate) async fn start_chat_completion_response_for_execution(
     state: &Arc<AppState>,
     user: &User,
     body: Value,
@@ -1790,7 +1868,7 @@ pub(crate) async fn get_chat_completion_response_for_execution(
     execution: CompletionExecutionContext<'_>,
     pinned: &PinnedCompletionRequest,
     response_execution: ResponseExecution,
-) -> Result<CompletionStream, CompletionExecutionError> {
+) -> Result<StartedCompletion, CompletionExecutionError> {
     let execution = execution.with_response_execution(response_execution)?;
     get_chat_completion_response_with_options(
         state,
@@ -1842,7 +1920,7 @@ pub(crate) async fn get_chat_completion_response_for_expected_route(
 
     let continuum_cache_salt = (route.provider_name == ProviderId::Continuum.as_str())
         .then(|| format!("server-selected-{}", Uuid::new_v4().simple()));
-    get_chat_completion_response_with_options(
+    let started = get_chat_completion_response_with_options(
         state,
         user,
         body,
@@ -1858,7 +1936,8 @@ pub(crate) async fn get_chat_completion_response_for_expected_route(
             non_streaming_body_limit: Some(MAX_BOUNDED_PROVIDER_RESPONSE_BYTES),
         },
     )
-    .await
+    .await?;
+    finish_started_completion(state, user, started).await
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1896,7 +1975,7 @@ async fn get_chat_completion_response_with_options(
     execution: CompletionExecutionContext<'_>,
     pinned: &PinnedCompletionRequest,
     options: CompletionExecutionOptions,
-) -> Result<CompletionStream, CompletionExecutionError> {
+) -> Result<StartedCompletion, CompletionExecutionError> {
     let CompletionExecutionContext {
         mut billing,
         routing,
@@ -2000,7 +2079,7 @@ async fn get_chat_completion_response_with_options(
         selected_route.provider.as_str()
     );
 
-    let (res, successful_provider, attempt, mut terminal_guard) = {
+    let (response, successful_provider, attempt, terminal_guard) = {
         let mut request_body = modified_body.clone();
         let proxy_config = selected_route.proxy.clone();
         let provider_model_name = selected_route.provider_model_id.clone();
@@ -2086,8 +2165,11 @@ async fn get_chat_completion_response_with_options(
                     failure.stage,
                     request_log_metadata
                 );
-                let execution_error =
-                    failed_completion_execution(attempt, failure, ApiError::from(err));
+                let execution_error = failed_completion_execution(
+                    attempt,
+                    failure.clone(),
+                    public_completion_error(&err, &failure),
+                );
                 terminal_guard.disarm();
                 return Err(execution_error);
             }
@@ -2099,6 +2181,46 @@ async fn get_chat_completion_response_with_options(
         successful_provider
     );
 
+    Ok(StartedCompletion {
+        response: Some(response),
+        successful_provider,
+        attempt,
+        response_model_id: selected_route.response_model_id,
+        is_streaming,
+        billing_context: billing,
+        non_streaming_body_limit: options.non_streaming_body_limit,
+        require_provider_done,
+        terminal_guard: Some(terminal_guard),
+        response_execution,
+        response_execution_guard,
+    })
+}
+
+/// Consumes a successfully started provider response. Billing remains internal
+/// until the usage-settlement stack separates the recorder.
+pub(crate) async fn finish_started_completion(
+    state: &Arc<AppState>,
+    user: &User,
+    mut started: StartedCompletion,
+) -> Result<CompletionStream, CompletionExecutionError> {
+    let response = started
+        .response
+        .take()
+        .expect("started completion response can only be consumed once");
+    let successful_provider = started.successful_provider.clone();
+    let attempt = started.attempt.clone();
+    let response_model_id = started.response_model_id.clone();
+    let is_streaming = started.is_streaming;
+    let billing_context = started.billing_context.clone();
+    let non_streaming_body_limit = started.non_streaming_body_limit;
+    let require_provider_done = started.require_provider_done;
+    let response_execution = started.response_execution.take();
+    let response_execution_guard = started.response_execution_guard.take();
+    let mut terminal_guard = started
+        .terminal_guard
+        .take()
+        .expect("started completion terminal guard can only be consumed once");
+
     // NOW: Process the response internally and handle billing
     if !is_streaming {
         // NON-STREAMING: Simple case
@@ -2106,10 +2228,10 @@ async fn get_chat_completion_response_with_options(
         // The request's streaming fields are forwarded unchanged, but this
         // encrypted endpoint currently buffers one byte-exact response carrier.
         let response_json = match read_non_streaming_completion_response(
-            res,
-            &selected_route.response_model_id,
+            response,
+            &response_model_id,
             &attempt,
-            options.non_streaming_body_limit,
+            non_streaming_body_limit,
         )
         .await
         {
@@ -2127,8 +2249,14 @@ async fn get_chat_completion_response_with_options(
 
         // ✅ Handle billing HERE, inside completions API
         if let Some(usage) = extract_usage(&response_json) {
-            publish_usage_event_internal(state, user, billing_context, usage, &successful_provider)
-                .await;
+            publish_usage_event_internal(
+                state,
+                user,
+                &billing_context,
+                usage,
+                &successful_provider,
+            )
+            .await;
         }
 
         // Return the full response as a single chunk
@@ -2161,14 +2289,13 @@ async fn get_chat_completion_response_with_options(
     let user_clone = user.clone();
     let billing_ctx = billing_context.clone();
     let provider = successful_provider.clone();
-    let response_model_id = selected_route.response_model_id.clone();
     let stream_attempt = attempt.clone();
     terminal_guard.set_stage(AttemptStage::Stream);
 
     tokio::spawn(async move {
         let _response_execution_guard = response_execution_guard;
         let result = process_completion_stream(
-            res,
+            response,
             &response_model_id,
             stream_attempt,
             &tx_consumer,
@@ -2202,6 +2329,21 @@ async fn get_chat_completion_response_with_options(
             attempt,
         },
     })
+}
+
+/// Executes one complete model turn. Responses uses the split start/finish
+/// functions so only the first response headers cross its persistence seam.
+pub(crate) async fn get_chat_completion_response(
+    state: &Arc<AppState>,
+    user: &User,
+    body: Value,
+    headers: &HeaderMap,
+    execution: CompletionExecutionContext<'_>,
+    pinned: &PinnedCompletionRequest,
+) -> Result<CompletionStream, CompletionExecutionError> {
+    let started =
+        start_chat_completion_response(state, user, body, headers, execution, pinned).await?;
+    finish_started_completion(state, user, started).await
 }
 
 pub(crate) fn ensure_completion_model_access(
@@ -2242,20 +2384,23 @@ fn extract_usage_observation(json: &Value) -> Option<CompletionUsageObservation>
     let prompt_tokens = usage_json
         .get("prompt_tokens")
         .and_then(|v| v.as_i64())
-        .map(|tokens| tokens.clamp(0, i32::MAX as i64) as i32);
+        .filter(|tokens| *tokens >= 0)
+        .map(|tokens| tokens.min(i32::MAX as i64) as i32);
 
     let cached_prompt_tokens = usage_json
         .get("prompt_tokens_details")
         .and_then(|details| details.get("cached_tokens"))
         .and_then(|v| v.as_i64())
-        .map(|tokens| tokens.clamp(0, i32::MAX as i64) as i32);
+        .filter(|tokens| *tokens >= 0)
+        .map(|tokens| tokens.min(i32::MAX as i64) as i32);
 
     Some(CompletionUsageObservation {
         prompt_tokens,
         completion_tokens: usage_json
             .get("completion_tokens")
             .and_then(|v| v.as_i64())
-            .map(|tokens| tokens.clamp(0, i32::MAX as i64) as i32),
+            .filter(|tokens| *tokens >= 0)
+            .map(|tokens| tokens.min(i32::MAX as i64) as i32),
         cached_prompt_tokens,
     })
 }
@@ -3786,9 +3931,9 @@ mod tests {
             .contains("private upstream capacity detail"));
 
         let failure = attempt_failure_from_provider_error(&error);
-        assert_eq!(failure.kind, AttemptFailureKind::HttpStatus);
+        assert_eq!(failure.kind, AttemptFailureKind::CapacityRejected);
         assert_eq!(failure.stage, AttemptStage::AwaitingResponse);
-        assert_eq!(failure.replay_safety, ReplaySafety::NotProvenPreAcceptance);
+        assert_eq!(failure.replay_safety, ReplaySafety::ProvenPreAcceptance);
         assert_eq!(failure.status, Some(429));
         assert_eq!(failure.retry_after, Some(Duration::from_secs(17)));
         assert_eq!(
@@ -3834,9 +3979,47 @@ mod tests {
             Ok(_) => panic!("mock 429 unexpectedly succeeded"),
         };
         let failure = attempt_failure_from_provider_error(&error);
-        assert_eq!(failure.kind, AttemptFailureKind::HttpStatus);
+        assert_eq!(failure.kind, AttemptFailureKind::CapacityRejected);
         assert_eq!(failure.status, Some(429));
         assert_eq!(failure.retry_after, Some(Duration::from_secs(23)));
+    }
+
+    #[tokio::test]
+    async fn mock_provider_capacity_matrix_normalizes_503_and_synthetic_529() {
+        for status in [503u16, 529u16] {
+            let app = Router::new().route(
+                "/v1/chat/completions",
+                post(move || async move {
+                    axum::http::Response::builder()
+                        .status(status)
+                        .header(header::RETRY_AFTER, "11")
+                        .body(axum::body::Body::from(
+                            r#"{"error":{"message":"private capacity detail"}}"#,
+                        ))
+                        .expect("mock capacity response")
+                }),
+            );
+            let (trace, server) = call_mock_provider(app).await;
+            server.abort();
+            let error = match trace.result {
+                Err(error) => error,
+                Ok(_) => panic!("capacity response unexpectedly succeeded"),
+            };
+            assert!(!error.to_string().contains("private capacity detail"));
+            let failure = attempt_failure_from_provider_error(&error);
+            assert_eq!(failure.kind, AttemptFailureKind::CapacityRejected);
+            assert_eq!(failure.replay_safety, ReplaySafety::ProvenPreAcceptance);
+            assert_eq!(failure.status, Some(status));
+            assert_eq!(failure.retry_after, Some(Duration::from_secs(11)));
+            assert!(matches!(
+                public_completion_error(&error, &failure),
+                ApiError::InferenceCapacity {
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    client_replay_safe: false,
+                    ..
+                }
+            ));
+        }
     }
 
     #[tokio::test]
@@ -3990,6 +4173,106 @@ mod tests {
             AttemptTerminal::Failed {
                 failure: AttemptFailure {
                     kind: AttemptFailureKind::StreamTimeout,
+                    ..
+                },
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn dropping_completion_consumer_cancels_a_pending_provider_body() {
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(|| async {
+                let pending = futures::stream::pending::<Result<bytes::Bytes, std::io::Error>>();
+                axum::http::Response::builder()
+                    .status(axum::http::StatusCode::OK)
+                    .header(header::CONTENT_TYPE, "text/event-stream")
+                    .body(axum::body::Body::from_stream(pending))
+                    .expect("mock pending response")
+            }),
+        );
+        let (trace, server) = call_mock_provider(app).await;
+        let response = trace.result.expect("mock provider response start");
+        let pinned = pinned_test_completion();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let (tx, rx) = mpsc::channel(1);
+        drop(rx);
+
+        let result = timeout(
+            Duration::from_millis(100),
+            process_completion_stream(
+                response,
+                "kimi-k3",
+                attempt,
+                &tx,
+                Duration::from_secs(30),
+                None,
+            ),
+        )
+        .await
+        .expect("consumer drop should cancel without waiting for chunk timeout");
+        server.abort();
+
+        assert!(matches!(
+            result.terminal,
+            AttemptTerminal::Failed {
+                failure: AttemptFailure {
+                    kind: AttemptFailureKind::ConsumerDropped,
+                    stage: AttemptStage::Stream,
+                    ..
+                },
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn explicit_response_cancellation_precedes_ready_provider_data() {
+        let (trace, server) = call_mock_provider(static_sse_app(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"ignored\"}}]}\n\ndata: [DONE]\n\n",
+        ))
+        .await;
+        let response = trace.result.expect("mock provider response start");
+        let pinned = pinned_test_completion();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let registry = crate::web::responses::ResponseExecutionRegistry::default();
+        let registration = registry
+            .register(Uuid::new_v4(), pinned.intent.account_uuid)
+            .expect("register response execution");
+        let execution = registration.execution();
+        let (tx, mut rx) = mpsc::channel(1);
+        execution.cancel();
+
+        let result = timeout(
+            Duration::from_millis(100),
+            process_completion_stream(
+                response,
+                "kimi-k3",
+                attempt,
+                &tx,
+                Duration::from_secs(30),
+                Some(&execution),
+            ),
+        )
+        .await
+        .expect("sticky cancellation should stop processing before provider data");
+        drop(tx);
+        server.abort();
+
+        assert!(rx.recv().await.is_none());
+        assert!(result.usage.is_none());
+        assert!(matches!(
+            result.terminal,
+            AttemptTerminal::Failed {
+                failure: AttemptFailure {
+                    kind: AttemptFailureKind::ConsumerDropped,
+                    stage: AttemptStage::Stream,
                     ..
                 },
                 ..
@@ -4210,8 +4493,8 @@ mod tests {
             upstream_request_id: Some("request-123".to_string()),
         });
         let failure = attempt_failure_from_provider_error(&upstream);
-        assert_eq!(failure.kind, AttemptFailureKind::HttpStatus);
-        assert_eq!(failure.replay_safety, ReplaySafety::NotProvenPreAcceptance);
+        assert_eq!(failure.kind, AttemptFailureKind::CapacityRejected);
+        assert_eq!(failure.replay_safety, ReplaySafety::ProvenPreAcceptance);
         assert_eq!(failure.status, Some(429));
         assert_eq!(failure.retry_after, Some(Duration::from_secs(60)));
         assert_eq!(failure.upstream_request_id.as_deref(), Some("request-123"));
@@ -4343,6 +4626,46 @@ mod tests {
         );
         assert_eq!(parse_retry_after_hint(Some("not-seconds")), None);
         assert_eq!(parse_retry_after_hint(None), None);
+    }
+
+    #[test]
+    fn capacity_statuses_are_explicit_rejections_and_529_is_normalized() {
+        for (upstream_status, public_status) in [
+            (429, StatusCode::TOO_MANY_REQUESTS),
+            (503, StatusCode::SERVICE_UNAVAILABLE),
+            (529, StatusCode::SERVICE_UNAVAILABLE),
+        ] {
+            let provider_error = ProviderRequestError::Upstream(UpstreamProviderError {
+                status: upstream_status,
+                retry_after: Some(Duration::from_secs(7)),
+                upstream_request_id: None,
+            });
+            let failure = attempt_failure_from_provider_error(&provider_error);
+            assert_eq!(failure.kind, AttemptFailureKind::CapacityRejected);
+            assert_eq!(failure.replay_safety, ReplaySafety::ProvenPreAcceptance);
+            assert_eq!(failure.status, Some(upstream_status));
+            assert!(matches!(
+                public_completion_error(&provider_error, &failure),
+                ApiError::InferenceCapacity {
+                    status,
+                    retry_after: Some(delay),
+                    client_replay_safe: false,
+                } if status == public_status && delay == Duration::from_secs(7)
+            ));
+        }
+
+        let generic = ProviderRequestError::Upstream(UpstreamProviderError {
+            status: 500,
+            retry_after: None,
+            upstream_request_id: None,
+        });
+        let failure = attempt_failure_from_provider_error(&generic);
+        assert_eq!(failure.kind, AttemptFailureKind::HttpStatus);
+        assert_eq!(failure.replay_safety, ReplaySafety::NotProvenPreAcceptance);
+        assert!(matches!(
+            public_completion_error(&generic, &failure),
+            ApiError::InternalServerError
+        ));
     }
 
     #[test]
@@ -4818,6 +5141,34 @@ mod tests {
     }
 
     #[test]
+    fn prompt_only_usage_defaults_completion_tokens_to_zero() {
+        let response = json!({
+            "usage": {
+                "prompt_tokens": 100
+            }
+        });
+
+        let usage = extract_usage(&response).expect("usage should parse");
+
+        assert_eq!(usage.prompt_tokens, 100);
+        assert_eq!(usage.completion_tokens, 0);
+    }
+
+    #[test]
+    fn negative_completion_usage_defaults_to_zero() {
+        let response = json!({
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": -1
+            }
+        });
+
+        let usage = extract_usage(&response).expect("prompt usage should parse");
+
+        assert_eq!(usage.completion_tokens, 0);
+    }
+
+    #[test]
     fn cached_prompt_tokens_are_optional_in_usage_details() {
         let response = json!({
             "usage": {
@@ -5057,6 +5408,18 @@ mod tests {
     }
 
     #[test]
+    fn regressing_cumulative_usage_preserves_highest_totals() {
+        let mut accumulator = StreamUsageAccumulator::default();
+        accumulator.observe(&stream_usage_chunk(500, 100, None, None, false));
+        accumulator.observe(&stream_usage_chunk(400, 0, None, Some("stop"), true));
+
+        let usage = accumulator
+            .take_final_usage(StreamUsageFinalization::ProviderDone)
+            .expect("provider [DONE] should finalize usage");
+        assert_usage(usage, 500, 100, None);
+    }
+
+    #[test]
     fn provider_done_uses_finish_usage_when_usage_only_frame_is_missing() {
         let mut accumulator = StreamUsageAccumulator::default();
         accumulator.observe(&stream_usage_chunk(400, 20, None, Some("stop"), false));
@@ -5172,6 +5535,21 @@ mod tests {
             .take_final_usage(StreamUsageFinalization::ProviderDone)
             .expect("non-zero prompt usage should be retained");
         assert_usage(usage, 33, 0, None);
+    }
+
+    #[test]
+    fn stream_prompt_only_usage_preserves_prompt_tokens() {
+        let mut accumulator = StreamUsageAccumulator::default();
+        accumulator.observe(&json!({
+            "choices": [{ "finish_reason": "tool_calls" }],
+            "usage": { "prompt_tokens": 33 }
+        }));
+
+        let usage = accumulator
+            .take_final_usage(StreamUsageFinalization::ProviderDone)
+            .expect("non-zero prompt usage should be retained");
+        assert_eq!(usage.prompt_tokens, 33);
+        assert_eq!(usage.completion_tokens, 0);
     }
 
     #[test]

--- a/src/web/responses/builders.rs
+++ b/src/web/responses/builders.rs
@@ -8,7 +8,7 @@ use crate::{
         conversations::ConversationResponse,
         handlers::{
             ContentPart, InputTokenDetails, OutputItem, OutputTokenDetails, ReasoningInfo,
-            ResponseUsage, ResponsesCreateResponse, TextFormat, TextFormatSpec,
+            ResponseError, ResponseUsage, ResponsesCreateResponse, TextFormat, TextFormatSpec,
         },
     },
 };
@@ -121,6 +121,11 @@ impl ResponseBuilder {
     /// * `metadata` - Optional JSON metadata
     pub fn metadata(mut self, metadata: Option<Value>) -> Self {
         self.response.metadata = metadata;
+        self
+    }
+
+    pub fn error(mut self, error: ResponseError) -> Self {
+        self.response.error = Some(error);
         self
     }
 

--- a/src/web/responses/constants.rs
+++ b/src/web/responses/constants.rs
@@ -29,7 +29,7 @@ pub const EVENT_RESPONSE_CONTENT_PART_DONE: &str = "response.content_part.done";
 pub const EVENT_RESPONSE_OUTPUT_ITEM_DONE: &str = "response.output_item.done";
 pub const EVENT_RESPONSE_COMPLETED: &str = "response.completed";
 pub const EVENT_RESPONSE_CANCELLED: &str = "response.cancelled";
-pub const EVENT_RESPONSE_ERROR: &str = "response.error";
+pub const EVENT_RESPONSE_FAILED: &str = "response.failed";
 
 /// Error event data
 pub const ERROR_DATA_ENCRYPTION_FAILED: &str = "encryption_failed";
@@ -38,6 +38,7 @@ pub const ERROR_DATA_SERIALIZATION_FAILED: &str = "serialization_failed";
 /// Message statuses
 pub const STATUS_IN_PROGRESS: &str = "in_progress";
 pub const STATUS_COMPLETED: &str = "completed";
+pub const STATUS_FAILED: &str = "failed";
 pub const STATUS_INCOMPLETE: &str = "incomplete";
 pub const STATUS_CANCELLED: &str = "cancelled";
 

--- a/src/web/responses/context_builder.rs
+++ b/src/web/responses/context_builder.rs
@@ -78,10 +78,7 @@ fn decrypt_instruction(
 }
 
 pub(crate) fn prompt_token_budget(model: &str) -> usize {
-    let max_ctx = model_max_ctx(model);
-    let response_reserve = 4096usize;
-    let safety = 500usize;
-    max_ctx.saturating_sub(response_reserve + safety)
+    model_max_ctx(model)
 }
 
 /// Return (messages, total_prompt_tokens)
@@ -1003,8 +1000,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_glm_5_2_prompt_budget_reserves_response_and_safety_tokens() {
-        assert_eq!(prompt_token_budget("glm-5-2"), 256_000 - 4096 - 500);
+    fn test_prompt_budget_uses_model_context_window() {
+        assert_eq!(prompt_token_budget("llama3-3-70b"), 131_072);
+        assert_eq!(prompt_token_budget("glm-5-2"), 393_216);
+        assert_eq!(prompt_token_budget("glm-5-3-flash"), 1_048_576);
     }
 
     // Helper to create a ChatMsg
@@ -1231,6 +1230,40 @@ mod tests {
     }
 
     #[test]
+    fn test_full_context_window_preserves_history_and_incoming_reservation() {
+        let incoming_tokens = 2_000;
+        let metadata = vec![
+            context_metadata("user", 1, 1_000),
+            context_metadata("assistant", 2, 389_216),
+            context_metadata("user", 3, 1_000),
+        ];
+        let (needed_ids, did_truncate) =
+            determine_needed_message_ids(&metadata, "glm-5-2", 0, incoming_tokens)
+                .expect("select history within the full context window");
+        assert!(!did_truncate);
+        assert_eq!(
+            needed_ids,
+            vec![
+                ("user".to_string(), 1),
+                ("assistant".to_string(), 2),
+                ("user".to_string(), 3),
+            ]
+        );
+
+        let history = vec![
+            create_chat_msg("user", "First question", Some(1_000)),
+            create_chat_msg("assistant", "Full answer", Some(389_216)),
+            create_chat_msg("user", "Follow-up", Some(1_000)),
+        ];
+        let (messages, history_tokens) =
+            build_prompt_from_chat_messages_with_token_reserve(history, "glm-5-2", incoming_tokens)
+                .expect("build history with room reserved for the incoming message");
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[1]["content"], "Full answer");
+        assert_eq!(history_tokens + incoming_tokens, 393_216);
+    }
+
+    #[test]
     fn test_truncation_preserves_first_and_last() {
         // Create many messages that will exceed token limit
         let mut msgs = vec![];
@@ -1244,7 +1277,7 @@ mod tests {
         ));
 
         // Many middle messages (each with high token count to trigger truncation)
-        // We need to exceed 59,404 token budget
+        // We need to exceed the 64,000-token model context window.
         for i in 0..35 {
             msgs.push(create_chat_msg(
                 "user",
@@ -1349,7 +1382,7 @@ mod tests {
         }
 
         // Total tokens should be within budget
-        let budget = 64_000 - 4096 - 500; // max - response_reserve - safety
+        let budget = 64_000;
         assert!(total_tokens <= budget);
     }
 
@@ -1358,10 +1391,10 @@ mod tests {
         // Force truncation with a system message at the start
         let msgs = vec![
             create_chat_msg("system", "You are a helpful assistant", Some(10)),
-            create_chat_msg("user", "First", Some(20000)),
-            create_chat_msg("assistant", "First reply", Some(20000)),
-            create_chat_msg("user", "Second", Some(20000)),
-            create_chat_msg("assistant", "Second reply", Some(20000)),
+            create_chat_msg("user", "First", Some(25000)),
+            create_chat_msg("assistant", "First reply", Some(25000)),
+            create_chat_msg("user", "Second", Some(25000)),
+            create_chat_msg("assistant", "Second reply", Some(25000)),
             create_chat_msg("user", "New message", Some(5)),
         ];
 
@@ -1458,7 +1491,7 @@ mod tests {
             ),
             create_chat_msg("user", "First", Some(20_000)),
             create_chat_msg("assistant", "First reply", Some(20_000)),
-            create_chat_msg("user", "Oversized current image context", Some(59_000)),
+            create_chat_msg("user", "Oversized current image context", Some(64_000)),
         ];
 
         let result = build_prompt_from_chat_messages(msgs, "test-model");
@@ -1476,7 +1509,7 @@ mod tests {
         //
         // Scenario:
         // - First user message: 100 tokens (kept in head)
-        // - Middle messages: 50,000 tokens total (will be truncated)
+        // - Middle messages: 60,000 tokens total (will be truncated)
         // - Recent user message: 10,000 tokens (HUGE - exceeds available tail budget)
         //
         // The recent message must survive even though it's larger than available_for_tail
@@ -1487,7 +1520,7 @@ mod tests {
         msgs.push(create_chat_msg("user", "First message", Some(100)));
 
         // Many middle messages to consume most of the budget
-        for i in 0..25 {
+        for i in 0..30 {
             msgs.push(create_chat_msg(
                 "user",
                 &format!("Middle user {}", i),
@@ -2102,7 +2135,7 @@ mod tests {
         let mut msgs = vec![create_chat_msg("user", "First question", Some(5))];
 
         // Bloat the middle with many old tool turns
-        for i in 0..20 {
+        for i in 0..22 {
             let id = uuid::Uuid::new_v4();
             msgs.push(create_tool_call_chat_msg(
                 id,
@@ -2158,7 +2191,7 @@ mod tests {
             .any(|m| m["content"].as_str().unwrap_or("").contains("truncated")));
 
         // Must stay inside the budget
-        let budget = 64_000 - 4096 - 500;
+        let budget = 64_000;
         assert!(
             total_tokens <= budget,
             "prompt tokens {} exceed budget {}",

--- a/src/web/responses/events.rs
+++ b/src/web/responses/events.rs
@@ -8,7 +8,7 @@ use tracing::{error, trace};
 use super::constants::{
     ERROR_DATA_ENCRYPTION_FAILED, ERROR_DATA_SERIALIZATION_FAILED, EVENT_RESPONSE_CANCELLED,
     EVENT_RESPONSE_COMPLETED, EVENT_RESPONSE_CONTENT_PART_ADDED, EVENT_RESPONSE_CONTENT_PART_DONE,
-    EVENT_RESPONSE_CREATED, EVENT_RESPONSE_ERROR, EVENT_RESPONSE_IN_PROGRESS,
+    EVENT_RESPONSE_CREATED, EVENT_RESPONSE_FAILED, EVENT_RESPONSE_IN_PROGRESS,
     EVENT_RESPONSE_OUTPUT_ITEM_ADDED, EVENT_RESPONSE_OUTPUT_ITEM_DONE,
     EVENT_RESPONSE_OUTPUT_TEXT_DELTA, EVENT_RESPONSE_OUTPUT_TEXT_DONE,
     EVENT_RESPONSE_REASONING_TEXT_DELTA, EVENT_RESPONSE_REASONING_TEXT_DONE,
@@ -16,7 +16,7 @@ use super::constants::{
 };
 use super::handlers::{
     encrypt_event, ResponseCancelledEvent, ResponseCompletedEvent, ResponseContentPartAddedEvent,
-    ResponseContentPartDoneEvent, ResponseCreatedEvent, ResponseErrorEvent,
+    ResponseContentPartDoneEvent, ResponseCreatedEvent, ResponseFailedEvent,
     ResponseInProgressEvent, ResponseOutputItemAddedEvent, ResponseOutputItemDoneEvent,
     ResponseOutputTextDeltaEvent, ResponseOutputTextDoneEvent, ResponseReasoningTextDeltaEvent,
     ResponseReasoningTextDoneEvent, ToolCallCreatedEvent, ToolOutputCreatedEvent,
@@ -144,7 +144,7 @@ pub enum ResponseEvent {
     OutputItemDone(ResponseOutputItemDoneEvent),
     Completed(ResponseCompletedEvent),
     Cancelled(ResponseCancelledEvent),
-    Error(ResponseErrorEvent),
+    Failed(ResponseFailedEvent),
     ToolCallCreated(ToolCallCreatedEvent),
     ToolOutputCreated(ToolOutputCreatedEvent),
 }
@@ -165,7 +165,7 @@ impl ResponseEvent {
             ResponseEvent::OutputItemDone(_) => EVENT_RESPONSE_OUTPUT_ITEM_DONE,
             ResponseEvent::Completed(_) => EVENT_RESPONSE_COMPLETED,
             ResponseEvent::Cancelled(_) => EVENT_RESPONSE_CANCELLED,
-            ResponseEvent::Error(_) => EVENT_RESPONSE_ERROR,
+            ResponseEvent::Failed(_) => EVENT_RESPONSE_FAILED,
             ResponseEvent::ToolCallCreated(_) => EVENT_TOOL_CALL_CREATED,
             ResponseEvent::ToolOutputCreated(_) => EVENT_TOOL_OUTPUT_CREATED,
         }
@@ -190,7 +190,7 @@ impl ResponseEvent {
             ResponseEvent::Cancelled(e) => {
                 emitter.emit_without_sequence(self.event_type(), e).await
             }
-            ResponseEvent::Error(e) => emitter.emit_without_sequence(self.event_type(), e).await,
+            ResponseEvent::Failed(e) => emitter.emit(self.event_type(), e).await,
             ResponseEvent::ToolCallCreated(e) => emitter.emit(self.event_type(), e).await,
             ResponseEvent::ToolOutputCreated(e) => emitter.emit(self.event_type(), e).await,
         }
@@ -201,8 +201,8 @@ impl ResponseEvent {
 mod tests {
     use super::*;
     use crate::web::responses::constants::{
-        OBJECT_TYPE_RESPONSE, STATUS_IN_PROGRESS, TEXT_FORMAT_TYPE, TOOL_CHOICE_AUTO,
-        TRUNCATION_DISABLED,
+        OBJECT_TYPE_RESPONSE, STATUS_FAILED, STATUS_IN_PROGRESS, TEXT_FORMAT_TYPE,
+        TOOL_CHOICE_AUTO, TRUNCATION_DISABLED,
     };
 
     #[derive(Serialize)]
@@ -239,48 +239,79 @@ mod tests {
         use uuid::Uuid;
 
         // Test that event types map correctly
+        let response = ResponsesCreateResponse {
+            id: Uuid::new_v4(),
+            object: OBJECT_TYPE_RESPONSE,
+            created_at: 0,
+            status: STATUS_IN_PROGRESS.to_string(),
+            background: false,
+            error: None,
+            incomplete_details: None,
+            instructions: None,
+            max_output_tokens: None,
+            max_tool_calls: None,
+            model: "test".to_string(),
+            output: vec![],
+            parallel_tool_calls: false,
+            previous_response_id: None,
+            prompt_cache_key: None,
+            reasoning: ReasoningInfo {
+                effort: None,
+                summary: None,
+            },
+            safety_identifier: None,
+            store: true,
+            temperature: 1.0,
+            text: TextFormat {
+                format: TextFormatSpec {
+                    format_type: TEXT_FORMAT_TYPE.to_string(),
+                },
+            },
+            tool_choice: TOOL_CHOICE_AUTO.to_string(),
+            tools: vec![],
+            top_logprobs: 0,
+            top_p: 1.0,
+            truncation: TRUNCATION_DISABLED,
+            usage: None,
+            user: None,
+            metadata: None,
+        };
         let created = ResponseEvent::Created(ResponseCreatedEvent {
             event_type: EVENT_RESPONSE_CREATED,
-            response: ResponsesCreateResponse {
-                id: Uuid::new_v4(),
-                object: OBJECT_TYPE_RESPONSE,
-                created_at: 0,
-                status: STATUS_IN_PROGRESS.to_string(),
-                background: false,
-                error: None,
-                incomplete_details: None,
-                instructions: None,
-                max_output_tokens: None,
-                max_tool_calls: None,
-                model: "test".to_string(),
-                output: vec![],
-                parallel_tool_calls: false,
-                previous_response_id: None,
-                prompt_cache_key: None,
-                reasoning: ReasoningInfo {
-                    effort: None,
-                    summary: None,
-                },
-                safety_identifier: None,
-                store: true,
-                temperature: 1.0,
-                text: TextFormat {
-                    format: TextFormatSpec {
-                        format_type: TEXT_FORMAT_TYPE.to_string(),
-                    },
-                },
-                tool_choice: TOOL_CHOICE_AUTO.to_string(),
-                tools: vec![],
-                top_logprobs: 0,
-                top_p: 1.0,
-                truncation: TRUNCATION_DISABLED,
-                usage: None,
-                user: None,
-                metadata: None,
-            },
+            response: response.clone(),
             sequence_number: 0,
         });
 
         assert_eq!(created.event_type(), EVENT_RESPONSE_CREATED);
+
+        let failed_payload = ResponseFailedEvent {
+            event_type: EVENT_RESPONSE_FAILED,
+            response: ResponsesCreateResponse {
+                status: STATUS_FAILED.to_string(),
+                error: Some(ResponseError {
+                    code: "rate_limit_exceeded".to_string(),
+                    message: "Inference capacity is temporarily unavailable.".to_string(),
+                }),
+                ..response
+            },
+            sequence_number: 1,
+            opensecret: Some(OpenSecretResponseError {
+                error_contract: "1",
+                error_code: "inference_capacity",
+            }),
+        };
+        let serialized = serde_json::to_value(&failed_payload).unwrap();
+        assert_eq!(serialized["type"], EVENT_RESPONSE_FAILED);
+        assert_eq!(serialized["response"]["status"], STATUS_FAILED);
+        assert_eq!(
+            serialized["response"]["error"]["code"],
+            "rate_limit_exceeded"
+        );
+        assert!(serialized.get("error").is_none());
+        assert_eq!(serialized["opensecret"]["error_code"], "inference_capacity");
+        assert_eq!(
+            ResponseEvent::Failed(failed_payload).event_type(),
+            EVENT_RESPONSE_FAILED
+        );
     }
 }

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -70,7 +70,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::{
     collections::{HashMap, HashSet},
-    convert::Infallible,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -5790,14 +5789,10 @@ async fn create_response_stream(
 
         if require_explicit_terminal && !saw_terminal {
             error!("Responses client stream closed without a terminal event");
-            let error_event = ResponseErrorEvent {
-                event_type: EVENT_RESPONSE_ERROR,
-                error: ResponseError {
-                    error_type: "stream_error".to_string(),
-                    message: "Response stream ended unexpectedly".to_string(),
-                },
-            };
-            yield Ok(ResponseEvent::Error(error_event).to_sse_event(&mut emitter).await);
+            // No storage-authoritative terminal arrived. Fail the body so the
+            // V2 gateway emits an authenticated transport error, without claiming
+            // that the response reached a durable failed state.
+            yield Err(ApiError::InternalServerError);
         }
 
         // Client stream is done, but storage and upstream tasks continue independently
@@ -5810,7 +5805,7 @@ async fn create_response_stream(
 
 fn responses_sse_response<S>(event_stream: S) -> Response
 where
-    S: Stream<Item = Result<Event, Infallible>> + Send + 'static,
+    S: Stream<Item = Result<Event, ApiError>> + Send + 'static,
 {
     let sse = Sse::new(event_stream).keep_alive(
         KeepAlive::new()

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -24,12 +24,12 @@ use crate::{
     web::{
         encryption_middleware::{decrypt_request, encrypt_response, Decrypted, TransportSession},
         openai::{
-            ensure_completion_model_access, get_chat_completion_response,
-            get_chat_completion_response_for_execution,
-            get_chat_completion_response_for_expected_route, prepare_completion_request,
+            ensure_completion_model_access, finish_started_completion,
+            get_chat_completion_response, get_chat_completion_response_for_expected_route,
+            prepare_completion_request, start_chat_completion_response_for_execution,
             BillingContext, CompletionCachePolicy, CompletionChunk, CompletionExecutionContext,
             CompletionExecutionError, InferenceRoutingContext, PinnedCompletionRequest,
-            ServerSelectedCompletionRoute,
+            ServerSelectedCompletionRoute, StartedCompletion,
         },
         openai_auth::AuthMethod,
         responses::{
@@ -46,10 +46,11 @@ use crate::{
             prompt_token_budget, storage_task, tools, ContentPartBuilder, DeletedObjectResponse,
             MessageContent, MessageContentConverter, MessageContentPart, OutputItemBuilder,
             ResponseBuilder, ResponseEvent, ResponseExecution, ResponseExecutionRegistry,
-            SseEventEmitter, StorageTaskOutcome,
+            ResponseExecutionTaskGuard, SseEventEmitter,
         },
     },
-    ApiError, AppState,
+    ApiError, AppState, ResponseMessageReservation, ResponseMessageReservationError,
+    ERROR_CONTRACT_VERSION, INFERENCE_CAPACITY_ERROR_CODE,
 };
 use axum::{
     extract::{Path, State},
@@ -63,7 +64,7 @@ use axum::{
     Extension, Router,
 };
 use chrono::Utc;
-use futures::Stream;
+use futures::{FutureExt, Stream};
 use secp256k1::SecretKey;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -73,16 +74,17 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::Instant as TokioInstant;
 use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
 
 const RESPONSES_SSE_KEEPALIVE_INTERVAL_SECS: u64 = 1;
 const RESPONSE_CANCEL_ACK_TIMEOUT: Duration = Duration::from_secs(4);
 const RESPONSE_CANCEL_ACK_POLL_INTERVAL: Duration = Duration::from_millis(20);
-const RESPONSE_STORAGE_JOIN_WARNING_AFTER: Duration = Duration::from_secs(4);
 const MAX_WEB_SEARCH_TOOL_TURNS_FREE: usize = 5;
 const MAX_WEB_SEARCH_TOOL_TURNS_PAID: usize = 30;
+const RESPONSE_EXECUTION_DEADLINE: Duration = Duration::from_secs(10 * 60);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ResponseCancellationAckDecision {
@@ -263,7 +265,116 @@ struct StreamedToolCall {
 #[derive(Debug, Clone)]
 enum AssistantTurnOutcome {
     ToolCall(ModelToolCall),
-    Final,
+    Final { finish_reason: String },
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ResponseExecutionPolicy {
+    deadline: TokioInstant,
+    max_model_turns: usize,
+    max_tool_executions: usize,
+}
+
+impl ResponseExecutionPolicy {
+    fn new(model_plan: ModelPlan, tools_enabled: bool) -> Self {
+        let max_tool_executions = if tools_enabled {
+            web_search_tool_turn_limit(model_plan)
+        } else {
+            0
+        };
+        let max_model_turns = if tools_enabled {
+            max_tool_executions + 2
+        } else {
+            1
+        };
+        Self {
+            deadline: TokioInstant::now() + RESPONSE_EXECUTION_DEADLINE,
+            max_model_turns,
+            max_tool_executions,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublicResponseFailure {
+    CapacityRateLimited,
+    CapacityOverloaded,
+    DeadlineExceeded,
+    Internal,
+}
+
+impl PublicResponseFailure {
+    fn from_completion_error(error: &CompletionExecutionError) -> Self {
+        match error.terminal() {
+            Some(AttemptTerminal::Failed { failure, .. })
+                if failure.kind == crate::inference::AttemptFailureKind::CapacityRejected =>
+            {
+                if failure.status == Some(429) {
+                    Self::CapacityRateLimited
+                } else {
+                    Self::CapacityOverloaded
+                }
+            }
+            _ => Self::Internal,
+        }
+    }
+
+    fn openai_code(self) -> &'static str {
+        match self {
+            Self::CapacityRateLimited => "rate_limit_exceeded",
+            Self::CapacityOverloaded | Self::DeadlineExceeded | Self::Internal => "server_error",
+        }
+    }
+
+    fn message(self) -> &'static str {
+        match self {
+            Self::CapacityRateLimited | Self::CapacityOverloaded => {
+                "Inference capacity is temporarily unavailable."
+            }
+            Self::DeadlineExceeded => "The response exceeded its execution deadline.",
+            Self::Internal => "The response could not be completed.",
+        }
+    }
+
+    fn contract_metadata(self) -> Option<OpenSecretResponseError> {
+        matches!(self, Self::CapacityRateLimited | Self::CapacityOverloaded).then_some(
+            OpenSecretResponseError {
+                error_contract: ERROR_CONTRACT_VERSION,
+                error_code: INFERENCE_CAPACITY_ERROR_CODE,
+            },
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResponseTerminal {
+    Completed { finish_reason: String },
+    Failed(PublicResponseFailure),
+    Cancelled,
+}
+
+impl ResponseTerminal {
+    pub(crate) fn status(&self) -> ResponseStatus {
+        match self {
+            Self::Completed { .. } => ResponseStatus::Completed,
+            Self::Failed(_) => ResponseStatus::Failed,
+            Self::Cancelled => ResponseStatus::Cancelled,
+        }
+    }
+}
+
+fn responses_pre_persistence_api_error(
+    error: CompletionExecutionError,
+    completed_image_descriptions: bool,
+) -> ApiError {
+    if completed_image_descriptions {
+        // Descriptor completions have already consumed provider capacity and
+        // published usage. The conversation is still cleanly replayable, but
+        // the whole HTTP request is not side-effect-free.
+        error.into_api_error()
+    } else {
+        error.into_pre_persistence_api_error()
+    }
 }
 
 fn web_search_is_selected(
@@ -461,40 +572,45 @@ fn final_assistant_finish_reason(tools_enabled: bool, finish_reason: Option<Stri
 mod tests {
     use super::{
         append_streamed_tool_calls, apply_responses_model_defaults,
-        assistant_turn_finished_with_tool_call, await_storage_completion,
-        await_storage_completion_with_warning_after, build_internal_system_prompt_for_now,
-        build_model_turn_request, build_provider_tools, client_cancellation_terminal_decision,
+        assistant_turn_finished_with_tool_call, build_internal_system_prompt_for_now,
+        build_model_turn_request, build_provider_tools, consume_assistant_turn,
         final_assistant_finish_reason, finalize_first_model_tool_call,
-        has_streamed_tool_call_entries, image_attachments, image_description_access,
-        image_description_api_error, image_description_attempt_failure_class,
-        maple_kagi_web_search_prompt, model_turn_request_without_user_payload,
-        next_client_message_after_durable_completion, resolve_responses_model,
-        resolve_responses_sampling, response_cancellation_ack_decision,
-        response_execution_for_status, send_storage_message,
-        wait_for_local_response_execution_quiescence, web_search_is_selected,
+        forward_authoritative_response_terminal, has_streamed_tool_call_entries, image_attachments,
+        image_description_access, image_description_api_error,
+        image_description_attempt_failure_class, maple_kagi_web_search_prompt,
+        model_turn_request_without_user_payload, reserve_response_message_uuid_with_check,
+        resolve_responses_model, resolve_responses_sampling, response_cancellation_ack_decision,
+        response_execution_for_status, responses_pre_persistence_api_error, run_response_worker,
+        send_storage_message, wait_for_local_response_execution_quiescence, web_search_is_selected,
         web_search_tool_turn_limit, web_search_tool_turn_limit_error,
-        web_search_tool_turn_limit_reached, ClientCancellationTerminalDecision,
-        ClientResponseState, ConversationParam, ImageAttachment, ImageDescriptionFailureClass,
-        ImageDescriptionInput, ImageDescriptionToolPair, InputMessage, MessageContent,
-        MessageContentPart, MessageInput, ResponseCancellationAckDecision, ResponsesCreateRequest,
-        StorageCompletionDecision, StorageMessage, StreamedToolCall,
+        web_search_tool_turn_limit_reached, AssistantTurnOutcome, ClientResponseState,
+        ConversationParam, ImageAttachment, ImageDescriptionFailureClass, ImageDescriptionInput,
+        ImageDescriptionToolPair, InputMessage, MessageContent, MessageContentPart, MessageInput,
+        PublicResponseFailure, ResponseCancellationAckDecision, ResponseExecutionPolicy,
+        ResponseTerminal, ResponsesCreateRequest, StorageMessage, StreamedToolCall,
         MAX_WEB_SEARCH_TOOL_TURNS_FREE, MAX_WEB_SEARCH_TOOL_TURNS_PAID, READ_IMAGE_TOOL_NAME,
     };
-    use crate::web::responses::{tools, StorageTaskOutcome};
+    use crate::web::responses::{constants::*, tools};
     use crate::{
         billing::{BillingClient, ChatBillingAccess},
-        inference::{AttemptFailure, AttemptFailureKind, AttemptStage, ReplaySafety},
+        inference::{
+            AttemptFailure, AttemptFailureKind, AttemptStage, AttemptTerminal, CompletionEvidence,
+            InferenceIntent, InferenceSurface, ReplaySafety, RouteIdentity, WorkloadClass,
+        },
         model_config::{ModelAliasTargets, ModelPlan},
         models::responses::ResponseStatus,
-        ApiError,
+        provider_registry::{ProviderId, RouteSelectionSource},
+        web::openai::{CompletionChunk, CompletionExecutionError, CompletionUsage},
+        ApiError, ResponseMessageReservation, ResponseMessageReservations,
     };
     use axum::{routing::get, Json, Router};
     use chrono::{TimeZone, Utc};
     use serde_json::json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::{
         net::TcpListener,
         sync::{mpsc, oneshot},
-        time::Duration,
+        time::{timeout, Duration},
     };
     use uuid::Uuid;
 
@@ -520,6 +636,83 @@ mod tests {
             .expect("load billing access");
         server.abort();
         access
+    }
+
+    fn counted_provider_start_after_message_admission(
+        reservations: &ResponseMessageReservations,
+        message_uuid: Uuid,
+        persisted_uuid_exists: bool,
+        starts: &AtomicUsize,
+    ) -> Result<ResponseMessageReservation, ApiError> {
+        let reservation =
+            reserve_response_message_uuid_with_check(reservations, message_uuid, |_| {
+                Ok(persisted_uuid_exists)
+            })?;
+        starts.fetch_add(1, Ordering::SeqCst);
+        Ok(reservation)
+    }
+
+    #[test]
+    fn persisted_message_uuid_is_rejected_before_provider_start() {
+        let reservations = ResponseMessageReservations::default();
+        let starts = AtomicUsize::new(0);
+
+        assert!(matches!(
+            counted_provider_start_after_message_admission(
+                &reservations,
+                Uuid::new_v4(),
+                true,
+                &starts,
+            ),
+            Err(ApiError::Conflict)
+        ));
+        assert_eq!(starts.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn concurrent_message_uuid_allows_only_one_provider_start() {
+        let reservations = ResponseMessageReservations::default();
+        let starts = AtomicUsize::new(0);
+        let message_uuid = Uuid::new_v4();
+        let first = counted_provider_start_after_message_admission(
+            &reservations,
+            message_uuid,
+            false,
+            &starts,
+        )
+        .expect("first request is admitted");
+
+        assert!(matches!(
+            counted_provider_start_after_message_admission(
+                &reservations,
+                message_uuid,
+                false,
+                &starts,
+            ),
+            Err(ApiError::Conflict)
+        ));
+        assert_eq!(starts.load(Ordering::SeqCst), 1);
+
+        drop(first);
+    }
+
+    #[test]
+    fn completed_image_descriptions_suppress_request_replay_safety() {
+        for (completed_image_descriptions, expected_replay_safe) in [(false, true), (true, false)] {
+            let error = CompletionExecutionError::from(ApiError::InferenceCapacity {
+                status: axum::http::StatusCode::TOO_MANY_REQUESTS,
+                retry_after: Some(Duration::from_secs(7)),
+                client_replay_safe: false,
+            });
+
+            assert!(matches!(
+                responses_pre_persistence_api_error(error, completed_image_descriptions),
+                ApiError::InferenceCapacity {
+                    client_replay_safe,
+                    ..
+                } if client_replay_safe == expected_replay_safe
+            ));
+        }
     }
 
     fn test_image_attachment() -> ImageAttachment {
@@ -642,10 +835,12 @@ mod tests {
         match &client_messages[0] {
             StorageMessage::ToolCall {
                 tool_call_id: actual_id,
+                tool_output_id: actual_output_id,
                 name,
                 arguments: actual_arguments,
             } => {
                 assert_eq!(*actual_id, tool_call_id);
+                assert_eq!(*actual_output_id, tool_output_id);
                 assert_eq!(name, READ_IMAGE_TOOL_NAME);
                 assert_eq!(actual_arguments, &arguments);
             }
@@ -1001,35 +1196,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn response_completion_waits_for_storage_acknowledgement() {
-        let (release_storage, storage_released) = oneshot::channel();
-        let storage_handle = tokio::spawn(async move {
-            storage_released.await.expect("release storage worker");
-            StorageTaskOutcome::Completed
-        });
-        let mut storage_handle = Some(storage_handle);
-        let (decision_tx, mut decision_rx) = oneshot::channel();
-
-        let waiter = tokio::spawn(async move {
-            let decision = await_storage_completion(&mut storage_handle).await;
-            decision_tx.send(decision).expect("send terminal decision");
-        });
-
-        tokio::task::yield_now().await;
-        assert!(matches!(
-            decision_rx.try_recv(),
-            Err(oneshot::error::TryRecvError::Empty)
-        ));
-
-        release_storage.send(()).expect("release storage worker");
-        assert_eq!(
-            decision_rx.await.expect("receive terminal decision"),
-            StorageCompletionDecision::Completed
-        );
-        waiter.await.expect("join completion waiter");
-    }
-
-    #[tokio::test]
     async fn terminal_cancel_rejection_waits_for_local_execution_quiescence() {
         let registry = crate::web::responses::ResponseExecutionRegistry::default();
         let registration = registry
@@ -1053,292 +1219,461 @@ mod tests {
             .expect("quiescence waiter should finish"));
     }
 
-    #[tokio::test]
-    async fn terminal_storage_message_waits_for_saturated_client_channel() {
-        let (storage_tx, mut storage_rx) = mpsc::channel(2);
-        let (client_tx, mut client_rx) = mpsc::channel(1);
-        client_tx
-            .send(StorageMessage::ContentDelta {
-                item_id: Uuid::new_v4(),
-                delta: "queued output".to_string(),
-            })
-            .await
-            .expect("fill client channel");
+    #[test]
+    fn model_turns_preserve_optional_output_limits_without_an_aggregate_budget() {
+        for model in ["llama3-3-70b", "glm-5-3", "kimi-k3"] {
+            for max_output_tokens in [None, Some(16_000), Some(i32::MAX)] {
+                let mut body = responses_request_for_model(model);
+                body.max_output_tokens = max_output_tokens;
+                let model_body = model_turn_request_without_user_payload(&body);
+                let mut prompt = vec![json!({"role": "user", "content": "Research this topic"})];
 
-        let terminal_sender = tokio::spawn(async move {
-            send_storage_message(
-                &storage_tx,
-                &client_tx,
-                StorageMessage::ResponseDone {
-                    finish_reason: "stop".to_string(),
-                },
-            )
-            .await
-        });
-
-        assert!(matches!(
-            storage_rx.recv().await,
-            Some(StorageMessage::ResponseDone { .. })
-        ));
-        tokio::task::yield_now().await;
-        assert!(
-            !terminal_sender.is_finished(),
-            "terminal event must wait instead of being dropped while the client channel is full"
-        );
-
-        assert!(matches!(
-            client_rx.recv().await,
-            Some(StorageMessage::ContentDelta { .. })
-        ));
-        terminal_sender
-            .await
-            .expect("join terminal sender")
-            .expect("send terminal message");
-        assert!(matches!(
-            client_rx.recv().await,
-            Some(StorageMessage::ResponseDone { .. })
-        ));
-    }
-
-    #[tokio::test]
-    async fn durable_completion_replays_buffered_output_when_client_terminal_send_is_interrupted() {
-        let (storage_tx, mut storage_rx) = mpsc::channel(1);
-        let (client_tx, mut client_rx) = mpsc::channel(3);
-        let item_id = Uuid::new_v4();
-        client_tx
-            .send(StorageMessage::MessageStarted { item_id })
-            .await
-            .expect("queue message start");
-        client_tx
-            .send(StorageMessage::ContentDelta {
-                item_id,
-                delta: "buffered output".to_string(),
-            })
-            .await
-            .expect("queue message content");
-        client_tx
-            .send(StorageMessage::MessageDone {
-                item_id,
-                finish_reason: "stop".to_string(),
-            })
-            .await
-            .expect("fill client channel");
-
-        let terminal_sender = tokio::spawn(async move {
-            send_storage_message(
-                &storage_tx,
-                &client_tx,
-                StorageMessage::ResponseDone {
-                    finish_reason: "stop".to_string(),
-                },
-            )
-            .await
-        });
-
-        assert!(matches!(
-            storage_rx.recv().await,
-            Some(StorageMessage::ResponseDone { .. })
-        ));
-        tokio::task::yield_now().await;
-        assert!(
-            !terminal_sender.is_finished(),
-            "terminal sender must be blocked behind buffered client output"
-        );
-        terminal_sender.abort();
-        assert!(terminal_sender
-            .await
-            .expect_err("terminal sender should be cancelled")
-            .is_cancelled());
-
-        assert!(matches!(
-            next_client_message_after_durable_completion(&mut client_rx),
-            StorageMessage::MessageStarted { item_id: replayed_id } if replayed_id == item_id
-        ));
-
-        assert!(matches!(
-            next_client_message_after_durable_completion(&mut client_rx),
-            StorageMessage::ContentDelta { item_id: replayed_id, delta }
-                if replayed_id == item_id && delta == "buffered output"
-        ));
-        assert!(matches!(
-            next_client_message_after_durable_completion(&mut client_rx),
-            StorageMessage::MessageDone { item_id: replayed_id, finish_reason }
-                if replayed_id == item_id && finish_reason == "stop"
-        ));
-        assert!(matches!(
-            next_client_message_after_durable_completion(&mut client_rx),
-            StorageMessage::ResponseDone { .. }
-        ));
+                // Initial inference and successive tool turns all use the same
+                // caller option; previous output cannot consume a shared budget.
+                for tools_enabled in [true, true, false] {
+                    let request = build_model_turn_request(&model_body, &prompt, tools_enabled);
+                    assert_eq!(request["max_tokens"], json!(max_output_tokens));
+                    assert_eq!(model_body.max_output_tokens, max_output_tokens);
+                    prompt.push(json!({"role": "assistant", "content": "Prior output"}));
+                }
+            }
+        }
     }
 
     #[test]
-    fn durable_storage_outcome_controls_the_client_cancellation_terminal() {
-        assert_eq!(
-            client_cancellation_terminal_decision(StorageCompletionDecision::Completed),
-            ClientCancellationTerminalDecision::ReplayCompleted
+    fn response_execution_policy_preserves_tool_and_model_turn_bounds() {
+        let free = ResponseExecutionPolicy::new(ModelPlan::Free, true);
+        assert_eq!(free.max_tool_executions, MAX_WEB_SEARCH_TOOL_TURNS_FREE);
+        assert_eq!(free.max_model_turns, MAX_WEB_SEARCH_TOOL_TURNS_FREE + 2);
+        let paid = ResponseExecutionPolicy::new(ModelPlan::Paid, true);
+        assert_eq!(paid.max_tool_executions, MAX_WEB_SEARCH_TOOL_TURNS_PAID);
+        assert_eq!(paid.max_model_turns, MAX_WEB_SEARCH_TOOL_TURNS_PAID + 2);
+        let no_tools = ResponseExecutionPolicy::new(ModelPlan::Paid, false);
+        assert_eq!(no_tools.max_tool_executions, 0);
+        assert_eq!(no_tools.max_model_turns, 1);
+    }
+
+    fn completed_attempt_chunk() -> CompletionChunk {
+        let intent = InferenceIntent::new(
+            Uuid::new_v4(),
+            "llama3-3-70b",
+            "llama3-3-70b",
+            ModelPlan::Free,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
         );
-        assert_eq!(
-            client_cancellation_terminal_decision(StorageCompletionDecision::Cancelled),
-            ClientCancellationTerminalDecision::EmitCancelled
+        let route = RouteIdentity::new(
+            ProviderId::Tinfoil,
+            "llama3-3-70b",
+            "llama3-3-70b",
+            "llama3-3-70b",
+            RouteSelectionSource::StaticSplit,
+            None,
         );
-        assert_eq!(
-            client_cancellation_terminal_decision(StorageCompletionDecision::Error),
-            ClientCancellationTerminalDecision::EmitError
-        );
+        CompletionChunk::Terminal(AttemptTerminal::Completed {
+            attempt: intent.begin_execution().begin_attempt(route),
+            evidence: CompletionEvidence::ProviderDone,
+        })
     }
 
     #[tokio::test]
-    async fn durable_completion_uses_an_already_queued_client_terminal_message() {
-        let (client_tx, mut client_rx) = mpsc::channel(2);
-        client_tx
-            .send(StorageMessage::Usage {
-                prompt_tokens: 3,
-                completion_tokens: 5,
-            })
-            .await
-            .expect("queue usage");
-        client_tx
-            .send(StorageMessage::ResponseDone {
-                finish_reason: "length".to_string(),
-            })
-            .await
-            .expect("queue terminal message");
+    async fn assistant_turn_accepts_missing_or_large_usage_after_client_disconnect() {
+        let (tx_storage, mut rx_storage) = mpsc::channel(16);
+        let (tx_client, rx_client) = mpsc::channel(1);
+        drop(rx_client);
+        let mut next_message_id = Some(Uuid::new_v4());
 
-        assert!(matches!(
-            next_client_message_after_durable_completion(&mut client_rx),
-            StorageMessage::Usage {
-                prompt_tokens: 3,
-                completion_tokens: 5
+        for completion_tokens in [None, Some(16_384), Some(32_768)] {
+            let (tx_completion, rx_completion) = mpsc::channel(3);
+            tx_completion
+                .send(CompletionChunk::StreamChunk(json!({
+                    "choices": [{"delta": {"content": "Full answer"}, "finish_reason": "stop"}]
+                })))
+                .await
+                .unwrap();
+            if let Some(completion_tokens) = completion_tokens {
+                tx_completion
+                    .send(CompletionChunk::Usage(CompletionUsage {
+                        prompt_tokens: 100,
+                        completion_tokens,
+                        cached_prompt_tokens: None,
+                    }))
+                    .await
+                    .unwrap();
             }
-        ));
-        assert!(matches!(
-            next_client_message_after_durable_completion(&mut client_rx),
-            StorageMessage::ResponseDone { finish_reason } if finish_reason == "length"
-        ));
-    }
+            tx_completion.send(completed_attempt_chunk()).await.unwrap();
+            drop(tx_completion);
 
-    #[tokio::test]
-    async fn transcript_delta_waits_for_saturated_client_channel() {
-        let (storage_tx, mut storage_rx) = mpsc::channel(2);
-        let (client_tx, mut client_rx) = mpsc::channel(1);
-        let queued_item_id = Uuid::new_v4();
-        let retained_item_id = Uuid::new_v4();
-        client_tx
-            .send(StorageMessage::ContentDelta {
-                item_id: queued_item_id,
-                delta: "already queued".to_string(),
-            })
-            .await
-            .expect("fill client channel");
-
-        let delta_sender = tokio::spawn(async move {
-            send_storage_message(
-                &storage_tx,
-                &client_tx,
-                StorageMessage::ContentDelta {
-                    item_id: retained_item_id,
-                    delta: "must not be dropped".to_string(),
-                },
+            let outcome = consume_assistant_turn(
+                rx_completion,
+                false,
+                &tx_client,
+                &tx_storage,
+                &mut next_message_id,
+                Uuid::new_v4(),
             )
             .await
-        });
-
-        assert!(matches!(
-            storage_rx.recv().await,
-            Some(StorageMessage::ContentDelta { item_id, .. }) if item_id == retained_item_id
-        ));
-        tokio::task::yield_now().await;
-        assert!(
-            !delta_sender.is_finished(),
-            "transcript deltas must apply backpressure instead of being dropped"
-        );
-
-        assert!(matches!(
-            client_rx.recv().await,
-            Some(StorageMessage::ContentDelta { item_id, .. }) if item_id == queued_item_id
-        ));
-        delta_sender
-            .await
-            .expect("join delta sender")
-            .expect("send retained delta");
-        assert!(matches!(
-            client_rx.recv().await,
-            Some(StorageMessage::ContentDelta { item_id, .. }) if item_id == retained_item_id
-        ));
-    }
-
-    #[tokio::test]
-    async fn response_completion_maps_non_successful_storage_outcomes() {
-        for (outcome, expected) in [
-            (
-                StorageTaskOutcome::Cancelled,
-                StorageCompletionDecision::Cancelled,
-            ),
-            (StorageTaskOutcome::Failed, StorageCompletionDecision::Error),
-        ] {
-            let mut storage_handle = Some(tokio::spawn(async move { outcome }));
-            assert_eq!(
-                await_storage_completion(&mut storage_handle).await,
-                expected
+            .expect("provider completion must not depend on a server output budget or live client");
+            assert!(
+                matches!(outcome, AssistantTurnOutcome::Final { finish_reason } if finish_reason == "stop")
             );
-            assert!(storage_handle.is_none());
+            assert!(matches!(
+                rx_storage.try_recv(),
+                Ok(StorageMessage::MessageStarted { .. })
+            ));
+            assert!(
+                matches!(rx_storage.try_recv(), Ok(StorageMessage::ContentDelta { delta, .. }) if delta == "Full answer")
+            );
+            if let Some(expected) = completion_tokens {
+                assert!(
+                    matches!(rx_storage.try_recv(), Ok(StorageMessage::Usage { completion_tokens, .. }) if completion_tokens == expected)
+                );
+            }
+            assert!(
+                matches!(rx_storage.try_recv(), Ok(StorageMessage::MessageDone { finish_reason, .. }) if finish_reason == "stop")
+            );
+            assert!(rx_storage.try_recv().is_err());
         }
     }
 
     #[tokio::test]
-    async fn response_completion_fails_closed_for_missing_or_aborted_storage_worker() {
-        let mut missing_handle = None;
-        assert_eq!(
-            await_storage_completion(&mut missing_handle).await,
-            StorageCompletionDecision::Error
-        );
-
-        let handle = tokio::spawn(async {
-            std::future::pending::<()>().await;
-            StorageTaskOutcome::Completed
-        });
-        handle.abort();
-        let mut aborted_handle = Some(handle);
-        assert_eq!(
-            await_storage_completion(&mut aborted_handle).await,
-            StorageCompletionDecision::Error
+    async fn assistant_tool_turn_without_usage_remains_executable() {
+        let (tx_completion, rx_completion) = mpsc::channel(2);
+        tx_completion
+            .send(CompletionChunk::StreamChunk(json!({
+                "choices": [{
+                    "delta": {"tool_calls": [{"index": 0, "function": {
+                        "name": "web_search", "arguments": "{\"query\":\"test\"}"
+                    }}]},
+                    "finish_reason": "tool_calls"
+                }]
+            })))
+            .await
+            .unwrap();
+        tx_completion.send(completed_attempt_chunk()).await.unwrap();
+        drop(tx_completion);
+        let (tx_storage, _rx_storage) = mpsc::channel(8);
+        let (tx_client, _rx_client) = mpsc::channel(8);
+        let outcome = consume_assistant_turn(
+            rx_completion,
+            true,
+            &tx_client,
+            &tx_storage,
+            &mut Some(Uuid::new_v4()),
+            Uuid::new_v4(),
+        )
+        .await
+        .expect("a completed tool turn does not require completion-token usage");
+        assert!(
+            matches!(outcome, AssistantTurnOutcome::ToolCall(call) if call.name == "web_search" && call.arguments == json!({"query": "test"}))
         );
     }
 
     #[tokio::test]
-    async fn response_completion_keeps_waiting_after_storage_join_warning() {
-        let (release_storage, storage_released) = oneshot::channel();
-        let handle = tokio::spawn(async move {
-            storage_released.await.expect("release storage worker");
-            StorageTaskOutcome::Completed
-        });
-        let abort_handle = handle.abort_handle();
-        let mut storage_handle = Some(handle);
-        let mut waiter = tokio::spawn(async move {
-            let decision = await_storage_completion_with_warning_after(
-                &mut storage_handle,
-                Duration::from_millis(20),
-            )
-            .await;
-            (decision, storage_handle.is_none())
-        });
-
-        assert!(
-            tokio::time::timeout(Duration::from_millis(75), &mut waiter)
-                .await
-                .is_err(),
-            "storage waiter must remain pending after the warning threshold"
-        );
-        assert!(!abort_handle.is_finished());
-
-        release_storage.send(()).expect("release storage worker");
-        let (decision, handle_consumed) = tokio::time::timeout(Duration::from_secs(1), waiter)
+    async fn client_disconnect_releases_backpressure_without_losing_storage_event() {
+        let (tx_storage, mut rx_storage) = mpsc::channel(1);
+        let (tx_client, rx_client) = mpsc::channel(1);
+        let item_id = Uuid::new_v4();
+        tx_client
+            .send(StorageMessage::MessageStarted { item_id })
             .await
-            .expect("storage waiter should resume after release")
-            .expect("join storage waiter");
-        assert_eq!(decision, StorageCompletionDecision::Completed);
-        assert!(handle_consumed);
-        assert!(abort_handle.is_finished());
+            .unwrap();
+        let fanout = send_storage_message(
+            &tx_storage,
+            &tx_client,
+            StorageMessage::ContentDelta {
+                item_id,
+                delta: "Retained".to_string(),
+            },
+        );
+        tokio::pin!(fanout);
+        assert!(futures::poll!(fanout.as_mut()).is_pending());
+        assert!(rx_storage.try_recv().is_err());
+        drop(rx_client);
+        fanout
+            .await
+            .expect("disconnect releases only the client copy");
+        assert!(
+            matches!(rx_storage.try_recv(), Ok(StorageMessage::ContentDelta { delta, .. }) if delta == "Retained")
+        );
+    }
+
+    #[tokio::test]
+    async fn disconnected_response_worker_continues_until_completed() {
+        let registry = crate::web::responses::ResponseExecutionRegistry::default();
+        let response_uuid = Uuid::new_v4();
+        let registration = registry.register(response_uuid, Uuid::new_v4()).unwrap();
+        let execution = registration.execution();
+        let worker_guard = execution.begin_task().unwrap();
+        let worker_execution = execution.clone();
+        let (tx_storage, mut rx_storage) = mpsc::channel(3);
+        let (tx_client, mut rx_client) = mpsc::channel(1);
+        let (release_worker, worker_released) = oneshot::channel();
+        let item_id = Uuid::new_v4();
+        let handle = tokio::spawn(async move {
+            let _worker_guard = worker_guard;
+            run_response_worker(
+                response_uuid,
+                &worker_execution,
+                tokio::time::Instant::now() + Duration::from_secs(60),
+                async move {
+                    send_storage_message(
+                        &tx_storage,
+                        &tx_client,
+                        StorageMessage::MessageStarted { item_id },
+                    )
+                    .await
+                    .unwrap();
+                    worker_released.await.unwrap();
+                    send_storage_message(
+                        &tx_storage,
+                        &tx_client,
+                        StorageMessage::ContentDelta {
+                            item_id,
+                            delta: "After disconnect".to_string(),
+                        },
+                    )
+                    .await
+                    .unwrap();
+                    send_storage_message(
+                        &tx_storage,
+                        &tx_client,
+                        StorageMessage::MessageDone {
+                            item_id,
+                            finish_reason: "stop".to_string(),
+                        },
+                    )
+                    .await
+                    .unwrap();
+                    ResponseTerminal::Completed {
+                        finish_reason: "stop".to_string(),
+                    }
+                },
+            )
+            .await
+        });
+        drop(registration);
+        assert!(matches!(
+            rx_client.recv().await,
+            Some(StorageMessage::MessageStarted { .. })
+        ));
+        drop(rx_client);
+        release_worker.send(()).unwrap();
+        let terminal = timeout(Duration::from_secs(1), handle)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            terminal,
+            ResponseTerminal::Completed {
+                finish_reason: "stop".to_string()
+            }
+        );
+        assert!(matches!(
+            rx_storage.recv().await,
+            Some(StorageMessage::MessageStarted { .. })
+        ));
+        assert!(
+            matches!(rx_storage.recv().await, Some(StorageMessage::ContentDelta { delta, .. }) if delta == "After disconnect")
+        );
+        assert!(matches!(
+            rx_storage.recv().await,
+            Some(StorageMessage::MessageDone { .. })
+        ));
+        timeout(Duration::from_secs(1), execution.wait_for_quiescence())
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn explicit_cancellation_drops_response_worker_before_quiescence() {
+        let registry = crate::web::responses::ResponseExecutionRegistry::default();
+        let response_uuid = Uuid::new_v4();
+        let registration = registry.register(response_uuid, Uuid::new_v4()).unwrap();
+        let execution = registration.execution();
+        let worker_execution = execution.clone();
+        let worker_guard = execution.begin_task().unwrap();
+        let (started, worker_started) = oneshot::channel();
+        let handle = tokio::spawn(async move {
+            run_response_worker(
+                response_uuid,
+                &worker_execution,
+                tokio::time::Instant::now() + Duration::from_secs(60),
+                async move {
+                    let _worker_guard = worker_guard;
+                    started.send(()).unwrap();
+                    std::future::pending::<ResponseTerminal>().await
+                },
+            )
+            .await
+        });
+        drop(registration);
+        worker_started.await.unwrap();
+        execution.cancel();
+        assert_eq!(
+            timeout(Duration::from_secs(1), handle)
+                .await
+                .unwrap()
+                .unwrap(),
+            ResponseTerminal::Cancelled
+        );
+        timeout(Duration::from_secs(1), execution.wait_for_quiescence())
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn authoritative_terminal_waits_for_delayed_storage_acknowledgement() {
+        let (tx_client, mut rx_client) = mpsc::channel(1);
+        let (tx_ack, rx_ack) = oneshot::channel();
+        let terminal = ResponseTerminal::Completed {
+            finish_reason: "length".to_string(),
+        };
+        let forwarder = forward_authoritative_response_terminal(Uuid::new_v4(), &tx_client, rx_ack);
+        tokio::pin!(forwarder);
+
+        assert!(futures::poll!(forwarder.as_mut()).is_pending());
+        assert!(rx_client.try_recv().is_err());
+        assert!(timeout(Duration::from_millis(25), forwarder.as_mut())
+            .await
+            .is_err());
+        assert!(rx_client.try_recv().is_err());
+
+        tx_ack.send(Ok(Some(terminal.clone()))).unwrap();
+        timeout(Duration::from_secs(1), forwarder).await.unwrap();
+        assert!(matches!(
+            rx_client.try_recv(),
+            Ok(StorageMessage::Terminal(observed)) if observed == terminal
+        ));
+        assert!(rx_client.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn authoritative_terminal_preserves_buffered_deltas_under_backpressure() {
+        for terminal in [
+            ResponseTerminal::Completed {
+                finish_reason: "stop".to_string(),
+            },
+            ResponseTerminal::Cancelled,
+            ResponseTerminal::Failed(PublicResponseFailure::CapacityRateLimited),
+        ] {
+            let (tx_client, mut rx_client) = mpsc::channel(2);
+            let item_id = Uuid::new_v4();
+            for delta in ["first", "second"] {
+                tx_client
+                    .send(StorageMessage::ContentDelta {
+                        item_id,
+                        delta: delta.to_string(),
+                    })
+                    .await
+                    .unwrap();
+            }
+            let (tx_ack, rx_ack) = oneshot::channel();
+            tx_ack.send(Ok(Some(terminal.clone()))).unwrap();
+            let forwarder =
+                forward_authoritative_response_terminal(Uuid::new_v4(), &tx_client, rx_ack);
+            tokio::pin!(forwarder);
+            assert!(futures::poll!(forwarder.as_mut()).is_pending());
+
+            assert!(matches!(
+                rx_client.try_recv(),
+                Ok(StorageMessage::ContentDelta { delta, .. }) if delta == "first"
+            ));
+            timeout(Duration::from_secs(1), forwarder).await.unwrap();
+            assert!(matches!(
+                rx_client.try_recv(),
+                Ok(StorageMessage::ContentDelta { delta, .. }) if delta == "second"
+            ));
+            assert!(matches!(
+                rx_client.try_recv(),
+                Ok(StorageMessage::Terminal(observed)) if observed == terminal
+            ));
+            assert!(rx_client.try_recv().is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn absent_or_failed_storage_acknowledgement_never_synthesizes_a_terminal() {
+        for acknowledgement in [
+            None,
+            Some(Err("storage failed".to_string())),
+            Some(Ok(None)),
+        ] {
+            let (tx_client, mut rx_client) = mpsc::channel(1);
+            let (tx_ack, rx_ack) = oneshot::channel();
+            match acknowledgement {
+                Some(acknowledgement) => tx_ack.send(acknowledgement).unwrap(),
+                None => drop(tx_ack),
+            }
+            timeout(
+                Duration::from_secs(1),
+                forward_authoritative_response_terminal(Uuid::new_v4(), &tx_client, rx_ack),
+            )
+            .await
+            .unwrap();
+            assert!(rx_client.try_recv().is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn cancelled_fanout_does_not_commit_to_only_one_channel() {
+        let (tx_storage, mut rx_storage) = tokio::sync::mpsc::channel(1);
+        let (tx_client, mut rx_client) = tokio::sync::mpsc::channel(1);
+        tx_client
+            .send(StorageMessage::Usage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+            })
+            .await
+            .unwrap();
+
+        let mut fanout = tokio::spawn(async move {
+            send_storage_message(
+                &tx_storage,
+                &tx_client,
+                StorageMessage::Usage {
+                    prompt_tokens: 2,
+                    completion_tokens: 2,
+                },
+            )
+            .await
+        });
+        tokio::task::yield_now().await;
+        assert!(timeout(Duration::from_millis(25), &mut fanout)
+            .await
+            .is_err());
+        fanout.abort();
+        let _ = fanout.await;
+
+        assert!(rx_storage.try_recv().is_err());
+        assert!(matches!(
+            rx_client.recv().await,
+            Some(StorageMessage::Usage {
+                prompt_tokens: 1,
+                completion_tokens: 1
+            })
+        ));
+        assert!(rx_client.try_recv().is_err());
+    }
+
+    #[test]
+    fn only_capacity_failures_expose_opensecret_terminal_metadata() {
+        let rate_limit = PublicResponseFailure::CapacityRateLimited;
+        assert_eq!(rate_limit.openai_code(), "rate_limit_exceeded");
+        let metadata = rate_limit.contract_metadata().unwrap();
+        assert_eq!(metadata.error_contract, "1");
+        assert_eq!(metadata.error_code, "inference_capacity");
+
+        assert_eq!(
+            PublicResponseFailure::CapacityOverloaded.openai_code(),
+            "server_error"
+        );
+        assert!(PublicResponseFailure::Internal
+            .contract_metadata()
+            .is_none());
+        assert!(PublicResponseFailure::DeadlineExceeded
+            .contract_metadata()
+            .is_none());
     }
 
     #[test]
@@ -1922,6 +2257,27 @@ mod tests {
             Some(tool_call_id_str.as_str())
         );
     }
+
+    #[test]
+    fn client_response_state_marks_only_done_items_completed() {
+        let mut state = ClientResponseState::default();
+        let message_id = Uuid::new_v4();
+        let reasoning_id = Uuid::new_v4();
+
+        state.push_message(message_id);
+        state.push_reasoning(reasoning_id);
+
+        let output_items = state.build_output_items();
+        assert_eq!(output_items[0].status, STATUS_INCOMPLETE);
+        assert_eq!(output_items[1].status, STATUS_INCOMPLETE);
+
+        assert!(state.mark_message_completed(message_id));
+        assert!(state.mark_reasoning_completed(reasoning_id));
+
+        let output_items = state.build_output_items();
+        assert_eq!(output_items[0].status, STATUS_COMPLETED);
+        assert_eq!(output_items[1].status, STATUS_COMPLETED);
+    }
 }
 
 /// Conversation parameter - can be a string UUID or an object with id field
@@ -2207,9 +2563,8 @@ pub struct OutputItem {
 /// Response error structure
 #[derive(Debug, Clone, Serialize)]
 pub struct ResponseError {
-    /// Error type
-    #[serde(rename = "type")]
-    pub error_type: String,
+    /// OpenAI-compatible stable error code
+    pub code: String,
 
     /// Error message
     pub message: String,
@@ -2269,15 +2624,21 @@ pub struct ResponseCompletedEvent {
     pub sequence_number: i32,
 }
 
-/// SSE Event wrapper for response.error
+/// SSE Event wrapper for the standard response.failed terminal.
 #[derive(Debug, Clone, Serialize)]
-pub struct ResponseErrorEvent {
-    /// Event type (always "response.error")
+pub struct ResponseFailedEvent {
     #[serde(rename = "type")]
     pub event_type: &'static str,
+    pub response: ResponsesCreateResponse,
+    pub sequence_number: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub opensecret: Option<OpenSecretResponseError>,
+}
 
-    /// The error information
-    pub error: ResponseError,
+#[derive(Debug, Clone, Serialize)]
+pub struct OpenSecretResponseError {
+    pub error_contract: &'static str,
+    pub error_code: &'static str,
 }
 
 /// SSE Event wrapper for response.cancelled
@@ -2629,14 +2990,11 @@ pub enum StorageMessage {
         prompt_tokens: i32,
         completion_tokens: i32,
     },
-    ResponseDone {
-        finish_reason: String,
-    },
-    Error(String),
-    Cancelled,
+    Terminal(ResponseTerminal),
     /// Tool-related messages
     ToolCall {
         tool_call_id: Uuid,
+        tool_output_id: Uuid,
         name: String,
         arguments: Value,
     },
@@ -2652,10 +3010,12 @@ enum StreamOutputItemRecord {
     Message {
         id: Uuid,
         text: String,
+        completed: bool,
     },
     Reasoning {
         id: Uuid,
         text: String,
+        completed: bool,
     },
     ToolCall {
         id: Uuid,
@@ -2682,6 +3042,7 @@ impl ClientResponseState {
         self.items.push(StreamOutputItemRecord::Message {
             id: item_id,
             text: String::new(),
+            completed: false,
         });
         self.indices.insert(item_id, output_index);
         output_index as i32
@@ -2692,6 +3053,7 @@ impl ClientResponseState {
         self.items.push(StreamOutputItemRecord::Reasoning {
             id: item_id,
             text: String::new(),
+            completed: false,
         });
         self.indices.insert(item_id, output_index);
         output_index as i32
@@ -2765,14 +3127,49 @@ impl ClientResponseState {
         }
     }
 
+    fn mark_message_completed(&mut self, item_id: Uuid) -> bool {
+        let Some(index) = self.indices.get(&item_id).copied() else {
+            return false;
+        };
+        match self.items.get_mut(index) {
+            Some(StreamOutputItemRecord::Message { completed, .. }) => {
+                *completed = true;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn mark_reasoning_completed(&mut self, item_id: Uuid) -> bool {
+        let Some(index) = self.indices.get(&item_id).copied() else {
+            return false;
+        };
+        match self.items.get_mut(index) {
+            Some(StreamOutputItemRecord::Reasoning { completed, .. }) => {
+                *completed = true;
+                true
+            }
+            _ => false,
+        }
+    }
+
     fn build_output_items(&self) -> Vec<OutputItem> {
         self.items
             .iter()
             .map(|item| match item {
-                StreamOutputItemRecord::Message { id, text } => OutputItem {
+                StreamOutputItemRecord::Message {
+                    id,
+                    text,
+                    completed,
+                } => OutputItem {
                     id: id.to_string(),
                     output_type: OUTPUT_TYPE_MESSAGE.to_string(),
-                    status: STATUS_COMPLETED.to_string(),
+                    status: if *completed {
+                        STATUS_COMPLETED
+                    } else {
+                        STATUS_INCOMPLETE
+                    }
+                    .to_string(),
                     role: Some(ROLE_ASSISTANT.to_string()),
                     content: Some(vec![
                         ContentPartBuilder::new_output_text(text.clone()).build()
@@ -2782,10 +3179,15 @@ impl ClientResponseState {
                     arguments: None,
                     output: None,
                 },
-                StreamOutputItemRecord::Reasoning { id, .. } => OutputItem {
+                StreamOutputItemRecord::Reasoning { id, completed, .. } => OutputItem {
                     id: id.to_string(),
                     output_type: "reasoning".to_string(),
-                    status: STATUS_COMPLETED.to_string(),
+                    status: if *completed {
+                        STATUS_COMPLETED
+                    } else {
+                        STATUS_INCOMPLETE
+                    }
+                    .to_string(),
                     role: None,
                     content: Some(vec![]),
                     call_id: None,
@@ -2836,6 +3238,7 @@ struct PreparedRequest {
     image_attachments: Vec<ImageAttachment>,
     user_message_tokens: i32,
     content_enc: Vec<u8>,
+    user_message_id: Uuid,
     assistant_message_id: Uuid,
 }
 
@@ -2887,6 +3290,7 @@ impl ImageDescriptionToolPair {
         [
             StorageMessage::ToolCall {
                 tool_call_id: self.tool_call_id,
+                tool_output_id: self.tool_output_id,
                 name: READ_IMAGE_TOOL_NAME.to_string(),
                 arguments: self.arguments.clone(),
             },
@@ -3241,7 +3645,6 @@ fn spawn_title_generation_task(
                 }
             ],
             "temperature": DEFAULT_TEMPERATURE,
-            "max_tokens": 15,
             "stream": false
         });
 
@@ -3472,6 +3875,7 @@ async fn validate_and_normalize_input(
         image_attachments,
         user_message_tokens,
         content_enc,
+        user_message_id: response_message_uuid(body),
         assistant_message_id,
     })
 }
@@ -3614,28 +4018,10 @@ async fn persist_request_data(
     body: &ResponsesCreateRequest,
     prepared: &PreparedRequest,
     conversation: &crate::models::responses::Conversation,
+    response_uuid: Uuid,
     image_descriptions: &[ImageDescriptionToolPair],
 ) -> Result<PersistedData, ApiError> {
     use crate::models::responses::{NewResponse, ResponseStatus};
-
-    // Extract internal_message_id from metadata if present
-    let message_uuid = if let Some(metadata) = &body.metadata {
-        if let Some(internal_id) = metadata.get("internal_message_id") {
-            if let Some(id_str) = internal_id.as_str() {
-                // Try to parse as UUID, use new UUID if parsing fails
-                Uuid::parse_str(id_str).unwrap_or_else(|_| {
-                    warn!("Invalid internal_message_id UUID; generating new one");
-                    Uuid::new_v4()
-                })
-            } else {
-                Uuid::new_v4()
-            }
-        } else {
-            Uuid::new_v4()
-        }
-    } else {
-        Uuid::new_v4()
-    };
 
     // Encrypt metadata if provided
     let metadata_enc = if let Some(metadata) = &body.metadata {
@@ -3651,7 +4037,7 @@ async fn persist_request_data(
 
     // Create the Response (job tracker)
     let new_response = NewResponse {
-        uuid: Uuid::new_v4(),
+        uuid: response_uuid,
         user_id: user.uuid,
         conversation_id: conversation.id,
         status: ResponseStatus::InProgress,
@@ -3664,16 +4050,16 @@ async fn persist_request_data(
         store: body.store,
         metadata_enc: metadata_enc.clone(),
     };
-    // Create the simplified user message with extracted UUID.
+    // Create the simplified user message with extracted UUID. The database
+    // fills its response_id from the response inserted in the same transaction.
     let new_msg = NewUserMessage {
-        uuid: message_uuid,
+        uuid: prepared.user_message_id,
         conversation_id: conversation.id,
         response_id: None,
         user_id: user.uuid,
         content_enc: prepared.content_enc.clone(),
         prompt_tokens: prepared.user_message_tokens,
     };
-
     let mut new_tool_items = Vec::with_capacity(image_descriptions.len());
     for pair in image_descriptions {
         let arguments_json = serde_json::to_string(&pair.arguments).map_err(|e| {
@@ -3735,6 +4121,62 @@ async fn persist_request_data(
     })
 }
 
+fn response_message_uuid(body: &ResponsesCreateRequest) -> Uuid {
+    body.metadata
+        .as_ref()
+        .and_then(|metadata| metadata.get("internal_message_id"))
+        .and_then(Value::as_str)
+        .and_then(|value| match Uuid::parse_str(value) {
+            Ok(uuid) => Some(uuid),
+            Err(_) => {
+                warn!("Invalid internal_message_id UUID; generating new one");
+                None
+            }
+        })
+        .unwrap_or_else(Uuid::new_v4)
+}
+
+fn reserve_response_message_uuid(
+    state: &AppState,
+    message_uuid: Uuid,
+) -> Result<ResponseMessageReservation, ApiError> {
+    reserve_response_message_uuid_with_check(
+        &state.responses_message_reservations,
+        message_uuid,
+        |uuid| {
+            state
+                .db
+                .user_message_uuid_exists(uuid)
+                .map_err(error_mapping::map_generic_db_error)
+        },
+    )
+}
+
+fn reserve_response_message_uuid_with_check(
+    reservations: &crate::ResponseMessageReservations,
+    message_uuid: Uuid,
+    persisted_uuid_exists: impl FnOnce(Uuid) -> Result<bool, ApiError>,
+) -> Result<ResponseMessageReservation, ApiError> {
+    let reservation = match reservations.try_reserve(message_uuid) {
+        Ok(reservation) => reservation,
+        Err(ResponseMessageReservationError::AlreadyReserved) => {
+            warn!("Responses request reused an active message UUID");
+            return Err(ApiError::Conflict);
+        }
+        Err(ResponseMessageReservationError::Unavailable) => {
+            error!("Responses message UUID reservation state is unavailable");
+            return Err(ApiError::InternalServerError);
+        }
+    };
+
+    if persisted_uuid_exists(message_uuid)? {
+        warn!("Responses request reused a persisted message UUID");
+        return Err(ApiError::Conflict);
+    }
+
+    Ok(reservation)
+}
+
 /// Helper function to check if tool_choice allows tool execution
 ///
 /// Returns false if tool_choice is explicitly set to "none", true otherwise
@@ -3785,28 +4227,19 @@ async fn execute_tool_call_and_wait(
 
     let tool_call_msg = StorageMessage::ToolCall {
         tool_call_id,
+        tool_output_id,
         name: tool_call.name.clone(),
         arguments: tool_call.arguments.clone(),
     };
 
-    if let Err(e) = tx_storage.send(tool_call_msg.clone()).await {
-        error!(
-            "Critical: Storage channel closed during tool_call for response {} - {:?}",
-            persisted.response.uuid, e
-        );
-        let _ = tx_client
-            .send(StorageMessage::Error(
-                "Internal storage failure - request aborted".to_string(),
-            ))
-            .await;
-        return Err(ApiError::InternalServerError);
-    }
-    if tx_client.send(tool_call_msg).await.is_err() {
-        warn!(
-            "Client channel closed before tool_call {} for response {}",
-            tool_call_id, persisted.response.uuid
-        );
-    }
+    send_storage_message(tx_storage, tx_client, tool_call_msg)
+        .await
+        .inspect_err(|_| {
+            error!(
+                "Failed to fan out tool_call for response {}",
+                persisted.response.uuid
+            );
+        })?;
     debug!(
         "Tool loop: enqueued tool_call {} ({}) for response {} in {} ms",
         tool_call_id,
@@ -3865,24 +4298,14 @@ async fn execute_tool_call_and_wait(
         output: tool_output,
     };
 
-    if let Err(e) = tx_storage.send(tool_output_msg.clone()).await {
-        error!(
-            "Critical: Storage channel closed during tool_output for response {} - {:?}",
-            persisted.response.uuid, e
-        );
-        let _ = tx_client
-            .send(StorageMessage::Error(
-                "Internal storage failure - request aborted".to_string(),
-            ))
-            .await;
-        return Err(ApiError::InternalServerError);
-    }
-    if tx_client.send(tool_output_msg).await.is_err() {
-        warn!(
-            "Client channel closed before tool_output {} for tool_call {} on response {}",
-            tool_output_id, tool_call_id, persisted.response.uuid
-        );
-    }
+    send_storage_message(tx_storage, tx_client, tool_output_msg)
+        .await
+        .inspect_err(|_| {
+            error!(
+                "Failed to fan out tool_output for response {}",
+                persisted.response.uuid
+            );
+        })?;
     debug!(
         "Tool loop: enqueued tool_output {} for tool_call {} on response {} in {} ms",
         tool_output_id,
@@ -3928,100 +4351,22 @@ async fn send_storage_message(
     tx_client: &mpsc::Sender<StorageMessage>,
     msg: StorageMessage,
 ) -> Result<(), ApiError> {
-    if tx_storage.send(msg.clone()).await.is_err() {
+    // Reserve both bounded queues before committing either copy. If this
+    // future is cancelled while backpressured, the acquired permit is dropped
+    // and neither observer crosses a partial event boundary.
+    let storage_permit = tx_storage.reserve().await.map_err(|_| {
         error!("Storage channel closed unexpectedly");
-        return Err(ApiError::InternalServerError);
-    }
-    // Every client item is part of the durable transcript projection. Apply
-    // bounded backpressure rather than dropping deltas or item-finalization
-    // events and then emitting a misleading response.completed.
-    if tx_client.send(msg).await.is_err() {
-        warn!("Client channel closed before response event");
+        ApiError::InternalServerError
+    })?;
+    // Client disconnect is not cancellation: storage continues independently.
+    // While connected, retaining both permits keeps cancellation from committing
+    // only one copy of an event when the client queue is backpressured.
+    let client_permit = tx_client.reserve().await.ok();
+    storage_permit.send(msg.clone());
+    if let Some(client_permit) = client_permit {
+        client_permit.send(msg);
     }
     Ok(())
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum StorageCompletionDecision {
-    Completed,
-    Cancelled,
-    Error,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ClientCancellationTerminalDecision {
-    EmitCancelled,
-    ReplayCompleted,
-    EmitError,
-}
-
-fn client_cancellation_terminal_decision(
-    storage_completion: StorageCompletionDecision,
-) -> ClientCancellationTerminalDecision {
-    match storage_completion {
-        StorageCompletionDecision::Cancelled => ClientCancellationTerminalDecision::EmitCancelled,
-        StorageCompletionDecision::Completed => ClientCancellationTerminalDecision::ReplayCompleted,
-        StorageCompletionDecision::Error => ClientCancellationTerminalDecision::EmitError,
-    }
-}
-
-/// Wait for the storage worker to acknowledge the terminal response state.
-///
-/// `ResponseDone` reaches the client and storage channels independently. The
-/// client must therefore join the storage worker before treating its copy as a
-/// durable `response.completed` event. A missing, failed, or panicked worker is
-/// fail-closed so callers never observe a false completion.
-async fn await_storage_completion(
-    storage_handle: &mut Option<tokio::task::JoinHandle<StorageTaskOutcome>>,
-) -> StorageCompletionDecision {
-    await_storage_completion_with_warning_after(storage_handle, RESPONSE_STORAGE_JOIN_WARNING_AFTER)
-        .await
-}
-
-async fn await_storage_completion_with_warning_after(
-    storage_handle: &mut Option<tokio::task::JoinHandle<StorageTaskOutcome>>,
-    warning_after: Duration,
-) -> StorageCompletionDecision {
-    let Some(mut handle) = storage_handle.take() else {
-        return StorageCompletionDecision::Error;
-    };
-
-    let storage_outcome = match tokio::time::timeout(warning_after, &mut handle).await {
-        Ok(outcome) => outcome,
-        Err(_) => {
-            warn!(
-                "Responses storage worker is still running after {} ms; continuing to wait for its authoritative terminal state",
-                warning_after.as_millis()
-            );
-            handle.await
-        }
-    };
-
-    match storage_outcome {
-        Ok(StorageTaskOutcome::Completed) => StorageCompletionDecision::Completed,
-        Ok(StorageTaskOutcome::Cancelled) => StorageCompletionDecision::Cancelled,
-        Ok(StorageTaskOutcome::Failed) | Err(_) => StorageCompletionDecision::Error,
-    }
-}
-
-/// Once storage has durably completed, every nonterminal client projection is
-/// already buffered or consumed because producers await each client send before
-/// enqueueing `ResponseDone` for storage. Cancellation can interrupt the
-/// redundant client-side `ResponseDone` send after storage received its copy,
-/// so synthesize only that terminal marker after the buffered projection drains.
-fn next_client_message_after_durable_completion(
-    rx_client: &mut mpsc::Receiver<StorageMessage>,
-) -> StorageMessage {
-    match rx_client.try_recv() {
-        Ok(message @ StorageMessage::ResponseDone { .. }) => message,
-        Ok(StorageMessage::Cancelled | StorageMessage::Error(_))
-        | Err(mpsc::error::TryRecvError::Empty | mpsc::error::TryRecvError::Disconnected) => {
-            StorageMessage::ResponseDone {
-                finish_reason: "stop".to_string(),
-            }
-        }
-        Ok(message) => message,
-    }
 }
 
 fn best_effort_fail_response_after_storage_error(
@@ -4115,13 +4460,12 @@ async fn ensure_message_started(
         StorageMessage::MessageStarted { item_id: id },
     )
     .await?;
-
     *current_message_id = Some(id);
     Ok(id)
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn stream_one_assistant_turn(
+async fn start_responses_assistant_turn(
     state: &Arc<AppState>,
     user: &User,
     body: &ResponsesCreateRequest,
@@ -4129,16 +4473,13 @@ async fn stream_one_assistant_turn(
     headers: &HeaderMap,
     prompt_messages: &[Value],
     tools_enabled: bool,
-    tx_client: &mpsc::Sender<StorageMessage>,
-    tx_storage: &mpsc::Sender<StorageMessage>,
-    next_message_id: &mut Option<Uuid>,
     response_uuid: Uuid,
     conversation_uuid: Uuid,
     tool_turn_count: usize,
     prompt_token_estimate: usize,
     response_execution: ResponseExecution,
     cache_policy: &CompletionCachePolicy,
-) -> Result<AssistantTurnOutcome, ApiError> {
+) -> Result<StartedCompletion, CompletionExecutionError> {
     let mut chat_request = build_model_turn_request(body, prompt_messages, tools_enabled);
 
     let chat_request_bytes = serde_json::to_vec(&chat_request)
@@ -4163,7 +4504,7 @@ async fn stream_one_assistant_turn(
         pinned_completion.intent().requested_model_id.clone(),
     );
 
-    let mut completion = get_chat_completion_response_for_execution(
+    start_chat_completion_response_for_execution(
         state,
         user,
         chat_request.take(),
@@ -4173,7 +4514,22 @@ async fn stream_one_assistant_turn(
         response_execution,
     )
     .await
-    .map_err(CompletionExecutionError::into_api_error)?;
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn stream_one_assistant_turn(
+    state: &Arc<AppState>,
+    user: &User,
+    started: StartedCompletion,
+    tools_enabled: bool,
+    tx_client: &mpsc::Sender<StorageMessage>,
+    tx_storage: &mpsc::Sender<StorageMessage>,
+    next_message_id: &mut Option<Uuid>,
+    response_uuid: Uuid,
+) -> Result<AssistantTurnOutcome, ApiError> {
+    let completion = finish_started_completion(state, user, started)
+        .await
+        .map_err(CompletionExecutionError::into_api_error)?;
 
     debug!(
         "Received Responses completion stream: request_id={}, execution_id={}, attempt_id={}, provider={}, model={}",
@@ -4184,6 +4540,25 @@ async fn stream_one_assistant_turn(
         completion.metadata.model_name
     );
 
+    consume_assistant_turn(
+        completion.stream,
+        tools_enabled,
+        tx_client,
+        tx_storage,
+        next_message_id,
+        response_uuid,
+    )
+    .await
+}
+
+async fn consume_assistant_turn(
+    mut completion: mpsc::Receiver<CompletionChunk>,
+    tools_enabled: bool,
+    tx_client: &mpsc::Sender<StorageMessage>,
+    tx_storage: &mpsc::Sender<StorageMessage>,
+    next_message_id: &mut Option<Uuid>,
+    response_uuid: Uuid,
+) -> Result<AssistantTurnOutcome, ApiError> {
     let mut streamed_tool_calls = Vec::new();
     let mut finish_reason: Option<String> = None;
     let mut current_message_id: Option<Uuid> = None;
@@ -4191,7 +4566,7 @@ async fn stream_one_assistant_turn(
     let mut saw_tool_calls = false;
     let mut ignored_disabled_tool_calls = false;
 
-    while let Some(chunk) = completion.stream.recv().await {
+    while let Some(chunk) = completion.recv().await {
         match chunk {
             crate::web::openai::CompletionChunk::StreamChunk(json) => {
                 let choice = json.get("choices").and_then(|choices| choices.get(0));
@@ -4395,15 +4770,9 @@ async fn stream_one_assistant_turn(
                 )
                 .await?;
 
-                send_storage_message(
-                    tx_storage,
-                    tx_client,
-                    StorageMessage::ResponseDone {
-                        finish_reason: final_finish_reason,
-                    },
-                )
-                .await?;
-                return Ok(AssistantTurnOutcome::Final);
+                return Ok(AssistantTurnOutcome::Final {
+                    finish_reason: final_finish_reason,
+                });
             }
             crate::web::openai::CompletionChunk::Terminal(AttemptTerminal::Failed {
                 failure,
@@ -4437,6 +4806,7 @@ async fn setup_completion_processor(
     user: &User,
     body: &ResponsesCreateRequest,
     pinned_completion: &PinnedCompletionRequest,
+    model_plan: ModelPlan,
     context: &BuiltContext,
     user_key: &SecretKey,
     assistant_message_id: Uuid,
@@ -4445,20 +4815,37 @@ async fn setup_completion_processor(
     tx_client: mpsc::Sender<StorageMessage>,
     tx_storage: mpsc::Sender<StorageMessage>,
     mut rx_tool_ack: mpsc::Receiver<Result<(), String>>,
+    first_started: StartedCompletion,
+    execution_policy: ResponseExecutionPolicy,
     response_execution: ResponseExecution,
     cache_policy: &CompletionCachePolicy,
-) -> Result<crate::models::responses::Response, ApiError> {
-    let model_plan = pinned_completion.intent().model_plan;
-    let tools_enabled = context.web_search_enabled;
+) -> ResponseTerminal {
+    let tools_requested = context.web_search_enabled;
     let mut prompt_messages = Arc::as_ref(&context.prompt_messages).clone();
     let mut prompt_token_estimate = context.total_prompt_tokens;
     let mut kagi_allowed_urls = tools::collect_kagi_allowed_urls_from_prompt(&prompt_messages);
+    let mut next_message_id = Some(assistant_message_id);
+    let mut tool_turn_count = 0usize;
+    let mut model_turn_count = 0usize;
+    let mut force_final_without_tools = false;
+    let mut first_started = Some(first_started);
 
-    let loop_result: Result<(), ApiError> = async {
-        let mut next_message_id = Some(assistant_message_id);
-        let mut tool_turn_count = 0usize;
-        loop {
-            match stream_one_assistant_turn(
+    loop {
+        if model_turn_count >= execution_policy.max_model_turns {
+            warn!(
+                "Responses model-turn limit reached: response_uuid={}, model_turns={}, max_model_turns={}",
+                persisted.response.uuid,
+                model_turn_count,
+                execution_policy.max_model_turns
+            );
+            return ResponseTerminal::Failed(PublicResponseFailure::Internal);
+        }
+        model_turn_count += 1;
+        let tools_enabled = tools_requested && !force_final_without_tools;
+
+        let started = match first_started.take() {
+            Some(started) => started,
+            None => match start_responses_assistant_turn(
                 state,
                 user,
                 body,
@@ -4466,9 +4853,6 @@ async fn setup_completion_processor(
                 headers,
                 &prompt_messages,
                 tools_enabled,
-                &tx_client,
-                &tx_storage,
-                &mut next_message_id,
                 persisted.response.uuid,
                 context.conversation.uuid,
                 tool_turn_count,
@@ -4476,56 +4860,217 @@ async fn setup_completion_processor(
                 response_execution.clone(),
                 cache_policy,
             )
-            .await?
+            .await
             {
-                AssistantTurnOutcome::ToolCall(tool_call) => {
-                    debug!(
-                        "Tool loop: assistant turn requested tool {} for response {}",
-                        tool_call.name, persisted.response.uuid
+                Ok(started) => started,
+                Err(error) => {
+                    let failure = PublicResponseFailure::from_completion_error(&error);
+                    error!(
+                        "Responses provider start failed after persistence: response_uuid={}, failure={:?}",
+                        persisted.response.uuid, failure
                     );
-
-                    tool_turn_count += 1;
-                    execute_tool_call_and_wait(
-                        state,
-                        persisted,
-                        tool_call,
-                        &tx_client,
-                        &tx_storage,
-                        &mut rx_tool_ack,
-                        &mut kagi_allowed_urls,
-                        tool_turn_count,
-                        model_plan,
-                    )
-                    .await?;
-
-                    let internal_system_prompt =
-                        build_internal_system_prompt(tools_enabled, model_plan);
-                    let (rebuilt_messages, rebuilt_tokens) = build_prompt(
-                        state.db.as_ref(),
-                        context.conversation.id,
-                        user.uuid,
-                        user_key,
-                        &body.model,
-                        body.instructions.as_deref(),
-                        Some(&internal_system_prompt),
-                    )?;
-                    prompt_messages = rebuilt_messages;
-                    prompt_token_estimate = rebuilt_tokens;
+                    return ResponseTerminal::Failed(failure);
                 }
-                AssistantTurnOutcome::Final => return Ok(()),
+            },
+        };
+
+        let turn = match stream_one_assistant_turn(
+            state,
+            user,
+            started,
+            tools_enabled,
+            &tx_client,
+            &tx_storage,
+            &mut next_message_id,
+            persisted.response.uuid,
+        )
+        .await
+        {
+            Ok(turn) => turn,
+            Err(_) => return ResponseTerminal::Failed(PublicResponseFailure::Internal),
+        };
+
+        match turn {
+            AssistantTurnOutcome::ToolCall(tool_call) => {
+                debug!(
+                    "Tool loop: assistant turn requested tool {} for response {}",
+                    tool_call.name, persisted.response.uuid
+                );
+                tool_turn_count += 1;
+                if execute_tool_call_and_wait(
+                    state,
+                    persisted,
+                    tool_call,
+                    &tx_client,
+                    &tx_storage,
+                    &mut rx_tool_ack,
+                    &mut kagi_allowed_urls,
+                    tool_turn_count,
+                    model_plan,
+                )
+                .await
+                .is_err()
+                {
+                    return ResponseTerminal::Failed(PublicResponseFailure::Internal);
+                }
+                if tool_turn_count > execution_policy.max_tool_executions {
+                    force_final_without_tools = true;
+                }
+
+                let internal_system_prompt =
+                    build_internal_system_prompt(tools_requested, model_plan);
+                let (rebuilt_messages, rebuilt_tokens) = match build_prompt(
+                    state.db.as_ref(),
+                    context.conversation.id,
+                    user.uuid,
+                    user_key,
+                    &body.model,
+                    body.instructions.as_deref(),
+                    Some(&internal_system_prompt),
+                ) {
+                    Ok(prompt) => prompt,
+                    Err(_) => return ResponseTerminal::Failed(PublicResponseFailure::Internal),
+                };
+                prompt_messages = rebuilt_messages;
+                prompt_token_estimate = rebuilt_tokens;
+            }
+            AssistantTurnOutcome::Final { finish_reason } => {
+                return ResponseTerminal::Completed { finish_reason };
             }
         }
     }
+}
+
+/// Run the independently owned response until an execution terminal is reached.
+/// Dropping the public SSE receiver does not cancel this worker. Explicit
+/// cancellation drops the worker before the supervisor queues storage cleanup.
+async fn run_response_worker(
+    response_uuid: Uuid,
+    response_execution: &ResponseExecution,
+    deadline: TokioInstant,
+    worker: impl std::future::Future<Output = ResponseTerminal>,
+) -> ResponseTerminal {
+    let worker = std::panic::AssertUnwindSafe(worker).catch_unwind();
+    tokio::pin!(worker);
+    tokio::select! {
+        biased;
+        _ = response_execution.cancelled() => ResponseTerminal::Cancelled,
+        _ = tokio::time::sleep_until(deadline) => {
+            warn!("Responses execution deadline reached: response_uuid={}", response_uuid);
+            ResponseTerminal::Failed(PublicResponseFailure::DeadlineExceeded)
+        }
+        result = &mut worker => match result {
+            Ok(terminal) => terminal,
+            Err(_) => {
+                error!("Responses execution worker panicked: response_uuid={}", response_uuid);
+                ResponseTerminal::Failed(PublicResponseFailure::Internal)
+            }
+        },
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn supervise_response_execution(
+    state: Arc<AppState>,
+    user: User,
+    body: ResponsesCreateRequest,
+    pinned_completion: PinnedCompletionRequest,
+    model_plan: ModelPlan,
+    context: BuiltContext,
+    user_key: SecretKey,
+    assistant_message_id: Uuid,
+    persisted: PersistedData,
+    headers: HeaderMap,
+    tx_client: mpsc::Sender<StorageMessage>,
+    tx_storage: mpsc::Sender<StorageMessage>,
+    rx_tool_ack: mpsc::Receiver<Result<(), String>>,
+    terminal_ack: oneshot::Receiver<Result<Option<ResponseTerminal>, String>>,
+    response_execution: ResponseExecution,
+    first_started: StartedCompletion,
+    execution_policy: ResponseExecutionPolicy,
+    _supervisor_execution_guard: ResponseExecutionTaskGuard,
+    cache_policy: CompletionCachePolicy,
+) {
+    let response_uuid = persisted.response.uuid;
+    let requested_terminal = run_response_worker(
+        response_uuid,
+        &response_execution,
+        execution_policy.deadline,
+        setup_completion_processor(
+            &state,
+            &user,
+            &body,
+            &pinned_completion,
+            model_plan,
+            &context,
+            &user_key,
+            assistant_message_id,
+            &persisted,
+            &headers,
+            tx_client.clone(),
+            tx_storage.clone(),
+            rx_tool_ack,
+            first_started,
+            execution_policy,
+            response_execution.clone(),
+            &cache_policy,
+        ),
+    )
     .await;
 
-    if let Err(e) = loop_result {
-        let msg = StorageMessage::Error(format!("Streaming failed: {:?}", e));
-        let _ = tx_storage.send(msg.clone()).await;
-        let _ = tx_client.send(msg).await;
-        return Err(e);
+    if tx_storage
+        .send(StorageMessage::Terminal(requested_terminal))
+        .await
+        .is_err()
+    {
+        error!(
+            "Storage task closed before terminal persistence: response_uuid={}",
+            response_uuid
+        );
+        return;
     }
 
-    Ok(persisted.response.clone())
+    forward_authoritative_response_terminal(response_uuid, &tx_client, terminal_ack).await;
+}
+
+/// Only the storage acknowledgement may authorize a client terminal. The
+/// supervisor retains execution ownership while this waits for durability and
+/// for preceding client output to drain under bounded backpressure.
+async fn forward_authoritative_response_terminal(
+    response_uuid: Uuid,
+    tx_client: &mpsc::Sender<StorageMessage>,
+    terminal_ack: oneshot::Receiver<Result<Option<ResponseTerminal>, String>>,
+) {
+    let authoritative = match terminal_ack.await {
+        Ok(Ok(Some(terminal))) => terminal,
+        Ok(Ok(None)) => {
+            debug!(
+                "Response was deleted before terminal persistence completed: response_uuid={}",
+                response_uuid
+            );
+            return;
+        }
+        Ok(Err(e)) => {
+            error!(
+                "Storage task could not verify terminal persistence: response_uuid={}, error={}",
+                response_uuid, e
+            );
+            return;
+        }
+        Err(_) => {
+            error!(
+                "Storage task dropped terminal acknowledgement: response_uuid={}",
+                response_uuid
+            );
+            return;
+        }
+    };
+
+    // This is the sole client-terminal writer. Awaiting the send preserves all
+    // preceding data under backpressure while the stream remains connected.
+    let _ = tx_client
+        .send(StorageMessage::Terminal(authoritative))
+        .await;
 }
 
 async fn create_response_stream(
@@ -4607,6 +5152,12 @@ async fn create_response_stream(
 
     // Phase 1: Validate and normalize input
     let prepared = validate_and_normalize_input(&state, &user, &auth_context, &body).await?;
+    // Reserve the caller-visible message UUID before any descriptor or main-model
+    // provider work. The database check catches completed prior requests, while
+    // the enclave-local reservation closes the same-enclave check/insert race.
+    // It remains held until the atomic request persistence commit below.
+    let _message_uuid_reservation =
+        reserve_response_message_uuid(&state, prepared.user_message_id)?;
     let image_access = image_description_access(&prepared.image_attachments, billing_access)?;
 
     // Phase 2a: Validate conversation ownership, base context, and quota before
@@ -4670,6 +5221,52 @@ async fn create_response_stream(
     let pinned_completion =
         prepare_completion_request(&state, &user, inference_intent, routing).await?;
 
+    // Start only the first provider request before persistence. Only locally
+    // proven pre-send/pre-acceptance capacity failures can authorize replay:
+    // an upstream capacity rejection remains ambiguous even without durable
+    // conversation writes. Successful response bodies remain untouched until
+    // Phase 3 commits, and prior descriptor work suppresses whole-request replay.
+    let execution_policy = ResponseExecutionPolicy::new(model_plan, context.web_search_enabled);
+    let response_uuid = Uuid::new_v4();
+    let response_execution_registration = state
+        .response_executions
+        .register(response_uuid, user.uuid)
+        .map_err(|_| ApiError::InternalServerError)?;
+    let response_execution = response_execution_registration.execution();
+    // Acquire the root lineages before persistence exposes the response. A
+    // concurrent cancellation may then seal admission without preventing the
+    // already-owned storage/supervisor tasks from performing ordered cleanup.
+    let response_setup_guard = response_execution
+        .begin_task()
+        .map_err(|_| ApiError::InternalServerError)?;
+    let storage_execution_guard = response_execution
+        .begin_task()
+        .map_err(|_| ApiError::InternalServerError)?;
+    let supervisor_execution_guard = response_execution
+        .begin_task()
+        .map_err(|_| ApiError::InternalServerError)?;
+    let client_execution_guard = response_execution
+        .begin_task()
+        .map_err(|_| ApiError::InternalServerError)?;
+    let model_turn_body = model_turn_request_without_user_payload(&body);
+    let first_started = start_responses_assistant_turn(
+        &state,
+        &user,
+        &model_turn_body,
+        &pinned_completion,
+        &headers,
+        context.prompt_messages.as_ref(),
+        context.web_search_enabled,
+        response_uuid,
+        context.conversation.uuid,
+        0,
+        context.total_prompt_tokens,
+        response_execution.clone(),
+        &cache_policy,
+    )
+    .await
+    .map_err(|error| responses_pre_persistence_api_error(error, !image_descriptions.is_empty()))?;
+
     // Phase 3: Persist request data
     let persisted = persist_request_data(
         &state,
@@ -4677,82 +5274,13 @@ async fn create_response_stream(
         &body,
         &prepared,
         &context.conversation,
+        response_uuid,
         &image_descriptions,
     )
     .await?;
 
-    // Derive the response-item clock before starting any detached work. If the
-    // timestamp cannot advance, fail the newly persisted response explicitly
-    // rather than leaving an in_progress row with no execution owner.
-    let Some(first_response_item_created_at) = persisted
-        .last_item_created_at
-        .checked_add_signed(chrono::Duration::microseconds(1))
-    else {
-        best_effort_fail_response_after_storage_error(
-            &state,
-            persisted.response.id,
-            persisted.response.uuid,
-        );
-        return Err(ApiError::InternalServerError);
-    };
-
-    let response_execution_registration = state
-        .response_executions
-        .register(persisted.response.uuid, user.uuid)
-        .map_err(|_| {
-            error!(
-                "Duplicate live execution registration for response {}",
-                persisted.response.uuid
-            );
-            best_effort_fail_response_after_storage_error(
-                &state,
-                persisted.response.id,
-                persisted.response.uuid,
-            );
-            ApiError::InternalServerError
-        })?;
-    let response_execution = response_execution_registration.execution();
-    // Bridge registration into lazy SSE startup. This guard is acquired before
-    // the response ID can be exposed and is released only after storage and
-    // orchestrator ownership have both been installed.
-    let response_setup_guard = response_execution.begin_task().map_err(|_| {
-        error!("Response execution closed during initial task registration");
-        best_effort_fail_response_after_storage_error(
-            &state,
-            persisted.response.id,
-            persisted.response.uuid,
-        );
-        ApiError::InternalServerError
-    })?;
-    let storage_execution_guard = response_execution.begin_task().map_err(|_| {
-        error!("Response execution closed before storage ownership was installed");
-        best_effort_fail_response_after_storage_error(
-            &state,
-            persisted.response.id,
-            persisted.response.uuid,
-        );
-        ApiError::InternalServerError
-    })?;
-    let orchestrator_execution_guard = response_execution.begin_task().map_err(|_| {
-        error!("Response execution closed before orchestrator ownership was installed");
-        best_effort_fail_response_after_storage_error(
-            &state,
-            persisted.response.id,
-            persisted.response.uuid,
-        );
-        ApiError::InternalServerError
-    })?;
-    let client_execution_guard = response_execution.begin_task().map_err(|_| {
-        error!("Response execution closed before client-stream ownership was installed");
-        best_effort_fail_response_after_storage_error(
-            &state,
-            persisted.response.id,
-            persisted.response.uuid,
-        );
-        ApiError::InternalServerError
-    })?;
-
-    // Check if first message and spawn title generation task
+    // Capture stream and title data before moving execution state into the
+    // supervisor task.
     let (user_count, assistant_count) =
         context
             .prompt_messages
@@ -4767,217 +5295,140 @@ async fn create_response_stream(
                 }
             });
 
-    if user_count == 1 && assistant_count == 0 {
-        let user_content =
-            MessageContentConverter::extract_text_for_token_counting(&prepared.message_content);
-        // Conversation title generation has its own lifecycle. It is not part
-        // of the main response execution barrier, so Stop is never delayed by
-        // this best-effort metadata task.
-        spawn_title_generation_task(
-            state.clone(),
+    let title_request = (user_count == 1 && assistant_count == 0).then(|| {
+        (
             context.conversation.id,
             context.conversation.uuid,
-            user.clone(),
             prepared.user_key,
-            user_content,
-            cache_policy.clone(),
+            MessageContentConverter::extract_text_for_token_counting(&prepared.message_content),
             routing.with_model_plan(ModelPlan::Free),
-        );
-    }
-
-    // Capture variables needed inside the stream
+        )
+    });
+    let assistant_message_id = prepared.assistant_message_id;
     let response_for_stream = persisted.response.clone();
     let decrypted_metadata = persisted.decrypted_metadata.clone();
-    let assistant_message_id = prepared.assistant_message_id;
     let total_prompt_tokens = context.total_prompt_tokens;
     let response_id = persisted.response.id;
     let response_uuid = persisted.response.uuid;
     // Persist all generated response items on a single monotonic timestamp sequence that
-    // begins immediately after the user message so retrieval order matches stream order.
+    // begins immediately after the last durable request item so retrieval order matches stream
+    // order even when read_image call/output pairs were persisted with the user message.
+    let Some(first_response_item_created_at) = persisted
+        .last_item_created_at
+        .checked_add_signed(chrono::Duration::microseconds(1))
+    else {
+        best_effort_fail_response_after_storage_error(&state, response_id, response_uuid);
+        return Err(ApiError::InternalServerError);
+    };
     let conversation_id = context.conversation.id;
     let user_id = user.uuid;
     let user_key = prepared.user_key;
-    let conversation_for_stream = context.conversation.clone();
-    let prompt_messages = context.prompt_messages.clone();
-    let web_search_enabled = context.web_search_enabled;
-    let image_descriptions_for_stream = Arc::new(image_descriptions);
-    let model_turn_body = model_turn_request_without_user_payload(&body);
-    let pinned_completion_for_stream = pinned_completion.clone();
-
-    // Install every response-owned worker eagerly. An HTTP body is lazy and
-    // may be dropped before its first poll; leaving worker startup inside the
-    // SSE generator would strand the already-persisted response in_progress.
-    trace!("Phase 4: Creating dual streams and spawning storage task");
+    drop(prepared);
     let (tx_storage, rx_storage) = mpsc::channel::<StorageMessage>(STORAGE_CHANNEL_BUFFER);
     let (tx_client, mut rx_client) = mpsc::channel::<StorageMessage>(CLIENT_CHANNEL_BUFFER);
+    let (tx_tool_ack, rx_tool_ack) = mpsc::channel::<Result<(), String>>(8);
+    let (tx_terminal_ack, rx_terminal_ack) =
+        oneshot::channel::<Result<Option<ResponseTerminal>, String>>();
 
-    // These pairs are already durable. Queue them before the orchestrator can
-    // enqueue assistant output so client order matches persistence order.
-    for pair in image_descriptions_for_stream.iter() {
+    // The image pairs are already durable. Emit them before the supervisor can
+    // enqueue any assistant output, and never send them back through storage.
+    for pair in &image_descriptions {
         for message in pair.client_messages() {
-            let _ = tx_client.send(message).await;
+            tx_client
+                .send(message)
+                .await
+                .map_err(|_| ApiError::InternalServerError)?;
         }
     }
 
-    let (tx_tool_ack, rx_tool_ack) = mpsc::channel::<Result<(), String>>(8);
-    let mut storage_handle = Some({
-        let db = state.db.clone();
-
-        tokio::spawn(async move {
-            let _storage_execution_guard = storage_execution_guard;
-            storage_task(
-                rx_storage,
-                Some(tx_tool_ack),
-                db,
-                response_id,
-                response_uuid,
-                first_response_item_created_at,
-                conversation_id,
-                user_id,
-                user_key,
-            )
-            .await
-        })
-    });
-
-    trace!("Spawning background orchestrator for phases 5-6");
-    let orchestrator_tx_client = tx_client.clone();
-    let orchestrator_tx_storage = tx_storage.clone();
-    let orchestrator_state = state.clone();
-    let orchestrator_user = user.clone();
-    let orchestrator_body = model_turn_body.clone();
-    let orchestrator_headers = headers.clone();
-    let orchestrator_response = response_for_stream.clone();
-    let orchestrator_metadata = decrypted_metadata.clone();
-    let orchestrator_last_item_created_at = persisted.last_item_created_at;
-    let orchestrator_conversation = conversation_for_stream.clone();
-    let orchestrator_prompt_messages = prompt_messages.clone();
-    let orchestrator_pinned_completion = pinned_completion_for_stream.clone();
-    let orchestrator_execution = response_execution.clone();
-    let orchestrator_cache_policy = cache_policy.clone();
-
+    let storage_db = state.db.clone();
     tokio::spawn(async move {
-        let _orchestrator_execution_guard = orchestrator_execution_guard;
-        trace!("Orchestrator: Starting phases 5-6 in background");
-
-        let cancelled = tokio::select! {
-            biased;
-            _ = orchestrator_execution.cancelled() => true,
-            _ = async {
-                trace!("Orchestrator: Setting up assistant/tool loop");
-
-                let context_for_completion = BuiltContext {
-                    conversation: orchestrator_conversation,
-                    prompt_messages: orchestrator_prompt_messages,
-                    total_prompt_tokens,
-                    web_search_enabled,
-                };
-
-                let persisted_for_completion = PersistedData {
-                    response: orchestrator_response.clone(),
-                    decrypted_metadata: orchestrator_metadata.clone(),
-                    last_item_created_at: orchestrator_last_item_created_at,
-                };
-
-                match setup_completion_processor(
-                    &orchestrator_state,
-                    &orchestrator_user,
-                    &orchestrator_body,
-                    &orchestrator_pinned_completion,
-                    &context_for_completion,
-                    &user_key,
-                    assistant_message_id,
-                    &persisted_for_completion,
-                    &orchestrator_headers,
-                    orchestrator_tx_client.clone(),
-                    orchestrator_tx_storage.clone(),
-                    rx_tool_ack,
-                    orchestrator_execution.clone(),
-                    &orchestrator_cache_policy,
-                )
-                .await
-                {
-                    Ok(_) => trace!("Orchestrator: Assistant/tool loop completed"),
-                    Err(e) => error!("Orchestrator: Assistant/tool loop failed: {:?}", e),
-                }
-            } => {
-                trace!("Orchestrator: Phases 5-6 completed normally");
-                false
-            }
-        };
-
-        if cancelled {
-            debug!(
-                "Orchestrator: stopping response {} before ordered storage cancellation",
-                response_uuid
-            );
-            // The non-selected completion future has been dropped, so no
-            // producer can enqueue more transcript messages. Storage drains
-            // every prior message before publishing durable cancellation.
-            let _ = orchestrator_tx_storage
-                .send(StorageMessage::Cancelled)
-                .await;
-        }
+        let _storage_execution_guard = storage_execution_guard;
+        storage_task(
+            rx_storage,
+            Some(tx_tool_ack),
+            Some(tx_terminal_ack),
+            storage_db,
+            response_id,
+            response_uuid,
+            first_response_item_created_at,
+            conversation_id,
+            user_id,
+            user_key,
+        )
+        .await;
     });
 
-    // All root lineages have been spawned. From this point quiescence means
-    // both owner setup and every response-owned child have finished.
+    tokio::spawn(supervise_response_execution(
+        state.clone(),
+        user.clone(),
+        model_turn_body,
+        pinned_completion,
+        model_plan,
+        context,
+        user_key,
+        assistant_message_id,
+        persisted,
+        headers,
+        tx_client,
+        tx_storage,
+        rx_tool_ack,
+        rx_terminal_ack,
+        response_execution.clone(),
+        first_started,
+        execution_policy,
+        supervisor_execution_guard,
+        cache_policy.clone(),
+    ));
+
     drop(response_execution_registration);
     drop(response_setup_guard);
     let mut client_execution_guard = Some(client_execution_guard);
 
+    if let Some((conversation_id, conversation_uuid, user_key, user_content, title_routing)) =
+        title_request
+    {
+        spawn_title_generation_task(
+            state.clone(),
+            conversation_id,
+            conversation_uuid,
+            user.clone(),
+            user_key,
+            user_content,
+            cache_policy.clone(),
+            title_routing,
+        );
+    }
+
+    // Storage and execution are already running; the body only translates the
+    // ordered client channel into encrypted SSE events.
     trace!("Creating SSE event stream for client");
     let event_stream = async_stream::stream! {
         trace!("=== STARTING SSE STREAM ===");
-
-        // Initialize the SSE event emitter
         let mut emitter = SseEventEmitter::new(&state, session_id, 0);
-
-        // Send initial response.created event IMMEDIATELY (before any processing)
-        trace!("Building response.created event");
         let created_response = ResponseBuilder::from_response(&response_for_stream)
             .status(STATUS_IN_PROGRESS)
             .metadata(decrypted_metadata.clone())
             .build();
-
         let created_event = ResponseCreatedEvent {
             event_type: EVENT_RESPONSE_CREATED,
             response: created_response.clone(),
             sequence_number: emitter.sequence_number(),
         };
-
-        // Event 2: response.in_progress
+        yield Ok(ResponseEvent::Created(created_event).to_sse_event(&mut emitter).await);
         let in_progress_event = ResponseInProgressEvent {
             event_type: EVENT_RESPONSE_IN_PROGRESS,
             response: created_response,
             sequence_number: emitter.sequence_number(),
         };
-
-        yield Ok(ResponseEvent::Created(created_event).to_sse_event(&mut emitter).await);
         yield Ok(ResponseEvent::InProgress(in_progress_event).to_sse_event(&mut emitter).await);
 
-        // NOW immediately start the event loop - it will receive events from orchestrator as they happen
         trace!("Starting event loop to receive messages from background tasks");
         let mut client_state = ClientResponseState::default();
         let mut total_prompt_tokens_used = 0i32;
         let mut total_completion_tokens = 0i32;
-        let mut durable_completion_pending = false;
         let mut saw_terminal = false;
-        loop {
-            let msg = if durable_completion_pending {
-                next_client_message_after_durable_completion(&mut rx_client)
-            } else {
-                tokio::select! {
-                    biased;
-                    _ = response_execution.cancelled() => StorageMessage::Cancelled,
-                    message = rx_client.recv() => {
-                        let Some(message) = message else {
-                            break;
-                        };
-                        message
-                    }
-                }
-            };
+        while let Some(msg) = rx_client.recv().await {
             trace!("Client stream received message from upstream processor");
             match msg {
                 StorageMessage::MessageStarted { item_id } => {
@@ -5062,6 +5513,7 @@ async fn create_response_stream(
                             .build(),
                     };
                     yield Ok(ResponseEvent::OutputItemDone(output_item_done_event).to_sse_event(&mut emitter).await);
+                    client_state.mark_message_completed(item_id);
                 }
                 StorageMessage::ReasoningStarted { item_id } => {
                     let output_index = client_state.push_reasoning(item_id);
@@ -5139,62 +5591,20 @@ async fn create_response_stream(
                         },
                     };
                     yield Ok(ResponseEvent::OutputItemDone(reasoning_item_done).to_sse_event(&mut emitter).await);
+                    client_state.mark_reasoning_completed(item_id);
                 }
-                StorageMessage::ResponseDone { finish_reason: _finish_reason } => {
-                    let storage_completion = if durable_completion_pending {
-                        StorageCompletionDecision::Completed
-                    } else {
-                        await_storage_completion(&mut storage_handle).await
-                    };
-                    match storage_completion {
-                        StorageCompletionDecision::Completed => {}
-                        StorageCompletionDecision::Cancelled => {
-                            debug!(
-                                "Storage completed response {} as cancelled before the client terminal event",
-                                response_uuid
-                            );
-                            let cancelled_event = ResponseCancelledEvent {
-                                id: Uuid::new_v4().to_string(),
-                                event_type: EVENT_RESPONSE_CANCELLED,
-                                created_at: Utc::now().timestamp(),
-                                data: ResponseCancelledData {
-                                    id: response_uuid,
-                                },
-                            };
-                            // A terminal SSE event is also the client-visible
-                            // release point for response lifecycle fences. Do
-                            // not emit it until every process-local task owned
-                            // by the main response has exited.
-                            drop(client_execution_guard.take());
-                            response_execution.wait_for_quiescence().await;
-                            saw_terminal = true;
-                            yield Ok(ResponseEvent::Cancelled(cancelled_event).to_sse_event(&mut emitter).await);
-                            break;
-                        }
-                        StorageCompletionDecision::Error => {
-                            error!(
-                                "Storage did not acknowledge durable completion for response {}",
-                                response_uuid
-                            );
-                            best_effort_fail_response_after_storage_error(
-                                &state,
-                                response_id,
-                                response_uuid,
-                            );
-                            let error_event = ResponseErrorEvent {
-                                event_type: EVENT_RESPONSE_ERROR,
-                                error: ResponseError {
-                                    error_type: "stream_error".to_string(),
-                                    message: "Internal storage failure - response was not completed".to_string(),
-                                },
-                            };
-                            drop(client_execution_guard.take());
-                            saw_terminal = true;
-                            yield Ok(ResponseEvent::Error(error_event).to_sse_event(&mut emitter).await);
-                            break;
-                        }
-                    }
-
+                StorageMessage::Usage { prompt_tokens, completion_tokens } => {
+                    trace!("Client stream received usage data");
+                    total_prompt_tokens_used += prompt_tokens;
+                    total_completion_tokens += completion_tokens;
+                }
+                StorageMessage::Terminal(terminal) => {
+                    // The supervisor only forwards a storage-authoritative terminal.
+                    // Release this stream's ownership before waiting for all other
+                    // response-owned work, including the provider child, to exit.
+                    drop(client_execution_guard.take());
+                    response_execution.wait_for_quiescence().await;
+                    saw_terminal = true;
                     let usage = build_usage(
                         if total_prompt_tokens_used > 0 {
                             total_prompt_tokens_used
@@ -5203,126 +5613,58 @@ async fn create_response_stream(
                         },
                         total_completion_tokens,
                     );
-
-                    let done_response = ResponseBuilder::from_response(&response_for_stream)
-                        .status(STATUS_COMPLETED)
-                        .output(client_state.build_output_items())
-                        .usage(usage)
-                        .metadata(decrypted_metadata.clone())
-                        .build();
-
-                    let completed_event = ResponseCompletedEvent {
-                        event_type: EVENT_RESPONSE_COMPLETED,
-                        response: done_response,
-                        sequence_number: emitter.sequence_number(),
-                    };
-
-                    drop(client_execution_guard.take());
-                    response_execution.wait_for_quiescence().await;
-                    saw_terminal = true;
-                    yield Ok(ResponseEvent::Completed(completed_event).to_sse_event(&mut emitter).await);
-                    break;
-                }
-                StorageMessage::Usage { prompt_tokens, completion_tokens } => {
-                    trace!("Client stream received usage data");
-                    total_prompt_tokens_used += prompt_tokens;
-                    total_completion_tokens += completion_tokens;
-                }
-                StorageMessage::Cancelled => {
-                    debug!("Client stream received cancellation signal");
-                    match client_cancellation_terminal_decision(
-                        await_storage_completion(&mut storage_handle).await,
-                    ) {
-                        ClientCancellationTerminalDecision::EmitCancelled => {}
-                        ClientCancellationTerminalDecision::ReplayCompleted => {
-                            debug!(
-                                "Cancellation for response {} lost to durable completion; draining the client projection before emitting response.completed",
-                                response_uuid
-                            );
-                            durable_completion_pending = true;
-                            continue;
-                        }
-                        ClientCancellationTerminalDecision::EmitError => {
-                            error!(
-                                "Storage did not acknowledge durable cancellation for response {}",
-                                response_uuid
-                            );
-                            best_effort_fail_response_after_storage_error(
-                                &state,
-                                response_id,
-                                response_uuid,
-                            );
-                            let error_event = ResponseErrorEvent {
-                                event_type: EVENT_RESPONSE_ERROR,
-                                error: ResponseError {
-                                    error_type: "stream_error".to_string(),
-                                    message: "Internal storage failure - response cancellation was not finalized".to_string(),
-                                },
+                    match terminal {
+                        ResponseTerminal::Completed { .. } => {
+                            let done_response = ResponseBuilder::from_response(&response_for_stream)
+                                .status(STATUS_COMPLETED)
+                                .output(client_state.build_output_items())
+                                .usage(usage)
+                                .metadata(decrypted_metadata.clone())
+                                .build();
+                            let completed_event = ResponseCompletedEvent {
+                                event_type: EVENT_RESPONSE_COMPLETED,
+                                response: done_response,
+                                sequence_number: emitter.sequence_number(),
                             };
-                            drop(client_execution_guard.take());
-                            saw_terminal = true;
-                            yield Ok(ResponseEvent::Error(error_event).to_sse_event(&mut emitter).await);
-                            break;
+                            yield Ok(ResponseEvent::Completed(completed_event).to_sse_event(&mut emitter).await);
+                        }
+                        ResponseTerminal::Cancelled => {
+                            let cancelled_event = ResponseCancelledEvent {
+                                id: Uuid::new_v4().to_string(),
+                                event_type: EVENT_RESPONSE_CANCELLED,
+                                created_at: Utc::now().timestamp(),
+                                data: ResponseCancelledData { id: response_uuid },
+                            };
+                            yield Ok(ResponseEvent::Cancelled(cancelled_event).to_sse_event(&mut emitter).await);
+                        }
+                        ResponseTerminal::Failed(failure) => {
+                            let failed_response = ResponseBuilder::from_response(&response_for_stream)
+                                .status(STATUS_FAILED)
+                                .output(client_state.build_output_items())
+                                .usage(usage)
+                                .metadata(decrypted_metadata.clone())
+                                .error(ResponseError {
+                                    code: failure.openai_code().to_string(),
+                                    message: failure.message().to_string(),
+                                })
+                                .build();
+                            let failed_event = ResponseFailedEvent {
+                                event_type: EVENT_RESPONSE_FAILED,
+                                response: failed_response,
+                                sequence_number: emitter.sequence_number(),
+                                opensecret: failure.contract_metadata(),
+                            };
+                            yield Ok(ResponseEvent::Failed(failed_event).to_sse_event(&mut emitter).await);
                         }
                     }
-
-                    // Send response.cancelled event
-                    let cancelled_event = ResponseCancelledEvent {
-                        id: Uuid::new_v4().to_string(),
-                        event_type: EVENT_RESPONSE_CANCELLED,
-                        created_at: Utc::now().timestamp(),
-                        data: ResponseCancelledData {
-                            id: response_uuid,
-                        },
-                    };
-
-                    drop(client_execution_guard.take());
-                    response_execution.wait_for_quiescence().await;
-                    saw_terminal = true;
-                    yield Ok(ResponseEvent::Cancelled(cancelled_event).to_sse_event(&mut emitter).await);
                     break;
                 }
-                StorageMessage::Error(error_msg) => {
-                    error!("Client stream received error: {}", error_msg);
-                    let storage_decision = await_storage_completion(&mut storage_handle).await;
-                    if matches!(storage_decision, StorageCompletionDecision::Cancelled) {
-                        let cancelled_event = ResponseCancelledEvent {
-                            id: Uuid::new_v4().to_string(),
-                            event_type: EVENT_RESPONSE_CANCELLED,
-                            created_at: Utc::now().timestamp(),
-                            data: ResponseCancelledData {
-                                id: response_uuid,
-                            },
-                        };
-                        drop(client_execution_guard.take());
-                        response_execution.wait_for_quiescence().await;
-                        saw_terminal = true;
-                        yield Ok(ResponseEvent::Cancelled(cancelled_event).to_sse_event(&mut emitter).await);
-                        break;
-                    }
-                    if matches!(storage_decision, StorageCompletionDecision::Error) {
-                        best_effort_fail_response_after_storage_error(
-                            &state,
-                            response_id,
-                            response_uuid,
-                        );
-                    }
-
-                    // Send error event to client
-                    let error_event = ResponseErrorEvent {
-                        event_type: EVENT_RESPONSE_ERROR,
-                        error: ResponseError {
-                            error_type: "stream_error".to_string(),
-                            message: error_msg,
-                        },
-                    };
-
-                    drop(client_execution_guard.take());
-                    saw_terminal = true;
-                    yield Ok(ResponseEvent::Error(error_event).to_sse_event(&mut emitter).await);
-                    break;
-                }
-                StorageMessage::ToolCall { tool_call_id, name, arguments } => {
+                StorageMessage::ToolCall {
+                    tool_call_id,
+                    tool_output_id: _,
+                    name,
+                    arguments,
+                } => {
                     debug!(
                         "Client stream received tool_call {} ({}) for response {}",
                         tool_call_id, name, response_uuid

--- a/src/web/responses/image_describer.rs
+++ b/src/web/responses/image_describer.rs
@@ -13,7 +13,6 @@ use tokio::time::timeout;
 pub const IMAGE_DESCRIPTION_ATTEMPT_TIMEOUT_SECS: u64 = 15;
 pub const IMAGE_DESCRIPTION_ATTEMPT_TIMEOUT: Duration =
     Duration::from_secs(IMAGE_DESCRIPTION_ATTEMPT_TIMEOUT_SECS);
-pub const IMAGE_DESCRIPTION_MAX_OUTPUT_TOKENS: u64 = 2_048;
 pub const MAX_IMAGE_DESCRIPTION_RESPONSE_BYTES: usize = 256 * 1024;
 pub const MAX_IMAGE_DESCRIPTION_CHARS: usize = 16 * 1024;
 
@@ -110,7 +109,6 @@ pub fn build_image_description_request(
         "model": candidate.public_model_id,
         "stream": false,
         "temperature": 0.0,
-        "max_tokens": IMAGE_DESCRIPTION_MAX_OUTPUT_TOKENS,
         "messages": [
             {
                 "role": "system",
@@ -528,6 +526,16 @@ mod tests {
         );
         assert_eq!(IMAGE_DESCRIPTION_CANDIDATES[2].provider.as_str(), "tinfoil");
         assert_eq!(IMAGE_DESCRIPTION_CANDIDATES[2].provider_model_id, "kimi-k3");
+    }
+
+    #[test]
+    fn image_description_requests_do_not_impose_output_token_limits() {
+        for candidate in IMAGE_DESCRIPTION_CANDIDATES {
+            let request = build_image_description_request(candidate, input()).expect("request");
+            assert!(request.get("max_tokens").is_none());
+            assert!(request.get("max_completion_tokens").is_none());
+            assert!(request.get("max_output_tokens").is_none());
+        }
     }
 
     #[test]

--- a/src/web/responses/mod.rs
+++ b/src/web/responses/mod.rs
@@ -33,7 +33,7 @@ pub(crate) use execution::{
     ResponseExecution, ResponseExecutionRegistry, ResponseExecutionTaskGuard,
 };
 pub use pagination::Paginator;
-pub use storage::{storage_task, StorageTaskOutcome};
+pub use storage::storage_task;
 // REMOVED: UpstreamStreamProcessor - no longer used with centralized billing architecture
 pub use types::{DeletedObjectResponse, MessageContent, MessageContentPart, NullableField};
 

--- a/src/web/responses/storage.rs
+++ b/src/web/responses/storage.rs
@@ -1,9 +1,11 @@
 //! Storage task components for persisting streaming response items.
 
 use crate::{
+    db::DBError,
     encrypt::encrypt_with_key,
     models::responses::{
         NewAssistantMessage, NewReasoningItem, NewToolCall, NewToolOutput, ResponseStatus,
+        ResponsesError,
     },
     tokens::count_tokens,
     web::responses::constants::{
@@ -13,19 +15,20 @@ use crate::{
 };
 use chrono::Utc;
 use secp256k1::SecretKey;
-use std::{collections::HashMap, sync::Arc, time::Instant};
-use tokio::sync::mpsc;
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, trace, warn};
 use uuid::Uuid;
 
-use super::handlers::StorageMessage;
+use super::handlers::{PublicResponseFailure, ResponseTerminal, StorageMessage};
 
-/// Terminal result of the per-response storage worker.
-///
-/// A `Completed` result is an acknowledgement that every queued response item
-/// was persisted successfully and the response status was durably advanced to
-/// `completed`. The streaming task must not emit `response.completed` for any
-/// other outcome.
+/// Terminal result of the per-response storage worker. A terminal result is
+/// returned only after pending items and the authoritative response status are
+/// durable. The execution guard separately proves that the task has exited.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StorageTaskOutcome {
     Completed,
@@ -33,22 +36,70 @@ pub enum StorageTaskOutcome {
     Failed,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TerminalStatusUpdate {
-    Updated,
-    AlreadyTerminal,
-    Failed,
+impl StorageTaskOutcome {
+    fn from_terminal(terminal: Option<&ResponseTerminal>) -> Self {
+        match terminal {
+            Some(ResponseTerminal::Completed { .. }) => Self::Completed,
+            Some(ResponseTerminal::Cancelled) => Self::Cancelled,
+            Some(ResponseTerminal::Failed(_)) | None => Self::Failed,
+        }
+    }
 }
 
-#[derive(Default)]
+const TERMINAL_RETRY_INITIAL_DELAY: Duration = Duration::from_millis(100);
+const TERMINAL_RETRY_MAX_DELAY: Duration = Duration::from_secs(5);
+const INTERRUPTED_TOOL_OUTPUT: &str = "Tool execution was interrupted before completion.";
+
+#[derive(Clone, Default)]
 struct PendingAssistantMessage {
     content: String,
     created_at: Option<chrono::DateTime<chrono::Utc>>,
+    completed_finish_reason: Option<String>,
 }
 
-#[derive(Default)]
+impl PendingAssistantMessage {
+    fn terminal_status_and_finish_reason(
+        &self,
+        incomplete_finish_reason: Option<String>,
+    ) -> (&'static str, Option<String>) {
+        match &self.completed_finish_reason {
+            Some(finish_reason) => (STATUS_COMPLETED, Some(finish_reason.clone())),
+            None => (STATUS_INCOMPLETE, incomplete_finish_reason),
+        }
+    }
+}
+
+#[derive(Clone, Default)]
 struct PendingReasoningItem {
     content: String,
+    created_at: Option<chrono::DateTime<chrono::Utc>>,
+    completed: bool,
+}
+
+impl PendingReasoningItem {
+    fn terminal_status(&self) -> &'static str {
+        if self.completed {
+            STATUS_COMPLETED
+        } else {
+            STATUS_INCOMPLETE
+        }
+    }
+}
+
+#[derive(Clone)]
+struct PendingToolCall {
+    name: String,
+    arguments: serde_json::Value,
+    created_at: chrono::DateTime<chrono::Utc>,
+    output_id: Uuid,
+    output: Option<String>,
+    output_created_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+impl PendingToolCall {
+    fn terminal_output(&self) -> &str {
+        self.output.as_deref().unwrap_or(INTERRUPTED_TOOL_OUTPUT)
+    }
 }
 
 fn clamp_token_count(text: &str, label: &str) -> i32 {
@@ -104,67 +155,63 @@ fn update_terminal_response_status(
     db: &Arc<dyn DBConnection + Send + Sync>,
     response_id: i64,
     response_uuid: Uuid,
-    status: ResponseStatus,
+    user_id: Uuid,
+    requested: ResponseTerminal,
     reason: &str,
-) -> TerminalStatusUpdate {
+) -> Result<Option<ResponseTerminal>, String> {
+    let status = requested.status();
     match db.update_response_status_if_current(
         response_id,
         ResponseStatus::InProgress,
         status,
         Some(Utc::now()),
     ) {
-        Ok(true) => TerminalStatusUpdate::Updated,
+        Ok(true) => Ok(Some(requested)),
         Ok(false) => {
             debug!(
                 "Storage: skipped setting response {} ({}) to {:?} after {}; response was no longer in_progress",
                 response_id, response_uuid, status, reason
             );
-            TerminalStatusUpdate::AlreadyTerminal
+            match db.get_response_by_uuid_and_user(response_uuid, user_id) {
+                Ok(response) => match response.status {
+                    ResponseStatus::Completed => Ok(Some(match requested {
+                        ResponseTerminal::Completed { .. } => requested,
+                        _ => ResponseTerminal::Completed {
+                            finish_reason: "stop".to_string(),
+                        },
+                    })),
+                    ResponseStatus::Cancelled => Ok(Some(ResponseTerminal::Cancelled)),
+                    ResponseStatus::Failed => Ok(Some(ResponseTerminal::Failed(
+                        PublicResponseFailure::Internal,
+                    ))),
+                    ResponseStatus::Queued | ResponseStatus::InProgress => Err(format!(
+                        "Response remained {:?} after terminal compare-and-set",
+                        response.status
+                    )),
+                },
+                Err(DBError::ResponsesError(ResponsesError::ResponseNotFound)) => {
+                    debug!(
+                        "Response {} ({}) was deleted before terminal persistence completed",
+                        response_id, response_uuid
+                    );
+                    Ok(None)
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to read authoritative response {} ({}) status after {}: {:?}",
+                        response_id, response_uuid, reason, e
+                    );
+                    Err("Failed to read authoritative terminal response status".to_string())
+                }
+            }
         }
         Err(e) => {
             error!(
                 "Failed to update response {} ({}) status to {:?} after {}: {:?}",
                 response_id, response_uuid, status, reason, e
             );
-            TerminalStatusUpdate::Failed
+            Err("Failed to persist terminal response status".to_string())
         }
-    }
-}
-
-fn terminal_outcome_after_status_update<F, E>(
-    response_uuid: Uuid,
-    status_update: TerminalStatusUpdate,
-    updated_outcome: StorageTaskOutcome,
-    get_persisted_status: F,
-) -> StorageTaskOutcome
-where
-    F: FnOnce() -> Result<ResponseStatus, E>,
-    E: std::fmt::Debug,
-{
-    match status_update {
-        TerminalStatusUpdate::Updated => updated_outcome,
-        TerminalStatusUpdate::Failed => StorageTaskOutcome::Failed,
-        TerminalStatusUpdate::AlreadyTerminal => match get_persisted_status() {
-            Ok(ResponseStatus::Cancelled) => {
-                // A competing cancellation worker already completed the same
-                // durable terminal transition, so its result is authoritative.
-                StorageTaskOutcome::Cancelled
-            }
-            Ok(status) => {
-                error!(
-                    "Storage: response {} was {:?} after a terminal status update lost its in_progress compare-and-set",
-                    response_uuid, status
-                );
-                StorageTaskOutcome::Failed
-            }
-            Err(e) => {
-                error!(
-                    "Storage: failed to read response {} after a terminal status update lost its in_progress compare-and-set: {:?}",
-                    response_uuid, e
-                );
-                StorageTaskOutcome::Failed
-            }
-        },
     }
 }
 
@@ -193,7 +240,7 @@ async fn finalize_assistant_message(
     .map_err(|e| format!("Failed to update assistant message: {:?}", e))
 }
 
-fn create_reasoning_item(
+fn create_reasoning_item_if_missing(
     db: &Arc<dyn DBConnection + Send + Sync>,
     conversation_id: i64,
     response_id: i64,
@@ -201,20 +248,25 @@ fn create_reasoning_item(
     item_id: Uuid,
     created_at: chrono::DateTime<chrono::Utc>,
 ) -> Result<(), String> {
-    db.create_reasoning_item(NewReasoningItem {
-        uuid: item_id,
-        conversation_id,
-        response_id: Some(response_id),
-        assistant_message_id: None,
-        user_id,
-        content_enc: None,
-        summary_enc: None,
-        reasoning_tokens: 0,
-        status: STATUS_IN_PROGRESS.to_string(),
-        created_at,
-    })
-    .map(|_| ())
-    .map_err(|e| format!("Failed to create reasoning item: {:?}", e))
+    match db.get_reasoning_item_by_uuid(item_id) {
+        Ok(Some(_)) => Ok(()),
+        Ok(None) => db
+            .create_reasoning_item(NewReasoningItem {
+                uuid: item_id,
+                conversation_id,
+                response_id: Some(response_id),
+                assistant_message_id: None,
+                user_id,
+                content_enc: None,
+                summary_enc: None,
+                reasoning_tokens: 0,
+                status: STATUS_IN_PROGRESS.to_string(),
+                created_at,
+            })
+            .map(|_| ())
+            .map_err(|e| format!("Failed to create reasoning item: {:?}", e)),
+        Err(e) => Err(format!("Failed to look up reasoning item: {:?}", e)),
+    }
 }
 
 async fn finalize_reasoning_item(
@@ -272,6 +324,38 @@ async fn persist_tool_call(
 }
 
 #[allow(clippy::too_many_arguments)]
+async fn persist_tool_call_if_missing(
+    db: &Arc<dyn DBConnection + Send + Sync>,
+    user_key: &SecretKey,
+    conversation_id: i64,
+    response_id: i64,
+    user_id: Uuid,
+    tool_call_id: Uuid,
+    name: String,
+    arguments: serde_json::Value,
+    created_at: chrono::DateTime<chrono::Utc>,
+) -> Result<(), String> {
+    match db.get_tool_call_by_uuid(tool_call_id, user_id) {
+        Ok(_) => Ok(()),
+        Err(DBError::ResponsesError(ResponsesError::ToolCallNotFound)) => {
+            persist_tool_call(
+                db,
+                user_key,
+                conversation_id,
+                response_id,
+                user_id,
+                tool_call_id,
+                name,
+                arguments,
+                created_at,
+            )
+            .await
+        }
+        Err(e) => Err(format!("Failed to look up tool_call: {:?}", e)),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn persist_tool_output(
     db: &Arc<dyn DBConnection + Send + Sync>,
     user_key: &SecretKey,
@@ -305,46 +389,326 @@ async fn persist_tool_output(
     .map_err(|e| format!("Failed to persist tool_output: {:?}", e))
 }
 
-async fn mark_pending_items_incomplete(
+#[allow(clippy::too_many_arguments)]
+async fn persist_tool_output_if_missing(
     db: &Arc<dyn DBConnection + Send + Sync>,
     user_key: &SecretKey,
+    conversation_id: i64,
+    response_id: i64,
+    user_id: Uuid,
+    tool_output_id: Uuid,
+    tool_call_id: Uuid,
+    output: String,
+    created_at: chrono::DateTime<chrono::Utc>,
+) -> Result<(), String> {
+    match db.get_tool_output_by_uuid(tool_output_id, user_id) {
+        Ok(_) => Ok(()),
+        Err(DBError::ResponsesError(ResponsesError::ToolOutputNotFound)) => {
+            persist_tool_output(
+                db,
+                user_key,
+                conversation_id,
+                response_id,
+                user_id,
+                tool_output_id,
+                tool_call_id,
+                output,
+                created_at,
+            )
+            .await
+        }
+        Err(e) => Err(format!("Failed to look up tool_output: {:?}", e)),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn finalize_pending_items_for_terminal(
+    db: &Arc<dyn DBConnection + Send + Sync>,
+    user_key: &SecretKey,
+    conversation_id: i64,
+    response_id: i64,
+    user_id: Uuid,
+    next_created_at: &mut chrono::DateTime<chrono::Utc>,
     pending_messages: &mut HashMap<Uuid, PendingAssistantMessage>,
     pending_reasoning: &mut HashMap<Uuid, PendingReasoningItem>,
     message_finish_reason: Option<String>,
-) -> bool {
-    let mut succeeded = true;
-    for (item_id, pending) in pending_messages.drain() {
-        if let Err(e) = finalize_assistant_message(
+) -> Result<(), String> {
+    let mut failures = Vec::new();
+    let message_ids: Vec<_> = pending_messages.keys().copied().collect();
+    for item_id in message_ids {
+        let pending = {
+            let Some(pending) = pending_messages.get_mut(&item_id) else {
+                continue;
+            };
+            pending
+                .created_at
+                .get_or_insert_with(|| allocate_created_at(next_created_at));
+            pending.clone()
+        };
+        let create_result = create_assistant_message_if_missing(
+            db,
+            conversation_id,
+            response_id,
+            user_id,
+            item_id,
+            pending
+                .created_at
+                .expect("pending message timestamp is set"),
+        );
+        let (status, finish_reason) =
+            pending.terminal_status_and_finish_reason(message_finish_reason.clone());
+        let result = match create_result {
+            Ok(()) => {
+                finalize_assistant_message(
+                    db,
+                    user_key,
+                    item_id,
+                    pending.content,
+                    status,
+                    finish_reason,
+                )
+                .await
+            }
+            Err(e) => Err(e),
+        };
+        match result {
+            Ok(()) => {
+                pending_messages.remove(&item_id);
+            }
+            Err(e) => {
+                error!(
+                    "Failed to finalize pending assistant message {}: {}",
+                    item_id, e
+                );
+                failures.push(e);
+            }
+        }
+    }
+
+    let reasoning_ids: Vec<_> = pending_reasoning.keys().copied().collect();
+    for item_id in reasoning_ids {
+        let pending = {
+            let Some(pending) = pending_reasoning.get_mut(&item_id) else {
+                continue;
+            };
+            pending
+                .created_at
+                .get_or_insert_with(|| allocate_created_at(next_created_at));
+            pending.clone()
+        };
+        let result = create_reasoning_item_if_missing(
+            db,
+            conversation_id,
+            response_id,
+            user_id,
+            item_id,
+            pending
+                .created_at
+                .expect("pending reasoning timestamp is set"),
+        );
+        let status = pending.terminal_status();
+        let result = match result {
+            Ok(()) => finalize_reasoning_item(db, user_key, item_id, pending.content, status).await,
+            Err(e) => Err(e),
+        };
+        match result {
+            Ok(()) => {
+                pending_reasoning.remove(&item_id);
+            }
+            Err(e) => {
+                error!(
+                    "Failed to finalize pending reasoning item {}: {}",
+                    item_id, e
+                );
+                failures.push(e);
+            }
+        }
+    }
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "Failed to finalize {} pending response item(s)",
+            failures.len()
+        ))
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn finalize_pending_tool_calls_for_terminal(
+    db: &Arc<dyn DBConnection + Send + Sync>,
+    user_key: &SecretKey,
+    conversation_id: i64,
+    response_id: i64,
+    user_id: Uuid,
+    next_created_at: &mut chrono::DateTime<chrono::Utc>,
+    pending_tool_calls: &mut HashMap<Uuid, PendingToolCall>,
+) -> Result<(), String> {
+    let mut failures = Vec::new();
+    let tool_call_ids: Vec<_> = pending_tool_calls.keys().copied().collect();
+
+    for tool_call_id in tool_call_ids {
+        let pending = {
+            let Some(pending) = pending_tool_calls.get_mut(&tool_call_id) else {
+                continue;
+            };
+            pending
+                .output_created_at
+                .get_or_insert_with(|| allocate_created_at(next_created_at));
+            pending.clone()
+        };
+        let terminal_output = pending.terminal_output().to_string();
+
+        let call_result = persist_tool_call_if_missing(
             db,
             user_key,
-            item_id,
-            pending.content,
-            STATUS_INCOMPLETE,
+            conversation_id,
+            response_id,
+            user_id,
+            tool_call_id,
+            pending.name,
+            pending.arguments,
+            pending.created_at,
+        )
+        .await;
+        let output_result = match call_result {
+            Ok(()) => {
+                persist_tool_output_if_missing(
+                    db,
+                    user_key,
+                    conversation_id,
+                    response_id,
+                    user_id,
+                    pending.output_id,
+                    tool_call_id,
+                    terminal_output,
+                    pending
+                        .output_created_at
+                        .expect("pending tool output timestamp is set"),
+                )
+                .await
+            }
+            Err(e) => Err(e),
+        };
+
+        match output_result {
+            Ok(()) => {
+                pending_tool_calls.remove(&tool_call_id);
+            }
+            Err(e) => {
+                error!(
+                    "Failed to terminalize pending tool_call {}: {}",
+                    tool_call_id, e
+                );
+                failures.push(e);
+            }
+        }
+    }
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "Failed to terminalize {} pending tool call(s)",
+            failures.len()
+        ))
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn persist_terminal_until_authoritative(
+    db: &Arc<dyn DBConnection + Send + Sync>,
+    user_key: &SecretKey,
+    conversation_id: i64,
+    response_id: i64,
+    response_uuid: Uuid,
+    user_id: Uuid,
+    next_created_at: &mut chrono::DateTime<chrono::Utc>,
+    pending_messages: &mut HashMap<Uuid, PendingAssistantMessage>,
+    pending_reasoning: &mut HashMap<Uuid, PendingReasoningItem>,
+    pending_tool_calls: &mut HashMap<Uuid, PendingToolCall>,
+    requested: ResponseTerminal,
+    message_finish_reason: Option<String>,
+    reason: &str,
+) -> Option<ResponseTerminal> {
+    let mut retry_delay = TERMINAL_RETRY_INITIAL_DELAY;
+
+    loop {
+        let item_cleanup_result = finalize_pending_items_for_terminal(
+            db,
+            user_key,
+            conversation_id,
+            response_id,
+            user_id,
+            next_created_at,
+            pending_messages,
+            pending_reasoning,
             message_finish_reason.clone(),
         )
-        .await
-        {
-            error!(
-                "Failed to finalize pending assistant message {}: {}",
-                item_id, e
-            );
-            succeeded = false;
+        .await;
+        let tool_cleanup_result = finalize_pending_tool_calls_for_terminal(
+            db,
+            user_key,
+            conversation_id,
+            response_id,
+            user_id,
+            next_created_at,
+            pending_tool_calls,
+        )
+        .await;
+        let cleanup_result = match (item_cleanup_result, tool_cleanup_result) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(e), Ok(())) | (Ok(()), Err(e)) => Err(e),
+            (Err(item_error), Err(tool_error)) => Err(format!(
+                "Pending item cleanup failed: {}; pending tool cleanup failed: {}",
+                item_error, tool_error
+            )),
+        };
+
+        let terminal_result = match cleanup_result {
+            Ok(()) => update_terminal_response_status(
+                db,
+                response_id,
+                response_uuid,
+                user_id,
+                requested.clone(),
+                reason,
+            ),
+            Err(cleanup_error) => match db.get_response_by_uuid_and_user(response_uuid, user_id) {
+                Err(DBError::ResponsesError(ResponsesError::ResponseNotFound)) => {
+                    debug!(
+                        "Response {} ({}) was deleted while pending item cleanup was retrying",
+                        response_id, response_uuid
+                    );
+                    Ok(None)
+                }
+                Ok(_) => Err(cleanup_error),
+                Err(e) => {
+                    warn!(
+                        "Failed to verify response existence after cleanup error: response_uuid={}, error={:?}",
+                        response_uuid, e
+                    );
+                    Err(cleanup_error)
+                }
+            },
+        };
+
+        match terminal_result {
+            Ok(authoritative) => return authoritative,
+            Err(e) => {
+                warn!(
+                    "Storage terminal persistence will retry: response_uuid={}, reason={}, retry_delay_ms={}, error={}",
+                    response_uuid,
+                    reason,
+                    retry_delay.as_millis(),
+                    e
+                );
+                tokio::time::sleep(retry_delay).await;
+                retry_delay = retry_delay.saturating_mul(2).min(TERMINAL_RETRY_MAX_DELAY);
+            }
         }
     }
-
-    for (item_id, pending) in pending_reasoning.drain() {
-        if let Err(e) =
-            finalize_reasoning_item(db, user_key, item_id, pending.content, STATUS_INCOMPLETE).await
-        {
-            error!(
-                "Failed to finalize pending reasoning item {}: {}",
-                item_id, e
-            );
-            succeeded = false;
-        }
-    }
-
-    succeeded
 }
 
 /// Main storage task that orchestrates per-item persistence.
@@ -352,6 +716,7 @@ async fn mark_pending_items_incomplete(
 pub async fn storage_task(
     mut rx: mpsc::Receiver<StorageMessage>,
     tool_persist_ack: Option<mpsc::Sender<Result<(), String>>>,
+    terminal_persist_ack: Option<oneshot::Sender<Result<Option<ResponseTerminal>, String>>>,
     db: Arc<dyn DBConnection + Send + Sync>,
     response_id: i64,
     response_uuid: Uuid,
@@ -361,10 +726,12 @@ pub async fn storage_task(
     user_key: SecretKey,
 ) -> StorageTaskOutcome {
     let tool_ack = tool_persist_ack;
+    let mut terminal_ack = terminal_persist_ack;
     let mut pending_messages: HashMap<Uuid, PendingAssistantMessage> = HashMap::new();
     let mut pending_reasoning: HashMap<Uuid, PendingReasoningItem> = HashMap::new();
+    let mut pending_tool_calls: HashMap<Uuid, PendingToolCall> = HashMap::new();
     let mut next_item_created_at = first_item_created_at;
-    let mut persistence_failed = false;
+    let mut storage_failed = false;
 
     while let Some(msg) = rx.recv().await {
         match msg {
@@ -384,6 +751,7 @@ pub async fn storage_task(
                     created_at,
                 ) {
                     error!("{}", e);
+                    storage_failed = true;
                 }
             }
             StorageMessage::ContentDelta { item_id, delta } => {
@@ -406,40 +774,56 @@ pub async fn storage_task(
                     "Storage: message done {} with finish_reason={}",
                     item_id, finish_reason
                 );
-                let pending = pending_messages.remove(&item_id).unwrap_or_default();
-                let created_at = pending
-                    .created_at
-                    .unwrap_or_else(|| allocate_created_at(&mut next_item_created_at));
-                if let Err(e) = create_assistant_message_if_missing(
+                let (created_at, content) = {
+                    let pending = pending_messages.entry(item_id).or_default();
+                    pending.completed_finish_reason = Some(finish_reason.clone());
+                    let created_at = pending
+                        .created_at
+                        .get_or_insert_with(|| allocate_created_at(&mut next_item_created_at))
+                        .to_owned();
+                    (created_at, pending.content.clone())
+                };
+                let create_result = create_assistant_message_if_missing(
                     &db,
                     conversation_id,
                     response_id,
                     user_id,
                     item_id,
                     created_at,
-                ) {
+                );
+                if let Err(e) = &create_result {
                     error!("{}", e);
-                    persistence_failed = true;
+                    storage_failed = true;
                 }
-                if let Err(e) = finalize_assistant_message(
-                    &db,
-                    &user_key,
-                    item_id,
-                    pending.content,
-                    STATUS_COMPLETED,
-                    Some(finish_reason),
-                )
-                .await
-                {
-                    error!("{}", e);
-                    persistence_failed = true;
+                if create_result.is_ok() {
+                    match finalize_assistant_message(
+                        &db,
+                        &user_key,
+                        item_id,
+                        content,
+                        STATUS_COMPLETED,
+                        Some(finish_reason),
+                    )
+                    .await
+                    {
+                        Ok(()) => {
+                            pending_messages.remove(&item_id);
+                        }
+                        Err(e) => {
+                            error!("{}", e);
+                            storage_failed = true;
+                        }
+                    }
                 }
             }
             StorageMessage::ReasoningStarted { item_id } => {
                 trace!("Storage: reasoning started {}", item_id);
-                pending_reasoning.entry(item_id).or_default();
-                let created_at = allocate_created_at(&mut next_item_created_at);
-                if let Err(e) = create_reasoning_item(
+                let pending = pending_reasoning.entry(item_id).or_default();
+                let created_at = pending
+                    .created_at
+                    .get_or_insert_with(|| allocate_created_at(&mut next_item_created_at))
+                    .to_owned();
+                if let Err(e) = create_reasoning_item_if_missing(
                     &db,
                     conversation_id,
                     response_id,
@@ -448,7 +832,7 @@ pub async fn storage_task(
                     created_at,
                 ) {
                     error!("{}", e);
-                    persistence_failed = true;
+                    storage_failed = true;
                 }
             }
             StorageMessage::ReasoningDelta { item_id, delta } => {
@@ -469,15 +853,14 @@ pub async fn storage_task(
                     "Storage: finalizing reasoning item {} for response {}",
                     item_id, response_id
                 );
-                let pending = pending_reasoning.remove(&item_id).unwrap_or_default();
-                if let Err(e) = finalize_reasoning_item(
-                    &db,
-                    &user_key,
-                    item_id,
-                    pending.content,
-                    STATUS_COMPLETED,
-                )
-                .await
+                let content = {
+                    let pending = pending_reasoning.entry(item_id).or_default();
+                    pending.completed = true;
+                    pending.content.clone()
+                };
+                if let Err(e) =
+                    finalize_reasoning_item(&db, &user_key, item_id, content, STATUS_COMPLETED)
+                        .await
                 {
                     error!(
                         "Failed to finalize reasoning item {} for response {} after {} ms: {}",
@@ -486,8 +869,9 @@ pub async fn storage_task(
                         reasoning_finalize_started.elapsed().as_millis(),
                         e
                     );
-                    persistence_failed = true;
+                    storage_failed = true;
                 } else {
+                    pending_reasoning.remove(&item_id);
                     debug!(
                         "Storage: finalized reasoning item {} for response {} in {} ms",
                         item_id,
@@ -499,150 +883,52 @@ pub async fn storage_task(
             StorageMessage::Usage { .. } => {
                 trace!("Storage: usage message ignored for item persistence");
             }
-            StorageMessage::ResponseDone { finish_reason } => {
-                debug!(
-                    "Storage: response done {} ({}) with finish_reason={}",
-                    response_id, response_uuid, finish_reason
-                );
-                // Sender invariant: stream_one_assistant_turn always emits MessageDone /
-                // ReasoningDone before ResponseDone. If that invariant ever breaks we'd
-                // leave items as "in_progress" forever, so defensively finalize any
-                // stragglers as incomplete and log loudly so the bug is visible.
-                if !pending_messages.is_empty() || !pending_reasoning.is_empty() {
-                    error!(
-                        "ResponseDone received with {} pending message(s) and {} pending reasoning item(s); sender invariant violated -- finalizing as incomplete",
-                        pending_messages.len(),
-                        pending_reasoning.len()
-                    );
-                    mark_pending_items_incomplete(
-                        &db,
-                        &user_key,
-                        &mut pending_messages,
-                        &mut pending_reasoning,
-                        None,
-                    )
-                    .await;
-                    persistence_failed = true;
-                }
-                if persistence_failed {
-                    let status_update = update_terminal_response_status(
-                        &db,
-                        response_id,
-                        response_uuid,
-                        ResponseStatus::Failed,
-                        "response item persistence failure",
-                    );
-                    return terminal_outcome_after_status_update(
-                        response_uuid,
-                        status_update,
-                        StorageTaskOutcome::Failed,
-                        || {
-                            db.get_response_by_uuid_and_user(response_uuid, user_id)
-                                .map(|response| response.status)
-                        },
-                    );
+            StorageMessage::Terminal(mut requested) => {
+                if storage_failed && matches!(requested, ResponseTerminal::Completed { .. }) {
+                    requested = ResponseTerminal::Failed(PublicResponseFailure::Internal);
                 }
 
-                let status_update = update_terminal_response_status(
-                    &db,
-                    response_id,
-                    response_uuid,
-                    ResponseStatus::Completed,
-                    "ResponseDone",
-                );
-                return terminal_outcome_after_status_update(
-                    response_uuid,
-                    status_update,
-                    StorageTaskOutcome::Completed,
-                    || {
-                        db.get_response_by_uuid_and_user(response_uuid, user_id)
-                            .map(|response| response.status)
-                    },
-                );
-            }
-            StorageMessage::Cancelled => {
-                debug!(
-                    "Storage: cancellation received for response {} ({})",
-                    response_id, response_uuid
-                );
-                let cleanup_succeeded = mark_pending_items_incomplete(
+                if (!pending_messages.is_empty()
+                    || !pending_reasoning.is_empty()
+                    || !pending_tool_calls.is_empty())
+                    && matches!(requested, ResponseTerminal::Completed { .. })
+                {
+                    error!(
+                        "Completed terminal received with {} pending message(s), {} pending reasoning item(s), and {} pending tool call(s); failing response",
+                        pending_messages.len(),
+                        pending_reasoning.len(),
+                        pending_tool_calls.len()
+                    );
+                    requested = ResponseTerminal::Failed(PublicResponseFailure::Internal);
+                }
+
+                let finish_reason = matches!(requested, ResponseTerminal::Cancelled)
+                    .then(|| FINISH_REASON_CANCELLED.to_string());
+                let effective = persist_terminal_until_authoritative(
                     &db,
                     &user_key,
-                    &mut pending_messages,
-                    &mut pending_reasoning,
-                    Some(FINISH_REASON_CANCELLED.to_string()),
-                )
-                .await;
-                // The cancelled database state is the endpoint's durability
-                // certificate. Publish it only after every pending item has
-                // been finalized, never before cleanup.
-                let (status, outcome, reason) = if cleanup_succeeded {
-                    (
-                        ResponseStatus::Cancelled,
-                        StorageTaskOutcome::Cancelled,
-                        "cancellation cleanup",
-                    )
-                } else {
-                    (
-                        ResponseStatus::Failed,
-                        StorageTaskOutcome::Failed,
-                        "cancellation cleanup failure",
-                    )
-                };
-                let status_update = update_terminal_response_status(
-                    &db,
+                    conversation_id,
                     response_id,
                     response_uuid,
-                    status,
-                    reason,
-                );
-                return terminal_outcome_after_status_update(
-                    response_uuid,
-                    status_update,
-                    outcome,
-                    || {
-                        db.get_response_by_uuid_and_user(response_uuid, user_id)
-                            .map(|response| response.status)
-                    },
-                );
-            }
-            StorageMessage::Error(error_msg) => {
-                error!(
-                    "Storage: received error for response {} ({}): {}",
-                    response_id, response_uuid, error_msg
-                );
-                let status_update = update_terminal_response_status(
-                    &db,
-                    response_id,
-                    response_uuid,
-                    ResponseStatus::Failed,
-                    "streaming error",
-                );
-                let cleanup_succeeded = mark_pending_items_incomplete(
-                    &db,
-                    &user_key,
+                    user_id,
+                    &mut next_item_created_at,
                     &mut pending_messages,
                     &mut pending_reasoning,
-                    None,
+                    &mut pending_tool_calls,
+                    requested,
+                    finish_reason,
+                    "supervised terminal",
                 )
                 .await;
-                let outcome = terminal_outcome_after_status_update(
-                    response_uuid,
-                    status_update,
-                    StorageTaskOutcome::Failed,
-                    || {
-                        db.get_response_by_uuid_and_user(response_uuid, user_id)
-                            .map(|response| response.status)
-                    },
-                );
-                return if cleanup_succeeded {
-                    outcome
-                } else {
-                    StorageTaskOutcome::Failed
-                };
+                let outcome = StorageTaskOutcome::from_terminal(effective.as_ref());
+                if let Some(ack) = terminal_ack.take() {
+                    let _ = ack.send(Ok(effective));
+                }
+                return outcome;
             }
             StorageMessage::ToolCall {
                 tool_call_id,
+                tool_output_id,
                 name,
                 arguments,
             } => {
@@ -653,7 +939,18 @@ pub async fn storage_task(
                     tool_call_id, tool_name, response_id
                 );
                 let created_at = allocate_created_at(&mut next_item_created_at);
-                match persist_tool_call(
+                pending_tool_calls.insert(
+                    tool_call_id,
+                    PendingToolCall {
+                        name: name.clone(),
+                        arguments: arguments.clone(),
+                        created_at,
+                        output_id: tool_output_id,
+                        output: None,
+                        output_created_at: None,
+                    },
+                );
+                match persist_tool_call_if_missing(
                     &db,
                     &user_key,
                     conversation_id,
@@ -682,7 +979,7 @@ pub async fn storage_task(
                             tool_call_persist_started.elapsed().as_millis(),
                             e
                         );
-                        persistence_failed = true;
+                        storage_failed = true;
                         if let Some(ack) = &tool_ack {
                             let _ = ack.send(Err(e)).await;
                         }
@@ -700,7 +997,12 @@ pub async fn storage_task(
                     tool_output_id, tool_call_id, response_id
                 );
                 let created_at = allocate_created_at(&mut next_item_created_at);
-                match persist_tool_output(
+                if let Some(pending) = pending_tool_calls.get_mut(&tool_call_id) {
+                    pending.output_id = tool_output_id;
+                    pending.output = Some(output.clone());
+                    pending.output_created_at = Some(created_at);
+                }
+                match persist_tool_output_if_missing(
                     &db,
                     &user_key,
                     conversation_id,
@@ -714,6 +1016,7 @@ pub async fn storage_task(
                 .await
                 {
                     Ok(()) => {
+                        pending_tool_calls.remove(&tool_call_id);
                         debug!(
                             "Storage: persisted tool_output {} for tool_call {} on response {} in {} ms",
                             tool_output_id,
@@ -734,7 +1037,7 @@ pub async fn storage_task(
                             tool_output_persist_started.elapsed().as_millis(),
                             e
                         );
-                        persistence_failed = true;
+                        storage_failed = true;
                         if let Some(ack) = &tool_ack {
                             let _ = ack.send(Err(e)).await;
                         }
@@ -745,25 +1048,30 @@ pub async fn storage_task(
     }
 
     warn!(
-        "Storage channel closed before receiving ResponseDone signal for response {} ({})",
+        "Storage channel closed before receiving a supervised terminal for response {} ({})",
         response_id, response_uuid
     );
-    update_terminal_response_status(
-        &db,
-        response_id,
-        response_uuid,
-        ResponseStatus::Failed,
-        "premature storage channel close",
-    );
-    mark_pending_items_incomplete(
+    let effective = persist_terminal_until_authoritative(
         &db,
         &user_key,
+        conversation_id,
+        response_id,
+        response_uuid,
+        user_id,
+        &mut next_item_created_at,
         &mut pending_messages,
         &mut pending_reasoning,
+        &mut pending_tool_calls,
+        ResponseTerminal::Failed(PublicResponseFailure::Internal),
         None,
+        "premature storage channel close",
     )
     .await;
-    StorageTaskOutcome::Failed
+    let outcome = StorageTaskOutcome::from_terminal(effective.as_ref());
+    if let Some(ack) = terminal_ack.take() {
+        let _ = ack.send(Ok(effective));
+    }
+    outcome
 }
 
 #[cfg(test)]
@@ -771,81 +1079,49 @@ mod tests {
     use super::*;
 
     #[test]
-    fn successful_terminal_status_update_uses_requested_outcome() {
-        let outcome = terminal_outcome_after_status_update(
-            Uuid::new_v4(),
-            TerminalStatusUpdate::Updated,
-            StorageTaskOutcome::Completed,
-            || -> Result<ResponseStatus, &'static str> {
-                panic!("a successful compare-and-set must not reread response status")
-            },
-        );
+    fn terminal_item_status_preserves_done_boundaries() {
+        let active_message = PendingAssistantMessage::default();
+        let (status, finish_reason) = active_message
+            .terminal_status_and_finish_reason(Some(FINISH_REASON_CANCELLED.to_string()));
+        assert_eq!(status, STATUS_INCOMPLETE);
+        assert_eq!(finish_reason.as_deref(), Some(FINISH_REASON_CANCELLED));
 
-        assert_eq!(outcome, StorageTaskOutcome::Completed);
+        let done_message = PendingAssistantMessage {
+            completed_finish_reason: Some("stop".to_string()),
+            ..PendingAssistantMessage::default()
+        };
+        let (status, finish_reason) = done_message
+            .terminal_status_and_finish_reason(Some(FINISH_REASON_CANCELLED.to_string()));
+        assert_eq!(status, STATUS_COMPLETED);
+        assert_eq!(finish_reason.as_deref(), Some("stop"));
 
-        let failed_outcome = terminal_outcome_after_status_update(
-            Uuid::new_v4(),
-            TerminalStatusUpdate::Updated,
-            StorageTaskOutcome::Failed,
-            || -> Result<ResponseStatus, &'static str> {
-                panic!("a successful compare-and-set must not reread response status")
-            },
+        assert_eq!(
+            PendingReasoningItem::default().terminal_status(),
+            STATUS_INCOMPLETE
         );
-        assert_eq!(failed_outcome, StorageTaskOutcome::Failed);
+        assert_eq!(
+            PendingReasoningItem {
+                completed: true,
+                ..PendingReasoningItem::default()
+            }
+            .terminal_status(),
+            STATUS_COMPLETED
+        );
     }
 
     #[test]
-    fn cancelled_database_state_wins_completion_race() {
-        for updated_outcome in [StorageTaskOutcome::Completed, StorageTaskOutcome::Failed] {
-            let outcome = terminal_outcome_after_status_update(
-                Uuid::new_v4(),
-                TerminalStatusUpdate::AlreadyTerminal,
-                updated_outcome,
-                || Ok::<ResponseStatus, &'static str>(ResponseStatus::Cancelled),
-            );
+    fn pending_tool_call_uses_real_output_or_interrupted_fallback() {
+        let mut pending = PendingToolCall {
+            name: "web_search".to_string(),
+            arguments: serde_json::json!({"query": "maple"}),
+            created_at: Utc::now(),
+            output_id: Uuid::new_v4(),
+            output: None,
+            output_created_at: None,
+        };
 
-            assert_eq!(outcome, StorageTaskOutcome::Cancelled);
-        }
-    }
-
-    #[test]
-    fn completion_fails_closed_for_other_terminal_state_or_read_error() {
-        for status in [
-            ResponseStatus::Queued,
-            ResponseStatus::InProgress,
-            ResponseStatus::Completed,
-            ResponseStatus::Failed,
-        ] {
-            assert_eq!(
-                terminal_outcome_after_status_update(
-                    Uuid::new_v4(),
-                    TerminalStatusUpdate::AlreadyTerminal,
-                    StorageTaskOutcome::Completed,
-                    || Ok::<ResponseStatus, &'static str>(status),
-                ),
-                StorageTaskOutcome::Failed
-            );
-        }
-
-        assert_eq!(
-            terminal_outcome_after_status_update(
-                Uuid::new_v4(),
-                TerminalStatusUpdate::AlreadyTerminal,
-                StorageTaskOutcome::Completed,
-                || Err::<ResponseStatus, &'static str>("read failed"),
-            ),
-            StorageTaskOutcome::Failed
-        );
-        assert_eq!(
-            terminal_outcome_after_status_update(
-                Uuid::new_v4(),
-                TerminalStatusUpdate::Failed,
-                StorageTaskOutcome::Completed,
-                || -> Result<ResponseStatus, &'static str> {
-                    panic!("a failed compare-and-set must not be reread")
-                },
-            ),
-            StorageTaskOutcome::Failed
-        );
+        assert_eq!(pending.terminal_output(), INTERRUPTED_TOOL_OUTPUT);
+        pending.output = Some("real tool output".to_string());
+        assert_eq!(pending.terminal_output(), "real tool output");
     }
 }


### PR DESCRIPTION
Responses execution survives a client disconnect and publishes terminal events only after the corresponding transcript and response state are durable. Capacity failures expose a conservative replay contract, while ordinary generation retains the model's supported context window and any explicit caller-supplied output parameter.

- Supervise provider, orchestration, storage, and terminal delivery using [#343's execution ownership and quiescence model](https://github.com/OpenSecretCloud/opensecret/pull/343). Closing the client stream drops only client delivery; provider execution and storage continue. Explicit cancellation remains a separate operation, and cancellation/deletion wait for owned work to become quiescent.
- Let storage acknowledge the authoritative terminal after persistence. If cancellation loses to durable completion, report completion; a warning deadline or unavailable acknowledgement cannot invent success. Preserve already-completed item state while settling unfinished items appropriately.
- Start the provider before atomically persisting the response and user message. Emit standard nested `response.failed` events for terminal failures, retaining the encrypted transport and sanitized error behavior.
- Normalize upstream 429/503/529 without exposing provider bodies. Only locally proven pre-send/pre-acceptance failures receive the versioned `inference_capacity` replay-safe marker. Upstream capacity errors, ambiguous failures, and post-persistence failures never authorize whole-request replay; completed image-description work also suppresses that permission.
- Impose no default, clamp, or cumulative generation-token allowance. An omitted `max_output_tokens` remains omitted/null at the provider boundary; an explicit caller value is preserved on every model turn. Internal title and image-description requests also omit imposed generation limits. Existing time, tool-execution, and turn bounds remain separate safeguards.
- Use the catalog context window directly when selecting history, retaining incoming-message/image reservation and coherent tool pairs. There is no additional fixed output reserve or safety subtraction. Token counts remain estimates, not provider-tokenizer proof.

The catalog now uses literal published configuration values:

| Public model | Context tokens |
| --- | ---: |
| Llama 3.3 70B, GPT OSS 120B, GPT OSS Safeguard 120B | 131,072 |
| Kimi K2.6, Kimi K3, Gemma 4 31B, standard GLM 5.3 | 262,144 |
| GLM 5.2 | 393,216 |
| DeepSeek V4 Flash, GLM 5.3 Flash | 1,048,576 |

Standard GLM 5.3 retains the shared window supported across its Continuum and Tinfoil routes. GLM 5.3 Flash remains a distinct model; no model substitution is introduced. These values are configuration-backed, not a claim that every deployment or maximum-size inference was exercised; GLM 5.2 availability remains separately qualified.

These lifecycle, capacity, and context fixes apply in both routing modes. Flag-off still selects the legacy route without consulting v2 health or replanning. Authorization, conversation ownership, canonical model identity, and billing attribution remain in the backend. Router v2 stays default off. [Maple #865](https://github.com/OpenSecretCloud/Maple/pull/865) consumes this contract and pins its integration suite to this PR's exact final head.

Local validation at `91ed2e573aa5f358cfd0d59defd04d414be762fe`: the pinned Rust all-feature suite passed **526 tests**, with 0 failures and 23 ignores. Direct pinned formatting and warning-denied all-target/all-feature Clippy passed. Independent review of this exact head found no P0/P1 blocker.

Final GitHub snapshot, 2026-09-04 23:32:16 UTC: RustSec passed, the only attached check; none are pending or failed. The exact head, parent base, and merge-base match; the PR is open, non-draft, mergeable/CLEAN, and zero commits behind. Maple's final integration suite passed against this exact #300 revision.

Cumulative encrypted SDK smoke at final backend `fc0e798a` and Maple `9cfcbc0e` passed all five Kimi mock scenarios with Router v2 both off and on: Chat, Responses, disconnect/reload, explicit cancellation, and tool continuation. Client disconnect after 24 characters still yielded durable completion with all 7,917 characters in a fresh session. Explicit cancellation instead returned HTTP 200, aborted the upstream request, and durably retained 24 characters. The advertised search tool's empty-query validation error and the second provider turn persisted correctly; no external search ran. The mock rejected numeric generation-limit fields, and each scenario used one client inference send. These are cumulative stack results, not isolated #300 runs.

Live standard GLM 5.3 Chat and Responses passed in both routing modes with one client inference send per scenario. Chat verified usage, one finish signal, and one `[DONE]`; Responses verified a terminal event and durable retrieval through a fresh encrypted session. Separate runtime identity and routing logs verify the final backend build, actual modes, and GLM's Continuum route. The separate GLM 5.3 Flash legacy Chat smoke passed on Tinfoil. Native Maple's packaged macOS debug overlay also completed a legacy Agent turn, survived quit/relaunch with its transcript/title/model lock, then completed a v2 turn. This does not establish deployed enclave or released-app behavior.

The exact final #300 scoped AEAD/database suite passed **20 tests, 0 failed, 0 ignored**, with process exit 0 under pinned Rust 1.90 and all 31 migrations applied. The complete disposable-DB helper nevertheless remains failed: OAuth printed two passing assertions and then exited with SIGSEGV, reproduced on unchanged master `efcaa686d7e98b4eed490d27f323abea526d2eb4`. The passing scoped suite does not make the whole helper green.

Stack **4/8**: [#299](https://github.com/OpenSecretCloud/opensecret/pull/299) → **#300** → [#301](https://github.com/OpenSecretCloud/opensecret/pull/301). Final base: **6429fca03df4f60c4c4cd66d2594cc81758d90a2**.

[Routing walkthrough: capacity and Responses](https://maple-routing-review.anthony599874.chatgpt.site/#stack-4) · [Execution handlers](https://github.com/OpenSecretCloud/opensecret/blob/91ed2e573aa5f358cfd0d59defd04d414be762fe/src/web/responses/handlers.rs) · [Storage](https://github.com/OpenSecretCloud/opensecret/blob/91ed2e573aa5f358cfd0d59defd04d414be762fe/src/web/responses/storage.rs) · [Catalog](https://github.com/OpenSecretCloud/opensecret/blob/91ed2e573aa5f358cfd0d59defd04d414be762fe/src/model_config.rs).
