### PR TITLE
fix(responses): identify exhausted image descriptions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -163,6 +163,7 @@ pub(crate) const ERROR_CODE_HEADER: &str = "x-opensecret-error-code";
 const ERROR_CONTRACT_VERSION: &str = "1";
 const SESSION_NOT_FOUND_ERROR_CODE: &str = "session_not_found";
 const ACCESS_TOKEN_EXPIRED_ERROR_CODE: &str = "access_token_expired";
+const IMAGE_DESCRIPTION_UNAVAILABLE_ERROR_CODE: &str = "image_description_unavailable";
 
 type PendingAttestationKey = [u8; 32];
 pub(crate) type SessionLease = CacheLease<SessionState>;
@@ -367,6 +368,9 @@ pub enum ApiError {
     #[error("Upstream provider temporarily unavailable")]
     ServiceUnavailable,
 
+    #[error("Upstream provider temporarily unavailable")]
+    ImageDescriptionUnavailable,
+
     #[error("Bad Request")]
     BadRequest,
 
@@ -437,6 +441,7 @@ impl IntoResponse for ApiError {
             ApiError::Unauthorized => StatusCode::UNAUTHORIZED,
             ApiError::InternalServerError => StatusCode::INTERNAL_SERVER_ERROR,
             ApiError::ServiceUnavailable => StatusCode::SERVICE_UNAVAILABLE,
+            ApiError::ImageDescriptionUnavailable => StatusCode::SERVICE_UNAVAILABLE,
             ApiError::BadRequest => StatusCode::BAD_REQUEST,
             ApiError::SessionNotFound => StatusCode::BAD_REQUEST,
             ApiError::Conflict => StatusCode::CONFLICT,
@@ -460,6 +465,7 @@ impl IntoResponse for ApiError {
         let error_code = match &self {
             ApiError::SessionNotFound => Some(SESSION_NOT_FOUND_ERROR_CODE),
             ApiError::AccessTokenExpired => Some(ACCESS_TOKEN_EXPIRED_ERROR_CODE),
+            ApiError::ImageDescriptionUnavailable => Some(IMAGE_DESCRIPTION_UNAVAILABLE_ERROR_CODE),
             _ => None,
         };
         let mut response = (
@@ -571,6 +577,28 @@ mod api_error_contract_tests {
             StatusCode::UNAUTHORIZED,
             br#"{"status":401,"message":"Invalid JWT"}"#,
             Some(ACCESS_TOKEN_EXPIRED_ERROR_CODE),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn image_description_unavailable_adds_code_without_changing_legacy_response() {
+        assert_error_response(
+            ApiError::ImageDescriptionUnavailable,
+            StatusCode::SERVICE_UNAVAILABLE,
+            br#"{"status":503,"message":"Upstream provider temporarily unavailable"}"#,
+            Some(IMAGE_DESCRIPTION_UNAVAILABLE_ERROR_CODE),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn generic_service_unavailable_remains_uncoded() {
+        assert_error_response(
+            ApiError::ServiceUnavailable,
+            StatusCode::SERVICE_UNAVAILABLE,
+            br#"{"status":503,"message":"Upstream provider temporarily unavailable"}"#,
+            None,
         )
         .await;
     }

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -2506,7 +2506,7 @@ async fn describe_images(
                         failure.error.summary
                     );
                 }
-                return Err(ApiError::ServiceUnavailable);
+                return Err(ApiError::ImageDescriptionUnavailable);
             }
         };
 

--- a/src/web/responses/image_describer.rs
+++ b/src/web/responses/image_describer.rs
@@ -132,12 +132,26 @@ pub fn build_image_description_request(
         ],
     });
 
-    // Gemma's ordinary Responses configuration enables thinking. Image
-    // description is a bounded preprocessing operation, so disable both
-    // supported reasoning controls for this fixed helper request.
-    if candidate.provider_model_id == "gemma4-31b" {
-        request["include_reasoning"] = json!(false);
-        request["chat_template_kwargs"] = json!({ "enable_thinking": false });
+    // Image description is a bounded preprocessing operation. These models use
+    // different native chat-template switches, so keep each provider/model
+    // control explicit rather than assuming one generic reasoning knob.
+    request["include_reasoning"] = json!(false);
+    match candidate.provider_model_id {
+        // Kimi K2.6's vLLM template uses `thinking`; `enable_thinking` is not
+        // the native switch and is ignored by some deployed template versions.
+        "kimi-k2.6" => {
+            request["chat_template_kwargs"] = json!({ "thinking": false });
+        }
+        // Gemma 4 uses vLLM's `enable_thinking` template switch.
+        "gemma4-31b" => {
+            request["chat_template_kwargs"] = json!({ "enable_thinking": false });
+        }
+        // Kimi K3's vLLM renderer accepts `enable_thinking` as an alias, but
+        // `thinking` is its canonical native control.
+        "kimi-k3" => {
+            request["chat_template_kwargs"] = json!({ "thinking": false });
+        }
+        _ => {}
     }
 
     Ok(request)
@@ -517,12 +531,18 @@ mod tests {
     }
 
     #[test]
-    fn continuum_request_uses_public_model_and_provider_managed_cache_fields() {
+    fn continuum_kimi_request_disables_thinking_and_uses_provider_managed_cache_fields() {
         let request = build_image_description_request(IMAGE_DESCRIPTION_CANDIDATES[0], input())
             .expect("request");
 
         assert_eq!(request["model"], "kimi-k2-6");
         assert_eq!(request["stream"], false);
+        assert_eq!(request["include_reasoning"], false);
+        assert_eq!(request["chat_template_kwargs"]["thinking"], false);
+        assert!(request["chat_template_kwargs"]
+            .get("enable_thinking")
+            .is_none());
+        assert!(request.get("reasoning_effort").is_none());
         assert!(request.get("cache_salt").is_none());
         assert_eq!(
             request["messages"][1]["content"][1]["image_url"]["url"],
@@ -542,6 +562,23 @@ mod tests {
         assert_eq!(request["model"], "gemma4-31b");
         assert_eq!(request["include_reasoning"], false);
         assert_eq!(request["chat_template_kwargs"]["enable_thinking"], false);
+        assert!(request["chat_template_kwargs"].get("thinking").is_none());
+        assert!(request.get("reasoning_effort").is_none());
+        assert!(request.get("cache_salt").is_none());
+    }
+
+    #[test]
+    fn tinfoil_kimi_k3_request_uses_native_thinking_control() {
+        let request = build_image_description_request(IMAGE_DESCRIPTION_CANDIDATES[2], input())
+            .expect("request");
+
+        assert_eq!(request["model"], "kimi-k3");
+        assert_eq!(request["include_reasoning"], false);
+        assert_eq!(request["chat_template_kwargs"]["thinking"], false);
+        assert!(request["chat_template_kwargs"]
+            .get("enable_thinking")
+            .is_none());
+        assert!(request.get("reasoning_effort").is_none());
         assert!(request.get("cache_salt").is_none());
     }
 


### PR DESCRIPTION
## Summary

- return a dedicated image_description_unavailable error code only when every image descriptor candidate fails
- retain HTTP 503 and the exact existing service-unavailable body for older clients
- leave unrelated 503 responses uncoded so their retry behavior is unchanged
- hard-disable reasoning for every fixed image descriptor candidate using its native serving-stack control:
  - Continuum Kimi K2.6: chat_template_kwargs.thinking=false
  - Tinfoil Gemma 4: chat_template_kwargs.enable_thinking=false
  - Tinfoil Kimi K3: chat_template_kwargs.thinking=false
- also send include_reasoning=false as output suppression; it is not treated as the generation-off switch

## Stack

Stacked on #304. Review and merge #304 first; after that, retarget this PR to master if GitHub does not do so automatically.

A corresponding stacked Maple PR consumes the terminal error code and restores the composer without an automatic image retry.

## Validation

- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test: 452 tests, zero failures (432 passed, 20 credential/database tests ignored)
- focused image-describer suite: 11 passed
- live Continuum Kimi K2.6 vision probe accepted thinking=false and returned null reasoning fields
- checked current Tinfoil Gemma 4 and Kimi K3 deployment repositories against their pinned vLLM behavior