### PR TITLE
[routing v2 5/8] Observe provider health in shadow mode

### DIFF
--- a/src/inference.rs
+++ b/src/inference.rs
@@ -4,6 +4,8 @@ use std::fmt;
 use std::time::Duration;
 use uuid::Uuid;
 
+pub(crate) mod health;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ModelSelectionMode {
     AutoQuick,

--- a/src/inference/health.rs
+++ b/src/inference/health.rs
@@ -1,0 +1,1145 @@
+//! Enclave-local shadow health classification for inference routes.
+//!
+//! This module deliberately has no route-selection API. Stack 5 records what a
+//! versioned policy would do, while the legacy router and shadow planner remain
+//! the only sources of route decisions.
+
+use super::{AttemptFailureKind, AttemptTerminal, RouteKey};
+use crate::provider_registry::{ProviderId, ProviderRegistry, RateLimitScope, PROVIDER_REGISTRY};
+use std::collections::{HashMap, VecDeque};
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+
+pub(crate) const SHADOW_HEALTH_POLICY_VERSION: &str = "routing-v2-health-shadow-v1";
+
+// These are observation-only v1 hypotheses, not active product policy. Stack 5
+// intentionally versions and exercises them against real incidents before a
+// later stack may use any disposition during route selection.
+const ROUTE_FAILURE_WINDOW: Duration = Duration::from_secs(60);
+const ROUTE_FAILURES_TO_OPEN: u8 = 3;
+const ROUTE_OPEN_COOLDOWN: Duration = Duration::from_secs(30);
+const DEFAULT_CAPACITY_COOLDOWN: Duration = Duration::from_secs(1);
+const MAX_CAPACITY_COOLDOWN: Duration = Duration::from_secs(60 * 60);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShadowObservationMode {
+    Update,
+    TelemetryOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum CapacityPoolKey {
+    ProviderModel(RouteKey),
+    ProviderAccount(ProviderId),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShadowDisposition {
+    Healthy,
+    Watch { consecutive_failures: u8 },
+    WouldOpen { remaining: Duration },
+    WouldProbe,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ShadowRouteSnapshot {
+    pub(crate) route_health: ShadowDisposition,
+    pub(crate) deployment_capacity: ShadowDisposition,
+    pub(crate) rate_limit_capacity: ShadowDisposition,
+    pub(crate) effective: ShadowDisposition,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShadowSignal {
+    Completed,
+    CapacityRejected {
+        status: u16,
+    },
+    RouteFailure {
+        kind: AttemptFailureKind,
+        status: Option<u16>,
+    },
+    Neutral {
+        kind: AttemptFailureKind,
+        status: Option<u16>,
+    },
+    UnknownRoute,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ShadowObservationReport {
+    pub(crate) policy_version: &'static str,
+    pub(crate) mode: ShadowObservationMode,
+    pub(crate) route: RouteKey,
+    pub(crate) signal: ShadowSignal,
+    pub(crate) capacity_pool: Option<CapacityPoolKey>,
+    pub(crate) snapshot: Option<ShadowRouteSnapshot>,
+    pub(crate) mutated: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ShadowHealthPolicy {
+    route_failure_window: Duration,
+    route_failures_to_open: u8,
+    route_open_cooldown: Duration,
+    default_capacity_cooldown: Duration,
+    max_capacity_cooldown: Duration,
+}
+
+impl Default for ShadowHealthPolicy {
+    fn default() -> Self {
+        Self {
+            route_failure_window: ROUTE_FAILURE_WINDOW,
+            route_failures_to_open: ROUTE_FAILURES_TO_OPEN,
+            route_open_cooldown: ROUTE_OPEN_COOLDOWN,
+            default_capacity_cooldown: DEFAULT_CAPACITY_COOLDOWN,
+            max_capacity_cooldown: MAX_CAPACITY_COOLDOWN,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct RouteHealthState {
+    failure_times: VecDeque<Instant>,
+    open_until: Option<Instant>,
+}
+
+#[derive(Debug, Default)]
+struct CapacityState {
+    open_until: Option<Instant>,
+}
+
+#[derive(Debug)]
+struct ShadowHealthInner {
+    route_health: HashMap<RouteKey, RouteHealthState>,
+    capacity: HashMap<CapacityPoolKey, CapacityState>,
+}
+
+/// Fixed-topology, enclave-local shadow state.
+///
+/// Every key is pre-populated from the static provider registry. Observations
+/// for unknown routes are reported but can never grow the maps.
+#[derive(Debug)]
+pub(crate) struct ShadowHealthState {
+    policy: ShadowHealthPolicy,
+    rate_limit_pools: HashMap<RouteKey, CapacityPoolKey>,
+    inner: Mutex<ShadowHealthInner>,
+    #[cfg(test)]
+    observation_count: AtomicUsize,
+}
+
+impl Default for ShadowHealthState {
+    fn default() -> Self {
+        Self::new(&PROVIDER_REGISTRY)
+    }
+}
+
+impl ShadowHealthState {
+    pub(crate) fn new(registry: &'static ProviderRegistry) -> Self {
+        Self::new_with_policy(registry, ShadowHealthPolicy::default())
+    }
+
+    fn new_with_policy(registry: &'static ProviderRegistry, policy: ShadowHealthPolicy) -> Self {
+        let mut route_health = HashMap::new();
+        let mut capacity = HashMap::new();
+        let mut rate_limit_pools = HashMap::new();
+
+        for model in registry.completion_models() {
+            for route in model.routes {
+                let route_key = RouteKey {
+                    provider: route.provider,
+                    provider_model_id: route.provider_model_id.to_string(),
+                };
+                let deployment_pool = CapacityPoolKey::ProviderModel(route_key.clone());
+                let rate_limit_pool = match route.rate_limit_scope {
+                    RateLimitScope::ProviderModel => deployment_pool.clone(),
+                    RateLimitScope::ProviderAccount => {
+                        CapacityPoolKey::ProviderAccount(route.provider)
+                    }
+                };
+
+                route_health.entry(route_key.clone()).or_default();
+                capacity.entry(deployment_pool).or_default();
+                capacity.entry(rate_limit_pool.clone()).or_default();
+                rate_limit_pools.entry(route_key).or_insert(rate_limit_pool);
+            }
+        }
+
+        Self {
+            policy,
+            rate_limit_pools,
+            inner: Mutex::new(ShadowHealthInner {
+                route_health,
+                capacity,
+            }),
+            #[cfg(test)]
+            observation_count: AtomicUsize::new(0),
+        }
+    }
+
+    pub(crate) fn observe_terminal(
+        &self,
+        terminal: &AttemptTerminal,
+        mode: ShadowObservationMode,
+    ) -> ShadowObservationReport {
+        let mut inner = self.lock();
+        let now = Instant::now();
+        self.observe_terminal_locked(&mut inner, terminal, mode, now)
+    }
+
+    pub(crate) fn snapshot(&self, route: &RouteKey) -> Option<ShadowRouteSnapshot> {
+        let inner = self.lock();
+        self.snapshot_locked(&inner, route, Instant::now())
+    }
+
+    fn observe_terminal_locked(
+        &self,
+        inner: &mut ShadowHealthInner,
+        terminal: &AttemptTerminal,
+        mode: ShadowObservationMode,
+        now: Instant,
+    ) -> ShadowObservationReport {
+        #[cfg(test)]
+        self.observation_count.fetch_add(1, Ordering::Relaxed);
+
+        let route = terminal.attempt().route.route_key();
+        let Some(rate_limit_pool) = self.rate_limit_pools.get(&route).cloned() else {
+            return ShadowObservationReport {
+                policy_version: SHADOW_HEALTH_POLICY_VERSION,
+                mode,
+                route,
+                signal: ShadowSignal::UnknownRoute,
+                capacity_pool: None,
+                snapshot: None,
+                mutated: false,
+            };
+        };
+
+        let mut signal = ShadowSignal::Completed;
+        let mut capacity_pool = None;
+        let mut mutation = Mutation::Completed;
+
+        if let AttemptTerminal::Failed { failure, .. } = terminal {
+            let status = failure.status;
+            if failure.kind == AttemptFailureKind::CapacityRejected {
+                match status {
+                    Some(429) => {
+                        signal = ShadowSignal::CapacityRejected { status: 429 };
+                        capacity_pool = Some(rate_limit_pool.clone());
+                        mutation = Mutation::Capacity {
+                            pool: rate_limit_pool.clone(),
+                            retry_after: failure.retry_after,
+                        };
+                    }
+                    Some(status @ (503 | 529)) => {
+                        let pool = CapacityPoolKey::ProviderModel(route.clone());
+                        signal = ShadowSignal::CapacityRejected { status };
+                        capacity_pool = Some(pool.clone());
+                        mutation = Mutation::Capacity {
+                            pool,
+                            retry_after: failure.retry_after,
+                        };
+                    }
+                    _ => {
+                        signal = ShadowSignal::Neutral {
+                            kind: failure.kind,
+                            status,
+                        };
+                        mutation = Mutation::None;
+                    }
+                }
+            } else if failure.kind == AttemptFailureKind::HttpStatus {
+                if status.is_some_and(|status| (500..=599).contains(&status)) {
+                    signal = ShadowSignal::RouteFailure {
+                        kind: failure.kind,
+                        status,
+                    };
+                    mutation = Mutation::RouteFailure;
+                } else {
+                    signal = ShadowSignal::Neutral {
+                        kind: failure.kind,
+                        status,
+                    };
+                    mutation = Mutation::None;
+                }
+            } else if is_route_health_failure(failure.kind) {
+                signal = ShadowSignal::RouteFailure {
+                    kind: failure.kind,
+                    status,
+                };
+                mutation = Mutation::RouteFailure;
+            } else {
+                signal = ShadowSignal::Neutral {
+                    kind: failure.kind,
+                    status,
+                };
+                mutation = Mutation::None;
+            }
+        }
+
+        let mutated = mode == ShadowObservationMode::Update && mutation != Mutation::None;
+        if mutated {
+            self.apply_mutation(inner, &route, &rate_limit_pool, mutation, now);
+        }
+
+        ShadowObservationReport {
+            policy_version: SHADOW_HEALTH_POLICY_VERSION,
+            mode,
+            route: route.clone(),
+            signal,
+            capacity_pool,
+            snapshot: self.snapshot_locked(inner, &route, now),
+            mutated,
+        }
+    }
+
+    fn apply_mutation(
+        &self,
+        inner: &mut ShadowHealthInner,
+        route: &RouteKey,
+        rate_limit_pool: &CapacityPoolKey,
+        mutation: Mutation,
+        now: Instant,
+    ) {
+        match mutation {
+            Mutation::Completed => {
+                if let Some(state) = inner.route_health.get_mut(route) {
+                    apply_route_success(state, now);
+                }
+
+                let deployment_pool = CapacityPoolKey::ProviderModel(route.clone());
+                if let Some(state) = inner.capacity.get_mut(&deployment_pool) {
+                    apply_capacity_success(state, now);
+                }
+                if rate_limit_pool != &deployment_pool {
+                    if let Some(state) = inner.capacity.get_mut(rate_limit_pool) {
+                        apply_capacity_success(state, now);
+                    }
+                }
+            }
+            Mutation::Capacity { pool, retry_after } => {
+                if let Some(state) = inner.capacity.get_mut(&pool) {
+                    let cooldown = retry_after
+                        .unwrap_or(self.policy.default_capacity_cooldown)
+                        .min(self.policy.max_capacity_cooldown);
+                    extend_open_until(&mut state.open_until, now, cooldown);
+                }
+            }
+            Mutation::RouteFailure => {
+                if let Some(state) = inner.route_health.get_mut(route) {
+                    apply_route_failure(state, self.policy, now);
+                }
+            }
+            Mutation::None => {}
+        }
+    }
+
+    fn snapshot_locked(
+        &self,
+        inner: &ShadowHealthInner,
+        route: &RouteKey,
+        now: Instant,
+    ) -> Option<ShadowRouteSnapshot> {
+        let route_health = route_health_disposition(
+            inner.route_health.get(route)?,
+            self.policy.route_failure_window,
+            now,
+        );
+        let deployment_pool = CapacityPoolKey::ProviderModel(route.clone());
+        let deployment_capacity = capacity_disposition(inner.capacity.get(&deployment_pool)?, now);
+        let rate_limit_pool = self.rate_limit_pools.get(route)?;
+        let rate_limit_capacity = capacity_disposition(inner.capacity.get(rate_limit_pool)?, now);
+        let effective =
+            strongest_disposition([route_health, deployment_capacity, rate_limit_capacity]);
+
+        Some(ShadowRouteSnapshot {
+            route_health,
+            deployment_capacity,
+            rate_limit_capacity,
+            effective,
+        })
+    }
+
+    fn lock(&self) -> MutexGuard<'_, ShadowHealthInner> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    #[cfg(test)]
+    fn with_policy(policy: ShadowHealthPolicy) -> Self {
+        Self::new_with_policy(&PROVIDER_REGISTRY, policy)
+    }
+
+    #[cfg(test)]
+    fn observe_terminal_at(
+        &self,
+        terminal: &AttemptTerminal,
+        mode: ShadowObservationMode,
+        now: Instant,
+    ) -> ShadowObservationReport {
+        let mut inner = self.lock();
+        self.observe_terminal_locked(&mut inner, terminal, mode, now)
+    }
+
+    #[cfg(test)]
+    fn snapshot_at(&self, route: &RouteKey, now: Instant) -> Option<ShadowRouteSnapshot> {
+        let inner = self.lock();
+        self.snapshot_locked(&inner, route, now)
+    }
+
+    #[cfg(test)]
+    fn cardinality(&self) -> (usize, usize) {
+        let inner = self.lock();
+        (inner.route_health.len(), inner.capacity.len())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn observation_count(&self) -> usize {
+        self.observation_count.load(Ordering::Relaxed)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Mutation {
+    Completed,
+    Capacity {
+        pool: CapacityPoolKey,
+        retry_after: Option<Duration>,
+    },
+    RouteFailure,
+    None,
+}
+
+fn is_route_health_failure(kind: AttemptFailureKind) -> bool {
+    match kind {
+        AttemptFailureKind::Connect
+        | AttemptFailureKind::Transport
+        | AttemptFailureKind::ResponseStartTimeout
+        | AttemptFailureKind::ResponseBody
+        | AttemptFailureKind::InvalidResponse
+        | AttemptFailureKind::UpstreamResponseError
+        | AttemptFailureKind::UpstreamStreamError
+        | AttemptFailureKind::StreamTimeout
+        | AttemptFailureKind::UnexpectedEof => true,
+        AttemptFailureKind::ProviderUnavailable
+        | AttemptFailureKind::RequestBuild
+        | AttemptFailureKind::HttpStatus
+        | AttemptFailureKind::CapacityRejected
+        | AttemptFailureKind::ConsumerDropped => false,
+    }
+}
+
+fn apply_route_failure(state: &mut RouteHealthState, policy: ShadowHealthPolicy, now: Instant) {
+    if state.open_until.is_some_and(|until| now < until) {
+        extend_open_until(&mut state.open_until, now, policy.route_open_cooldown);
+        return;
+    }
+
+    state.failure_times.retain(|failure_at| {
+        now.checked_duration_since(*failure_at)
+            .is_none_or(|age| age <= policy.route_failure_window)
+    });
+    state.failure_times.push_back(now);
+
+    // The queue never needs more entries than the threshold. Keeping only the
+    // bounded recent tail makes the fixed-topology state safe even if a future
+    // shadow policy raises its observation volume.
+    let threshold = usize::from(policy.route_failures_to_open.max(1));
+    while state.failure_times.len() > threshold {
+        state.failure_times.pop_front();
+    }
+
+    if state.failure_times.len() >= threshold {
+        extend_open_until(&mut state.open_until, now, policy.route_open_cooldown);
+    } else {
+        state.open_until = None;
+    }
+}
+
+fn apply_route_success(state: &mut RouteHealthState, now: Instant) {
+    if state.open_until.is_some_and(|until| now < until) {
+        return;
+    }
+    state.failure_times.clear();
+    state.open_until = None;
+}
+
+fn apply_capacity_success(state: &mut CapacityState, now: Instant) {
+    if state.open_until.is_some_and(|until| now >= until) {
+        state.open_until = None;
+    }
+}
+
+fn extend_open_until(open_until: &mut Option<Instant>, now: Instant, cooldown: Duration) {
+    let candidate = now.checked_add(cooldown).unwrap_or(now);
+    *open_until = Some(open_until.map_or(candidate, |current| current.max(candidate)));
+}
+
+fn route_health_disposition(
+    state: &RouteHealthState,
+    failure_window: Duration,
+    now: Instant,
+) -> ShadowDisposition {
+    if let Some(until) = state.open_until {
+        return if now < until {
+            ShadowDisposition::WouldOpen {
+                remaining: until.duration_since(now),
+            }
+        } else {
+            ShadowDisposition::WouldProbe
+        };
+    }
+
+    let current_failures = state
+        .failure_times
+        .iter()
+        .filter(|failure_at| {
+            now.checked_duration_since(**failure_at)
+                .is_none_or(|age| age <= failure_window)
+        })
+        .count();
+    if current_failures > 0 {
+        ShadowDisposition::Watch {
+            consecutive_failures: u8::try_from(current_failures).unwrap_or(u8::MAX),
+        }
+    } else {
+        ShadowDisposition::Healthy
+    }
+}
+
+fn capacity_disposition(state: &CapacityState, now: Instant) -> ShadowDisposition {
+    match state.open_until {
+        Some(until) if now < until => ShadowDisposition::WouldOpen {
+            remaining: until.duration_since(now),
+        },
+        Some(_) => ShadowDisposition::WouldProbe,
+        None => ShadowDisposition::Healthy,
+    }
+}
+
+fn strongest_disposition(
+    dispositions: impl IntoIterator<Item = ShadowDisposition>,
+) -> ShadowDisposition {
+    dispositions
+        .into_iter()
+        .fold(ShadowDisposition::Healthy, stronger_disposition)
+}
+
+fn stronger_disposition(left: ShadowDisposition, right: ShadowDisposition) -> ShadowDisposition {
+    match (left, right) {
+        (
+            ShadowDisposition::WouldOpen {
+                remaining: left_remaining,
+            },
+            ShadowDisposition::WouldOpen {
+                remaining: right_remaining,
+            },
+        ) => ShadowDisposition::WouldOpen {
+            remaining: left_remaining.max(right_remaining),
+        },
+        (left @ ShadowDisposition::WouldOpen { .. }, _) => left,
+        (_, right @ ShadowDisposition::WouldOpen { .. }) => right,
+        (ShadowDisposition::WouldProbe, _) | (_, ShadowDisposition::WouldProbe) => {
+            ShadowDisposition::WouldProbe
+        }
+        (
+            ShadowDisposition::Watch {
+                consecutive_failures: left_failures,
+            },
+            ShadowDisposition::Watch {
+                consecutive_failures: right_failures,
+            },
+        ) => ShadowDisposition::Watch {
+            consecutive_failures: left_failures.max(right_failures),
+        },
+        (left @ ShadowDisposition::Watch { .. }, _) => left,
+        (_, right @ ShadowDisposition::Watch { .. }) => right,
+        (ShadowDisposition::Healthy, ShadowDisposition::Healthy) => ShadowDisposition::Healthy,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inference::{
+        AttemptFailure, AttemptStage, CompletionEvidence, InferenceExecution, ReplaySafety,
+        RouteIdentity,
+    };
+    use crate::provider_registry::RouteSelectionSource;
+    use std::sync::Arc;
+    use std::thread;
+
+    fn route(provider: ProviderId, public_model: &str, provider_model: &str) -> RouteIdentity {
+        RouteIdentity::new(
+            provider,
+            public_model,
+            provider_model,
+            public_model,
+            RouteSelectionSource::StaticSplit,
+            None,
+        )
+    }
+
+    fn completed(route: RouteIdentity) -> AttemptTerminal {
+        AttemptTerminal::Completed {
+            attempt: InferenceExecution {
+                request_id: super::super::InferenceRequestId::new(),
+                execution_id: super::super::InferenceExecutionId::new(),
+            }
+            .begin_attempt(route),
+            evidence: CompletionEvidence::ProviderDone,
+        }
+    }
+
+    fn failed(
+        route: RouteIdentity,
+        kind: AttemptFailureKind,
+        status: Option<u16>,
+        retry_after: Option<Duration>,
+    ) -> AttemptTerminal {
+        let mut failure = AttemptFailure::new(
+            kind,
+            AttemptStage::AwaitingResponse,
+            ReplaySafety::NotProvenPreAcceptance,
+        );
+        failure.status = status;
+        failure.retry_after = retry_after;
+        AttemptTerminal::Failed {
+            attempt: InferenceExecution {
+                request_id: super::super::InferenceRequestId::new(),
+                execution_id: super::super::InferenceExecutionId::new(),
+            }
+            .begin_attempt(route),
+            failure,
+        }
+    }
+
+    fn test_policy() -> ShadowHealthPolicy {
+        ShadowHealthPolicy {
+            route_failure_window: Duration::from_secs(10),
+            route_failures_to_open: 3,
+            route_open_cooldown: Duration::from_secs(5),
+            default_capacity_cooldown: Duration::from_secs(4),
+            max_capacity_cooldown: Duration::from_secs(10),
+        }
+    }
+
+    #[test]
+    fn classifier_is_exhaustive_and_only_provider_faults_penalize_health() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let now = Instant::now();
+        let kimi = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+
+        let route_failures = [
+            AttemptFailureKind::Connect,
+            AttemptFailureKind::Transport,
+            AttemptFailureKind::ResponseStartTimeout,
+            AttemptFailureKind::ResponseBody,
+            AttemptFailureKind::InvalidResponse,
+            AttemptFailureKind::UpstreamResponseError,
+            AttemptFailureKind::UpstreamStreamError,
+            AttemptFailureKind::StreamTimeout,
+            AttemptFailureKind::UnexpectedEof,
+        ];
+        for kind in route_failures {
+            let report = state.observe_terminal_at(
+                &failed(kimi.clone(), kind, None, None),
+                ShadowObservationMode::TelemetryOnly,
+                now,
+            );
+            assert!(matches!(
+                report.signal,
+                ShadowSignal::RouteFailure {
+                    kind: observed,
+                    status: None
+                } if observed == kind
+            ));
+            assert!(!report.mutated);
+        }
+
+        for kind in [
+            AttemptFailureKind::ProviderUnavailable,
+            AttemptFailureKind::RequestBuild,
+            AttemptFailureKind::ConsumerDropped,
+        ] {
+            let report = state.observe_terminal_at(
+                &failed(kimi.clone(), kind, None, None),
+                ShadowObservationMode::Update,
+                now,
+            );
+            assert!(matches!(report.signal, ShadowSignal::Neutral { .. }));
+            assert!(!report.mutated);
+        }
+
+        let server = state.observe_terminal_at(
+            &failed(
+                kimi.clone(),
+                AttemptFailureKind::HttpStatus,
+                Some(500),
+                None,
+            ),
+            ShadowObservationMode::TelemetryOnly,
+            now,
+        );
+        assert!(matches!(server.signal, ShadowSignal::RouteFailure { .. }));
+
+        let caller = state.observe_terminal_at(
+            &failed(
+                kimi.clone(),
+                AttemptFailureKind::HttpStatus,
+                Some(400),
+                None,
+            ),
+            ShadowObservationMode::Update,
+            now,
+        );
+        assert!(matches!(caller.signal, ShadowSignal::Neutral { .. }));
+        assert!(!caller.mutated);
+
+        let malformed_capacity = state.observe_terminal_at(
+            &failed(kimi, AttemptFailureKind::CapacityRejected, Some(500), None),
+            ShadowObservationMode::Update,
+            now,
+        );
+        assert!(matches!(
+            malformed_capacity.signal,
+            ShadowSignal::Neutral { .. }
+        ));
+        assert!(!malformed_capacity.mutated);
+    }
+
+    #[test]
+    fn provider_specific_rate_limit_scopes_and_deployment_capacity_are_isolated() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let now = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let quick = route(ProviderId::Tinfoil, "gpt-oss-120b", "gpt-oss-120b");
+        let k2 = route(ProviderId::Continuum, "kimi-k2-6", "kimi-k2.6");
+        let glm_continuum = route(ProviderId::Continuum, "glm-5-3", "glm-5.3");
+        let glm_tinfoil = route(ProviderId::Tinfoil, "glm-5-3", "glm-5-3");
+        let glm_flash = route(ProviderId::Tinfoil, "glm-5-3-flash", "glm-5-3-flash");
+
+        let tinfoil = state.observe_terminal_at(
+            &failed(
+                k3.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(5)),
+            ),
+            ShadowObservationMode::Update,
+            now,
+        );
+        assert_eq!(
+            tinfoil.capacity_pool,
+            Some(CapacityPoolKey::ProviderModel(k3.route_key()))
+        );
+        assert!(matches!(
+            state.snapshot_at(&k3.route_key(), now).unwrap().effective,
+            ShadowDisposition::WouldOpen { .. }
+        ));
+        assert_eq!(
+            state
+                .snapshot_at(&quick.route_key(), now)
+                .unwrap()
+                .effective,
+            ShadowDisposition::Healthy
+        );
+
+        let continuum = state.observe_terminal_at(
+            &failed(
+                k2.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(5)),
+            ),
+            ShadowObservationMode::Update,
+            now,
+        );
+        assert_eq!(
+            continuum.capacity_pool,
+            Some(CapacityPoolKey::ProviderAccount(ProviderId::Continuum))
+        );
+        assert!(matches!(
+            state
+                .snapshot_at(&glm_continuum.route_key(), now)
+                .unwrap()
+                .effective,
+            ShadowDisposition::WouldOpen { .. }
+        ));
+        assert_eq!(
+            state
+                .snapshot_at(&glm_tinfoil.route_key(), now)
+                .unwrap()
+                .effective,
+            ShadowDisposition::Healthy
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&glm_flash.route_key(), now)
+                .unwrap()
+                .effective,
+            ShadowDisposition::Healthy
+        );
+
+        let tinfoil_glm = state.observe_terminal_at(
+            &failed(
+                glm_tinfoil.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(5)),
+            ),
+            ShadowObservationMode::Update,
+            now,
+        );
+        assert_eq!(
+            tinfoil_glm.capacity_pool,
+            Some(CapacityPoolKey::ProviderModel(glm_tinfoil.route_key()))
+        );
+        assert!(matches!(
+            state
+                .snapshot_at(&glm_tinfoil.route_key(), now)
+                .unwrap()
+                .effective,
+            ShadowDisposition::WouldOpen { .. }
+        ));
+        assert_eq!(
+            state
+                .snapshot_at(&glm_flash.route_key(), now)
+                .unwrap()
+                .effective,
+            ShadowDisposition::Healthy
+        );
+
+        for status in [503, 529] {
+            let deployment_state = ShadowHealthState::with_policy(test_policy());
+            deployment_state.observe_terminal_at(
+                &failed(
+                    k2.clone(),
+                    AttemptFailureKind::CapacityRejected,
+                    Some(status),
+                    Some(Duration::from_secs(5)),
+                ),
+                ShadowObservationMode::Update,
+                now,
+            );
+            assert!(matches!(
+                deployment_state
+                    .snapshot_at(&k2.route_key(), now)
+                    .unwrap()
+                    .effective,
+                ShadowDisposition::WouldOpen { .. }
+            ));
+            assert_eq!(
+                deployment_state
+                    .snapshot_at(&glm_continuum.route_key(), now)
+                    .unwrap()
+                    .effective,
+                ShadowDisposition::Healthy
+            );
+
+            deployment_state.observe_terminal_at(
+                &failed(
+                    glm_tinfoil.clone(),
+                    AttemptFailureKind::CapacityRejected,
+                    Some(status),
+                    Some(Duration::from_secs(5)),
+                ),
+                ShadowObservationMode::Update,
+                now,
+            );
+            assert!(matches!(
+                deployment_state
+                    .snapshot_at(&glm_tinfoil.route_key(), now)
+                    .unwrap()
+                    .effective,
+                ShadowDisposition::WouldOpen { .. }
+            ));
+            assert_eq!(
+                deployment_state
+                    .snapshot_at(&glm_flash.route_key(), now)
+                    .unwrap()
+                    .effective,
+                ShadowDisposition::Healthy
+            );
+        }
+    }
+
+    #[test]
+    fn capacity_cooldowns_are_bounded_and_success_cannot_clear_them_early() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let start = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let key = k3.route_key();
+
+        state.observe_terminal_at(
+            &failed(
+                k3.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                None,
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+        assert_eq!(
+            state.snapshot_at(&key, start).unwrap().effective,
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(4)
+            }
+        );
+
+        state.observe_terminal_at(
+            &completed(k3.clone()),
+            ShadowObservationMode::Update,
+            start + Duration::from_secs(1),
+        );
+        assert!(matches!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(1))
+                .unwrap()
+                .effective,
+            ShadowDisposition::WouldOpen { .. }
+        ));
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(4))
+                .unwrap()
+                .effective,
+            ShadowDisposition::WouldProbe
+        );
+
+        state.observe_terminal_at(
+            &completed(k3.clone()),
+            ShadowObservationMode::Update,
+            start + Duration::from_secs(4),
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(4))
+                .unwrap()
+                .effective,
+            ShadowDisposition::Healthy
+        );
+
+        state.observe_terminal_at(
+            &failed(
+                k3,
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(100)),
+            ),
+            ShadowObservationMode::Update,
+            start + Duration::from_secs(20),
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(20))
+                .unwrap()
+                .effective,
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(10)
+            }
+        );
+    }
+
+    #[test]
+    fn route_health_uses_a_window_threshold_and_terminal_success_reset() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let start = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let key = k3.route_key();
+        let fault = || failed(k3.clone(), AttemptFailureKind::StreamTimeout, None, None);
+
+        state.observe_terminal_at(&fault(), ShadowObservationMode::Update, start);
+        assert_eq!(
+            state.snapshot_at(&key, start).unwrap().route_health,
+            ShadowDisposition::Watch {
+                consecutive_failures: 1
+            }
+        );
+
+        state.observe_terminal_at(
+            &completed(k3.clone()),
+            ShadowObservationMode::Update,
+            start + Duration::from_secs(1),
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(1))
+                .unwrap()
+                .route_health,
+            ShadowDisposition::Healthy
+        );
+
+        for offset in [2, 3, 4] {
+            state.observe_terminal_at(
+                &fault(),
+                ShadowObservationMode::Update,
+                start + Duration::from_secs(offset),
+            );
+        }
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(4))
+                .unwrap()
+                .route_health,
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(5)
+            }
+        );
+
+        state.observe_terminal_at(
+            &completed(k3.clone()),
+            ShadowObservationMode::Update,
+            start + Duration::from_secs(5),
+        );
+        assert!(matches!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(5))
+                .unwrap()
+                .route_health,
+            ShadowDisposition::WouldOpen { .. }
+        ));
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(9))
+                .unwrap()
+                .route_health,
+            ShadowDisposition::WouldProbe
+        );
+
+        state.observe_terminal_at(
+            &completed(k3.clone()),
+            ShadowObservationMode::Update,
+            start + Duration::from_secs(9),
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(9))
+                .unwrap()
+                .route_health,
+            ShadowDisposition::Healthy
+        );
+
+        state.observe_terminal_at(
+            &fault(),
+            ShadowObservationMode::Update,
+            start + Duration::from_secs(30),
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(30))
+                .unwrap()
+                .route_health,
+            ShadowDisposition::Watch {
+                consecutive_failures: 1
+            }
+        );
+    }
+
+    #[test]
+    fn route_health_threshold_uses_one_bounded_rolling_window() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let start = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let key = k3.route_key();
+        let fault = || failed(k3.clone(), AttemptFailureKind::StreamTimeout, None, None);
+
+        for offset in [0, 9, 18] {
+            state.observe_terminal_at(
+                &fault(),
+                ShadowObservationMode::Update,
+                start + Duration::from_secs(offset),
+            );
+        }
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(18))
+                .unwrap()
+                .route_health,
+            ShadowDisposition::Watch {
+                consecutive_failures: 2
+            }
+        );
+
+        state.observe_terminal_at(
+            &fault(),
+            ShadowObservationMode::Update,
+            start + Duration::from_secs(19),
+        );
+        assert!(matches!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(19))
+                .unwrap()
+                .route_health,
+            ShadowDisposition::WouldOpen { .. }
+        ));
+    }
+
+    #[test]
+    fn recovered_transport_attempts_are_telemetry_only() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let now = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let key = k3.route_key();
+
+        let recovered = state.observe_terminal_at(
+            &failed(k3.clone(), AttemptFailureKind::Connect, None, None),
+            ShadowObservationMode::TelemetryOnly,
+            now,
+        );
+        assert!(matches!(
+            recovered.signal,
+            ShadowSignal::RouteFailure {
+                kind: AttemptFailureKind::Connect,
+                ..
+            }
+        ));
+        assert!(!recovered.mutated);
+
+        state.observe_terminal_at(
+            &completed(k3),
+            ShadowObservationMode::Update,
+            now + Duration::from_millis(1),
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&key, now + Duration::from_millis(1))
+                .unwrap()
+                .effective,
+            ShadowDisposition::Healthy
+        );
+    }
+
+    #[test]
+    fn registry_topology_bounds_state_under_concurrent_observation() {
+        let state = Arc::new(ShadowHealthState::with_policy(test_policy()));
+        let cardinality = state.cardinality();
+        let terminal = completed(route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3"));
+
+        let threads = (0..32)
+            .map(|_| {
+                let state = Arc::clone(&state);
+                let terminal = terminal.clone();
+                thread::spawn(move || {
+                    state.observe_terminal(&terminal, ShadowObservationMode::Update)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for thread in threads {
+            let report = thread.join().expect("observation thread");
+            assert!(report.mutated);
+        }
+        assert_eq!(state.cardinality(), cardinality);
+
+        let unknown = completed(route(ProviderId::Tinfoil, "unknown", "unknown"));
+        let report = state.observe_terminal(&unknown, ShadowObservationMode::Update);
+        assert_eq!(report.signal, ShadowSignal::UnknownRoute);
+        assert!(!report.mutated);
+        assert_eq!(state.cardinality(), cardinality);
+    }
+}

--- a/src/provider_registry.rs
+++ b/src/provider_registry.rs
@@ -41,11 +41,24 @@ pub(crate) struct ProviderSpec {
     pub(crate) enabled: bool,
 }
 
+/// Scope of an upstream 429 for a configured completion route.
+///
+/// Tinfoil meters the shared OpenSecret credential per model, while
+/// Continuum/Edgeless documents organization-level limits. Keeping this in the
+/// credential-free registry prevents runtime error text or arbitrary model
+/// strings from defining health-state keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RateLimitScope {
+    ProviderModel,
+    ProviderAccount,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ModelRouteSpec {
     pub(crate) provider: ProviderId,
     pub(crate) provider_model_id: &'static str,
     pub(crate) response_model_id: &'static str,
+    pub(crate) rate_limit_scope: RateLimitScope,
     pub(crate) weight: u16,
     pub(crate) enabled: bool,
 }
@@ -78,7 +91,6 @@ impl ProviderRegistry {
             .find(|model| model.public_model_id == public_model_id)
     }
 
-    #[cfg(test)]
     pub(crate) fn completion_models(&self) -> &'static [CompletionModelSpec] {
         self.completion_models
     }
@@ -101,6 +113,7 @@ const GPT_OSS_120B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider: ProviderId::Tinfoil,
     provider_model_id: QUICK_MODEL_ID,
     response_model_id: QUICK_MODEL_ID,
+    rate_limit_scope: RateLimitScope::ProviderModel,
     weight: 100,
     enabled: true,
 }];
@@ -109,6 +122,7 @@ const GEMMA4_31B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider: ProviderId::Tinfoil,
     provider_model_id: "gemma4-31b",
     response_model_id: "gemma4-31b",
+    rate_limit_scope: RateLimitScope::ProviderModel,
     weight: 100,
     enabled: true,
 }];
