### PR TITLE
[routing v2 6/8] Activate GLM same-model provider circuit

### DIFF
--- a/src/inference/health.rs
+++ b/src/inference/health.rs
@@ -1,8 +1,8 @@
-//! Enclave-local shadow health classification for inference routes.
+//! Enclave-local health classification for inference routes.
 //!
-//! This module deliberately has no route-selection API. Stack 5 records what a
-//! versioned policy would do, while the legacy router and shadow planner remain
-//! the only sources of route decisions.
+//! Stack 5 introduced this state observationally. Stack 6 consumes one coherent
+//! snapshot only for the explicit GLM 5.3 canary; every other route remains
+//! observational until its own rollout boundary.
 
 use super::{AttemptFailureKind, AttemptTerminal, RouteKey};
 use crate::provider_registry::{ProviderId, ProviderRegistry, RateLimitScope, PROVIDER_REGISTRY};
@@ -20,7 +20,10 @@ pub(crate) const SHADOW_HEALTH_POLICY_VERSION: &str = "routing-v2-health-shadow-
 const ROUTE_FAILURE_WINDOW: Duration = Duration::from_secs(60);
 const ROUTE_FAILURES_TO_OPEN: u8 = 3;
 const ROUTE_OPEN_COOLDOWN: Duration = Duration::from_secs(30);
-const DEFAULT_CAPACITY_COOLDOWN: Duration = Duration::from_secs(1);
+// A missing or zero upstream hint must not turn an active circuit into a hot
+// retry loop. Thirty seconds matches the route-health cooldown while remaining
+// bounded well below the one-hour maximum accepted from providers.
+pub(crate) const MIN_CAPACITY_COOLDOWN: Duration = Duration::from_secs(30);
 const MAX_CAPACITY_COOLDOWN: Duration = Duration::from_secs(60 * 60);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -84,7 +87,7 @@ struct ShadowHealthPolicy {
     route_failure_window: Duration,
     route_failures_to_open: u8,
     route_open_cooldown: Duration,
-    default_capacity_cooldown: Duration,
+    minimum_capacity_cooldown: Duration,
     max_capacity_cooldown: Duration,
 }
 
@@ -94,7 +97,7 @@ impl Default for ShadowHealthPolicy {
             route_failure_window: ROUTE_FAILURE_WINDOW,
             route_failures_to_open: ROUTE_FAILURES_TO_OPEN,
             route_open_cooldown: ROUTE_OPEN_COOLDOWN,
-            default_capacity_cooldown: DEFAULT_CAPACITY_COOLDOWN,
+            minimum_capacity_cooldown: MIN_CAPACITY_COOLDOWN,
             max_capacity_cooldown: MAX_CAPACITY_COOLDOWN,
         }
     }
@@ -192,6 +195,18 @@ impl ShadowHealthState {
     pub(crate) fn snapshot(&self, route: &RouteKey) -> Option<ShadowRouteSnapshot> {
         let inner = self.lock();
         self.snapshot_locked(&inner, route, Instant::now())
+    }
+
+    /// Returns a point-in-time snapshot for every requested route while holding
+    /// the state lock once. Active selection must not combine observations from
+    /// different instants when deciding whether all canary routes are open.
+    pub(crate) fn snapshot_routes(&self, routes: &[RouteKey]) -> Option<Vec<ShadowRouteSnapshot>> {
+        let inner = self.lock();
+        let now = Instant::now();
+        routes
+            .iter()
+            .map(|route| self.snapshot_locked(&inner, route, now))
+            .collect()
     }
 
     fn observe_terminal_locked(
@@ -322,7 +337,8 @@ impl ShadowHealthState {
             Mutation::Capacity { pool, retry_after } => {
                 if let Some(state) = inner.capacity.get_mut(&pool) {
                     let cooldown = retry_after
-                        .unwrap_or(self.policy.default_capacity_cooldown)
+                        .unwrap_or(self.policy.minimum_capacity_cooldown)
+                        .max(self.policy.minimum_capacity_cooldown)
                         .min(self.policy.max_capacity_cooldown);
                     extend_open_until(&mut state.open_until, now, cooldown);
                 }
@@ -622,7 +638,7 @@ mod tests {
             route_failure_window: Duration::from_secs(10),
             route_failures_to_open: 3,
             route_open_cooldown: Duration::from_secs(5),
-            default_capacity_cooldown: Duration::from_secs(4),
+            minimum_capacity_cooldown: Duration::from_secs(4),
             max_capacity_cooldown: Duration::from_secs(10),
         }
     }
@@ -926,6 +942,33 @@ mod tests {
 
         state.observe_terminal_at(
             &failed(
+                k3.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::ZERO),
+            ),
+            ShadowObservationMode::Update,
+            start + Duration::from_secs(10),
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(10))
+                .unwrap()
+                .effective,
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(4)
+            }
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(14))
+                .unwrap()
+                .effective,
+            ShadowDisposition::WouldProbe
+        );
+
+        state.observe_terminal_at(
+            &failed(
                 k3,
                 AttemptFailureKind::CapacityRejected,
                 Some(429),
@@ -943,6 +986,29 @@ mod tests {
                 remaining: Duration::from_secs(10)
             }
         );
+    }
+
+    #[test]
+    fn route_snapshots_share_one_point_in_time_and_fail_closed_for_unknown_routes() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let glm_tinfoil = route(ProviderId::Tinfoil, "glm-5-3", "glm-5-3").route_key();
+        let glm_continuum = route(ProviderId::Continuum, "glm-5-3", "glm-5.3").route_key();
+
+        let snapshots = state
+            .snapshot_routes(&[glm_tinfoil.clone(), glm_continuum.clone()])
+            .expect("registered GLM routes");
+        assert_eq!(snapshots.len(), 2);
+        assert!(snapshots
+            .iter()
+            .all(|snapshot| snapshot.effective == ShadowDisposition::Healthy));
+
+        let unknown = RouteKey {
+            provider: ProviderId::Tinfoil,
+            provider_model_id: "not-registered".to_string(),
+        };
+        assert!(state
+            .snapshot_routes(&[glm_tinfoil, unknown, glm_continuum])
+            .is_none());
     }
 
     #[test]

--- a/src/inference_planning.rs
+++ b/src/inference_planning.rs
@@ -1,8 +1,9 @@
 //! Deterministic, credential-free completion route planning.
 //!