@@ -117,6 +131,7 @@ const KIMI_K3_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider: ProviderId::Tinfoil,
     provider_model_id: KIMI_K3_MODEL_ID,
     response_model_id: KIMI_K3_MODEL_ID,
+    rate_limit_scope: RateLimitScope::ProviderModel,
     weight: 100,
     enabled: true,
 }];
@@ -125,6 +140,7 @@ const KIMI_K2_6_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider: ProviderId::Continuum,
     provider_model_id: "kimi-k2.6",
     response_model_id: KIMI_K2_6_MODEL_ID,
+    rate_limit_scope: RateLimitScope::ProviderAccount,
     weight: 100,
     enabled: true,
 }];
@@ -133,6 +149,7 @@ const GLM_5_2_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider: ProviderId::Tinfoil,
     provider_model_id: GLM_5_2_MODEL_ID,
     response_model_id: GLM_5_2_MODEL_ID,
+    rate_limit_scope: RateLimitScope::ProviderModel,
     weight: 100,
     enabled: true,
 }];
@@ -142,6 +159,7 @@ const GLM_5_3_ROUTES: &[ModelRouteSpec] = &[
         provider: ProviderId::Continuum,
         provider_model_id: "glm-5.3",
         response_model_id: GLM_5_3_MODEL_ID,
+        rate_limit_scope: RateLimitScope::ProviderAccount,
         weight: 100,
         enabled: true,
     },
@@ -149,6 +167,7 @@ const GLM_5_3_ROUTES: &[ModelRouteSpec] = &[
         provider: ProviderId::Tinfoil,
         provider_model_id: GLM_5_3_MODEL_ID,
         response_model_id: GLM_5_3_MODEL_ID,
+        rate_limit_scope: RateLimitScope::ProviderModel,
         weight: 100,
         enabled: true,
     },
@@ -158,6 +177,7 @@ const GLM_5_3_FLASH_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider: ProviderId::Tinfoil,
     provider_model_id: GLM_5_3_FLASH_MODEL_ID,
     response_model_id: GLM_5_3_FLASH_MODEL_ID,
+    rate_limit_scope: RateLimitScope::ProviderModel,
     weight: 100,
     enabled: true,
 }];
@@ -166,6 +186,7 @@ const DEEPSEEK_V4_FLASH_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider: ProviderId::Tinfoil,
     provider_model_id: DEEPSEEK_V4_FLASH_MODEL_ID,
     response_model_id: DEEPSEEK_V4_FLASH_MODEL_ID,
+    rate_limit_scope: RateLimitScope::ProviderModel,
     weight: 100,
     enabled: true,
 }];
@@ -174,6 +195,7 @@ const LLAMA3_3_70B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider: ProviderId::Tinfoil,
     provider_model_id: "llama3-3-70b",
     response_model_id: "llama3-3-70b",