-//! The plan produced here is shadow-only. It describes route identity and
-//! ordered same-model candidates, but it cannot name or invoke an executable
-//! provider endpoint.
+//! The plan describes route identity and ordered same-model candidates without
+//! naming or invoking an executable endpoint. It remains the baseline shadow
+//! planner for every model and is also reused by Stack 6 after GLM's active
+//! canary has filtered its configured providers through one health snapshot.
 
 use crate::inference::{InferenceIntent, RouteIdentity};
 use crate::provider_registry::{

--- a/src/provider_registry.rs
+++ b/src/provider_registry.rs
@@ -1,8 +1,8 @@
 //! Credential-free provider topology for completion routing.
 //!
-//! This registry is intentionally independent from the legacy execution
-//! router. Stack 3 exercises it in shadow mode so the topology and planner can
-//! be validated before either is allowed to select an executable proxy.
+//! This registry is intentionally independent from executable credentials.
+//! Stack 3 introduced it in shadow mode; Stack 6 consumes it for the explicit
+//! GLM same-model provider canary while other active routes remain unchanged.
 
 use crate::model_config::{
     DEEPSEEK_V4_FLASH_MODEL_ID, GLM_5_2_MODEL_ID, GLM_5_3_FLASH_MODEL_ID, GLM_5_3_MODEL_ID,

--- a/src/provider_routing.rs
+++ b/src/provider_routing.rs
@@ -1,7 +1,10 @@
 use crate::inference::health::{
-    ShadowHealthState, ShadowObservationMode, ShadowObservationReport, ShadowRouteSnapshot,
+    ShadowDisposition, ShadowHealthState, ShadowObservationMode, ShadowObservationReport,
+    ShadowRouteSnapshot, MIN_CAPACITY_COOLDOWN,
 };
-use crate::inference::{AttemptTerminal, InferenceIntent, RouteIdentity, RouteKey};
+use crate::inference::{
+    AttemptTerminal, InferenceIntent, ModelSelectionMode, RouteIdentity, RouteKey,
+};
 use crate::inference_planning::{
     plan_completion_route, ConfiguredProviders, ProviderPreference, RoutePlan, RoutePlanningError,
     RoutePlanningInput,
@@ -14,6 +17,7 @@ use crate::provider_registry::{
     ProviderId, ProviderRegistry, RouteSelectionSource, PROVIDER_REGISTRY,
 };
 use crate::proxy_config::{canonicalize_tinfoil_model, ProxyConfig, ProxyRouter};
+use std::time::Duration;
 use uuid::Uuid;
 
 /// Selects the completion-routing implementation once at an authenticated
@@ -114,6 +118,10 @@ impl SelectedProviderRoute {
 pub(crate) enum ProviderRoutingError {
     UnsupportedModel(String),
     NoEligibleRoute(String),
+    CapacityUnavailable {
+        model: String,
+        retry_after: Duration,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -297,44 +305,49 @@ impl ProviderRouter {
     }
 
     /// Dispatch completion routing through the request-scoped implementation
-    /// selected at the public inference entrypoint. Router v2 intentionally
-    /// delegates to the legacy implementation in this foundation stack; later
-    /// stacks may evolve only the v2 branch while the legacy path stays intact.
+    /// selected at the public inference entrypoint. The legacy implementation
+    /// stays intact while Router v2 may evolve independently.
     pub(crate) fn select_completion_route_for_mode(
         &self,
         proxy_router: &ProxyRouter,
-        account_uuid: Uuid,
-        requested_model: &str,
+        intent: &InferenceIntent,
         provider_preference: Option<ProviderPreference>,
         routing_mode: InferenceRoutingMode,
     ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
         match routing_mode {
             InferenceRoutingMode::Legacy => self.select_completion_route_with_preference(
                 proxy_router,
-                account_uuid,
-                requested_model,
+                intent.account_uuid,
+                &intent.public_model_id,
                 provider_preference,
             ),
-            InferenceRoutingMode::V2 => self.select_completion_route_v2(
-                proxy_router,
-                account_uuid,
-                requested_model,
-                provider_preference,
-            ),
+            InferenceRoutingMode::V2 => {
+                self.select_active_completion_route(proxy_router, intent, provider_preference)
+            }
         }
     }
 
-    fn select_completion_route_v2(
+    /// Selects the route used by a newly prepared logical request.
+    ///
+    /// Stack 6 activates health filtering only for explicit GLM 5.3 requests.
+    /// Auto aliases and every other public model deliberately retain the legacy
+    /// route decision until their own rollout stack.
+    pub(crate) fn select_active_completion_route(
         &self,
         proxy_router: &ProxyRouter,
-        account_uuid: Uuid,
-        requested_model: &str,
+        intent: &InferenceIntent,
         provider_preference: Option<ProviderPreference>,
     ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
+        if intent.selection_mode == ModelSelectionMode::Explicit
+            && intent.public_model_id == GLM_5_3_MODEL_ID
+        {
+            return self.select_glm_canary_route(proxy_router, intent, provider_preference);
+        }
+
         self.select_completion_route_with_preference(
             proxy_router,
-            account_uuid,
-            requested_model,
+            intent.account_uuid,
+            &intent.public_model_id,
             provider_preference,
         )
     }
@@ -364,6 +377,110 @@ impl ProviderRouter {
                 provider_preference,
             },
         )
+    }
+
+    fn select_glm_canary_route(
+        &self,
+        proxy_router: &ProxyRouter,
+        intent: &InferenceIntent,
+        provider_preference: Option<ProviderPreference>,
+    ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
+        let model = self
+            .registry
+            .completion_model(&intent.public_model_id)
+            .ok_or_else(|| {
+                ProviderRoutingError::UnsupportedModel(intent.public_model_id.clone())
+            })?;
+
+        let configured_routes = model
+            .routes
+            .iter()
+            .filter_map(|route| {
+                let provider = self.registry.provider(route.provider)?;
+                if !route.enabled
+                    || route.weight == 0
+                    || !provider.enabled
+                    || provider.weight == 0
+                    || proxy_for_provider(proxy_router, route.provider).is_none()
+                {
+                    return None;
+                }
+
+                Some((
+                    route.provider,
+                    RouteKey {
+                        provider: route.provider,
+                        provider_model_id: route.provider_model_id.to_string(),
+                    },
+                ))
+            })
+            .collect::<Vec<_>>();
+
+        if configured_routes.is_empty() {
+            return Err(ProviderRoutingError::NoEligibleRoute(
+                intent.public_model_id.clone(),
+            ));
+        }
+
+        let route_keys = configured_routes
+            .iter()
+            .map(|(_, route)| route.clone())
+            .collect::<Vec<_>>();
+        let snapshots = self
+            .shadow_health
+            .snapshot_routes(&route_keys)
+            .ok_or_else(|| ProviderRoutingError::CapacityUnavailable {
+                model: intent.public_model_id.clone(),
+                retry_after: MIN_CAPACITY_COOLDOWN,
+            })?;
+
+        let mut available_providers = ConfiguredProviders::none();
+        let mut earliest_recovery = None;
+        for ((provider, _), snapshot) in configured_routes.iter().zip(snapshots) {
+            match snapshot.effective {
+                ShadowDisposition::WouldOpen { remaining } => {
+                    let remaining = ceil_retry_after(remaining);
+                    earliest_recovery = Some(
+                        earliest_recovery
+                            .map_or(remaining, |current: Duration| current.min(remaining)),
+                    );
+                }
+                disposition if route_is_available_for_new_request(disposition) => {
+                    available_providers = available_providers.with_provider(*provider);
+                }
+                _ => unreachable!("WouldOpen is handled above"),
+            }
+        }
+
+        if available_providers == ConfiguredProviders::none() {
+            return Err(ProviderRoutingError::CapacityUnavailable {
+                model: intent.public_model_id.clone(),
+                retry_after: earliest_recovery.unwrap_or(MIN_CAPACITY_COOLDOWN),
+            });
+        }
+
+        let plan = plan_completion_route(
+            self.registry,
+            RoutePlanningInput {
+                intent,
+                configured_providers: available_providers,
+                provider_preference,
+            },
+        )
+        .map_err(provider_routing_error_from_plan)?;
+
+        let selected = plan.selected;
+        let proxy = proxy_for_provider(proxy_router, selected.provider)
+            .ok_or_else(|| ProviderRoutingError::NoEligibleRoute(intent.public_model_id.clone()))?;
+        Ok(SelectedProviderRoute {
+            provider: selected.provider,
+            proxy,
+            public_model_id: selected.public_model_id,
+            provider_model_id: selected.provider_model_id,
+            response_model_id: selected.response_model_id,
+            bucket: selected.bucket,
+            selection_source: selected.selection_source,
+        })
     }
 
     pub(crate) fn provider_routing_flag_for_completion_model(
@@ -538,6 +655,9 @@ pub(crate) fn compare_shadow_route(
         Err(ProviderRoutingError::NoEligibleRoute(_)) => {
             CredentialFreeRouteOutcome::NoEligibleRoute
         }
+        Err(ProviderRoutingError::CapacityUnavailable { .. }) => {
+            CredentialFreeRouteOutcome::NoEligibleRoute
+        }
     };
     let (shadow_outcome, decision, candidate_count) = match shadow {
         Ok(plan) => (
@@ -614,6 +734,27 @@ fn stable_account_bucket(account_uuid: Uuid) -> u8 {
     (u128::from_be_bytes(*account_uuid.as_bytes()) % 100) as u8
 }
 
+fn provider_routing_error_from_plan(error: RoutePlanningError) -> ProviderRoutingError {
+    match error {
+        RoutePlanningError::UnsupportedModel(model) => {
+            ProviderRoutingError::UnsupportedModel(model)
+        }
+        RoutePlanningError::NoEligibleRoute(model) => ProviderRoutingError::NoEligibleRoute(model),
+    }
+}
+
+fn ceil_retry_after(duration: Duration) -> Duration {
+    let seconds = duration
+        .as_secs()
+        .saturating_add(u64::from(duration.subsec_nanos() > 0))
+        .max(1);
+    Duration::from_secs(seconds)
+}
+
+fn route_is_available_for_new_request(disposition: ShadowDisposition) -> bool {
+    !matches!(disposition, ShadowDisposition::WouldOpen { .. })
+}
+
 fn proxy_for_provider(proxy_router: &ProxyRouter, provider: ProviderId) -> Option<ProxyConfig> {
     match provider {
         ProviderId::Tinfoil => Some(proxy_router.get_tinfoil_proxy()),
@@ -635,7 +776,7 @@ mod tests {
     use crate::model_config::{
         ModelAliasTargets, ModelPlan, PaidModelAliasOverrides, AUTO_POWERFUL_MODEL_ID,
         AUTO_QUICK_MODEL_ID, DEEPSEEK_V4_FLASH_MODEL_ID, GLM_5_2_MODEL_ID, GLM_5_3_FLASH_MODEL_ID,
-        GLM_5_3_MODEL_ID, KIMI_K3_MODEL_ID, QUICK_MODEL_ID,
+        GLM_5_3_MODEL_ID, KIMI_K2_6_MODEL_ID, KIMI_K3_MODEL_ID, QUICK_MODEL_ID,
     };
     use crate::os_flags::PAID_POWERFUL_GLM_5_3_ALIAS_FLAG_KEY;
     use std::collections::HashMap;
@@ -651,6 +792,73 @@ mod tests {
 
     fn uuid_for_bucket(bucket: u8) -> Uuid {
         Uuid::from_u128(u128::from(bucket))
+    }
+
+    fn intent(requested_model: &str, public_model: &str) -> InferenceIntent {
+        InferenceIntent::new(
+            uuid_for_bucket(73),
+            requested_model,
+            public_model,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        )
+    }
+
+    fn capacity_terminal(
+        provider: ProviderId,
+        public_model: &str,
+        provider_model: &str,
+        status: u16,
+        retry_after: Duration,
+    ) -> AttemptTerminal {
+        let mut failure = AttemptFailure::new(
+            AttemptFailureKind::CapacityRejected,
+            AttemptStage::AwaitingResponse,
+            ReplaySafety::ProvenPreAcceptance,
+        );
+        failure.status = Some(status);
+        failure.retry_after = Some(retry_after);
+        let route = RouteIdentity::new(
+            provider,
+            public_model,
+            provider_model,
+            public_model,
+            RouteSelectionSource::DefaultProvider,
+            None,
+        );
+        AttemptTerminal::Failed {
+            attempt: intent(public_model, public_model)
+                .begin_execution()
+                .begin_attempt(route),
+            failure,
+        }
+    }
+
+    fn route_failure_terminal(
+        provider: ProviderId,
+        public_model: &str,
+        provider_model: &str,
+    ) -> AttemptTerminal {
+        let failure = AttemptFailure::new(
+            AttemptFailureKind::StreamTimeout,
+            AttemptStage::Stream,
+            ReplaySafety::NotProvenPreAcceptance,
+        );
+        let route = RouteIdentity::new(
+            provider,
+            public_model,
+            provider_model,
+            public_model,
+            RouteSelectionSource::DefaultProvider,
+            None,
+        );
+        AttemptTerminal::Failed {
+            attempt: intent(public_model, public_model)
+                .begin_execution()
+                .begin_attempt(route),
+            failure,
+        }
     }
 
     #[test]
@@ -678,7 +886,7 @@ mod tests {
     }
 
     #[test]
-    fn initial_router_v2_seam_is_route_identical_to_legacy() {
+    fn healthy_router_v2_seam_is_route_identical_to_legacy() {
         let router = ProviderRouter::default();
         let proxy_router = proxy_router_with_both_providers();
         let cases = [
@@ -698,11 +906,11 @@ mod tests {
         ];
 
         for (model, preference) in cases {
+            let intent = intent(model, model);
             let legacy = router
                 .select_completion_route_for_mode(
                     &proxy_router,
-                    uuid_for_bucket(73),
-                    model,
+                    &intent,
                     preference,
                     InferenceRoutingMode::Legacy,
                 )
@@ -710,8 +918,7 @@ mod tests {
             let v2 = router
                 .select_completion_route_for_mode(
                     &proxy_router,
-                    uuid_for_bucket(73),
-                    model,
+                    &intent,
                     preference,
                     InferenceRoutingMode::V2,
                 )
@@ -728,6 +935,45 @@ mod tests {
             assert_eq!(legacy.bucket, v2.bucket, "{model}");
             assert_eq!(legacy.selection_source, v2.selection_source, "{model}");
         }
+    }
+
+    #[test]
+    fn router_v2_gate_is_the_only_glm_health_activation_boundary() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        let intent = intent(GLM_5_3_MODEL_ID, GLM_5_3_MODEL_ID);
+
+        router.observe_attempt_terminal(
+            &capacity_terminal(
+                ProviderId::Continuum,
+                GLM_5_3_MODEL_ID,
+                "glm-5.3",
+                429,
+                Duration::from_secs(60),
+            ),
+            ShadowObservationMode::Update,
+        );
+
+        let legacy = router
+            .select_completion_route_for_mode(
+                &proxy_router,
+                &intent,
+                None,
+                InferenceRoutingMode::Legacy,
+            )
+            .expect("legacy GLM route ignores Router v2 health");
+        let v2 = router
+            .select_completion_route_for_mode(
+                &proxy_router,
+                &intent,
+                None,
+                InferenceRoutingMode::V2,
+            )
+            .expect("Router v2 selects the healthy GLM route");
+
+        assert_eq!(legacy.provider, ProviderId::Continuum);
+        assert_eq!(v2.provider, ProviderId::Tinfoil);
+        assert_eq!(legacy.public_model_id, v2.public_model_id);
     }
 
     #[test]
@@ -1035,7 +1281,7 @@ mod tests {
     }
 
     #[test]
-    fn hypothetical_open_capacity_never_changes_active_or_shadow_route_selection() {
+    fn legacy_selector_and_baseline_planner_remain_health_independent() {
         let router = ProviderRouter::default();
         let proxy_router = proxy_router_with_both_providers();
         let account_uuid = uuid_for_bucket(73);
@@ -1098,6 +1344,308 @@ mod tests {
             compare_shadow_route(&Ok(active_after), &Ok(shadow_after)),
             ShadowRouteComparison::Match { .. }
         ));
+    }
+
+    #[test]
+    fn active_glm_canary_preserves_healthy_preferences_and_canonical_identity() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        let intent = intent(GLM_5_3_MODEL_ID, GLM_5_3_MODEL_ID);
+
+        let cases = [
+            (
+                None,
+                ProviderId::Continuum,
+                "glm-5.3",
+                RouteSelectionSource::DefaultProvider,
+            ),
+            (
+                Some(ProviderPreference::feature_flag(ProviderId::Tinfoil)),
+                ProviderId::Tinfoil,
+                GLM_5_3_MODEL_ID,
+                RouteSelectionSource::FeatureFlag,
+            ),
+            (
+                Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
+                ProviderId::Continuum,
+                "glm-5.3",
+                RouteSelectionSource::FeatureFlag,
+            ),
+        ];
+
+        for (preference, provider, provider_model, source) in cases {
+            let selected = router
+                .select_active_completion_route(&proxy_router, &intent, preference)
+                .expect("healthy GLM route");
+            assert_eq!(selected.provider, provider);
+            assert_eq!(selected.provider_model_id, provider_model);
+            assert_eq!(selected.public_model_id, GLM_5_3_MODEL_ID);
+            assert_eq!(selected.response_model_id, GLM_5_3_MODEL_ID);
+            assert_eq!(selected.selection_source, source);
+        }
+    }
+
+    #[test]
+    fn active_glm_canary_switches_only_new_requests_to_same_model_alternate() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        let intent = intent(GLM_5_3_MODEL_ID, GLM_5_3_MODEL_ID);
+
+        let pinned_before_failure = router
+            .select_active_completion_route(&proxy_router, &intent, None)
+            .expect("initial Continuum route");
+        assert_eq!(pinned_before_failure.provider, ProviderId::Continuum);
+
+        router.observe_attempt_terminal(
+            &capacity_terminal(
+                ProviderId::Continuum,
+                GLM_5_3_MODEL_ID,
+                "glm-5.3",
+                429,
+                Duration::from_secs(60),
+            ),
+            ShadowObservationMode::Update,
+        );
+
+        // The previously returned pin is immutable; only a fresh preparation
+        // observes the newly opened circuit.
+        assert_eq!(pinned_before_failure.provider, ProviderId::Continuum);
+        assert_eq!(pinned_before_failure.provider_model_id, "glm-5.3");
+
+        let selected_after_failure = router
+            .select_active_completion_route(&proxy_router, &intent, None)
+            .expect("Tinfoil GLM fallback");
+        assert_eq!(selected_after_failure.provider, ProviderId::Tinfoil);
+        assert_eq!(selected_after_failure.provider_model_id, GLM_5_3_MODEL_ID);
+        assert_eq!(selected_after_failure.public_model_id, GLM_5_3_MODEL_ID);
+        assert_eq!(
+            selected_after_failure.selection_source,
+            RouteSelectionSource::Fallback
+        );
+    }
+
+    #[test]
+    fn active_glm_canary_bypasses_an_open_feature_flag_preference() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        let intent = intent(GLM_5_3_MODEL_ID, GLM_5_3_MODEL_ID);
+
+        router.observe_attempt_terminal(
+            &capacity_terminal(
+                ProviderId::Tinfoil,
+                GLM_5_3_MODEL_ID,
+                GLM_5_3_MODEL_ID,
+                503,
+                Duration::from_secs(60),
+            ),
+            ShadowObservationMode::Update,
+        );
+
+        let selected = router
+            .select_active_completion_route(
+                &proxy_router,
+                &intent,
+                Some(ProviderPreference::feature_flag(ProviderId::Tinfoil)),
+            )
+            .expect("Continuum GLM fallback");
+        assert_eq!(selected.provider, ProviderId::Continuum);
+        assert_eq!(selected.provider_model_id, "glm-5.3");
+        assert_eq!(selected.selection_source, RouteSelectionSource::Fallback);
+    }
+
+    #[test]
+    fn active_glm_canary_returns_typed_capacity_when_every_configured_route_is_open() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        let intent = intent(GLM_5_3_MODEL_ID, GLM_5_3_MODEL_ID);
+
+        for terminal in [
+            capacity_terminal(
+                ProviderId::Tinfoil,
+                GLM_5_3_MODEL_ID,
+                GLM_5_3_MODEL_ID,
+                429,
+                Duration::from_secs(40),
+            ),
+            capacity_terminal(
+                ProviderId::Continuum,
+                GLM_5_3_MODEL_ID,
+                "glm-5.3",
+                529,
+                Duration::from_secs(10),
+            ),
+        ] {
+            router.observe_attempt_terminal(&terminal, ShadowObservationMode::Update);
+        }
+
+        let error = router
+            .select_active_completion_route(&proxy_router, &intent, None)
+            .expect_err("both GLM routes are open");
+        match error {
+            ProviderRoutingError::CapacityUnavailable { model, retry_after } => {
+                assert_eq!(model, GLM_5_3_MODEL_ID);
+                assert_eq!(retry_after, Duration::from_secs(30));
+            }
+            other => panic!("unexpected route error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn active_glm_canary_uses_route_failure_threshold_but_not_watch_state() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        let intent = intent(GLM_5_3_MODEL_ID, GLM_5_3_MODEL_ID);
+        let failure = || route_failure_terminal(ProviderId::Continuum, GLM_5_3_MODEL_ID, "glm-5.3");
+
+        for observed_failures in 1..=3 {
+            router.observe_attempt_terminal(&failure(), ShadowObservationMode::Update);
+            let selected = router
+                .select_active_completion_route(&proxy_router, &intent, None)
+                .expect("GLM route");
+            let expected = if observed_failures < 3 {
+                ProviderId::Continuum
+            } else {
+                ProviderId::Tinfoil
+            };
+            assert_eq!(selected.provider, expected, "failure {observed_failures}");
+        }
+    }
+
+    #[test]
+    fn active_glm_canary_consumes_continuum_account_429_without_changing_kimi_routing() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        router.observe_attempt_terminal(
+            &capacity_terminal(
+                ProviderId::Continuum,
+                KIMI_K2_6_MODEL_ID,
+                "kimi-k2.6",
+                429,
+                Duration::from_secs(60),
+            ),
+            ShadowObservationMode::Update,
+        );
+
+        let glm = router
+            .select_active_completion_route(
+                &proxy_router,
+                &intent(GLM_5_3_MODEL_ID, GLM_5_3_MODEL_ID),
+                Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
+            )
+            .expect("Tinfoil GLM after Continuum account limit");
+        assert_eq!(glm.provider, ProviderId::Tinfoil);
+
+        let kimi = router
+            .select_active_completion_route(
+                &proxy_router,
+                &intent(KIMI_K2_6_MODEL_ID, KIMI_K2_6_MODEL_ID),
+                None,
+            )
+            .expect("Kimi remains on its legacy route in Stack 6");
+        assert_eq!(kimi.provider, ProviderId::Continuum);
+        assert_eq!(kimi.provider_model_id, "kimi-k2.6");
+    }
+
+    #[test]
+    fn active_glm_health_filter_is_inert_for_auto_and_other_models() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        router.observe_attempt_terminal(
+            &capacity_terminal(
+                ProviderId::Continuum,
+                GLM_5_3_MODEL_ID,
+                "glm-5.3",
+                429,
+                Duration::from_secs(60),
+            ),
+            ShadowObservationMode::Update,
+        );
+
+        let synthetic_auto_glm = intent(AUTO_POWERFUL_MODEL_ID, GLM_5_3_MODEL_ID);
+        let auto_route = router
+            .select_active_completion_route(&proxy_router, &synthetic_auto_glm, None)
+            .expect("Auto stays on legacy selection until Stack 7");
+        assert_eq!(auto_route.provider, ProviderId::Continuum);
+
+        for (requested, public, expected_provider) in [
+            (GLM_5_2_MODEL_ID, GLM_5_2_MODEL_ID, ProviderId::Tinfoil),
+            (
+                GLM_5_3_FLASH_MODEL_ID,
+                GLM_5_3_FLASH_MODEL_ID,
+                ProviderId::Tinfoil,
+            ),
+            (KIMI_K3_MODEL_ID, KIMI_K3_MODEL_ID, ProviderId::Tinfoil),
+            (
+                KIMI_K2_6_MODEL_ID,
+                KIMI_K2_6_MODEL_ID,
+                ProviderId::Continuum,
+            ),
+            (QUICK_MODEL_ID, QUICK_MODEL_ID, ProviderId::Tinfoil),
+        ] {
+            let selected = router
+                .select_active_completion_route(&proxy_router, &intent(requested, public), None)
+                .expect("non-canary route");
+            assert_eq!(selected.provider, expected_provider, "{requested}");
+        }
+    }
+
+    #[test]
+    fn non_canary_glm_models_ignore_their_own_open_health_in_stack_6() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+
+        for model in [GLM_5_2_MODEL_ID, GLM_5_3_FLASH_MODEL_ID] {
+            router.observe_attempt_terminal(
+                &capacity_terminal(
+                    ProviderId::Tinfoil,
+                    model,
+                    model,
+                    429,
+                    Duration::from_secs(60),
+                ),
+                ShadowObservationMode::Update,
+            );
+
+            let selected = router
+                .select_active_completion_route(&proxy_router, &intent(model, model), None)
+                .expect("non-canary GLM route remains on legacy selection");
+            assert_eq!(selected.provider, ProviderId::Tinfoil, "{model}");
+            assert_eq!(selected.public_model_id, model, "{model}");
+            assert_eq!(selected.provider_model_id, model, "{model}");
+        }
+    }
+
+    #[test]
+    fn only_would_open_blocks_a_new_canary_request() {
+        assert!(route_is_available_for_new_request(
+            ShadowDisposition::Healthy
+        ));
+        assert!(route_is_available_for_new_request(
+            ShadowDisposition::Watch {
+                consecutive_failures: 2
+            }
+        ));
+        assert!(route_is_available_for_new_request(
+            ShadowDisposition::WouldProbe
+        ));
+        assert!(!route_is_available_for_new_request(
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(1)
+            }
+        ));
+    }
+
+    #[test]
+    fn retry_after_rounds_up_and_never_returns_zero() {
+        assert_eq!(ceil_retry_after(Duration::ZERO), Duration::from_secs(1));
+        assert_eq!(
+            ceil_retry_after(Duration::from_nanos(1)),
+            Duration::from_secs(1)
+        );
+        assert_eq!(
+            ceil_retry_after(Duration::from_millis(1_001)),
+            Duration::from_secs(2)
+        );
     }
 
     #[test]

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -23,7 +23,7 @@ use crate::provider_routing::{
     compare_shadow_route, InferenceRoutingMode, ProviderRouter, ProviderRoutingError,
     SelectedProviderRoute, ShadowRouteComparison,
 };
-use crate::proxy_config::ProxyConfig;
+use crate::proxy_config::{ProxyConfig, ProxyRouter};
 use crate::sqs::UsageEvent;
 use crate::web::audio_utils::{merge_transcriptions, AudioSplitter, TINFOIL_MAX_SIZE};
 use crate::web::encryption_middleware::{
@@ -1725,6 +1725,33 @@ fn retain_active_route_after_shadow_observation(
             candidate_scope,
             comparison
         ),
+        ShadowRouteComparison::Mismatch { .. }
+            if matches!(
+                active,
+                Err(ProviderRoutingError::CapacityUnavailable { .. })
+            ) =>
+        {
+            debug!(
+                "GLM canary found every configured same-model route open: request_id={}, public_model={}, policy_version={}, candidate_scope={:?}",
+                intent.request_id,
+                intent.public_model_id,
+                policy_version,
+                candidate_scope
+            )
+        }
+        ShadowRouteComparison::Mismatch { .. }
+            if !intent.selection_mode.is_auto()
+                && intent.public_model_id == crate::model_config::GLM_5_3_MODEL_ID =>
+        {
+            debug!(
+            "Health-aware route differed from the baseline plan; retaining the active route: request_id={}, public_model={}, policy_version={}, candidate_scope={:?}, comparison={:?}",
+            intent.request_id,
+            intent.public_model_id,
+            policy_version,
+            candidate_scope,
+            comparison
+            )
+        }
         ShadowRouteComparison::Mismatch { .. } => warn!(
             "Shadow route differed from active route; retaining active route: request_id={}, public_model={}, policy_version={}, candidate_scope={:?}, comparison={:?}",
             intent.request_id,
@@ -1736,6 +1763,44 @@ fn retain_active_route_after_shadow_observation(
     }
 
     active
+}
+
+fn provider_routing_api_error(error: ProviderRoutingError) -> ApiError {
+    match error {
+        ProviderRoutingError::UnsupportedModel(model) => {
+            error!("Unsupported completion model requested: {}", model);
+            ApiError::BadRequest
+        }
+        ProviderRoutingError::NoEligibleRoute(model) => {
+            error!("No eligible provider route for completion model: {}", model);
+            ApiError::InternalServerError
+        }
+        ProviderRoutingError::CapacityUnavailable { model, retry_after } => {
+            debug!(
+                "All configured same-model routes are temporarily unavailable: public_model={}, retry_after_seconds={}",
+                model,
+                retry_after.as_secs()
+            );
+            ApiError::InferenceCapacity {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                retry_after: Some(retry_after),
+                client_replay_safe: true,
+            }
+        }
+    }
+}
+
+fn select_prepared_completion_route(
+    provider_router: &ProviderRouter,
+    proxy_router: &ProxyRouter,
+    intent: &InferenceIntent,
+    provider_preference: Option<crate::inference_planning::ProviderPreference>,
+    baseline_plan: Result<RoutePlan, RoutePlanningError>,
+) -> Result<SelectedProviderRoute, ApiError> {
+    let active =
+        provider_router.select_active_completion_route(proxy_router, intent, provider_preference);
+    retain_active_route_after_shadow_observation(intent, active, baseline_plan)
+        .map_err(provider_routing_api_error)
 }
 
 pub(crate) async fn prepare_completion_request(
@@ -1757,15 +1822,16 @@ pub(crate) async fn prepare_completion_request(
     let provider_preference = state
         .provider_routing_preference(user.uuid, &intent.public_model_id)
         .await;
-    let active = state.provider_router.select_completion_route_for_mode(
-        &state.proxy_router,
-        user.uuid,
-        &intent.public_model_id,
-        provider_preference,
-        routing.mode(),
-    );
-    let selected = match routing.mode() {
-        InferenceRoutingMode::Legacy => active,
+    let route = match routing.mode() {
+        InferenceRoutingMode::Legacy => state
+            .provider_router
+            .select_completion_route_for_mode(
+                &state.proxy_router,
+                &intent,
+                provider_preference,
+                InferenceRoutingMode::Legacy,
+            )
+            .map_err(provider_routing_api_error)?,
         InferenceRoutingMode::V2 => {
             let shadow = state.provider_router.shadow_completion_plan(
                 &state.proxy_router,
@@ -1796,19 +1862,15 @@ pub(crate) async fn prepare_completion_request(
                     candidate_health
                 );
             }
-            retain_active_route_after_shadow_observation(&intent, active, shadow)
+            select_prepared_completion_route(
+                &state.provider_router,
+                &state.proxy_router,
+                &intent,
+                provider_preference,
+                shadow,
+            )?
         }
     };
-    let route = selected.map_err(|err| match err {
-        ProviderRoutingError::UnsupportedModel(model) => {
-            error!("Unsupported completion model requested: {}", model);
-            ApiError::BadRequest
-        }
-        ProviderRoutingError::NoEligibleRoute(model) => {
-            error!("No eligible provider route for completion model: {}", model);
-            ApiError::InternalServerError
-        }
-    })?;
 
     debug!(
         "Pinned inference route: request_id={}, routing_mode={:?}, selection_mode={:?}, auto={}, surface={:?}, workload={:?}, requested_model={}, public_model={}, provider={}, provider_model={}, bucket={:?}, source={:?}",
@@ -3754,6 +3816,8 @@ fn is_safe_identifier_char(character: char) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::Json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn completion_error_payload_is_openai_shaped_json() {
@@ -3797,7 +3861,7 @@ mod tests {
         );
     }
 
-    async fn call_mock_provider(app: Router) -> (ProviderSendTrace, tokio::task::JoinHandle<()>) {
+    async fn start_mock_provider(app: Router) -> (String, tokio::task::JoinHandle<()>) {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind mock provider");
@@ -3807,7 +3871,11 @@ mod tests {
                 .await
                 .expect("serve mock provider");
         });
-        let base_url = format!("http://{address}");
+        (format!("http://{address}"), server)
+    }
+
+    async fn call_mock_provider(app: Router) -> (ProviderSendTrace, tokio::task::JoinHandle<()>) {
+        let (base_url, server) = start_mock_provider(app).await;
         let client = ProviderClient::for_test(base_url.clone()).expect("mock provider client");
         let proxy = ProxyConfig {
             base_url,
@@ -4208,6 +4276,337 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn glm_capacity_failure_switches_only_the_next_request_to_the_mock_alternate() {
+        let tinfoil_count = Arc::new(AtomicUsize::new(0));
+        let tinfoil_bodies = Arc::new(std::sync::Mutex::new(Vec::<Value>::new()));
+        let tinfoil_app = {
+            let count = Arc::clone(&tinfoil_count);
+            let bodies = Arc::clone(&tinfoil_bodies);
+            Router::new().route(
+                "/v1/chat/completions",
+                post(move |Json(body): Json<Value>| {
+                    let count = Arc::clone(&count);
+                    let bodies = Arc::clone(&bodies);
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        bodies.lock().expect("Tinfoil body lock").push(body);
+                        axum::http::Response::builder()
+                            .status(StatusCode::OK)
+                            .header(header::CONTENT_TYPE, "application/json")
+                            .body(axum::body::Body::from(
+                                r#"{"model":"glm-5-3","choices":[{"message":{"role":"assistant","content":"ok"}}]}"#,
+                            ))
+                            .expect("mock Tinfoil success")
+                    }
+                }),
+            )
+        };
+        let continuum_count = Arc::new(AtomicUsize::new(0));
+        let continuum_bodies = Arc::new(std::sync::Mutex::new(Vec::<Value>::new()));
+        let continuum_app = {
+            let count = Arc::clone(&continuum_count);
+            let bodies = Arc::clone(&continuum_bodies);
+            Router::new().route(
+                "/v1/chat/completions",
+                post(move |Json(body): Json<Value>| {
+                    let count = Arc::clone(&count);
+                    let bodies = Arc::clone(&bodies);
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        bodies.lock().expect("Continuum body lock").push(body);
+                        axum::http::Response::builder()
+                            .status(StatusCode::TOO_MANY_REQUESTS)
+                            .header(header::RETRY_AFTER, "60")
+                            .body(axum::body::Body::empty())
+                            .expect("mock Continuum 429")
+                    }
+                }),
+            )
+        };
+
+        let (tinfoil_url, tinfoil_server) = start_mock_provider(tinfoil_app).await;
+        let (continuum_url, continuum_server) = start_mock_provider(continuum_app).await;
+        let provider_client =
+            ProviderClient::for_test(tinfoil_url.clone()).expect("test provider client");
+        let proxy_router = crate::proxy_config::ProxyRouter::new(continuum_url, None, tinfoil_url);
+        let provider_router = ProviderRouter::default();
+        let intent = InferenceIntent::new(
+            Uuid::nil(),
+            crate::model_config::GLM_5_3_MODEL_ID,
+            crate::model_config::GLM_5_3_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+
+        let first_baseline = provider_router.shadow_completion_plan(&proxy_router, &intent, None);
+        let first_route = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &intent,
+            None,
+            first_baseline,
+        )
+        .expect("initial GLM route");
+        assert_eq!(first_route.provider, ProviderId::Continuum);
+        let first_trace = try_provider(
+            &provider_client,
+            &first_route.proxy,
+            json!({
+                "model": first_route.provider_model_id,
+                "messages": [{"role": "user", "content": "one"}]
+            })
+            .to_string(),
+            &HeaderMap::new(),
+        )
+        .await;
+        assert!(first_trace.prior_failures.is_empty());
+        let first_error = match first_trace.result {
+            Err(error) => error,
+            Ok(_) => panic!("mock Continuum unexpectedly succeeded"),
+        };
+        let first_failure = attempt_failure_from_provider_error(&first_error);
+        let first_attempt = intent
+            .begin_execution()
+            .begin_attempt(first_route.identity());
+        let surfaced = public_completion_error(&first_error, &first_failure);
+        let _ =
+            failed_completion_execution(&provider_router, first_attempt, first_failure, surfaced);
+
+        // The triggering logical request made exactly one provider call and did
+        // not replay or fail over to Tinfoil.
+        assert_eq!(continuum_count.load(Ordering::SeqCst), 1);
+        assert_eq!(tinfoil_count.load(Ordering::SeqCst), 0);
+
+        let second_intent = InferenceIntent::new(
+            Uuid::nil(),
+            crate::model_config::GLM_5_3_MODEL_ID,
+            crate::model_config::GLM_5_3_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+        assert_ne!(second_intent.request_id, intent.request_id);
+        let second_baseline =
+            provider_router.shadow_completion_plan(&proxy_router, &second_intent, None);
+        let second_route = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &second_intent,
+            None,
+            second_baseline,
+        )
+        .expect("next request uses Tinfoil GLM");
+        assert_eq!(second_route.provider, ProviderId::Tinfoil);
+        assert_eq!(second_route.provider_model_id, "glm-5-3");
+        assert_eq!(
+            second_route.response_model_id,
+            crate::model_config::GLM_5_3_MODEL_ID
+        );
+        let second_trace = try_provider(
+            &provider_client,
+            &second_route.proxy,
+            json!({
+                "model": second_route.provider_model_id,
+                "messages": [{"role": "user", "content": "two"}]
+            })
+            .to_string(),
+            &HeaderMap::new(),
+        )
+        .await;
+        assert!(second_trace.prior_failures.is_empty());
+        let response = second_trace.result.expect("mock Tinfoil succeeds");
+        let second_attempt = second_intent
+            .begin_execution()
+            .begin_attempt(second_route.identity());
+        let canonical_response = read_non_streaming_completion_response(
+            response,
+            &second_route.response_model_id,
+            &second_attempt,
+            None,
+        )
+        .await
+        .expect("canonical Tinfoil response");
+        assert_eq!(
+            canonical_response["model"],
+            crate::model_config::GLM_5_3_MODEL_ID
+        );
+        assert_eq!(
+            second_attempt.route.public_model_id,
+            crate::model_config::GLM_5_3_MODEL_ID
+        );
+        assert_eq!(second_attempt.route.provider, ProviderId::Tinfoil);
+
+        assert_eq!(tinfoil_count.load(Ordering::SeqCst), 1);
+        assert_eq!(continuum_count.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            tinfoil_bodies.lock().expect("Tinfoil bodies")[0]["model"],
+            crate::model_config::GLM_5_3_MODEL_ID
+        );
+        assert_eq!(
+            continuum_bodies.lock().expect("Continuum bodies")[0]["model"],
+            "glm-5.3"
+        );
+
+        tinfoil_server.abort();
+        continuum_server.abort();
+    }
+
+    #[tokio::test]
+    async fn glm_tool_turns_keep_the_original_mock_provider_after_health_opens() {
+        let tinfoil_count = Arc::new(AtomicUsize::new(0));
+        let tinfoil_app = {
+            let count = Arc::clone(&tinfoil_count);
+            Router::new().route(
+                "/v1/chat/completions",
+                post(move |Json(_body): Json<Value>| {
+                    let count = Arc::clone(&count);
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        Json(json!({
+                            "model": "glm-5-3",
+                            "choices": [{"message": {"role": "assistant", "content": "ok"}}]
+                        }))
+                    }
+                }),
+            )
+        };
+        let continuum_count = Arc::new(AtomicUsize::new(0));
+        let continuum_app = {
+            let count = Arc::clone(&continuum_count);
+            Router::new().route(
+                "/v1/chat/completions",
+                post(move |Json(_body): Json<Value>| {
+                    let count = Arc::clone(&count);
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        Json(json!({
+                            "model": "glm-5.3",
+                            "choices": [{"message": {"role": "assistant", "content": "ok"}}]
+                        }))
+                    }
+                }),
+            )
+        };
+        let (tinfoil_url, tinfoil_server) = start_mock_provider(tinfoil_app).await;
+        let (continuum_url, continuum_server) = start_mock_provider(continuum_app).await;
+        let provider_client =
+            ProviderClient::for_test(tinfoil_url.clone()).expect("test provider client");
+        let proxy_router = ProxyRouter::new(continuum_url, None, tinfoil_url);
+        let provider_router = ProviderRouter::default();
+        let intent = InferenceIntent::new(
+            Uuid::nil(),
+            crate::model_config::GLM_5_3_MODEL_ID,
+            crate::model_config::GLM_5_3_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+        let baseline = provider_router.shadow_completion_plan(&proxy_router, &intent, None);
+        let route = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &intent,
+            None,
+            baseline,
+        )
+        .expect("initial GLM route");
+        let pinned = PinnedCompletionRequest {
+            intent,
+            route,
+            routing_mode: InferenceRoutingMode::V2,
+        };
+
+        let send_pinned_turn = |content: &'static str| {
+            let provider_client = &provider_client;
+            let pinned = &pinned;
+            async move {
+                let trace = try_provider(
+                    provider_client,
+                    &pinned.route.proxy,
+                    json!({
+                        "model": pinned.route.provider_model_id,
+                        "messages": [{"role": "user", "content": content}]
+                    })
+                    .to_string(),
+                    &HeaderMap::new(),
+                )
+                .await;
+                assert!(trace.prior_failures.is_empty());
+                let response = trace.result.expect("pinned mock turn succeeds");
+                let attempt = pinned
+                    .begin_execution()
+                    .begin_attempt(pinned.route.identity());
+                let response = read_non_streaming_completion_response(
+                    response,
+                    &pinned.route.response_model_id,
+                    &attempt,
+                    None,
+                )
+                .await
+                .expect("canonical pinned response");
+                assert_eq!(response["model"], crate::model_config::GLM_5_3_MODEL_ID);
+                attempt
+            }
+        };
+
+        let first_attempt = send_pinned_turn("first tool turn").await;
+        let external_error = ProviderRequestError::Upstream(UpstreamProviderError {
+            status: 429,
+            retry_after: Some(Duration::from_secs(60)),
+            upstream_request_id: None,
+        });
+        let external_failure = attempt_failure_from_provider_error(&external_error);
+        let external_intent = InferenceIntent::new(
+            Uuid::from_u128(1),
+            crate::model_config::GLM_5_3_MODEL_ID,
+            crate::model_config::GLM_5_3_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+        let _ = failed_completion_execution(
+            &provider_router,
+            external_intent
+                .begin_execution()
+                .begin_attempt(pinned.route.identity()),
+            external_failure.clone(),
+            public_completion_error(&external_error, &external_failure),
+        );
+
+        let second_attempt = send_pinned_turn("second tool turn").await;
+        assert_eq!(first_attempt.request_id, second_attempt.request_id);
+        assert_ne!(first_attempt.execution_id, second_attempt.execution_id);
+        assert_eq!(first_attempt.route, second_attempt.route);
+        assert_eq!(continuum_count.load(Ordering::SeqCst), 2);
+        assert_eq!(tinfoil_count.load(Ordering::SeqCst), 0);
+
+        let next_intent = InferenceIntent::new(
+            Uuid::nil(),
+            crate::model_config::GLM_5_3_MODEL_ID,
+            crate::model_config::GLM_5_3_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+        let next_baseline =
+            provider_router.shadow_completion_plan(&proxy_router, &next_intent, None);
+        let next_route = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &next_intent,
+            None,
+            next_baseline,
+        )
+        .expect("next logical request switches providers");
+        assert_eq!(next_route.provider, ProviderId::Tinfoil);
+        assert_eq!(next_route.provider_model_id, "glm-5-3");
+
+        tinfoil_server.abort();
+        continuum_server.abort();
+    }
+
+    #[tokio::test]
     async fn mock_provider_429_does_not_wait_for_pending_error_body() {
         let app = Router::new().route(
             "/v1/chat/completions",
@@ -4342,6 +4741,133 @@ mod tests {
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(response.headers()[crate::CLIENT_REPLAY_HEADER], "safe");
         assert_eq!(response.headers()[header::RETRY_AFTER], "3");
+    }
+
+    #[tokio::test]
+    async fn prepared_all_open_glm_route_sends_zero_requests_and_returns_capacity_contract() {
+        let tinfoil_count = Arc::new(AtomicUsize::new(0));
+        let tinfoil_app = {
+            let count = Arc::clone(&tinfoil_count);
+            Router::new().route(
+                "/v1/chat/completions",
+                post(move || {
+                    let count = Arc::clone(&count);
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        StatusCode::OK
+                    }
+                }),
+            )
+        };
+        let continuum_count = Arc::new(AtomicUsize::new(0));
+        let continuum_app = {
+            let count = Arc::clone(&continuum_count);
+            Router::new().route(
+                "/v1/chat/completions",
+                post(move || {
+                    let count = Arc::clone(&count);
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        StatusCode::OK
+                    }
+                }),
+            )
+        };
+        let (tinfoil_url, tinfoil_server) = start_mock_provider(tinfoil_app).await;
+        let (continuum_url, continuum_server) = start_mock_provider(continuum_app).await;
+        let proxy_router = ProxyRouter::new(continuum_url, None, tinfoil_url);
+        let provider_router = ProviderRouter::default();
+
+        let new_intent = || {
+            InferenceIntent::new(
+                Uuid::nil(),
+                crate::model_config::GLM_5_3_MODEL_ID,
+                crate::model_config::GLM_5_3_MODEL_ID,
+                ModelPlan::Paid,
+                InferenceSurface::Responses,
+                WorkloadClass::Interactive,
+            )
+        };
+        let first_intent = new_intent();
+        let first_baseline =
+            provider_router.shadow_completion_plan(&proxy_router, &first_intent, None);
+        let first_route = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &first_intent,
+            None,
+            first_baseline,
+        )
+        .expect("initial Continuum GLM route");
+        assert_eq!(first_route.provider, ProviderId::Continuum);
+        let first_error = ProviderRequestError::Upstream(UpstreamProviderError {
+            status: 429,
+            retry_after: Some(Duration::from_secs(40)),
+            upstream_request_id: None,
+        });
+        let first_failure = attempt_failure_from_provider_error(&first_error);
+        let _ = failed_completion_execution(
+            &provider_router,
+            first_intent
+                .begin_execution()
+                .begin_attempt(first_route.identity()),
+            first_failure.clone(),
+            public_completion_error(&first_error, &first_failure),
+        );
+
+        let second_intent = new_intent();
+        let second_baseline =
+            provider_router.shadow_completion_plan(&proxy_router, &second_intent, None);
+        let second_route = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &second_intent,
+            None,
+            second_baseline,
+        )
+        .expect("Tinfoil GLM route while Continuum is open");
+        assert_eq!(second_route.provider, ProviderId::Tinfoil);
+        let second_error = ProviderRequestError::Upstream(UpstreamProviderError {
+            status: 503,
+            retry_after: Some(Duration::from_secs(10)),
+            upstream_request_id: None,
+        });
+        let second_failure = attempt_failure_from_provider_error(&second_error);
+        let _ = failed_completion_execution(
+            &provider_router,
+            second_intent
+                .begin_execution()
+                .begin_attempt(second_route.identity()),
+            second_failure.clone(),
+            public_completion_error(&second_error, &second_failure),
+        );
+
+        let third_intent = new_intent();
+        let third_baseline =
+            provider_router.shadow_completion_plan(&proxy_router, &third_intent, None);
+        let error = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &third_intent,
+            None,
+            third_baseline,
+        )
+        .expect_err("both GLM routes are open");
+        let response = error.into_response();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response.headers()[crate::CLIENT_REPLAY_HEADER], "safe");
+        assert_eq!(response.headers()[crate::ERROR_CONTRACT_HEADER], "1");
+        assert_eq!(
+            response.headers()[crate::ERROR_CODE_HEADER],
+            crate::INFERENCE_CAPACITY_ERROR_CODE
+        );
+        assert_eq!(response.headers()[header::RETRY_AFTER], "30");
+        assert_eq!(tinfoil_count.load(Ordering::SeqCst), 0);
+        assert_eq!(continuum_count.load(Ordering::SeqCst), 0);
+
+        tinfoil_server.abort();
+        continuum_server.abort();
     }
 
     #[tokio::test]

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -370,7 +370,14 @@ fn responses_pre_persistence_api_error(
         // Descriptor completions have already consumed provider capacity and
         // published usage. The conversation is still cleanly replayable, but
         // the whole HTTP request is not side-effect-free.
-        error.into_api_error()
+        let mut error = error.into_api_error();
+        if let ApiError::InferenceCapacity {
+            client_replay_safe, ..
+        } = &mut error
+        {
+            *client_replay_safe = false;
+        }
+        error
     } else {
         error.into_pre_persistence_api_error()
     }
@@ -712,6 +719,23 @@ mod tests {
                 } if client_replay_safe == expected_replay_safe
             ));
         }
+    }
+
+    #[test]
+    fn route_preparation_capacity_after_image_descriptions_is_not_replay_safe() {
+        let route_error = ApiError::InferenceCapacity {
+            status: axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            retry_after: Some(Duration::from_secs(30)),
+            client_replay_safe: true,
+        };
+
+        assert!(matches!(
+            responses_pre_persistence_api_error(route_error.into(), true),
+            ApiError::InferenceCapacity {
+                client_replay_safe: false,
+                ..
+            }
+        ));
     }
 
     fn test_image_attachment() -> ImageAttachment {
@@ -5217,8 +5241,11 @@ async fn create_response_stream(
         InferenceSurface::Responses,
         WorkloadClass::Interactive,
     );
-    let pinned_completion =
-        prepare_completion_request(&state, &user, inference_intent, routing).await?;
+    let pinned_completion = prepare_completion_request(&state, &user, inference_intent, routing)
+        .await
+        .map_err(|error| {
+            responses_pre_persistence_api_error(error.into(), !image_descriptions.is_empty())
+        })?;
 
     // Start only the first provider request before persistence. Only locally
     // proven pre-send/pre-acceptance capacity failures can authorize replay:


### PR DESCRIPTION
Explicit standard GLM 5.3 requests can avoid a known-open provider route when Router v2 is enabled. Selection stays within the same public model and occurs before provider execution.

- Choose between Continuum `glm-5.3` and Tinfoil `glm-5-3`, preserving canonical public response and billing identity.
- Retain Continuum as the default preference. `provider-routing.glm-5-3.tinfoil=true` prefers Tinfoil; false/missing prefers Continuum. An open route can be bypassed in favor of the other healthy route serving that same model.
- Return local pre-send capacity unavailable when both configured routes are open. Never retry or fail over an inference that may already have started; later Responses turns remain provider-pinned.
- Keep Auto requests, GLM 5.2, distinct GLM 5.3 Flash, and other public models on legacy selection at this layer. General filtering belongs to #303; single-winner half-open recovery belongs to #339.

Flag-off returns through the existing Router-v1 selector and its preference rules without consulting health. The Router-v2 flag remains default off and independent of alias/provider-preference flags. Health remains enclave-local; no customer admission policy is added.

The restack preserves [#300's capacity contract, disconnect durability, explicit caller-parameter preservation, and literal catalog windows](https://github.com/OpenSecretCloud/opensecret/pull/300), together with [#343's ownership and durable cancellation/deletion behavior](https://github.com/OpenSecretCloud/opensecret/pull/343).

Local validation at `1d68451d3559a1bf57b23f045d30f4dbab853662`: the pinned Rust all-feature suite passed 554 tests, with 0 failed and 23 ignored. Direct pinned format and warning-denied all-target/all-feature Clippy passed; independent exact-head review found no P0/P1 blockers. Focused coverage includes flag-off parity, subsequent-request provider switching, both-open zero-send rejection, provider translation, account-scope coupling, identity, and pinned turns.

GitHub snapshot, 2026-09-04 23:32:16 UTC: OPEN, non-draft, mergeable/CLEAN, and 0 commits behind. The exact head matches the local validation above; base `codex-routing-v2-health-shadow` at `b84e9af4a4251a3e393ffc6346ded34db0bf2515` is also the merge base. RustSec is SUCCESS, with no pending or failed checks. It is the only attached check because full workflows target master; this is the existing stacked-PR coverage limitation.

Cumulative integration at backend `fc0e798a` / Maple `9cfcbc0e` passed all five encrypted Kimi mock scenarios with Router v2 off and on: Chat, Responses, disconnect/reload, explicit cancellation, and tool continuation. Disconnect at 24 characters produced all 7,917 characters through fresh encrypted retrieval; HTTP-200 cancellation preserved 24 durable characters and aborted the upstream stream. Advertised `web_search` persisted the local empty-query error and continued on a second provider turn without external Kagi access. Mock requests contained no numeric generation-limit fields; the final mock instance recorded 9 requests, 7 completed, 2 aborted, and 0 failed.

Live standard GLM 5.3 Chat and Responses passed in both modes with one client inference send each. Chat verified usage and one finish/`[DONE]`; Responses verified one terminal event and fresh encrypted retrieval of durable completion. Routing evidence confirmed Continuum inference and Tinfoil Llama titles. A separate legacy Chat check passed for the distinct Tinfoil GLM 5.3 Flash model. These results exercise the cumulative stack, not #302 in isolation.

DB qualification: exact final #300 (`91ed2e57`) passed 20 AEAD/database tests, with 0 failed, 0 ignored, and process exit 0. The separate whole disposable-DB helper remains failed because of the inherited OAuth exit SIGSEGV also reproduced on unchanged master.

Stack **6/8**: [#301](https://github.com/OpenSecretCloud/opensecret/pull/301) → **#302** → [#303](https://github.com/OpenSecretCloud/opensecret/pull/303). Final base: **b84e9af4a4251a3e393ffc6346ded34db0bf2515**.

[Routing walkthrough: explicit GLM canary](https://maple-routing-review.anthony599874.chatgpt.site/#stack-6) · [Routing policy](https://github.com/OpenSecretCloud/opensecret/blob/1d68451d3559a1bf57b23f045d30f4dbab853662/src/provider_routing.rs).