+    rate_limit_scope: RateLimitScope::ProviderModel,
     weight: 100,
     enabled: true,
 }];
@@ -182,6 +204,7 @@ const GPT_OSS_SAFEGUARD_120B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider: ProviderId::Tinfoil,
     provider_model_id: "gpt-oss-safeguard-120b",
     response_model_id: "gpt-oss-safeguard-120b",
+    rate_limit_scope: RateLimitScope::ProviderModel,
     weight: 100,
     enabled: true,
 }];
@@ -414,5 +437,50 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    #[test]
+    fn registry_pins_provider_specific_rate_limit_scopes() {
+        let scopes = PROVIDER_REGISTRY
+            .completion_models()
+            .iter()
+            .flat_map(|model| {
+                model.routes.iter().map(move |route| {
+                    (
+                        route.provider,
+                        route.provider_model_id,
+                        route.rate_limit_scope,
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+
+        assert!(scopes.iter().all(|(provider, _, scope)| match provider {
+            ProviderId::Tinfoil => *scope == RateLimitScope::ProviderModel,
+            ProviderId::Continuum => *scope == RateLimitScope::ProviderAccount,
+        }));
+        assert!(scopes
+            .iter()
+            .any(|(provider, model, scope)| *provider == ProviderId::Tinfoil
+                && *model == KIMI_K3_MODEL_ID
+                && *scope == RateLimitScope::ProviderModel));
+        assert!(scopes.iter().any(|(provider, model, scope)| {
+            *provider == ProviderId::Continuum
+                && *model == "glm-5.3"
+                && *scope == RateLimitScope::ProviderAccount
+        }));
+        assert!(scopes.iter().any(|(provider, model, scope)| {
+            *provider == ProviderId::Tinfoil
+                && *model == GLM_5_3_MODEL_ID
+                && *scope == RateLimitScope::ProviderModel
+        }));
+        assert!(scopes.iter().any(|(provider, model, scope)| {
+            *provider == ProviderId::Tinfoil
+                && *model == GLM_5_3_FLASH_MODEL_ID
+                && *scope == RateLimitScope::ProviderModel
+        }));
+        assert!(!scopes.iter().any(|(provider, model, _)| {
+            *provider == ProviderId::Continuum && *model == "glm-5.2"
+        }));
     }
 }

--- a/src/provider_routing.rs
+++ b/src/provider_routing.rs
@@ -1,4 +1,7 @@
-use crate::inference::{InferenceIntent, RouteIdentity};
+use crate::inference::health::{
+    ShadowHealthState, ShadowObservationMode, ShadowObservationReport, ShadowRouteSnapshot,
+};
+use crate::inference::{AttemptTerminal, InferenceIntent, RouteIdentity, RouteKey};
 use crate::inference_planning::{
     plan_completion_route, ConfiguredProviders, ProviderPreference, RoutePlan, RoutePlanningError,
     RoutePlanningInput,
@@ -139,6 +142,7 @@ pub(crate) enum ShadowRouteComparison {
 pub(crate) struct ProviderRouter {
     config: &'static ProviderRoutingConfig,
     registry: &'static ProviderRegistry,
+    shadow_health: ShadowHealthState,
 }
 
 #[derive(Debug, Clone)]
@@ -233,11 +237,29 @@ impl Default for ProviderRouter {
         Self {
             config: &DEFAULT_PROVIDER_ROUTING_CONFIG,
             registry: &PROVIDER_REGISTRY,
+            shadow_health: ShadowHealthState::new(&PROVIDER_REGISTRY),
         }
     }
 }
 
 impl ProviderRouter {
+    pub(crate) fn observe_attempt_terminal(
+        &self,
+        terminal: &AttemptTerminal,
+        mode: ShadowObservationMode,
+    ) -> ShadowObservationReport {
+        self.shadow_health.observe_terminal(terminal, mode)
+    }
+
+    pub(crate) fn shadow_health_snapshot(&self, route: &RouteKey) -> Option<ShadowRouteSnapshot> {
+        self.shadow_health.snapshot(route)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn shadow_observation_count(&self) -> usize {
+        self.shadow_health.observation_count()
+    }
+
     #[cfg(test)]
     pub(crate) fn select_completion_route(
         &self,
@@ -605,7 +627,11 @@ fn proxy_for_provider(proxy_router: &ProxyRouter, provider: ProviderId) -> Optio
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::inference::{InferenceSurface, WorkloadClass};
+    use crate::inference::health::{ShadowDisposition, ShadowObservationMode};
+    use crate::inference::{
+        AttemptFailure, AttemptFailureKind, AttemptStage, AttemptTerminal, InferenceSurface,
+        ReplaySafety, WorkloadClass,
+    };
     use crate::model_config::{
         ModelAliasTargets, ModelPlan, PaidModelAliasOverrides, AUTO_POWERFUL_MODEL_ID,
         AUTO_QUICK_MODEL_ID, DEEPSEEK_V4_FLASH_MODEL_ID, GLM_5_2_MODEL_ID, GLM_5_3_FLASH_MODEL_ID,
@@ -613,6 +639,7 @@ mod tests {
     };
     use crate::os_flags::PAID_POWERFUL_GLM_5_3_ALIAS_FLAG_KEY;
     use std::collections::HashMap;
+    use std::time::Duration;
 
     fn proxy_router_with_both_providers() -> ProxyRouter {
         ProxyRouter::new(
@@ -1005,6 +1032,72 @@ mod tests {
                 }
             ));
         }
+    }
+
+    #[test]
+    fn hypothetical_open_capacity_never_changes_active_or_shadow_route_selection() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        let account_uuid = uuid_for_bucket(73);
+        let provider_preference = Some(ProviderPreference::feature_flag(ProviderId::Tinfoil));
+        let intent = InferenceIntent::new(
+            account_uuid,
+            GLM_5_3_MODEL_ID,
+            GLM_5_3_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+
+        let active_before = router
+            .select_completion_route_with_preference(
+                &proxy_router,
+                account_uuid,
+                GLM_5_3_MODEL_ID,
+                provider_preference,
+            )
+            .expect("active route before shadow health");
+        let shadow_before = router
+            .shadow_completion_plan(&proxy_router, &intent, provider_preference)
+            .expect("shadow route before shadow health");
+
+        let mut failure = AttemptFailure::new(
+            AttemptFailureKind::CapacityRejected,
+            AttemptStage::AwaitingResponse,
+            ReplaySafety::ProvenPreAcceptance,
+        );
+        failure.status = Some(429);
+        failure.retry_after = Some(Duration::from_secs(60));
+        let terminal = AttemptTerminal::Failed {
+            attempt: intent
+                .begin_execution()
+                .begin_attempt(active_before.identity()),
+            failure,
+        };
+        let report = router.observe_attempt_terminal(&terminal, ShadowObservationMode::Update);
+        assert!(matches!(
+            report.snapshot.expect("known route").effective,
+            ShadowDisposition::WouldOpen { .. }
+        ));
+
+        let active_after = router
+            .select_completion_route_with_preference(
+                &proxy_router,
+                account_uuid,
+                GLM_5_3_MODEL_ID,
+                provider_preference,
+            )
+            .expect("active route after shadow health");
+        let shadow_after = router
+            .shadow_completion_plan(&proxy_router, &intent, provider_preference)
+            .expect("shadow route after shadow health");
+
+        assert_eq!(active_after.identity(), active_before.identity());
+        assert_eq!(shadow_after, shadow_before);
+        assert!(matches!(
+            compare_shadow_route(&Ok(active_after), &Ok(shadow_after)),
+            ShadowRouteComparison::Match { .. }
+        ));
     }
 
     #[test]

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -1,3 +1,4 @@
+use crate::inference::health::ShadowObservationMode;
 use crate::inference::{
     AttemptFailure, AttemptFailureKind, AttemptOutcome, AttemptStage, AttemptTerminal,
     CompletionEvidence, InferenceAttempt, InferenceExecution, InferenceIntent, InferenceSurface,
@@ -19,8 +20,8 @@ use crate::provider_client::{
 };
 use crate::provider_registry::{ProviderId, SHADOW_ROUTING_POLICY_VERSION};
 use crate::provider_routing::{
-    compare_shadow_route, InferenceRoutingMode, ProviderRoutingError, SelectedProviderRoute,
-    ShadowRouteComparison,
+    compare_shadow_route, InferenceRoutingMode, ProviderRouter, ProviderRoutingError,
+    SelectedProviderRoute, ShadowRouteComparison,
 };
 use crate::proxy_config::ProxyConfig;
 use crate::sqs::UsageEvent;
@@ -891,77 +892,20 @@ impl From<ApiError> for CompletionExecutionError {
 }
 
 fn failed_completion_execution(
+    provider_router: &ProviderRouter,
     attempt: InferenceAttempt,
     failure: AttemptFailure,
     public_error: ApiError,
 ) -> CompletionExecutionError {
     let terminal = AttemptTerminal::Failed { attempt, failure };
-    record_attempt_outcome(&AttemptOutcome::Terminal(terminal.clone()));
+    record_attempt_outcome(
+        provider_router,
+        &AttemptOutcome::Terminal(terminal.clone()),
+        ShadowObservationMode::Update,
+    );
     CompletionExecutionError::Attempt {
         terminal,
         public_error,
-    }
-}
-
-/// Ensures cancellation or panic cannot make an in-flight attempt disappear
-/// from the typed terminal stream. Later routing layers may attach health
-/// observation to the same lifecycle without changing its exactly-once shape.
-struct AttemptTerminalGuard {
-    attempt: InferenceAttempt,
-    stage: AttemptStage,
-    armed: bool,
-}
-
-impl AttemptTerminalGuard {
-    fn new(attempt: InferenceAttempt, stage: AttemptStage) -> Self {
-        Self {
-            attempt,
-            stage,
-            armed: true,
-        }
-    }
-
-    fn set_stage(&mut self, stage: AttemptStage) {
-        self.stage = stage;
-    }
-
-    fn disarm(&mut self) {
-        self.armed = false;
-    }
-
-    fn record_terminal(&mut self, terminal: &AttemptTerminal) {
-        debug_assert_eq!(terminal.attempt(), &self.attempt);
-        record_attempt_outcome(&AttemptOutcome::Terminal(terminal.clone()));
-        self.disarm();
-    }
-
-    fn cancellation_terminal(&self) -> AttemptTerminal {
-        AttemptTerminal::Failed {
-            attempt: self.attempt.clone(),
-            failure: AttemptFailure::new(
-                AttemptFailureKind::ConsumerDropped,
-                self.stage,
-                ReplaySafety::NotProvenPreAcceptance,
-            ),
-        }
-    }
-}
-
-impl Drop for AttemptTerminalGuard {
-    fn drop(&mut self) {
-        if !self.armed {
-            return;
-        }
-
-        let terminal = self.cancellation_terminal();
-        record_attempt_outcome(&AttemptOutcome::Terminal(terminal));
-        warn!(
-            "Inference attempt abandoned before terminal processing: request_id={}, execution_id={}, attempt_id={}, stage={:?}",
-            self.attempt.request_id,
-            self.attempt.execution_id,
-            self.attempt.attempt_id,
-            self.stage
-        );
     }
 }
 
@@ -1037,6 +981,7 @@ fn public_completion_error(error: &ProviderRequestError, failure: &AttemptFailur
 }
 
 fn terminalize_recovered_provider_failures(
+    provider_router: &ProviderRouter,
     execution: InferenceExecution,
     route: &crate::inference::RouteIdentity,
     prior_failures: Vec<ProviderRequestError>,
@@ -1050,7 +995,11 @@ fn terminalize_recovered_provider_failures(
                 attempt: attempt.clone(),
                 failure: failure.clone(),
             };
-            record_attempt_outcome(&AttemptOutcome::Terminal(terminal.clone()));
+            record_attempt_outcome(
+                provider_router,
+                &AttemptOutcome::Terminal(terminal.clone()),
+                ShadowObservationMode::TelemetryOnly,
+            );
             warn!(
                 "Inference transport recovered a failed attempt: request_id={}, execution_id={}, attempt_id={}, kind={:?}, replay_safety={:?}",
                 attempt.request_id,
@@ -1064,7 +1013,11 @@ fn terminalize_recovered_provider_failures(
         .collect()
 }
 
-fn record_attempt_outcome(outcome: &AttemptOutcome) {
+fn record_attempt_outcome(
+    provider_router: &ProviderRouter,
+    outcome: &AttemptOutcome,
+    shadow_mode: ShadowObservationMode,
+) {
     match outcome {
         AttemptOutcome::ResponseStarted { attempt, status } => {
             let route_key = attempt.route.route_key();
@@ -1086,6 +1039,21 @@ fn record_attempt_outcome(outcome: &AttemptOutcome) {
         }
         AttemptOutcome::Terminal(terminal) => {
             let attempt = terminal.attempt();
+            let shadow_report = provider_router.observe_attempt_terminal(terminal, shadow_mode);
+            debug!(
+                "Inference shadow health observation: request_id={}, execution_id={}, attempt_id={}, policy_version={}, mode={:?}, route_provider={}, route_model={}, signal={:?}, capacity_pool={:?}, snapshot={:?}, mutated={}",
+                attempt.request_id,
+                attempt.execution_id,
+                attempt.attempt_id,
+                shadow_report.policy_version,
+                shadow_report.mode,
+                shadow_report.route.provider.as_str(),
+                shadow_report.route.provider_model_id,
+                shadow_report.signal,
+                shadow_report.capacity_pool,
+                shadow_report.snapshot,
+                shadow_report.mutated
+            );
             match terminal {
                 AttemptTerminal::Completed { evidence, .. } => debug!(
                     "Inference attempt completed: request_id={}, execution_id={}, attempt_id={}, provider={}, public_model={}, provider_model={}, evidence={:?}",
@@ -1116,6 +1084,20 @@ fn record_attempt_outcome(outcome: &AttemptOutcome) {
             }
         }
     }
+}
+
+#[cfg(test)]
+async fn send_attempt_terminal(
+    provider_router: &ProviderRouter,
+    sender: &mpsc::Sender<CompletionChunk>,
+    terminal: AttemptTerminal,
+) {
+    record_attempt_outcome(
+        provider_router,
+        &AttemptOutcome::Terminal(terminal.clone()),
+        ShadowObservationMode::Update,
+    );
+    let _ = sender.send(CompletionChunk::Terminal(terminal)).await;
 }
 
 fn stream_end_terminal(
@@ -1790,6 +1772,30 @@ pub(crate) async fn prepare_completion_request(
                 &intent,
                 provider_preference,
             );
+            if let Ok(plan) = &shadow {
+                let candidate_health = plan
+                    .eligible_routes
+                    .iter()
+                    .map(|candidate| {
+                        let route_key = crate::inference::RouteKey {
+                            provider: candidate.provider,
+                            provider_model_id: candidate.provider_model_id.clone(),
+                        };
+                        (
+                            candidate.provider.as_str(),
+                            candidate.provider_model_id.as_str(),
+                            state.provider_router.shadow_health_snapshot(&route_key),
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                debug!(
+                    "Shadow route health remained observational: request_id={}, public_model={}, routing_policy_version={}, candidate_health={:?}",
+                    intent.request_id,
+                    intent.public_model_id,
+                    plan.policy_version,
+                    candidate_health
+                );
+            }
             retain_active_route_after_shadow_observation(&intent, active, shadow)
         }
     };
@@ -1827,6 +1833,94 @@ pub(crate) async fn prepare_completion_request(
     })
 }
 
+/// Ensures cancellation or panic cannot make an in-flight attempt disappear
+/// from the terminal observation stream. Consumer cancellation is deliberately
+/// neutral for route health, but it must still be represented exactly once.
+struct AttemptObservationGuard {
+    attempt: InferenceAttempt,
+    provider_router: Arc<ProviderRouter>,
+    stage: AttemptStage,
+    armed: bool,
+}
+
+impl AttemptObservationGuard {
+    fn new(
+        attempt: InferenceAttempt,
+        provider_router: Arc<ProviderRouter>,
+        stage: AttemptStage,
+    ) -> Self {
+        Self {
+            attempt,
+            provider_router,
+            stage,
+            armed: true,
+        }
+    }
+
+    fn attempt(&self) -> &InferenceAttempt {
+        &self.attempt
+    }
+
+    fn set_stage(&mut self, stage: AttemptStage) {
+        self.stage = stage;
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+
+    fn record_terminal(&mut self, terminal: &AttemptTerminal) {
+        debug_assert_eq!(terminal.attempt(), &self.attempt);
+        record_attempt_outcome(
+            &self.provider_router,
+            &AttemptOutcome::Terminal(terminal.clone()),
+            ShadowObservationMode::Update,
+        );
+        self.disarm();
+    }
+
+    fn cancellation_terminal(&self) -> AttemptTerminal {
+        AttemptTerminal::Failed {
+            attempt: self.attempt.clone(),
+            failure: AttemptFailure::new(
+                AttemptFailureKind::ConsumerDropped,
+                self.stage,
+                ReplaySafety::NotProvenPreAcceptance,
+            ),
+        }
+    }
+}
+
+impl Drop for AttemptObservationGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        let terminal = self.cancellation_terminal();
+        record_attempt_outcome(
+            &self.provider_router,
+            &AttemptOutcome::Terminal(terminal),
+            ShadowObservationMode::Update,
+        );
+        warn!(
+            "Inference attempt abandoned before terminal processing: request_id={}, execution_id={}, attempt_id={}, stage={:?}",
+            self.attempt.request_id,
+            self.attempt.execution_id,
+            self.attempt.attempt_id,
+            self.stage
+        );
+    }
+}
+
+async fn await_attempt_result<T>(
+    terminal_guard: AttemptObservationGuard,
+    future: impl std::future::Future<Output = T>,
+) -> (T, AttemptObservationGuard) {
+    let result = future.await;
+    (result, terminal_guard)
+}
+
 /// A provider response whose HTTP success status has been observed, but whose
 /// body has not yet been consumed. Responses holds this value only across its
 /// persistence boundary so a capacity rejection can still be returned as an
@@ -1835,12 +1929,12 @@ pub(crate) struct StartedCompletion {
     response: Option<ProviderResponse>,
     successful_provider: String,
     attempt: InferenceAttempt,
+    terminal_guard: Option<AttemptObservationGuard>,
     response_model_id: String,
     is_streaming: bool,
     billing_context: BillingContext,
     non_streaming_body_limit: Option<usize>,
     require_provider_done: bool,
-    terminal_guard: Option<AttemptTerminalGuard>,
     response_execution: Option<ResponseExecution>,
     response_execution_guard: Option<ResponseExecutionTaskGuard>,
 }
@@ -2110,6 +2204,7 @@ async fn get_chat_completion_response_with_options(
                     attempt.request_id, attempt.execution_id, attempt.attempt_id, error
                 );
                 return Err(failed_completion_execution(
+                    &state.provider_router,
                     attempt,
                     failure,
                     ApiError::InternalServerError,
@@ -2128,29 +2223,46 @@ async fn get_chat_completion_response_with_options(
             request_log_metadata
         );
 
-        let attempt = execution.begin_attempt(route_identity.clone());
-        let mut terminal_guard =
-            AttemptTerminalGuard::new(attempt.clone(), AttemptStage::AwaitingResponse);
-        let ProviderSendTrace {
-            prior_failures,
-            result,
-        } = try_provider(
-            &state.provider_client,
-            &proxy_config,
-            request_body_json,
-            headers,
+        let terminal_guard = AttemptObservationGuard::new(
+            execution.begin_attempt(route_identity.clone()),
+            Arc::clone(&state.provider_router),
+            AttemptStage::AwaitingResponse,
+        );
+        let (
+            ProviderSendTrace {
+                prior_failures,
+                result,
+            },
+            mut terminal_guard,
+        ) = await_attempt_result(
+            terminal_guard,
+            try_provider(
+                &state.provider_client,
+                &proxy_config,
+                request_body_json,
+                headers,
+            ),
         )
         .await;
 
-        let _recovered_terminals =
-            terminalize_recovered_provider_failures(execution, &route_identity, prior_failures);
+        let _recovered_terminals = terminalize_recovered_provider_failures(
+            &state.provider_router,
+            execution,
+            &route_identity,
+            prior_failures,
+        );
 
+        let attempt = terminal_guard.attempt().clone();
         match result {
             Ok(response) => {
-                record_attempt_outcome(&AttemptOutcome::ResponseStarted {
-                    attempt: attempt.clone(),
-                    status: response.status_code(),
-                });
+                record_attempt_outcome(
+                    &state.provider_router,
+                    &AttemptOutcome::ResponseStarted {
+                        attempt: attempt.clone(),
+                        status: response.status_code(),
+                    },
+                    ShadowObservationMode::Update,
+                );
                 info!(
                     "Inference response started: request_id={}, execution_id={}, attempt_id={}",
                     attempt.request_id, attempt.execution_id, attempt.attempt_id
@@ -2175,6 +2287,7 @@ async fn get_chat_completion_response_with_options(
                     request_log_metadata
                 );
                 let execution_error = failed_completion_execution(
+                    &state.provider_router,
                     attempt,
                     failure.clone(),
                     public_completion_error(&err, &failure),
@@ -2194,12 +2307,12 @@ async fn get_chat_completion_response_with_options(
         response: Some(response),
         successful_provider,
         attempt,
+        terminal_guard: Some(terminal_guard),
         response_model_id: selected_route.response_model_id,
         is_streaming,
         billing_context: billing,
         non_streaming_body_limit: options.non_streaming_body_limit,
         require_provider_done,
-        terminal_guard: Some(terminal_guard),
         response_execution,
         response_execution_guard,
     })
@@ -2216,6 +2329,10 @@ pub(crate) async fn finish_started_completion(
         .response
         .take()
         .expect("started completion response can only be consumed once");
+    let mut terminal_guard = started
+        .terminal_guard
+        .take()
+        .expect("started completion terminal guard can only be consumed once");
     let successful_provider = started.successful_provider.clone();
     let attempt = started.attempt.clone();
     let response_model_id = started.response_model_id.clone();
@@ -2225,10 +2342,6 @@ pub(crate) async fn finish_started_completion(
     let require_provider_done = started.require_provider_done;
     let response_execution = started.response_execution.take();
     let response_execution_guard = started.response_execution_guard.take();
-    let mut terminal_guard = started
-        .terminal_guard
-        .take()
-        .expect("started completion terminal guard can only be consumed once");
 
     // NOW: Process the response internally and handle billing
     if !is_streaming {
@@ -2247,6 +2360,7 @@ pub(crate) async fn finish_started_completion(
             Ok(response_json) => response_json,
             Err(failure) => {
                 let execution_error = failed_completion_execution(
+                    &state.provider_router,
                     attempt.clone(),
                     failure,
                     ApiError::InternalServerError,
@@ -2255,6 +2369,12 @@ pub(crate) async fn finish_started_completion(
                 return Err(execution_error);
             }
         };
+
+        let terminal = AttemptTerminal::Completed {
+            attempt: attempt.clone(),
+            evidence: CompletionEvidence::NonStreamingResponse,
+        };
+        terminal_guard.record_terminal(&terminal);
 
         // ✅ Handle billing HERE, inside completions API
         if let Some(usage) = extract_usage(&response_json) {
@@ -2269,11 +2389,6 @@ pub(crate) async fn finish_started_completion(
         }
 
         // Return the full response as a single chunk
-        let terminal = AttemptTerminal::Completed {
-            attempt: attempt.clone(),
-            evidence: CompletionEvidence::NonStreamingResponse,
-        };
-        terminal_guard.record_terminal(&terminal);
         let (tx, rx) = mpsc::channel(2); // Need space for FullResponse + terminal
         let _ = tx.send(CompletionChunk::FullResponse(response_json)).await;
         let _ = tx.send(CompletionChunk::Terminal(terminal)).await;
@@ -2313,6 +2428,8 @@ pub(crate) async fn finish_started_completion(
             require_provider_done,
         )
         .await;
+        let terminal = result.terminal.clone();
+        terminal_guard.record_terminal(&terminal);
         publish_stream_usage(
             result.usage,
             result.finalization,
@@ -2323,10 +2440,7 @@ pub(crate) async fn finish_started_completion(
             &tx_consumer,
         )
         .await;
-        terminal_guard.record_terminal(&result.terminal);
-        let _ = tx_consumer
-            .send(CompletionChunk::Terminal(result.terminal))
-            .await;
+        let _ = tx_consumer.send(CompletionChunk::Terminal(terminal)).await;
     });
 
     Ok(CompletionStream {
@@ -3823,6 +3937,98 @@ mod tests {
         ));
     }
 
+    async fn record_terminal_once(
+        provider_router: &ProviderRouter,
+        terminal: &AttemptTerminal,
+    ) -> crate::inference::health::ShadowRouteSnapshot {
+        let route_key = terminal.attempt().route.route_key();
+        let (terminal_tx, mut terminal_rx) = mpsc::channel(1);
+        send_attempt_terminal(provider_router, &terminal_tx, terminal.clone()).await;
+        drop(terminal_tx);
+        assert!(matches!(
+            terminal_rx.recv().await,
+            Some(CompletionChunk::Terminal(_))
+        ));
+        assert!(terminal_rx.recv().await.is_none());
+        provider_router
+            .shadow_health_snapshot(&route_key)
+            .expect("registered terminal route")
+    }
+
+    #[tokio::test]
+    async fn cancelling_while_awaiting_provider_result_records_one_neutral_terminal() {
+        let provider_router = Arc::new(ProviderRouter::default());
+        let pinned = pinned_test_completion();
+        let route_key = pinned.route.identity().route_key();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let terminal_guard = AttemptObservationGuard::new(
+            attempt,
+            Arc::clone(&provider_router),
+            AttemptStage::AwaitingResponse,
+        );
+
+        let result = timeout(
+            Duration::from_millis(5),
+            await_attempt_result(terminal_guard, futures::future::pending::<()>()),
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(provider_router.shadow_observation_count(), 1);
+        assert_eq!(
+            provider_router
+                .shadow_health_snapshot(&route_key)
+                .expect("registered K3 route")
+                .effective,
+            crate::inference::health::ShadowDisposition::Healthy
+        );
+    }
+
+    #[tokio::test]
+    async fn taking_started_response_does_not_disarm_drop_observation() {
+        let (trace, server) = call_mock_provider(static_sse_app("data: [DONE]\n\n")).await;
+        let response = trace.result.expect("mock provider response start");
+        let provider_router = Arc::new(ProviderRouter::default());
+        let pinned = pinned_test_completion();
+        let route_key = pinned.route.identity().route_key();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let terminal_guard = AttemptObservationGuard::new(
+            attempt.clone(),
+            Arc::clone(&provider_router),
+            AttemptStage::ResponseBody,
+        );
+        let mut started = StartedCompletion {
+            response: Some(response),
+            successful_provider: ProviderId::Tinfoil.as_str().to_string(),
+            attempt,
+            terminal_guard: Some(terminal_guard),
+            response_model_id: "kimi-k3".to_string(),
+            is_streaming: false,
+            billing_context: BillingContext::new(AuthMethod::Jwt, "kimi-k3".to_string()),
+            non_streaming_body_limit: None,
+            require_provider_done: false,
+            response_execution: None,
+            response_execution_guard: None,
+        };
+
+        drop(started.response.take());
+        drop(started);
+        server.abort();
+
+        assert_eq!(provider_router.shadow_observation_count(), 1);
+        assert_eq!(
+            provider_router
+                .shadow_health_snapshot(&route_key)
+                .expect("registered K3 route")
+                .effective,
+            crate::inference::health::ShadowDisposition::Healthy
+        );
+    }
+
     #[tokio::test]
     async fn mock_provider_streams_produce_one_sanitized_terminal_result() {
         enum ExpectedTerminal {
@@ -3891,6 +4097,23 @@ mod tests {
                 "{name}"
             );
 
+            let provider_router = ProviderRouter::default();
+            let health = record_terminal_once(&provider_router, &result.terminal).await;
+            match &result.terminal {
+                AttemptTerminal::Completed { .. } => assert_eq!(
+                    health.effective,
+                    crate::inference::health::ShadowDisposition::Healthy,
+                    "{name}"
+                ),
+                AttemptTerminal::Failed { .. } => assert_eq!(
+                    health.route_health,
+                    crate::inference::health::ShadowDisposition::Watch {
+                        consecutive_failures: 1
+                    },
+                    "{name}"
+                ),
+            }
+
             match (expected, result.terminal) {
                 (
                     ExpectedTerminal::Completed(expected_evidence),
@@ -3949,6 +4172,26 @@ mod tests {
             failure.upstream_request_id.as_deref(),
             Some("req-429_a.b:c")
         );
+
+        let provider_router = ProviderRouter::default();
+        let pinned = pinned_test_completion();
+        let route_key = pinned.route.identity().route_key();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let _ = failed_completion_execution(
+            &provider_router,
+            attempt,
+            failure,
+            ApiError::InternalServerError,
+        );
+        assert!(matches!(
+            provider_router
+                .shadow_health_snapshot(&route_key)
+                .expect("registered K3 route")
+                .effective,
+            crate::inference::health::ShadowDisposition::WouldOpen { .. }
+        ));
     }
 
     #[tokio::test]
@@ -4028,6 +4271,26 @@ mod tests {
                     ..
                 }
             ));
+
+            let provider_router = ProviderRouter::default();
+            let pinned = pinned_test_completion();
+            let route_key = pinned.route.identity().route_key();
+            let attempt = pinned
+                .begin_execution()
+                .begin_attempt(pinned.route.identity());
+            let _ = failed_completion_execution(
+                &provider_router,
+                attempt,
+                failure,
+                ApiError::InternalServerError,
+            );
+            assert!(matches!(
+                provider_router
+                    .shadow_health_snapshot(&route_key)
+                    .expect("registered K3 route")
+                    .deployment_capacity,
+                crate::inference::health::ShadowDisposition::WouldOpen { .. }
+            ));
         }
     }
 
@@ -4043,7 +4306,9 @@ mod tests {
         let attempt = pinned
             .begin_execution()
             .begin_attempt(pinned.route.identity());
+        let provider_router = ProviderRouter::default();
         let response = failed_completion_execution(
+            &provider_router,
             attempt,
             failure.clone(),
             public_completion_error(&provider_error, &failure),
@@ -4112,6 +4377,16 @@ mod tests {
         assert_eq!(failure.replay_safety, ReplaySafety::NotProvenPreAcceptance);
         assert_eq!(failure.upstream_code.as_deref(), Some("capacity_error-17"));
         assert!(!format!("{failure:?}").contains("private upstream detail"));
+
+        let provider_router = ProviderRouter::default();
+        let terminal = AttemptTerminal::Failed { attempt, failure };
+        let health = record_terminal_once(&provider_router, &terminal).await;
+        assert_eq!(
+            health.route_health,
+            crate::inference::health::ShadowDisposition::Watch {
+                consecutive_failures: 1
+            }
+        );
     }
 
     #[tokio::test]
@@ -4235,6 +4510,14 @@ mod tests {
                 ..
             }
         ));
+        let provider_router = ProviderRouter::default();
+        let health = record_terminal_once(&provider_router, &result.terminal).await;
+        assert_eq!(
+            health.route_health,
+            crate::inference::health::ShadowDisposition::Watch {
+                consecutive_failures: 1
+            }
+        );
     }
 
     #[tokio::test]
@@ -4286,6 +4569,12 @@ mod tests {
                 ..
             }
         ));
+        let provider_router = ProviderRouter::default();
+        let health = record_terminal_once(&provider_router, &result.terminal).await;
+        assert_eq!(
+            health.effective,
+            crate::inference::health::ShadowDisposition::Healthy
+        );
     }
 
     #[tokio::test]
@@ -4425,6 +4714,54 @@ mod tests {
                 ..
             }
         ));
+        let provider_router = ProviderRouter::default();
+        let health = record_terminal_once(&provider_router, &result.terminal).await;
+        assert_eq!(
+            health.route_health,
+            crate::inference::health::ShadowDisposition::Watch {
+                consecutive_failures: 1
+            }
+        );
+    }
+
+    #[test]
+    fn response_started_is_not_a_health_success_and_cannot_clear_capacity() {
+        let provider_router = ProviderRouter::default();
+        let pinned = pinned_test_completion();
+        let route = pinned.route.identity();
+        let route_key = route.route_key();
+        let execution = pinned.begin_execution();
+        let mut capacity_failure = AttemptFailure::new(
+            AttemptFailureKind::CapacityRejected,
+            AttemptStage::AwaitingResponse,
+            ReplaySafety::ProvenPreAcceptance,
+        );
+        capacity_failure.status = Some(429);
+        capacity_failure.retry_after = Some(Duration::from_secs(60));
+        record_attempt_outcome(
+            &provider_router,
+            &AttemptOutcome::Terminal(AttemptTerminal::Failed {
+                attempt: execution.begin_attempt(route.clone()),
+                failure: capacity_failure,
+            }),
+            ShadowObservationMode::Update,
+        );
+        record_attempt_outcome(
+            &provider_router,
+            &AttemptOutcome::ResponseStarted {
+                attempt: execution.begin_attempt(route),
+                status: 200,
+            },
+            ShadowObservationMode::Update,
+        );
+
+        assert!(matches!(
+            provider_router
+                .shadow_health_snapshot(&route_key)
+                .expect("registered K3 route")
+                .effective,
+            crate::inference::health::ShadowDisposition::WouldOpen { .. }
+        ));
     }
 
     #[test]
@@ -4561,11 +4898,16 @@ mod tests {
 
     #[test]
     fn cancelled_in_flight_attempt_has_one_conservative_terminal_shape() {
+        let provider_router = Arc::new(ProviderRouter::default());
         let pinned = pinned_test_completion();
         let attempt = pinned
             .begin_execution()
             .begin_attempt(pinned.route.identity());
-        let mut guard = AttemptTerminalGuard::new(attempt.clone(), AttemptStage::AwaitingResponse);
+        let mut guard = AttemptObservationGuard::new(
+            attempt.clone(),
+            provider_router,
+            AttemptStage::AwaitingResponse,
+        );
 
         assert!(matches!(
             guard.cancellation_terminal(),
@@ -4585,9 +4927,11 @@ mod tests {
     #[test]
     fn recovered_transport_retry_gets_a_distinct_attempt_in_the_same_execution() {
         let pinned = pinned_test_completion();
+        let provider_router = ProviderRouter::default();
         let execution = pinned.begin_execution();
         let route = pinned.route.identity();
         let recovered = terminalize_recovered_provider_failures(
+            &provider_router,
             execution,
             &route,
             vec![ProviderRequestError::Connect(
@@ -4617,6 +4961,25 @@ mod tests {
         )
         .await;
         assert_eq!(chunks.len(), 1);
+        let provider_router = ProviderRouter::default();
+        let failed_observation = provider_router
+            .observe_attempt_terminal(&without_done.terminal, ShadowObservationMode::Update);
+        assert!(matches!(
+            failed_observation.signal,
+            crate::inference::health::ShadowSignal::RouteFailure {
+                kind: AttemptFailureKind::UnexpectedEof,
+                ..
+            }
+        ));
+        assert_eq!(
+            failed_observation
+                .snapshot
+                .expect("registered route")
+                .route_health,
+            crate::inference::health::ShadowDisposition::Watch {
+                consecutive_failures: 1,
+            }
+        );
         assert!(matches!(
             without_done.terminal,
             AttemptTerminal::Failed {
@@ -4637,6 +5000,15 @@ mod tests {
             true,
         )
         .await;
+        let completed_observation = provider_router
+            .observe_attempt_terminal(&with_done.terminal, ShadowObservationMode::Update);
+        assert_eq!(
+            completed_observation
+                .snapshot
+                .expect("registered route")
+                .route_health,
+            crate::inference::health::ShadowDisposition::Healthy
+        );
         assert!(matches!(
             with_done.terminal,
             AttemptTerminal::Completed {


### PR DESCRIPTION
Provider outcomes now update a fixed-topology, enclave-local health model in shadow mode. This layer records how infrastructure failures would affect routing without using health to change provider selection.

- Classify Tinfoil 429 by provider/model, Continuum 429 by provider account, and 503/529 by provider/model deployment. These centralized infrastructure classifications reflect the current provider topology.
- Keep GLM 5.2, standard GLM 5.3, and GLM 5.3 Flash route state separate; Continuum's declared account-rate scope is shared across its routes.
- Record authoritative attempt terminals, with recovered Tinfoil sub-attempts remaining telemetry-only and cancellation health-neutral. Threshold transport, timeout, malformed-response, EOF, and provider-server failures in a bounded rolling window.
- Expose bounded Healthy/Watch/WouldOpen/WouldProbe observations. Registry-defined keys bound state cardinality; state is process-local, in memory, and reset on restart.

Both routing modes contribute observations. Router v1 never consumes health for selection, and this shadow layer does not reroute Router v2 either. Later layers selectively activate its observations. Router v2 remains default off; customer admission policy and distributed coordination are outside this change.

The restack preserves [#300's disconnect durability, storage acknowledgement, generation-limit removal, and catalog-window corrections](https://github.com/OpenSecretCloud/opensecret/pull/300), including integration with [#343's execution ownership and quiescence](https://github.com/OpenSecretCloud/opensecret/pull/343).

Local validation at `b84e9af4a4251a3e393ffc6346ded34db0bf2515`: the pinned Rust all-feature suite passed 538 tests, with 0 failed and 23 ignored. Direct pinned format and warning-denied all-target/all-feature Clippy passed; independent exact-head review found no P0/P1 blockers. Coverage includes classifiers, scopes, model isolation, terminal observations, cooldowns, cardinality, and flag-off inertness.

GitHub snapshot, 2026-09-04 23:32:16 UTC: OPEN, non-draft, mergeable/CLEAN, and 0 commits behind. The exact head matches the local validation above; base `codex-routing-v2-capacity` at `91ed2e573aa5f358cfd0d59defd04d414be762fe` is also the merge base. RustSec is SUCCESS, with no pending or failed checks. It is the only attached check because full workflows target master; this is the existing stacked-PR coverage limitation.

Cumulative integration at backend `fc0e798a` / Maple `9cfcbc0e` passed all five encrypted Kimi mock scenarios with Router v2 off and on: Chat, Responses, disconnect/reload, explicit cancellation, and tool continuation. Disconnect at 24 characters produced all 7,917 characters through fresh encrypted retrieval; HTTP-200 cancellation preserved 24 durable characters and aborted the upstream stream. Advertised `web_search` persisted the local empty-query error and continued on a second provider turn without external Kagi access. Mock requests contained no numeric generation-limit fields; the final mock instance recorded 9 requests, 7 completed, 2 aborted, and 0 failed.

Live standard GLM 5.3 Chat and Responses passed in both modes with one client inference send each. Chat verified usage and one finish/`[DONE]`; Responses verified one terminal event and fresh encrypted retrieval of durable completion. Routing evidence confirmed Continuum inference and Tinfoil Llama titles. A separate legacy Chat check passed for the distinct Tinfoil GLM 5.3 Flash model. These results exercise the cumulative stack, not #301 in isolation.

DB qualification: exact final #300 (`91ed2e57`) passed 20 AEAD/database tests, with 0 failed, 0 ignored, and process exit 0. The separate whole disposable-DB helper remains failed because of the inherited OAuth exit SIGSEGV also reproduced on unchanged master.

Stack **5/8**: [#300](https://github.com/OpenSecretCloud/opensecret/pull/300) → **#301** → [#302](https://github.com/OpenSecretCloud/opensecret/pull/302). Final base: **91ed2e573aa5f358cfd0d59defd04d414be762fe**.

[Routing walkthrough: health observation](https://maple-routing-review.anthony599874.chatgpt.site/#stack-5) · [Health classifier](https://github.com/OpenSecretCloud/opensecret/blob/b84e9af4a4251a3e393ffc6346ded34db0bf2515/src/inference/health.rs).
