### PR TITLE
Add enclave-local inference admission control

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ protected environment variables. Billing and feature flags are optional
 external HTTP APIs whose administrative credentials remain in the backend;
 their server implementations are not part of this repository setup.
 
+Inference concurrency and bounded queues use a reviewed policy compiled into
+the OpenSecret binary; there is no environment-variable or enclave-secret
+override in the first release. The controller is local to one process or
+enclave and does not guess provider RPM/TPM limits. See
+[`docs/inference-admission.md`](docs/inference-admission.md) for the baseline,
+accounting model, replica boundary, and future control-plane seam.
+
 Protected routes require OpenSecret attestation/key exchange and encrypted
 sessions. “OpenAI-shaped” describes decrypted payloads, not a plaintext
 OpenAI-compatible wire endpoint. Use an OpenSecret SDK or Maple for

--- a/docs/inference-admission.md
+++ b/docs/inference-admission.md
@@ -1,0 +1,142 @@
+# Inference admission policy
+
+OpenSecret applies bounded, enclave-local admission control before starting a
+completion provider turn. It limits concurrent work, bounds waiting queues,
+gives interactive requests fair access across accounts, and immediately sheds
+background work when capacity is unavailable. It does not coordinate state
+between replicas and it does not replay an accepted provider request.
+
+The first release uses one policy compiled into the OpenSecret binary. It does
+not read an environment variable, database row, or encrypted enclave secret.
+Changing the policy requires code review, a new build, and a process or enclave
+restart. The scheduler still consumes a typed, validated `AdmissionPolicy` so a
+future authenticated admin control plane can replace the source without
+rewriting the admission machinery.
+
+## Compiled baseline
+
+The source constants bound local concurrency and memory use:
+
+| Internal field | Baseline | Meaning |
+| --- | ---: | --- |
+| `deployment_in_flight` | `4` | Concurrent turns per provider-model deployment |
+| `per_account_in_flight` | `2` | Concurrent logical responses per account |
+| `pool_queue` | `16` | Waiting turns per provider quota pool |
+| `per_account_queue` | `2` | Waiting logical responses or turns per account and pool |
+| `interactive_wait_ms` | `5000` | Maximum interactive wait for local capacity |
+| `background_wait_ms` | `0` | Background work is immediate-only; this must remain zero |
+| `local_retry_ms` | `1000` | Client retry hint for local-capacity rejection |
+| `rolling_window_seconds` | `60` | Local provider-budget accounting window |
+| `completion_default_reservation` | `4096` | Per-choice completion reservation and provider-visible cap when the request has no limit |
+| `max_completion_choices` | `8` | Maximum provider sequences (`n`) admitted for one request |
+
+The compiled baseline deliberately does **not** assign an RPM, prompt-token,
+completion-token, or cached-token quota to any provider. Those entitlements can
+drift and may differ by environment, so this release does not promote example
+or public-plan numbers into production policy. Upstream enforcement and the
+local 429/503 health gates still apply. Add a source-level provider budget only
+from a confirmed current limit, with rollout headroom and explicit review.
+
+## Internal policy topology
+
+The typed policy retains provider quota and deployment-override maps as the
+future control-plane seam. Their keys are derived from the provider registry:
+
+- `provider:account` is a provider-account quota shared by all mapped models,
+  for example `continuum:account`.
+- `provider:model:<provider_model_id>` is a provider-model quota, for example
+  `tinfoil:model:kimi-k3`.
+
+Quota budgets must use the scope declared by the registry. Deployment
+overrides always use the provider-model form because concurrency is tracked per
+deployment even when quota is provider-account scoped. The compiled baseline
+leaves both maps empty and uses the global deployment limit above.
+
+A future source may supply any combination of request, prompt-token,
+completion-token, and cached-token budgets. They are evaluated over the rolling
+window, and omitted dimensions remain unmetered. Policy validation rejects
+unknown topology keys or invalid limits before a controller can be created.
+
+## Reservation accounting
+
+Prompt reservations use the UTF-8 byte length of the complete serialized
+provider-visible request after replacing message image payloads with small
+sentinels, plus conservative per-request, per-message, and per-tool template
+allowances and the full worst-case expansion of provider-rendered `&amp;` and
+`&quot;` attribute entities. It also accounts for normalized JSON delimiter
+spacing, Unicode escaping, model-visible tool-call tags, and parsed argument
+entries. A shared tokenizer is not used for admission because provider
+tokenizers can split identical text very differently. The byte bound counts
+JSON keys, numbers, structure, tool schemas, response-format schemas,
+documents, and provider template arguments without tokenizing base64 image
+bytes. Each explicit or shorthand image part instead uses the selected
+deployment's registry bound: Kimi K3 reserves 16,384 prompt tokens per image
+and Continuum Kimi K2.6 reserves 4,096. Vision bounds are route metadata, so a
+provider preprocessor or model change must update the registry and its tests in
+the same release. Video content and provider-internal cached image/embed
+carriers are rejected on these image-only public routes; they are not forwarded
+with an unbounded or guessed media-token reservation.
+
+An explicit completion limit is multiplied by the request's positive `n`
+value; `n` defaults to one. If both completion-limit fields are absent or null,
+OpenSecret forwards `completion_default_reservation` as `max_tokens` and
+reserves that cap per generated choice and model turn. This structurally bounds
+provider extensions such as `ignore_eos` and token allowlists. Forwarded
+`min_tokens` raises both the injected cap and reservation whenever it exceeds
+the compiled baseline. Non-null explicit limits remain provider-validated and
+are never silently repaired.
+
+Output maxima, `n`, `min_tokens`, and `stream` must use their canonical JSON
+integer/boolean types. Provider-coercible strings, floats, and numeric stream
+flags are rejected before admission so local reservations and response parsing
+cannot disagree with the provider. `n` is also capped by
+`max_completion_choices` independently of provider quotas, preventing
+one deployment slot from expanding into thousands of provider sequences.
+Provider-internal KV-transfer parameters
+are stripped before estimation and forwarding; clients cannot replace the
+rendered conversation with pre-tokenized prompt IDs.
+
+Message, function, and named tool-choice names follow the OpenAI-compatible
+1-64 byte `[A-Za-z0-9_-]` contract. Enforcing that boundary prevents provider
+templates from entity-expanding or duplicating an unbounded function name
+across tool-result messages. Historical assistant tool arguments must be valid
+JSON strings no larger than 1 MiB; their normalized JSON rendering is included
+in the reservation so exponent-form numbers and other canonicalization cannot
+expand behind admission.
+
+The controller initially reserves the full prompt estimate against both prompt
+and cached-token dimensions. Terminal usage reconciles prompt, completion, and
+cached observations independently. A provider-omitted dimension retains a
+conservative reservation; it is never interpreted as an authoritative zero.
+
+OpenSecret is the sole owner of model selection and tool-loop execution.
+Tinfoil router-only options (including built-in tool profiles and per-function
+auto-continue) are stripped before the provider send so one admitted turn
+cannot fan out into hidden provider generations.
+
+## Replica budgeting
+
+Admission state and accounting are intentionally local to one OpenSecret
+process or enclave. If a confirmed provider budget is later compiled into the
+policy, assign each enclave only its intended share, including headroom for
+uneven sticky-routing traffic. Recalculate and review those constants whenever
+the replica count, provider entitlement, model mapping, or observed traffic
+distribution changes.
+
+This is a rollout-safety boundary, not a distributed quota guarantee. One
+enclave can temporarily leave capacity unused while another is saturated.
+
+## Deployment
+
+There is no admission-policy provisioning step for local or Nitro deployments.
+OpenSecret constructs the compiled baseline while building `AppState`; a stray
+environment variable or `enclave_secrets` row cannot alter it. To change the
+policy, edit the baseline constants and typed policy construction, run the
+admission and routing test suites, build a new artifact, and restart or roll the
+affected processes or enclaves.
+
+This deliberately temporary ownership model avoids treating the encrypted
+secrets table as a manual control plane. A future admin API should authenticate
+and authorize policy changes, validate the complete policy against the fixed
+provider registry, and make rollout/audit semantics explicit before it replaces
+the compiled source.

--- a/src/db.rs
+++ b/src/db.rs
@@ -703,6 +703,8 @@ pub trait DBConnection {
 
     // Reasoning items
     fn create_reasoning_item(&self, new_item: NewReasoningItem) -> Result<ReasoningItem, DBError>;
+    fn get_reasoning_item_by_uuid(&self, item_uuid: Uuid)
+        -> Result<Option<ReasoningItem>, DBError>;
     fn update_reasoning_item(
         &self,
         item_uuid: Uuid,
@@ -715,6 +717,7 @@ pub trait DBConnection {
     fn create_tool_call(&self, new_call: NewToolCall) -> Result<ToolCall, DBError>;
     fn get_tool_call_by_uuid(&self, uuid: Uuid, user_id: Uuid) -> Result<ToolCall, DBError>;
     fn create_tool_output(&self, new_output: NewToolOutput) -> Result<ToolOutput, DBError>;
+    fn get_tool_output_by_uuid(&self, uuid: Uuid, user_id: Uuid) -> Result<ToolOutput, DBError>;
 
     // Context reconstruction
     fn get_conversation_context_messages(
@@ -2885,6 +2888,14 @@ impl DBConnection for PostgresConnection {
         new_item.insert(conn).map_err(DBError::from)
     }
 
+    fn get_reasoning_item_by_uuid(
+        &self,
+        item_uuid: Uuid,
+    ) -> Result<Option<ReasoningItem>, DBError> {
+        let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
+        ReasoningItem::get_by_uuid(conn, item_uuid).map_err(DBError::from)
+    }
+
     fn update_reasoning_item(
         &self,
         item_uuid: Uuid,
@@ -2911,6 +2922,11 @@ impl DBConnection for PostgresConnection {
     fn create_tool_output(&self, new_output: NewToolOutput) -> Result<ToolOutput, DBError> {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         new_output.insert(conn).map_err(DBError::from)
+    }
+
+    fn get_tool_output_by_uuid(&self, uuid: Uuid, user_id: Uuid) -> Result<ToolOutput, DBError> {
+        let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
+        ToolOutput::get_by_uuid(conn, uuid, user_id).map_err(DBError::from)
     }
 
     // Context reconstruction

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -4,6 +4,8 @@ use std::fmt;
 use std::time::Duration;
 use uuid::Uuid;
 
+pub(crate) mod health;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ModelSelectionMode {
     AutoQuick,

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::time::Duration;
 use uuid::Uuid;
 
+pub(crate) mod admission;
 pub(crate) mod health;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -62,6 +63,12 @@ macro_rules! inference_id {
 inference_id!(InferenceRequestId);
 inference_id!(InferenceExecutionId);
 inference_id!(InferenceAttemptId);
+
+impl InferenceExecutionId {
+    pub(crate) const fn as_uuid(self) -> Uuid {
+        self.0
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct InferenceIntent {

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -103,6 +103,14 @@ impl InferenceIntent {
             execution_id: InferenceExecutionId::new(),
         }
     }
+
+    /// Clones the logical request for planning one policy-approved public-model
+    /// candidate while preserving the original selector and request identity.
+    pub(crate) fn for_candidate_public_model(&self, public_model_id: impl Into<String>) -> Self {
+        let mut candidate = self.clone();
+        candidate.public_model_id = public_model_id.into();
+        candidate
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -342,6 +350,25 @@ mod tests {
 
         assert_eq!(intent.selection_mode, ModelSelectionMode::Explicit);
         assert!(!intent.selection_mode.is_auto());
+    }
+
+    #[test]
+    fn candidate_intent_preserves_original_auto_authority_and_request_identity() {
+        let preferred = InferenceIntent::new(
+            Uuid::nil(),
+            AUTO_POWERFUL_MODEL_ID,
+            "kimi-k3",
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+        let candidate = preferred.for_candidate_public_model("kimi-k2-6");
+
+        assert_eq!(candidate.request_id, preferred.request_id);
+        assert_eq!(candidate.requested_model_id, AUTO_POWERFUL_MODEL_ID);
+        assert_eq!(candidate.selection_mode, ModelSelectionMode::AutoPowerful);
+        assert_eq!(preferred.public_model_id, "kimi-k3");
+        assert_eq!(candidate.public_model_id, "kimi-k2-6");
     }
 
     #[test]

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1,0 +1,390 @@
+use crate::model_config::{ModelPlan, AUTO_POWERFUL_MODEL_ID, AUTO_QUICK_MODEL_ID};
+use crate::provider_routing::{ProviderName, ProviderSelectionSource};
+use std::fmt;
+use std::time::Duration;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ModelSelectionMode {
+    AutoQuick,
+    AutoPowerful,
+    Explicit,
+}
+
+impl ModelSelectionMode {
+    pub(crate) fn from_requested_model(model: &str) -> Self {
+        match model {
+            AUTO_QUICK_MODEL_ID => Self::AutoQuick,
+            AUTO_POWERFUL_MODEL_ID => Self::AutoPowerful,
+            _ => Self::Explicit,
+        }
+    }
+
+    pub(crate) const fn is_auto(self) -> bool {
+        matches!(self, Self::AutoQuick | Self::AutoPowerful)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum InferenceSurface {
+    ChatCompletions,
+    Responses,
+    Internal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WorkloadClass {
+    Interactive,
+    Background,
+}
+
+macro_rules! inference_id {
+    ($name:ident) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        pub(crate) struct $name(Uuid);
+
+        impl $name {
+            fn new() -> Self {
+                Self(Uuid::new_v4())
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.0.fmt(formatter)
+            }
+        }
+    };
+}
+
+inference_id!(InferenceRequestId);
+inference_id!(InferenceExecutionId);
+inference_id!(InferenceAttemptId);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InferenceIntent {
+    pub(crate) request_id: InferenceRequestId,
+    pub(crate) account_uuid: Uuid,
+    pub(crate) requested_model_id: String,
+    pub(crate) public_model_id: String,
+    pub(crate) selection_mode: ModelSelectionMode,
+    pub(crate) model_plan: ModelPlan,
+    pub(crate) surface: InferenceSurface,
+    pub(crate) workload_class: WorkloadClass,
+}
+
+impl InferenceIntent {
+    pub(crate) fn new(
+        account_uuid: Uuid,
+        requested_model_id: impl Into<String>,
+        public_model_id: impl Into<String>,
+        model_plan: ModelPlan,
+        surface: InferenceSurface,
+        workload_class: WorkloadClass,
+    ) -> Self {
+        let requested_model_id = requested_model_id.into();
+        Self {
+            request_id: InferenceRequestId::new(),
+            account_uuid,
+            selection_mode: ModelSelectionMode::from_requested_model(&requested_model_id),
+            requested_model_id,
+            public_model_id: public_model_id.into(),
+            model_plan,
+            surface,
+            workload_class,
+        }
+    }
+
+    pub(crate) fn begin_execution(&self) -> InferenceExecution {
+        InferenceExecution {
+            request_id: self.request_id,
+            execution_id: InferenceExecutionId::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RouteIdentity {
+    pub(crate) provider: ProviderName,
+    pub(crate) public_model_id: String,
+    pub(crate) provider_model_id: String,
+    pub(crate) response_model_id: String,
+    pub(crate) selection_source: ProviderSelectionSource,
+    pub(crate) bucket: Option<u8>,
+}
+
+impl RouteIdentity {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        provider: ProviderName,
+        public_model_id: impl Into<String>,
+        provider_model_id: impl Into<String>,
+        response_model_id: impl Into<String>,
+        selection_source: ProviderSelectionSource,
+        bucket: Option<u8>,
+    ) -> Self {
+        Self {
+            provider,
+            public_model_id: public_model_id.into(),
+            provider_model_id: provider_model_id.into(),
+            response_model_id: response_model_id.into(),
+            selection_source,
+            bucket,
+        }
+    }
+
+    pub(crate) fn route_key(&self) -> RouteKey {
+        RouteKey {
+            provider: self.provider,
+            provider_model_id: self.provider_model_id.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct RouteKey {
+    pub(crate) provider: ProviderName,
+    pub(crate) provider_model_id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct InferenceExecution {
+    pub(crate) request_id: InferenceRequestId,
+    pub(crate) execution_id: InferenceExecutionId,
+}
+
+impl InferenceExecution {
+    pub(crate) fn begin_attempt(&self, route: RouteIdentity) -> InferenceAttempt {
+        InferenceAttempt {
+            request_id: self.request_id,
+            execution_id: self.execution_id,
+            attempt_id: InferenceAttemptId::new(),
+            route,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct InferenceAttempt {
+    pub(crate) request_id: InferenceRequestId,
+    pub(crate) execution_id: InferenceExecutionId,
+    pub(crate) attempt_id: InferenceAttemptId,
+    pub(crate) route: RouteIdentity,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AttemptStage {
+    BeforeSend,
+    AwaitingResponse,
+    ResponseBody,
+    Stream,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReplaySafety {
+    ProvenPreAcceptance,
+    NotProvenPreAcceptance,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AttemptFailureKind {
+    ProviderUnavailable,
+    RequestBuild,
+    Connect,
+    Transport,
+    ResponseStartTimeout,
+    HttpStatus,
+    ResponseBody,
+    InvalidResponse,
+    UpstreamResponseError,
+    UpstreamStreamError,
+    StreamTimeout,
+    UnexpectedEof,
+    ConsumerDropped,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AttemptFailure {
+    pub(crate) kind: AttemptFailureKind,
+    pub(crate) stage: AttemptStage,
+    pub(crate) replay_safety: ReplaySafety,
+    pub(crate) status: Option<u16>,
+    pub(crate) retry_after: Option<Duration>,
+    pub(crate) upstream_request_id: Option<String>,
+    pub(crate) upstream_code: Option<String>,
+}
+
+impl AttemptFailure {
+    pub(crate) const fn new(
+        kind: AttemptFailureKind,
+        stage: AttemptStage,
+        replay_safety: ReplaySafety,
+    ) -> Self {
+        Self {
+            kind,
+            stage,
+            replay_safety,
+            status: None,
+            retry_after: None,
+            upstream_request_id: None,
+            upstream_code: None,
+        }
+    }
+
+    pub(crate) fn with_upstream_response(
+        mut self,
+        status: u16,
+        retry_after: Option<Duration>,
+        upstream_request_id: Option<String>,
+    ) -> Self {
+        self.status = Some(status);
+        self.retry_after = retry_after;
+        self.upstream_request_id = upstream_request_id;
+        self
+    }
+
+    pub(crate) fn with_upstream_code(mut self, upstream_code: Option<String>) -> Self {
+        self.upstream_code = upstream_code;
+        self
+    }
+
+    pub(crate) const fn client_message(&self) -> &'static str {
+        match self.kind {
+            AttemptFailureKind::InvalidResponse => "Invalid response from inference provider",
+            AttemptFailureKind::StreamTimeout => "Inference provider stream timed out",
+            AttemptFailureKind::UnexpectedEof => "Inference provider stream ended unexpectedly",
+            _ => "Inference provider request failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CompletionEvidence {
+    NonStreamingResponse,
+    ProviderDone,
+    FinishSignalThenEof,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AttemptTerminal {
+    Completed {
+        attempt: InferenceAttempt,
+        evidence: CompletionEvidence,
+    },
+    Failed {
+        attempt: InferenceAttempt,
+        failure: AttemptFailure,
+    },
+}
+
+impl AttemptTerminal {
+    pub(crate) fn attempt(&self) -> &InferenceAttempt {
+        match self {
+            Self::Completed { attempt, .. } | Self::Failed { attempt, .. } => attempt,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AttemptOutcome {
+    ResponseStarted {
+        attempt: InferenceAttempt,
+        status: u16,
+    },
+    Terminal(AttemptTerminal),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn route() -> RouteIdentity {
+        RouteIdentity::new(
+            ProviderName::Tinfoil,
+            "kimi-k3",
+            "kimi-k3",
+            "kimi-k3",
+            ProviderSelectionSource::StaticSplit,
+            None,
+        )
+    }
+
+    #[test]
+    fn intent_preserves_requested_auto_selector_and_resolved_public_model() {
+        let intent = InferenceIntent::new(
+            Uuid::nil(),
+            AUTO_POWERFUL_MODEL_ID,
+            "kimi-k3",
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+
+        assert_eq!(intent.requested_model_id, AUTO_POWERFUL_MODEL_ID);
+        assert_eq!(intent.public_model_id, "kimi-k3");
+        assert_eq!(intent.selection_mode, ModelSelectionMode::AutoPowerful);
+        assert!(intent.selection_mode.is_auto());
+    }
+
+    #[test]
+    fn explicit_intent_remains_explicit() {
+        let intent = InferenceIntent::new(
+            Uuid::nil(),
+            "kimi-k3",
+            "kimi-k3",
+            ModelPlan::Paid,
+            InferenceSurface::ChatCompletions,
+            WorkloadClass::Interactive,
+        );
+
+        assert_eq!(intent.selection_mode, ModelSelectionMode::Explicit);
+        assert!(!intent.selection_mode.is_auto());
+    }
+
+    #[test]
+    fn executions_and_attempts_keep_parent_ids_and_get_unique_ids() {
+        let intent = InferenceIntent::new(
+            Uuid::nil(),
+            "glm-5-2",
+            "glm-5-2",
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+        let first_execution = intent.begin_execution();
+        let second_execution = intent.begin_execution();
+        let first_attempt = first_execution.begin_attempt(route());
+        let second_attempt = first_execution.begin_attempt(route());
+
+        assert_eq!(first_execution.request_id, intent.request_id);
+        assert_eq!(second_execution.request_id, intent.request_id);
+        assert_ne!(first_execution.execution_id, second_execution.execution_id);
+        assert_eq!(first_attempt.execution_id, first_execution.execution_id);
+        assert_eq!(second_attempt.execution_id, first_execution.execution_id);
+        assert_ne!(first_attempt.attempt_id, second_attempt.attempt_id);
+        assert_ne!(
+            first_attempt.attempt_id.to_string(),
+            Uuid::nil().to_string()
+        );
+    }
+
+    #[test]
+    fn route_key_uses_typed_provider_and_upstream_model() {
+        let route = RouteIdentity::new(
+            ProviderName::Continuum,
+            "glm-5-2",
+            "glm-5.2",
+            "glm-5-2",
+            ProviderSelectionSource::FeatureFlag,
+            None,
+        );
+
+        assert_eq!(
+            route.route_key(),
+            RouteKey {
+                provider: ProviderName::Continuum,
+                provider_model_id: "glm-5.2".to_string(),
+            }
+        );
+    }
+}

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -1,5 +1,5 @@
 use crate::model_config::{ModelPlan, AUTO_POWERFUL_MODEL_ID, AUTO_QUICK_MODEL_ID};
-use crate::provider_routing::{ProviderName, ProviderSelectionSource};
+use crate::provider_registry::{ProviderId, RouteSelectionSource};
 use std::fmt;
 use std::time::Duration;
 use uuid::Uuid;
@@ -105,22 +105,22 @@ impl InferenceIntent {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RouteIdentity {
-    pub(crate) provider: ProviderName,
+    pub(crate) provider: ProviderId,
     pub(crate) public_model_id: String,
     pub(crate) provider_model_id: String,
     pub(crate) response_model_id: String,
-    pub(crate) selection_source: ProviderSelectionSource,
+    pub(crate) selection_source: RouteSelectionSource,
     pub(crate) bucket: Option<u8>,
 }
 
 impl RouteIdentity {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
-        provider: ProviderName,
+        provider: ProviderId,
         public_model_id: impl Into<String>,
         provider_model_id: impl Into<String>,
         response_model_id: impl Into<String>,
-        selection_source: ProviderSelectionSource,
+        selection_source: RouteSelectionSource,
         bucket: Option<u8>,
     ) -> Self {
         Self {
@@ -143,7 +143,7 @@ impl RouteIdentity {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct RouteKey {
-    pub(crate) provider: ProviderName,
+    pub(crate) provider: ProviderId,
     pub(crate) provider_model_id: String,
 }
 
@@ -300,11 +300,11 @@ mod tests {
 
     fn route() -> RouteIdentity {
         RouteIdentity::new(
-            ProviderName::Tinfoil,
+            ProviderId::Tinfoil,
             "kimi-k3",
             "kimi-k3",
             "kimi-k3",
-            ProviderSelectionSource::StaticSplit,
+            RouteSelectionSource::StaticSplit,
             None,
         )
     }
@@ -371,18 +371,18 @@ mod tests {
     #[test]
     fn route_key_uses_typed_provider_and_upstream_model() {
         let route = RouteIdentity::new(
-            ProviderName::Continuum,
+            ProviderId::Continuum,
             "glm-5-2",
             "glm-5.2",
             "glm-5-2",
-            ProviderSelectionSource::FeatureFlag,
+            RouteSelectionSource::FeatureFlag,
             None,
         );
 
         assert_eq!(
             route.route_key(),
             RouteKey {
-                provider: ProviderName::Continuum,
+                provider: ProviderId::Continuum,
                 provider_model_id: "glm-5.2".to_string(),
             }
         );

--- a/src/inference.rs
+++ b/src/inference.rs
@@ -194,6 +194,7 @@ pub(crate) enum AttemptFailureKind {
     Transport,
     ResponseStartTimeout,
     HttpStatus,
+    CapacityRejected,
     ResponseBody,
     InvalidResponse,
     UpstreamResponseError,

--- a/src/inference/admission.rs
+++ b/src/inference/admission.rs
@@ -1,0 +1,2600 @@
+//! Enclave-local admission control for completion inference.
+//!
+//! The controller deliberately has no distributed coordination. It uses the
+//! credential-free provider registry as a fixed topology, bounds every waiting
+//! queue, and admits a turn only when its quota-pool reservation and deployment
+//! concurrency slot can be acquired atomically. Logical tickets provide a
+//! separate per-account bound for a complete response/tool loop.
+
+use super::health::CapacityPoolKey;
+use super::{RouteKey, WorkloadClass};
+use crate::provider_registry::{ProviderRegistry, RateLimitScope, PROVIDER_REGISTRY};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+use thiserror::Error;
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+// The first release deliberately owns its policy in code. Changing these
+// values requires review, a new enclave build, and a restart. AdmissionPolicy
+// remains the typed boundary that a future authenticated admin control plane
+// can populate without changing scheduler internals.
+const BASELINE_DEPLOYMENT_IN_FLIGHT: usize = 4;
+const BASELINE_PER_ACCOUNT_IN_FLIGHT: usize = 2;
+const BASELINE_POOL_QUEUE: usize = 16;
+const BASELINE_PER_ACCOUNT_QUEUE: usize = 2;
+const BASELINE_INTERACTIVE_WAIT: Duration = Duration::from_secs(5);
+const BASELINE_BACKGROUND_WAIT: Duration = Duration::ZERO;
+const BASELINE_LOCAL_RETRY: Duration = Duration::from_secs(1);
+const BASELINE_ROLLING_WINDOW: Duration = Duration::from_secs(60);
+const BASELINE_COMPLETION_RESERVATION: u64 = 4_096;
+const BASELINE_MAX_COMPLETION_CHOICES: u64 = 8;
+const MAX_POLICY_COMPLETION_CHOICES: u64 = 128;
+
+// Individual accounting dimensions are added with saturating arithmetic, but
+// rejecting values above i64::MAX avoids accepting an accidental overflow
+// sentinel as a real provider limit and keeps a future persisted policy
+// round-trippable through common control-plane stores.
+const MAX_POLICY_BUDGET: u64 = i64::MAX as u64;
+
+/// Typed, enclave-local admission policy.
+///
+/// The initial policy is compiled into the enclave. No provider quota is
+/// guessed: absent RPM/TPM dimensions remain unmetered until a reviewed source
+/// policy supplies a confirmed limit.
+#[derive(Debug, Clone)]
+pub(crate) struct AdmissionPolicy {
+    deployment_in_flight: usize,
+    per_account_in_flight: usize,
+    pool_queue: usize,
+    per_account_queue: usize,
+    interactive_wait: Duration,
+    background_wait: Duration,
+    local_retry: Duration,
+    rolling_window: Duration,
+    completion_default_reservation: u64,
+    max_completion_choices: u64,
+    quota_budgets: HashMap<CapacityPoolKey, QuotaBudget>,
+    deployment_overrides: HashMap<RouteKey, usize>,
+}
+
+impl AdmissionPolicy {
+    fn baseline() -> Self {
+        Self {
+            deployment_in_flight: BASELINE_DEPLOYMENT_IN_FLIGHT,
+            per_account_in_flight: BASELINE_PER_ACCOUNT_IN_FLIGHT,
+            pool_queue: BASELINE_POOL_QUEUE,
+            per_account_queue: BASELINE_PER_ACCOUNT_QUEUE,
+            interactive_wait: BASELINE_INTERACTIVE_WAIT,
+            background_wait: BASELINE_BACKGROUND_WAIT,
+            local_retry: BASELINE_LOCAL_RETRY,
+            rolling_window: BASELINE_ROLLING_WINDOW,
+            completion_default_reservation: BASELINE_COMPLETION_RESERVATION,
+            max_completion_choices: BASELINE_MAX_COMPLETION_CHOICES,
+            // Provider entitlements can drift and may differ by environment.
+            // Do not guess them in the compiled baseline.
+            quota_budgets: HashMap::new(),
+            deployment_overrides: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn baseline_for(
+        registry: &'static ProviderRegistry,
+    ) -> Result<Self, AdmissionConfigError> {
+        let policy = Self::baseline();
+        policy.validate_for(registry)?;
+        Ok(policy)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_deployment_in_flight_for_test(
+        registry: &'static ProviderRegistry,
+        deployment_in_flight: usize,
+    ) -> Result<Self, AdmissionConfigError> {
+        let mut policy = Self::baseline();
+        policy.deployment_in_flight = deployment_in_flight;
+        policy.validate_for(registry)?;
+        Ok(policy)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn deployment_in_flight(&self) -> usize {
+        self.deployment_in_flight
+    }
+
+    pub(crate) fn per_account_in_flight(&self) -> usize {
+        self.per_account_in_flight
+    }
+
+    #[cfg(test)]
+    pub(crate) fn pool_queue(&self) -> usize {
+        self.pool_queue
+    }
+
+    #[cfg(test)]
+    pub(crate) fn per_account_queue(&self) -> usize {
+        self.per_account_queue
+    }
+
+    pub(crate) fn interactive_wait(&self) -> Duration {
+        self.interactive_wait
+    }
+
+    pub(crate) fn background_wait(&self) -> Duration {
+        self.background_wait
+    }
+
+    #[cfg(test)]
+    pub(crate) fn local_retry(&self) -> Duration {
+        self.local_retry
+    }
+
+    #[cfg(test)]
+    pub(crate) fn rolling_window(&self) -> Duration {
+        self.rolling_window
+    }
+
+    pub(crate) fn completion_default_reservation(&self) -> u64 {
+        self.completion_default_reservation
+    }
+
+    pub(crate) fn max_completion_choices(&self) -> u64 {
+        self.max_completion_choices
+    }
+
+    fn validate_for(
+        &self,
+        registry: &'static ProviderRegistry,
+    ) -> Result<(), AdmissionConfigError> {
+        if self.deployment_in_flight == 0 {
+            return Err(AdmissionConfigError::InvalidValue {
+                field: "deployment_in_flight",
+                reason: "must be greater than zero",
+            });
+        }
+        if self.per_account_in_flight == 0 {
+            return Err(AdmissionConfigError::InvalidValue {
+                field: "per_account_in_flight",
+                reason: "must be greater than zero",
+            });
+        }
+        if self.pool_queue == 0 {
+            return Err(AdmissionConfigError::InvalidValue {
+                field: "pool_queue",
+                reason: "must be greater than zero",
+            });
+        }
+        if self.per_account_queue == 0 {
+            return Err(AdmissionConfigError::InvalidValue {
+                field: "per_account_queue",
+                reason: "must be greater than zero",
+            });
+        }
+        if self.interactive_wait.is_zero() {
+            return Err(AdmissionConfigError::InvalidValue {
+                field: "interactive_wait_ms",
+                reason: "must be greater than zero",
+            });
+        }
+        if !self.background_wait.is_zero() {
+            return Err(AdmissionConfigError::InvalidValue {
+                field: "background_wait_ms",
+                reason: "background work is immediate-only and must use zero",
+            });
+        }
+        if self.local_retry.is_zero() {
+            return Err(AdmissionConfigError::InvalidValue {
+                field: "local_retry_ms",
+                reason: "must be greater than zero",
+            });
+        }
+        if self.rolling_window.is_zero() {
+            return Err(AdmissionConfigError::InvalidValue {
+                field: "rolling_window_seconds",
+                reason: "must be greater than zero",
+            });
+        }
+        if self.completion_default_reservation == 0
+            || self.completion_default_reservation > MAX_POLICY_BUDGET
+        {
+            return Err(AdmissionConfigError::InvalidValue {
+                field: "completion_default_reservation",
+                reason: "must be between 1 and i64::MAX",
+            });
+        }
+        if self.max_completion_choices == 0
+            || self.max_completion_choices > MAX_POLICY_COMPLETION_CHOICES
+        {
+            return Err(AdmissionConfigError::InvalidValue {
+                field: "max_completion_choices",
+                reason: "must be between 1 and 128",
+            });
+        }
+        validate_instant_duration("interactive_wait_ms", self.interactive_wait)?;
+        validate_instant_duration("background_wait_ms", self.background_wait)?;
+        validate_instant_duration("local_retry_ms", self.local_retry)?;
+        validate_instant_duration("rolling_window_seconds", self.rolling_window)?;
+
+        let topology = Topology::from_registry(registry)?;
+        for (pool, budget) in &self.quota_budgets {
+            if !topology.quota_pools.contains(pool) {
+                return Err(AdmissionConfigError::UnknownPoolId(capacity_pool_id(pool)));
+            }
+            budget.validate()?;
+        }
+        for (route, limit) in &self.deployment_overrides {
+            if !topology.routes.contains(route) {
+                return Err(AdmissionConfigError::UnknownDeploymentId(
+                    deployment_pool_id(route),
+                ));
+            }
+            if *limit == 0 {
+                return Err(AdmissionConfigError::InvalidValue {
+                    field: "deployments[].in_flight",
+                    reason: "must be greater than zero",
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub(crate) enum AdmissionConfigError {
+    #[error("invalid admission policy field {field}: {reason}")]
+    InvalidValue {
+        field: &'static str,
+        reason: &'static str,
+    },
+    #[error("unknown admission quota pool ID: {0}")]
+    UnknownPoolId(String),
+    #[error("unknown admission deployment ID: {0}")]
+    UnknownDeploymentId(String),
+    #[error("provider registry maps route {route} to conflicting quota scopes")]
+    ConflictingRouteScope { route: String },
+}
+
+fn validate_instant_duration(
+    field: &'static str,
+    duration: Duration,
+) -> Result<(), AdmissionConfigError> {
+    if Instant::now().checked_add(duration).is_none() {
+        return Err(AdmissionConfigError::InvalidValue {
+            field,
+            reason: "duration overflows a monotonic deadline",
+        });
+    }
+    Ok(())
+}
+
+/// A conservative reservation estimate. The prompt estimate is reserved
+/// against both prompt and cached-token budgets because cached usage is not
+/// reliably knowable before the upstream accepts the request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AdmissionEstimate {
+    pub(crate) prompt_tokens: u64,
+    pub(crate) completion_tokens: Option<u64>,
+}
+
+impl AdmissionEstimate {
+    pub(crate) const fn new(prompt_tokens: u64, completion_tokens: Option<u64>) -> Self {
+        Self {
+            prompt_tokens,
+            completion_tokens,
+        }
+    }
+}
+
+/// Usage known after a provider turn. Missing dimensions conservatively keep
+/// their original reservations during reconciliation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct ActualUsage {
+    pub(crate) prompt_tokens: Option<u64>,
+    pub(crate) completion_tokens: Option<u64>,
+    pub(crate) cached_prompt_tokens: Option<u64>,
+}
+
+impl ActualUsage {
+    #[cfg(test)]
+    pub(crate) const fn complete(
+        prompt_tokens: u64,
+        completion_tokens: u64,
+        cached_prompt_tokens: Option<u64>,
+    ) -> Self {
+        Self {
+            prompt_tokens: Some(prompt_tokens),
+            completion_tokens: Some(completion_tokens),
+            cached_prompt_tokens,
+        }
+    }
+}
+
+/// Whether an upstream terminal permits the reservation to be changed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TerminalDisposition {
+    /// The turn completed and reported usage may replace reserved dimensions.
+    Completed,
+    /// The request is proven not to have been accepted; refund it completely.
+    ProvenPreAcceptance,
+    /// Acceptance or usage is ambiguous; retain the full reservation.
+    Ambiguous,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AdmissionRejectionKind {
+    RateBudget,
+    DeploymentBusy,
+    AccountBusy,
+    QueueFull,
+    WaitTimeout,
+    BackgroundShed,
+    UnknownRoute,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("inference admission rejected: {kind:?}")]
+pub(crate) struct AdmissionRejection {
+    pub(crate) kind: AdmissionRejectionKind,
+    pub(crate) retry_after: Duration,
+}
+
+impl AdmissionRejection {
+    pub(crate) const fn status_hint(&self) -> u16 {
+        match self.kind {
+            AdmissionRejectionKind::RateBudget => 429,
+            AdmissionRejectionKind::DeploymentBusy
+            | AdmissionRejectionKind::AccountBusy
+            | AdmissionRejectionKind::QueueFull
+            | AdmissionRejectionKind::WaitTimeout
+            | AdmissionRejectionKind::BackgroundShed
+            | AdmissionRejectionKind::UnknownRoute => 503,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct UsageAmount {
+    requests: u64,
+    prompt_tokens: u64,
+    completion_tokens: u64,
+    cached_tokens: u64,
+}
+
+impl UsageAmount {
+    fn saturating_add(self, other: Self) -> Self {
+        Self {
+            requests: self.requests.saturating_add(other.requests),
+            prompt_tokens: self.prompt_tokens.saturating_add(other.prompt_tokens),
+            completion_tokens: self
+                .completion_tokens
+                .saturating_add(other.completion_tokens),
+            cached_tokens: self.cached_tokens.saturating_add(other.cached_tokens),
+        }
+    }
+
+    fn saturating_sub(self, other: Self) -> Self {
+        Self {
+            requests: self.requests.saturating_sub(other.requests),
+            prompt_tokens: self.prompt_tokens.saturating_sub(other.prompt_tokens),
+            completion_tokens: self
+                .completion_tokens
+                .saturating_sub(other.completion_tokens),
+            cached_tokens: self.cached_tokens.saturating_sub(other.cached_tokens),
+        }
+    }
+
+    fn is_zero(self) -> bool {
+        self == Self::default()
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct QuotaBudget {
+    requests: Option<u64>,
+    prompt_tokens: Option<u64>,
+    completion_tokens: Option<u64>,
+    cached_tokens: Option<u64>,
+}
+
+impl QuotaBudget {
+    fn validate(self) -> Result<(), AdmissionConfigError> {
+        for (field, value) in [
+            ("rpm", self.requests),
+            ("prompt_tpm", self.prompt_tokens),
+            ("completion_tpm", self.completion_tokens),
+            ("cached_tpm", self.cached_tokens),
+        ] {
+            if value.is_some_and(|value| value == 0 || value > MAX_POLICY_BUDGET) {
+                return Err(AdmissionConfigError::InvalidValue {
+                    field,
+                    reason: "must be between 1 and i64::MAX",
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn charged(self, usage: UsageAmount) -> UsageAmount {
+        UsageAmount {
+            requests: self.requests.map_or(0, |_| usage.requests),
+            prompt_tokens: self.prompt_tokens.map_or(0, |_| usage.prompt_tokens),
+            completion_tokens: self
+                .completion_tokens
+                .map_or(0, |_| usage.completion_tokens),
+            cached_tokens: self.cached_tokens.map_or(0, |_| usage.cached_tokens),
+        }
+    }
+
+    fn fits(self, current: UsageAmount, requested: UsageAmount) -> bool {
+        fn dimension_fits(current: u64, requested: u64, limit: Option<u64>) -> bool {
+            limit.is_none_or(|limit| current.saturating_add(requested) <= limit)
+        }
+
+        dimension_fits(current.requests, requested.requests, self.requests)
+            && dimension_fits(
+                current.prompt_tokens,
+                requested.prompt_tokens,
+                self.prompt_tokens,
+            )
+            && dimension_fits(
+                current.completion_tokens,
+                requested.completion_tokens,
+                self.completion_tokens,
+            )
+            && dimension_fits(
+                current.cached_tokens,
+                requested.cached_tokens,
+                self.cached_tokens,
+            )
+    }
+
+    fn request_can_ever_fit(self, requested: UsageAmount) -> bool {
+        self.fits(UsageAmount::default(), requested)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TimedUsage {
+    started_at: Instant,
+    amount: UsageAmount,
+}
+
+#[derive(Debug, Default)]
+struct QuotaLedger {
+    completed: VecDeque<TimedUsage>,
+    active: HashMap<u64, TimedUsage>,
+}
+
+impl QuotaLedger {
+    fn purge(&mut self, now: Instant, window: Duration) {
+        while self.completed.front().is_some_and(|entry| {
+            entry
+                .started_at
+                .checked_add(window)
+                .is_none_or(|expires| expires <= now)
+        }) {
+            self.completed.pop_front();
+        }
+    }
+
+    fn total(&self) -> UsageAmount {
+        self.completed
+            .iter()
+            .chain(self.active.values())
+            .fold(UsageAmount::default(), |total, entry| {
+                total.saturating_add(entry.amount)
+            })
+    }
+
+    fn reserve(&mut self, id: u64, started_at: Instant, amount: UsageAmount) {
+        let replaced = self.active.insert(id, TimedUsage { started_at, amount });
+        debug_assert!(replaced.is_none(), "admission reservation IDs are unique");
+    }
+
+    fn cancel_pending(&mut self, id: u64) -> bool {
+        self.active.remove(&id).is_some()
+    }
+
+    fn finish(
+        &mut self,
+        id: u64,
+        budget: QuotaBudget,
+        usage: Option<ActualUsage>,
+        disposition: TerminalDisposition,
+        now: Instant,
+        window: Duration,
+    ) -> bool {
+        let Some(reserved) = self.active.remove(&id) else {
+            return false;
+        };
+
+        let retained = match disposition {
+            TerminalDisposition::ProvenPreAcceptance => None,
+            TerminalDisposition::Ambiguous => Some(reserved.amount),
+            TerminalDisposition::Completed => usage.map_or(Some(reserved.amount), |usage| {
+                let completion_tokens = usage
+                    .completion_tokens
+                    .unwrap_or(reserved.amount.completion_tokens);
+                let (prompt_tokens, cached_tokens) =
+                    match (usage.prompt_tokens, usage.cached_prompt_tokens) {
+                        // Both dimensions are authoritative. Cached prompt
+                        // tokens are a subset of total prompt tokens.
+                        (Some(total), Some(cached)) => {
+                            let cached = cached.min(total);
+                            (total.saturating_sub(cached), cached)
+                        }
+                        // The total is authoritative but its cached split is
+                        // missing. Charge all of it as uncached and preserve a
+                        // cached charge at least as large as both known total
+                        // prompt usage and the original reservation.
+                        (Some(total), None) => (total, reserved.amount.cached_tokens.max(total)),
+                        // A cached count without a total cannot safely reduce
+                        // the uncached reservation. The explicit cached count
+                        // is nevertheless authoritative and must not be
+                        // clamped to a synthesized total.
+                        (None, Some(cached)) => (reserved.amount.prompt_tokens, cached),
+                        // Neither prompt dimension is known, so retain both
+                        // original reservations.
+                        (None, None) => {
+                            (reserved.amount.prompt_tokens, reserved.amount.cached_tokens)
+                        }
+                    };
+                Some(UsageAmount {
+                    requests: reserved.amount.requests,
+                    prompt_tokens,
+                    completion_tokens,
+                    cached_tokens,
+                })
+            }),
+        };
+
+        if let Some(amount) = retained.map(|amount| budget.charged(amount)) {
+            let still_in_window = reserved
+                .started_at
+                .checked_add(window)
+                .is_some_and(|expires| expires > now);
+            if still_in_window && !amount.is_zero() {
+                let entry = TimedUsage {
+                    started_at: reserved.started_at,
+                    amount,
+                };
+                let insertion = self
+                    .completed
+                    .iter()
+                    .position(|existing| existing.started_at > entry.started_at)
+                    .unwrap_or(self.completed.len());
+                self.completed.insert(insertion, entry);
+            }
+        }
+        self.purge(now, window);
+        true
+    }
+
+    fn earliest_expiry(&self, window: Duration, now: Instant) -> Option<Instant> {
+        self.completed.iter().find_map(|entry| {
+            entry
+                .started_at
+                .checked_add(window)
+                .filter(|expires| *expires > now)
+        })
+    }
+
+    fn earliest_budget_fit(
+        &self,
+        budget: QuotaBudget,
+        requested: UsageAmount,
+        window: Duration,
+        now: Instant,
+    ) -> Option<Instant> {
+        let mut remaining = self.total();
+        for entry in &self.completed {
+            let Some(expiry) = entry.started_at.checked_add(window) else {
+                continue;
+            };
+            if expiry <= now {
+                continue;
+            }
+            remaining = remaining.saturating_sub(entry.amount);
+            if budget.fits(remaining, requested) {
+                return Some(expiry);
+            }
+        }
+        None
+    }
+}
+
+#[derive(Debug)]
+struct LogicalWaiter {
+    id: u64,
+    deadline: Instant,
+    sender: oneshot::Sender<Result<(), AdmissionRejection>>,
+}
+
+#[derive(Debug, Default)]
+struct LogicalAccountState {
+    in_flight: usize,
+    waiters: VecDeque<LogicalWaiter>,
+}
+
+#[derive(Debug)]
+struct TurnWaiter {
+    id: u64,
+    account: Uuid,
+    route: RouteKey,
+    reservation: UsageAmount,
+    deadline: Instant,
+    sender: oneshot::Sender<Result<(), AdmissionRejection>>,
+}
+
+#[derive(Debug, Default)]
+struct FairQueue {
+    by_account: HashMap<Uuid, VecDeque<TurnWaiter>>,
+    round_robin: VecDeque<Uuid>,
+    len: usize,
+}
+
+impl FairQueue {
+    fn push(&mut self, waiter: TurnWaiter) {
+        let account = waiter.account;
+        let queue = self.by_account.entry(account).or_default();
+        if queue.is_empty() {
+            self.round_robin.push_back(account);
+        }
+        queue.push_back(waiter);
+        self.len += 1;
+    }
+
+    fn account_len(&self, account: Uuid) -> usize {
+        self.by_account.get(&account).map_or(0, VecDeque::len)
+    }
+
+    fn pop_round_robin_account(&mut self) -> Option<Uuid> {
+        self.round_robin.pop_front()
+    }
+
+    fn take_front(&mut self, account: Uuid) -> Option<TurnWaiter> {
+        let waiter = self.by_account.get_mut(&account)?.pop_front()?;
+        self.len -= 1;
+        Some(waiter)
+    }
+
+    fn restore_front(&mut self, account: Uuid, waiter: TurnWaiter) {
+        self.by_account
+            .entry(account)
+            .or_default()
+            .push_front(waiter);
+        self.len += 1;
+    }
+
+    fn account_has_more(&mut self, account: Uuid) -> bool {
+        let empty = self.by_account.get(&account).is_none_or(VecDeque::is_empty);
+        if empty {
+            self.by_account.remove(&account);
+        }
+        !empty
+    }
+
+    fn remove(&mut self, account: Uuid, id: u64) -> bool {
+        let mut removed = false;
+        if let Some(queue) = self.by_account.get_mut(&account) {
+            let before = queue.len();
+            queue.retain(|waiter| waiter.id != id);
+            removed = queue.len() != before;
+            if removed {
+                self.len -= 1;
+            }
+            if queue.is_empty() {
+                self.by_account.remove(&account);
+                self.round_robin.retain(|queued| *queued != account);
+            }
+        }
+        removed
+    }
+}
+
+#[derive(Debug)]
+struct DeploymentState {
+    in_flight: usize,
+    limit: usize,
+}
+
+#[derive(Debug)]
+struct QuotaPoolState {
+    budget: QuotaBudget,
+    ledger: QuotaLedger,
+    queue: FairQueue,
+    wake_at: Option<Instant>,
+}
+
+#[derive(Debug, Clone)]
+struct PendingTurnGrant {
+    route: RouteKey,
+    quota_pool: CapacityPoolKey,
+}
+
+#[derive(Debug)]
+struct AdmissionInner {
+    next_id: u64,
+    deployments: HashMap<RouteKey, DeploymentState>,
+    quota_pools: HashMap<CapacityPoolKey, QuotaPoolState>,
+    logical_accounts: HashMap<Uuid, LogicalAccountState>,
+    pending_logical: HashMap<u64, Uuid>,
+    pending_turns: HashMap<u64, PendingTurnGrant>,
+}
+
+impl AdmissionInner {
+    fn allocate_id(&mut self) -> u64 {
+        loop {
+            self.next_id = self.next_id.wrapping_add(1);
+            if self.next_id != 0
+                && !self.pending_logical.contains_key(&self.next_id)
+                && !self.pending_turns.contains_key(&self.next_id)
+                && self
+                    .quota_pools
+                    .values()
+                    .all(|pool| !pool.ledger.active.contains_key(&self.next_id))
+            {
+                return self.next_id;
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Topology {
+    routes: HashSet<RouteKey>,
+    quota_pools: HashSet<CapacityPoolKey>,
+    route_to_quota: HashMap<RouteKey, CapacityPoolKey>,
+}
+
+impl Topology {
+    fn from_registry(registry: &'static ProviderRegistry) -> Result<Self, AdmissionConfigError> {
+        let mut routes = HashSet::new();
+        let mut quota_pools = HashSet::new();
+        let mut route_to_quota = HashMap::new();
+
+        for model in registry.completion_models() {
+            for route in model.routes {
+                let route_key = RouteKey {
+                    provider: route.provider,
+                    provider_model_id: route.provider_model_id.to_string(),
+                };
+                let quota_pool = match route.rate_limit_scope {
+                    RateLimitScope::ProviderModel => {
+                        CapacityPoolKey::ProviderModel(route_key.clone())
+                    }
+                    RateLimitScope::ProviderAccount => {
+                        CapacityPoolKey::ProviderAccount(route.provider)
+                    }
+                };
+
+                if let Some(existing) = route_to_quota.insert(route_key.clone(), quota_pool.clone())
+                {
+                    if existing != quota_pool {
+                        return Err(AdmissionConfigError::ConflictingRouteScope {
+                            route: deployment_pool_id(&route_key),
+                        });
+                    }
+                }
+                routes.insert(route_key.clone());
+                quota_pools.insert(quota_pool.clone());
+            }
+        }
+
+        Ok(Self {
+            routes,
+            quota_pools,
+            route_to_quota,
+        })
+    }
+}
+
+pub(crate) fn capacity_pool_id(pool: &CapacityPoolKey) -> String {
+    match pool {
+        CapacityPoolKey::ProviderAccount(provider) => {
+            format!("{}:account", provider.as_str())
+        }
+        CapacityPoolKey::ProviderModel(route) => deployment_pool_id(route),
+    }
+}
+
+pub(crate) fn deployment_pool_id(route: &RouteKey) -> String {
+    format!(
+        "{}:model:{}",
+        route.provider.as_str(),
+        route.provider_model_id
+    )
+}
+
+#[derive(Debug)]
+struct AdmissionShared {
+    policy: AdmissionPolicy,
+    route_to_quota: HashMap<RouteKey, CapacityPoolKey>,
+    inner: Mutex<AdmissionInner>,
+}
+
+/// Cloneable handle to one enclave's admission state.
+#[derive(Debug, Clone)]
+pub(crate) struct AdmissionController {
+    shared: Arc<AdmissionShared>,
+}
+
+impl Default for AdmissionController {
+    fn default() -> Self {
+        Self::new(&PROVIDER_REGISTRY, AdmissionPolicy::baseline())
+            .expect("static provider registry has a valid baseline admission topology")
+    }
+}
+
+impl AdmissionController {
+    pub(crate) fn new(
+        registry: &'static ProviderRegistry,
+        policy: AdmissionPolicy,
+    ) -> Result<Self, AdmissionConfigError> {
+        policy.validate_for(registry)?;
+        let topology = Topology::from_registry(registry)?;
+
+        let deployments = topology
+            .routes
+            .iter()
+            .map(|route| {
+                let limit = policy
+                    .deployment_overrides
+                    .get(route)
+                    .copied()
+                    .unwrap_or(policy.deployment_in_flight);
+                (
+                    route.clone(),
+                    DeploymentState {
+                        in_flight: 0,
+                        limit,
+                    },
+                )
+            })
+            .collect();
+        let quota_pools = topology
+            .quota_pools
+            .iter()
+            .map(|pool| {
+                (
+                    pool.clone(),
+                    QuotaPoolState {
+                        budget: policy.quota_budgets.get(pool).copied().unwrap_or_default(),
+                        ledger: QuotaLedger::default(),
+                        queue: FairQueue::default(),
+                        wake_at: None,
+                    },
+                )
+            })
+            .collect();
+
+        Ok(Self {
+            shared: Arc::new(AdmissionShared {
+                policy,
+                route_to_quota: topology.route_to_quota,
+                inner: Mutex::new(AdmissionInner {
+                    next_id: 0,
+                    deployments,
+                    quota_pools,
+                    logical_accounts: HashMap::new(),
+                    pending_logical: HashMap::new(),
+                    pending_turns: HashMap::new(),
+                }),
+            }),
+        })
+    }
+
+    pub(crate) fn policy(&self) -> &AdmissionPolicy {
+        &self.shared.policy
+    }
+
+    /// Acquires the per-account logical-request allowance. Hold the returned
+    /// ticket for the complete response, including any tool loop.
+    pub(crate) async fn acquire_logical(
+        &self,
+        account: Uuid,
+        workload: WorkloadClass,
+    ) -> Result<LogicalAdmissionTicket, AdmissionRejection> {
+        let now = Instant::now();
+        let wait = self.wait_for(workload);
+        let deadline = checked_deadline(now, wait);
+        let (receiver, id) = {
+            let mut inner = self.lock();
+            let can_admit = inner.logical_accounts.get(&account).is_none_or(|state| {
+                state.in_flight < self.shared.policy.per_account_in_flight
+                    && state.waiters.is_empty()
+            });
+            if can_admit {
+                inner.logical_accounts.entry(account).or_default().in_flight += 1;
+                return Ok(LogicalAdmissionTicket {
+                    controller: self.clone(),
+                    account,
+                    released: false,
+                });
+            }
+
+            if matches!(workload, WorkloadClass::Background) && wait.is_zero() {
+                return Err(self.rejection(AdmissionRejectionKind::BackgroundShed));
+            }
+            if wait.is_zero() || deadline <= now {
+                return Err(self.rejection(AdmissionRejectionKind::AccountBusy));
+            }
+            let queued = inner
+                .logical_accounts
+                .get(&account)
+                .map_or(0, |state| state.waiters.len());
+            if queued >= self.shared.policy.per_account_queue {
+                return Err(self.rejection(AdmissionRejectionKind::QueueFull));
+            }
+
+            let id = inner.allocate_id();
+            let (sender, receiver) = oneshot::channel();
+            inner
+                .logical_accounts
+                .entry(account)
+                .or_default()
+                .waiters
+                .push_back(LogicalWaiter {
+                    id,
+                    deadline,
+                    sender,
+                });
+            self.pump_logical_locked(&mut inner, account, now);
+            (receiver, id)
+        };
+
+        let mut cancellation = CancellationGuard::logical(self.clone(), id, account);
+        match tokio::time::timeout_at(deadline.into(), receiver).await {
+            Ok(Ok(Ok(()))) if self.activate_logical(id, account) => {
+                cancellation.disarm();
+                Ok(LogicalAdmissionTicket {
+                    controller: self.clone(),
+                    account,
+                    released: false,
+                })
+            }
+            Ok(Ok(Err(rejection))) => Err(rejection),
+            Ok(Err(_)) | Err(_) => Err(self.rejection(AdmissionRejectionKind::WaitTimeout)),
+            Ok(Ok(Ok(()))) => Err(self.rejection(AdmissionRejectionKind::WaitTimeout)),
+        }
+    }
+
+    /// Atomically acquires a provider quota reservation and a deployment slot.
+    /// The route must come from the fixed provider registry.
+    pub(crate) async fn acquire_turn(
+        &self,
+        route: &RouteKey,
+        account: Uuid,
+        workload: WorkloadClass,
+        estimate: AdmissionEstimate,
+        absolute_deadline: Option<Instant>,
+    ) -> Result<RouteTurnPermit, AdmissionRejection> {
+        let Some(quota_pool) = self.shared.route_to_quota.get(route).cloned() else {
+            return Err(self.rejection(AdmissionRejectionKind::UnknownRoute));
+        };
+        let now = Instant::now();
+        let workload_deadline = checked_deadline(now, self.wait_for(workload));
+        let deadline = absolute_deadline
+            .map(|deadline| deadline.min(workload_deadline))
+            .unwrap_or(workload_deadline);
+        let reservation = UsageAmount {
+            requests: 1,
+            prompt_tokens: estimate.prompt_tokens,
+            completion_tokens: estimate
+                .completion_tokens
+                .unwrap_or(self.shared.policy.completion_default_reservation),
+            cached_tokens: estimate.prompt_tokens,
+        };
+
+        let (receiver, id) = {
+            let mut inner = self.lock();
+            let id = inner.allocate_id();
+            let queue_empty = inner
+                .quota_pools
+                .get(&quota_pool)
+                .is_some_and(|pool| pool.queue.len == 0);
+            if queue_empty {
+                match self.try_reserve_turn_locked(
+                    &mut inner,
+                    TurnReservation {
+                        id,
+                        route: route.clone(),
+                        quota_pool: quota_pool.clone(),
+                        reservation,
+                        now,
+                        pending: false,
+                    },
+                ) {
+                    Ok(()) => {
+                        return Ok(RouteTurnPermit::new(
+                            self.clone(),
+                            id,
+                            route.clone(),
+                            quota_pool,
+                        ));
+                    }
+                    Err(blocked)
+                        if matches!(workload, WorkloadClass::Background) || deadline <= now =>
+                    {
+                        return Err(AdmissionRejection {
+                            kind: blocked.kind,
+                            retry_after: blocked.retry_after,
+                        });
+                    }
+                    Err(_) => {}
+                }
+            } else if matches!(workload, WorkloadClass::Background) {
+                // A background request never jumps an interactive queue.
+                return Err(self.rejection(AdmissionRejectionKind::BackgroundShed));
+            }
+
+            if matches!(workload, WorkloadClass::Background) || deadline <= now {
+                return Err(
+                    self.rejection(if matches!(workload, WorkloadClass::Background) {
+                        AdmissionRejectionKind::BackgroundShed
+                    } else {
+                        AdmissionRejectionKind::WaitTimeout
+                    }),
+                );
+            }
+
+            let pool = inner
+                .quota_pools
+                .get(&quota_pool)
+                .expect("fixed admission topology contains every route quota pool");
+            if !pool
+                .budget
+                .request_can_ever_fit(pool.budget.charged(reservation))
+            {
+                return Err(AdmissionRejection {
+                    kind: AdmissionRejectionKind::RateBudget,
+                    retry_after: self.shared.policy.rolling_window,
+                });
+            }
+            if pool.queue.len >= self.shared.policy.pool_queue
+                || pool.queue.account_len(account) >= self.shared.policy.per_account_queue
+            {
+                return Err(self.rejection(AdmissionRejectionKind::QueueFull));
+            }
+
+            let (sender, receiver) = oneshot::channel();
+            inner
+                .quota_pools
+                .get_mut(&quota_pool)
+                .expect("fixed admission topology contains every route quota pool")
+                .queue
+                .push(TurnWaiter {
+                    id,
+                    account,
+                    route: route.clone(),
+                    reservation,
+                    deadline,
+                    sender,
+                });
+            self.pump_turn_pool_locked(&mut inner, &quota_pool, now);
+            (receiver, id)
+        };
+        self.schedule_pool_wake(quota_pool.clone());
+
+        let mut cancellation =
+            CancellationGuard::turn(self.clone(), id, account, quota_pool.clone());
+        match tokio::time::timeout_at(deadline.into(), receiver).await {
+            Ok(Ok(Ok(()))) => {
+                if let Some(grant) = self.activate_turn(id) {
+                    cancellation.disarm();
+                    Ok(RouteTurnPermit::new(
+                        self.clone(),
+                        id,
+                        grant.route,
+                        grant.quota_pool,
+                    ))
+                } else {
+                    Err(self.rejection(AdmissionRejectionKind::WaitTimeout))
+                }
+            }
+            Ok(Ok(Err(rejection))) => {
+                cancellation.disarm();
+                Err(rejection)
+            }
+            Ok(Err(_)) | Err(_) => {
+                let rejection = self.timeout_turn(id, account, &quota_pool, reservation);
+                cancellation.disarm();
+                Err(rejection)
+            }
+        }
+    }
+
+    fn wait_for(&self, workload: WorkloadClass) -> Duration {
+        match workload {
+            WorkloadClass::Interactive => self.shared.policy.interactive_wait,
+            WorkloadClass::Background => self.shared.policy.background_wait,
+        }
+    }
+
+    fn rejection(&self, kind: AdmissionRejectionKind) -> AdmissionRejection {
+        AdmissionRejection {
+            kind,
+            retry_after: self.shared.policy.local_retry,
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, AdmissionInner> {
+        self.shared
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn activate_logical(&self, id: u64, account: Uuid) -> bool {
+        self.lock().pending_logical.remove(&id) == Some(account)
+    }
+
+    fn activate_turn(&self, id: u64) -> Option<PendingTurnGrant> {
+        self.lock().pending_turns.remove(&id)
+    }
+
+    fn rate_budget_blocked_locked(
+        &self,
+        pool: &mut QuotaPoolState,
+        reservation: UsageAmount,
+        now: Instant,
+    ) -> Option<Blocked> {
+        pool.ledger.purge(now, self.shared.policy.rolling_window);
+        let charged = pool.budget.charged(reservation);
+        if !pool.budget.request_can_ever_fit(charged) {
+            return Some(Blocked {
+                kind: AdmissionRejectionKind::RateBudget,
+                retry_after: self.shared.policy.rolling_window,
+            });
+        }
+        if pool.budget.fits(pool.ledger.total(), charged) {
+            return None;
+        }
+
+        let retry_after = pool
+            .ledger
+            .earliest_budget_fit(pool.budget, charged, self.shared.policy.rolling_window, now)
+            .and_then(|expiry| expiry.checked_duration_since(now))
+            .unwrap_or(self.shared.policy.rolling_window);
+        Some(Blocked {
+            kind: AdmissionRejectionKind::RateBudget,
+            retry_after,
+        })
+    }
+
+    fn turn_wait_timeout_rejection_locked(
+        &self,
+        inner: &mut AdmissionInner,
+        quota_pool: &CapacityPoolKey,
+        reservation: UsageAmount,
+        now: Instant,
+    ) -> AdmissionRejection {
+        let rate_block = inner
+            .quota_pools
+            .get_mut(quota_pool)
+            .and_then(|pool| self.rate_budget_blocked_locked(pool, reservation, now));
+        rate_block.map_or_else(
+            || self.rejection(AdmissionRejectionKind::WaitTimeout),
+            |blocked| AdmissionRejection {
+                kind: blocked.kind,
+                retry_after: blocked.retry_after,
+            },
+        )
+    }
+
+    fn try_reserve_turn_locked(
+        &self,
+        inner: &mut AdmissionInner,
+        request: TurnReservation,
+    ) -> Result<(), Blocked> {
+        let TurnReservation {
+            id,
+            route,
+            quota_pool,
+            reservation,
+            now,
+            pending,
+        } = request;
+        let pool = inner
+            .quota_pools
+            .get_mut(&quota_pool)
+            .expect("fixed admission topology contains every route quota pool");
+        if let Some(blocked) = self.rate_budget_blocked_locked(pool, reservation, now) {
+            return Err(blocked);
+        }
+        let charged = pool.budget.charged(reservation);
+
+        let deployment = inner
+            .deployments
+            .get_mut(&route)
+            .expect("fixed admission topology contains every route deployment");
+        if deployment.in_flight >= deployment.limit {
+            return Err(Blocked {
+                kind: AdmissionRejectionKind::DeploymentBusy,
+                retry_after: self.shared.policy.local_retry,
+            });
+        }
+
+        deployment.in_flight += 1;
+        pool.ledger.reserve(id, now, charged);
+        if pending {
+            let replaced = inner
+                .pending_turns
+                .insert(id, PendingTurnGrant { route, quota_pool });
+            debug_assert!(replaced.is_none());
+        }
+        Ok(())
+    }
+
+    fn pump_logical_locked(&self, inner: &mut AdmissionInner, account: Uuid, now: Instant) {
+        loop {
+            let Some(state) = inner.logical_accounts.get_mut(&account) else {
+                return;
+            };
+            if state.in_flight >= self.shared.policy.per_account_in_flight {
+                return;
+            }
+            let Some(waiter) = state.waiters.pop_front() else {
+                return;
+            };
+            if waiter.deadline <= now {
+                let _ = waiter
+                    .sender
+                    .send(Err(self.rejection(AdmissionRejectionKind::WaitTimeout)));
+                continue;
+            }
+
+            state.in_flight += 1;
+            inner.pending_logical.insert(waiter.id, account);
+            if waiter.sender.send(Ok(())).is_err() {
+                inner.pending_logical.remove(&waiter.id);
+                state.in_flight -= 1;
+                continue;
+            }
+        }
+    }
+
+    fn pump_turn_pool_locked(
+        &self,
+        inner: &mut AdmissionInner,
+        quota_pool: &CapacityPoolKey,
+        now: Instant,
+    ) {
+        loop {
+            let accounts_this_round = inner
+                .quota_pools
+                .get(quota_pool)
+                .map_or(0, |pool| pool.queue.round_robin.len());
+            if accounts_this_round == 0 {
+                return;
+            }
+            let mut made_progress_this_round = false;
+            // Accounts which did not receive service stay ahead of accounts
+            // which did. Keeping these lists outside the queue prevents a
+            // blocked account from rotating behind a just-serviced account
+            // merely because capacity filled part-way through the round.
+            let mut unserved_accounts = Vec::with_capacity(accounts_this_round);
+            let mut served_accounts = Vec::with_capacity(accounts_this_round);
+
+            for _ in 0..accounts_this_round {
+                let account = inner
+                    .quota_pools
+                    .get_mut(quota_pool)
+                    .and_then(|pool| pool.queue.pop_round_robin_account())
+                    .expect("round-robin cardinality was captured under the same lock");
+                let waiter = inner
+                    .quota_pools
+                    .get_mut(quota_pool)
+                    .and_then(|pool| pool.queue.take_front(account))
+                    .expect("round-robin accounts always have a waiter");
+
+                if waiter.deadline <= now {
+                    made_progress_this_round = true;
+                    let rejection = self.turn_wait_timeout_rejection_locked(
+                        inner,
+                        quota_pool,
+                        waiter.reservation,
+                        now,
+                    );
+                    let has_more = inner
+                        .quota_pools
+                        .get_mut(quota_pool)
+                        .expect("fixed quota pool")
+                        .queue
+                        .account_has_more(account);
+                    if has_more {
+                        unserved_accounts.push(account);
+                    }
+                    let _ = waiter.sender.send(Err(rejection));
+                    continue;
+                }
+
+                match self.try_reserve_turn_locked(
+                    inner,
+                    TurnReservation {
+                        id: waiter.id,
+                        route: waiter.route.clone(),
+                        quota_pool: quota_pool.clone(),
+                        reservation: waiter.reservation,
+                        now,
+                        pending: true,
+                    },
+                ) {
+                    Ok(()) => {
+                        let has_more = inner
+                            .quota_pools
+                            .get_mut(quota_pool)
+                            .expect("fixed quota pool")
+                            .queue
+                            .account_has_more(account);
+                        if waiter.sender.send(Ok(())).is_err() {
+                            made_progress_this_round = true;
+                            self.cancel_pending_turn_locked(inner, waiter.id);
+                            if has_more {
+                                unserved_accounts.push(account);
+                            }
+                        } else {
+                            made_progress_this_round = true;
+                            if has_more {
+                                served_accounts.push(account);
+                            }
+                        }
+                    }
+                    Err(_) => {
+                        inner
+                            .quota_pools
+                            .get_mut(quota_pool)
+                            .expect("fixed quota pool")
+                            .queue
+                            .restore_front(account, waiter);
+                        unserved_accounts.push(account);
+                    }
+                }
+            }
+
+            let queue = &mut inner
+                .quota_pools
+                .get_mut(quota_pool)
+                .expect("fixed quota pool")
+                .queue;
+            queue.round_robin.extend(unserved_accounts);
+            queue.round_robin.extend(served_accounts);
+
+            if !made_progress_this_round {
+                return;
+            }
+        }
+    }
+
+    fn release_logical(&self, account: Uuid) {
+        let now = Instant::now();
+        let mut inner = self.lock();
+        if let Some(state) = inner.logical_accounts.get_mut(&account) {
+            state.in_flight = state.in_flight.saturating_sub(1);
+        }
+        self.pump_logical_locked(&mut inner, account, now);
+        self.prune_logical_locked(&mut inner, account);
+    }
+
+    fn cancel_logical(&self, id: u64, account: Uuid) {
+        let now = Instant::now();
+        let mut inner = self.lock();
+        let removed_waiter = inner
+            .logical_accounts
+            .get_mut(&account)
+            .is_some_and(|state| {
+                let before = state.waiters.len();
+                state.waiters.retain(|waiter| waiter.id != id);
+                state.waiters.len() != before
+            });
+        if !removed_waiter && inner.pending_logical.remove(&id) == Some(account) {
+            if let Some(state) = inner.logical_accounts.get_mut(&account) {
+                state.in_flight = state.in_flight.saturating_sub(1);
+            }
+        }
+        self.pump_logical_locked(&mut inner, account, now);
+        self.prune_logical_locked(&mut inner, account);
+    }
+
+    fn prune_logical_locked(&self, inner: &mut AdmissionInner, account: Uuid) {
+        let can_prune = inner
+            .logical_accounts
+            .get(&account)
+            .is_some_and(|state| state.in_flight == 0 && state.waiters.is_empty())
+            && !inner
+                .pending_logical
+                .values()
+                .any(|pending| *pending == account);
+        if can_prune {
+            inner.logical_accounts.remove(&account);
+        }
+    }
+
+    fn cancel_turn(&self, id: u64, account: Uuid, quota_pool: &CapacityPoolKey) {
+        let now = Instant::now();
+        let mut inner = self.lock();
+        let removed_waiter = inner
+            .quota_pools
+            .get_mut(quota_pool)
+            .is_some_and(|pool| pool.queue.remove(account, id));
+        if !removed_waiter {
+            self.cancel_pending_turn_locked(&mut inner, id);
+        }
+        self.pump_turn_pool_locked(&mut inner, quota_pool, now);
+        drop(inner);
+        self.schedule_pool_wake(quota_pool.clone());
+    }
+
+    fn timeout_turn(
+        &self,
+        id: u64,
+        account: Uuid,
+        quota_pool: &CapacityPoolKey,
+        reservation: UsageAmount,
+    ) -> AdmissionRejection {
+        self.timeout_turn_at(id, account, quota_pool, reservation, Instant::now())
+    }
+
+    fn timeout_turn_at(
+        &self,
+        id: u64,
+        account: Uuid,
+        quota_pool: &CapacityPoolKey,
+        reservation: UsageAmount,
+        now: Instant,
+    ) -> AdmissionRejection {
+        let mut inner = self.lock();
+        let removed_waiter = inner
+            .quota_pools
+            .get_mut(quota_pool)
+            .is_some_and(|pool| pool.queue.remove(account, id));
+        let rejection = if removed_waiter {
+            self.turn_wait_timeout_rejection_locked(&mut inner, quota_pool, reservation, now)
+        } else {
+            self.rejection(AdmissionRejectionKind::WaitTimeout)
+        };
+        if !removed_waiter {
+            self.cancel_pending_turn_locked(&mut inner, id);
+        }
+        self.pump_turn_pool_locked(&mut inner, quota_pool, now);
+        drop(inner);
+        self.schedule_pool_wake(quota_pool.clone());
+        rejection
+    }
+
+    fn cancel_pending_turn_locked(&self, inner: &mut AdmissionInner, id: u64) {
+        let Some(grant) = inner.pending_turns.remove(&id) else {
+            return;
+        };
+        let removed = inner
+            .quota_pools
+            .get_mut(&grant.quota_pool)
+            .is_some_and(|pool| pool.ledger.cancel_pending(id));
+        if removed {
+            if let Some(deployment) = inner.deployments.get_mut(&grant.route) {
+                deployment.in_flight = deployment.in_flight.saturating_sub(1);
+            }
+        }
+    }
+
+    fn finish_turn(
+        &self,
+        id: u64,
+        route: &RouteKey,
+        quota_pool: &CapacityPoolKey,
+        usage: Option<ActualUsage>,
+        disposition: TerminalDisposition,
+    ) {
+        let now = Instant::now();
+        let mut inner = self.lock();
+        let finished = inner.quota_pools.get_mut(quota_pool).is_some_and(|pool| {
+            pool.ledger.finish(
+                id,
+                pool.budget,
+                usage,
+                disposition,
+                now,
+                self.shared.policy.rolling_window,
+            )
+        });
+        if finished {
+            if let Some(deployment) = inner.deployments.get_mut(route) {
+                deployment.in_flight = deployment.in_flight.saturating_sub(1);
+            }
+        }
+        self.pump_turn_pool_locked(&mut inner, quota_pool, now);
+        drop(inner);
+        self.schedule_pool_wake(quota_pool.clone());
+    }
+
+    fn schedule_pool_wake(&self, quota_pool: CapacityPoolKey) {
+        let now = Instant::now();
+        let wake_at = {
+            let mut inner = self.lock();
+            let Some(pool) = inner.quota_pools.get_mut(&quota_pool) else {
+                return;
+            };
+            if pool.queue.len == 0 {
+                pool.wake_at = None;
+                return;
+            }
+            pool.ledger.purge(now, self.shared.policy.rolling_window);
+            let Some(candidate) = pool
+                .ledger
+                .earliest_expiry(self.shared.policy.rolling_window, now)
+            else {
+                return;
+            };
+            if pool.wake_at.is_some_and(|scheduled| scheduled <= candidate) {
+                return;
+            }
+            pool.wake_at = Some(candidate);
+            candidate
+        };
+
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        let controller = self.clone();
+        runtime.spawn(async move {
+            tokio::time::sleep_until(wake_at.into()).await;
+            controller.on_pool_wake(quota_pool, wake_at);
+        });
+    }
+
+    fn on_pool_wake(&self, quota_pool: CapacityPoolKey, wake_at: Instant) {
+        let now = Instant::now();
+        let mut inner = self.lock();
+        let Some(pool) = inner.quota_pools.get_mut(&quota_pool) else {
+            return;
+        };
+        if pool.wake_at != Some(wake_at) {
+            return;
+        }
+        pool.wake_at = None;
+        pool.ledger.purge(now, self.shared.policy.rolling_window);
+        self.pump_turn_pool_locked(&mut inner, &quota_pool, now);
+        drop(inner);
+        self.schedule_pool_wake(quota_pool);
+    }
+
+    #[cfg(test)]
+    fn debug_counts(&self) -> DebugCounts {
+        let inner = self.lock();
+        DebugCounts {
+            deployment_pools: inner.deployments.len(),
+            quota_pools: inner.quota_pools.len(),
+            logical_accounts: inner.logical_accounts.len(),
+            queued_turns: inner.quota_pools.values().map(|pool| pool.queue.len).sum(),
+            active_turns: inner
+                .deployments
+                .values()
+                .map(|deployment| deployment.in_flight)
+                .sum(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Blocked {
+    kind: AdmissionRejectionKind,
+    retry_after: Duration,
+}
+
+#[derive(Debug)]
+struct TurnReservation {
+    id: u64,
+    route: RouteKey,
+    quota_pool: CapacityPoolKey,
+    reservation: UsageAmount,
+    now: Instant,
+    pending: bool,
+}
+
+fn checked_deadline(now: Instant, wait: Duration) -> Instant {
+    now.checked_add(wait).unwrap_or(now)
+}
+
+/// RAII guard held for a complete logical response/tool loop.
+#[derive(Debug)]
+pub(crate) struct LogicalAdmissionTicket {
+    controller: AdmissionController,
+    account: Uuid,
+    released: bool,
+}
+
+impl Drop for LogicalAdmissionTicket {
+    fn drop(&mut self) {
+        if !self.released {
+            self.released = true;
+            self.controller.release_logical(self.account);
+        }
+    }
+}
+
+/// Non-cloneable RAII guard for one provider turn.
+#[derive(Debug)]
+pub(crate) struct RouteTurnPermit {
+    controller: AdmissionController,
+    reservation_id: u64,
+    route: RouteKey,
+    quota_pool: CapacityPoolKey,
+    released: bool,
+}
+
+impl RouteTurnPermit {
+    fn new(
+        controller: AdmissionController,
+        reservation_id: u64,
+        route: RouteKey,
+        quota_pool: CapacityPoolKey,
+    ) -> Self {
+        Self {
+            controller,
+            reservation_id,
+            route,
+            quota_pool,
+            released: false,
+        }
+    }
+
+    /// Reconciles the reservation exactly once and releases concurrency. The
+    /// consuming receiver prevents accidental double settlement.
+    pub(crate) fn settle(mut self, actual: Option<ActualUsage>, disposition: TerminalDisposition) {
+        self.controller.finish_turn(
+            self.reservation_id,
+            &self.route,
+            &self.quota_pool,
+            actual,
+            disposition,
+        );
+        self.released = true;
+    }
+}
+
+impl Drop for RouteTurnPermit {
+    fn drop(&mut self) {
+        if !self.released {
+            self.controller.finish_turn(
+                self.reservation_id,
+                &self.route,
+                &self.quota_pool,
+                None,
+                TerminalDisposition::Ambiguous,
+            );
+            self.released = true;
+        }
+    }
+}
+
+#[derive(Debug)]
+enum CancellationKind {
+    Logical {
+        account: Uuid,
+    },
+    Turn {
+        account: Uuid,
+        quota_pool: CapacityPoolKey,
+    },
+}
+
+#[derive(Debug)]
+struct CancellationGuard {
+    controller: AdmissionController,
+    id: u64,
+    kind: CancellationKind,
+    armed: bool,
+}
+
+impl CancellationGuard {
+    fn logical(controller: AdmissionController, id: u64, account: Uuid) -> Self {
+        Self {
+            controller,
+            id,
+            kind: CancellationKind::Logical { account },
+            armed: true,
+        }
+    }
+
+    fn turn(
+        controller: AdmissionController,
+        id: u64,
+        account: Uuid,
+        quota_pool: CapacityPoolKey,
+    ) -> Self {
+        Self {
+            controller,
+            id,
+            kind: CancellationKind::Turn {
+                account,
+                quota_pool,
+            },
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for CancellationGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        match &self.kind {
+            CancellationKind::Logical { account } => {
+                self.controller.cancel_logical(self.id, *account);
+            }
+            CancellationKind::Turn {
+                account,
+                quota_pool,
+            } => self.controller.cancel_turn(self.id, *account, quota_pool),
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DebugCounts {
+    deployment_pools: usize,
+    quota_pools: usize,
+    logical_accounts: usize,
+    queued_turns: usize,
+    active_turns: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider_registry::ProviderId;
+    use tokio::task::JoinHandle;
+
+    fn route(provider: ProviderId, model: &str) -> RouteKey {
+        RouteKey {
+            provider,
+            provider_model_id: model.to_string(),
+        }
+    }
+
+    fn k3() -> RouteKey {
+        route(ProviderId::Tinfoil, "kimi-k3")
+    }
+
+    fn continuum_k2() -> RouteKey {
+        route(ProviderId::Continuum, "kimi-k2.6")
+    }
+
+    fn continuum_glm() -> RouteKey {
+        route(ProviderId::Continuum, "glm-5.2")
+    }
+
+    fn test_policy(deployment_limit: usize) -> AdmissionPolicy {
+        AdmissionPolicy {
+            deployment_in_flight: deployment_limit,
+            per_account_in_flight: 1,
+            pool_queue: 4,
+            per_account_queue: 2,
+            interactive_wait: Duration::from_secs(1),
+            background_wait: Duration::ZERO,
+            local_retry: Duration::from_millis(1),
+            rolling_window: Duration::from_millis(30),
+            completion_default_reservation: 10,
+            max_completion_choices: BASELINE_MAX_COMPLETION_CHOICES,
+            quota_budgets: HashMap::new(),
+            deployment_overrides: HashMap::new(),
+        }
+    }
+
+    fn controller(policy: AdmissionPolicy) -> AdmissionController {
+        AdmissionController::new(&PROVIDER_REGISTRY, policy).unwrap()
+    }
+
+    fn spawn_turn(
+        controller: AdmissionController,
+        route: RouteKey,
+        account: Uuid,
+    ) -> JoinHandle<Result<RouteTurnPermit, AdmissionRejection>> {
+        tokio::spawn(async move {
+            controller
+                .acquire_turn(
+                    &route,
+                    account,
+                    WorkloadClass::Interactive,
+                    AdmissionEstimate::new(1, Some(1)),
+                    None,
+                )
+                .await
+        })
+    }
+
+    #[test]
+    fn compiled_baseline_is_bounded_and_does_not_guess_provider_quotas() {
+        let policy = AdmissionPolicy::baseline_for(&PROVIDER_REGISTRY).unwrap();
+        assert_eq!(policy.deployment_in_flight(), 4);
+        assert_eq!(policy.per_account_in_flight(), 2);
+        assert_eq!(policy.pool_queue(), 16);
+        assert_eq!(policy.per_account_queue(), 2);
+        assert_eq!(policy.interactive_wait(), Duration::from_secs(5));
+        assert_eq!(policy.background_wait(), Duration::ZERO);
+        assert_eq!(policy.local_retry(), Duration::from_secs(1));
+        assert_eq!(policy.rolling_window(), Duration::from_secs(60));
+        assert_eq!(policy.completion_default_reservation(), 4_096);
+        assert_eq!(policy.max_completion_choices(), 8);
+        assert!(policy.quota_budgets.is_empty());
+        assert!(policy.deployment_overrides.is_empty());
+    }
+
+    #[test]
+    fn test_only_policy_override_still_passes_the_production_validator() {
+        let policy =
+            AdmissionPolicy::with_deployment_in_flight_for_test(&PROVIDER_REGISTRY, 3).unwrap();
+        assert_eq!(policy.deployment_in_flight(), 3);
+        assert!(
+            AdmissionPolicy::with_deployment_in_flight_for_test(&PROVIDER_REGISTRY, 0).is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn logical_account_bound_queues_fifo_and_prunes_account_state() {
+        let controller = controller(test_policy(2));
+        let account = Uuid::new_v4();
+        let first = controller
+            .acquire_logical(account, WorkloadClass::Interactive)
+            .await
+            .unwrap();
+        let waiting = {
+            let controller = controller.clone();
+            tokio::spawn(async move {
+                controller
+                    .acquire_logical(account, WorkloadClass::Interactive)
+                    .await
+            })
+        };
+        tokio::task::yield_now().await;
+        assert_eq!(controller.debug_counts().logical_accounts, 1);
+        drop(first);
+        let second = waiting.await.unwrap().unwrap();
+        drop(second);
+        assert_eq!(controller.debug_counts().logical_accounts, 0);
+    }
+
+    #[tokio::test]
+    async fn fair_queue_round_robins_accounts_without_intra_account_reordering() {
+        let controller = controller(test_policy(1));
+        let route = k3();
+        let blocker = controller
+            .acquire_turn(
+                &route,
+                Uuid::new_v4(),
+                WorkloadClass::Interactive,
+                AdmissionEstimate::new(1, Some(1)),
+                None,
+            )
+            .await
+            .unwrap();
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let a1 = spawn_turn(controller.clone(), route.clone(), a);
+        tokio::task::yield_now().await;
+        let a2 = spawn_turn(controller.clone(), route.clone(), a);
+        tokio::task::yield_now().await;
+        let b1 = spawn_turn(controller.clone(), route.clone(), b);
+        tokio::task::yield_now().await;
+
+        drop(blocker);
+        let permit_a1 = a1.await.unwrap().unwrap();
+        assert!(!a2.is_finished());
+        assert!(!b1.is_finished());
+        drop(permit_a1);
+        let permit_b1 = b1.await.unwrap().unwrap();
+        assert!(!a2.is_finished());
+        drop(permit_b1);
+        drop(a2.await.unwrap().unwrap());
+        assert_eq!(controller.debug_counts().queued_turns, 0);
+    }
+
+    #[test]
+    fn expired_head_waiter_does_not_strand_live_same_account_waiter() {
+        let controller = controller(test_policy(1));
+        let route = k3();
+        let quota_pool = controller
+            .shared
+            .route_to_quota
+            .get(&route)
+            .expect("registered K3 quota pool")
+            .clone();
+        let account = Uuid::new_v4();
+        let now = Instant::now();
+        let reservation = UsageAmount {
+            requests: 1,
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            cached_tokens: 1,
+        };
+        let (expired_sender, mut expired_receiver) = oneshot::channel();
+        let (live_sender, mut live_receiver) = oneshot::channel();
+
+        let live_id = {
+            let mut inner = controller.lock();
+            let expired_id = inner.allocate_id();
+            let live_id = inner.allocate_id();
+            let queue = &mut inner
+                .quota_pools
+                .get_mut(&quota_pool)
+                .expect("fixed K3 quota pool")
+                .queue;
+            queue.push(TurnWaiter {
+                id: expired_id,
+                account,
+                route: route.clone(),
+                reservation,
+                deadline: now
+                    .checked_sub(Duration::from_millis(1))
+                    .expect("test instant supports one millisecond of history"),
+                sender: expired_sender,
+            });
+            queue.push(TurnWaiter {
+                id: live_id,
+                account,
+                route: route.clone(),
+                reservation,
+                deadline: now
+                    .checked_add(Duration::from_secs(1))
+                    .expect("test instant supports one second of future"),
+                sender: live_sender,
+            });
+
+            controller.pump_turn_pool_locked(&mut inner, &quota_pool, now);
+            live_id
+        };
+
+        assert!(matches!(
+            expired_receiver.try_recv(),
+            Ok(Err(AdmissionRejection {
+                kind: AdmissionRejectionKind::WaitTimeout,
+                ..
+            }))
+        ));
+        assert!(matches!(live_receiver.try_recv(), Ok(Ok(()))));
+        assert_eq!(controller.debug_counts().queued_turns, 0);
+        assert_eq!(controller.debug_counts().active_turns, 1);
+
+        let grant = controller
+            .activate_turn(live_id)
+            .expect("live waiter received a pending grant");
+        RouteTurnPermit::new(controller.clone(), live_id, grant.route, grant.quota_pool)
+            .settle(None, TerminalDisposition::ProvenPreAcceptance);
+        assert_eq!(controller.debug_counts().active_turns, 0);
+    }
+
+    #[tokio::test]
+    async fn arrivals_never_bypass_existing_waiters() {
+        let controller = controller(test_policy(1));
+        let route = k3();
+        let blocker = controller
+            .acquire_turn(
+                &route,
+                Uuid::new_v4(),
+                WorkloadClass::Interactive,
+                AdmissionEstimate::new(1, Some(1)),
+                None,
+            )
+            .await
+            .unwrap();
+        let old = spawn_turn(controller.clone(), route.clone(), Uuid::new_v4());
+        tokio::task::yield_now().await;
+        drop(blocker);
+        let newcomer = spawn_turn(controller.clone(), route, Uuid::new_v4());
+        let old_permit = old.await.unwrap().unwrap();
+        assert!(!newcomer.is_finished());
+        drop(old_permit);
+        drop(newcomer.await.unwrap().unwrap());
+    }
+
+    #[tokio::test]
+    async fn queue_bounds_and_background_shedding_are_enforced() {
+        let mut policy = test_policy(1);
+        policy.pool_queue = 2;
+        policy.per_account_queue = 1;
+        let controller = controller(policy);
+        let route = k3();
+        let blocker = controller
+            .acquire_turn(
+                &route,
+                Uuid::new_v4(),
+                WorkloadClass::Interactive,
+                AdmissionEstimate::new(1, Some(1)),
+                None,
+            )
+            .await
+            .unwrap();
+        let account = Uuid::new_v4();
+        let queued = spawn_turn(controller.clone(), route.clone(), account);
+        tokio::task::yield_now().await;
+        let duplicate = controller
+            .acquire_turn(
+                &route,
+                account,
+                WorkloadClass::Interactive,
+                AdmissionEstimate::new(1, Some(1)),
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(duplicate.kind, AdmissionRejectionKind::QueueFull);
+
+        let second_queued = spawn_turn(controller.clone(), route.clone(), Uuid::new_v4());
+        tokio::task::yield_now().await;
+        let pool_full = controller
+            .acquire_turn(
+                &route,
+                Uuid::new_v4(),
+                WorkloadClass::Interactive,
+                AdmissionEstimate::new(1, Some(1)),
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(pool_full.kind, AdmissionRejectionKind::QueueFull);
+
+        let background = controller
+            .acquire_turn(
+                &route,
+                Uuid::new_v4(),
+                WorkloadClass::Background,
+                AdmissionEstimate::new(1, Some(1)),
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(background.kind, AdmissionRejectionKind::BackgroundShed);
+        assert_eq!(background.status_hint(), 503);
+        drop(blocker);
+        drop(queued.await.unwrap().unwrap());
+        drop(second_queued.await.unwrap().unwrap());
+    }
+
+    #[tokio::test]
+    async fn cancelled_and_timed_out_waiters_are_removed() {
+        let mut policy = test_policy(1);
+        policy.interactive_wait = Duration::from_millis(15);
+        let controller = controller(policy);
+        let route = k3();
+        let blocker = controller
+            .acquire_turn(
+                &route,
+                Uuid::new_v4(),
+                WorkloadClass::Interactive,
+                AdmissionEstimate::new(1, Some(1)),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let cancelled = spawn_turn(controller.clone(), route.clone(), Uuid::new_v4());
+        tokio::task::yield_now().await;
+        cancelled.abort();
+        let _ = cancelled.await;
+        tokio::task::yield_now().await;
+        assert_eq!(controller.debug_counts().queued_turns, 0);
+
+        let timeout = controller
+            .acquire_turn(
+                &route,
+                Uuid::new_v4(),
+                WorkloadClass::Interactive,
+                AdmissionEstimate::new(1, Some(1)),
+                Some(Instant::now() + Duration::from_millis(5)),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(timeout.kind, AdmissionRejectionKind::WaitTimeout);
+        assert_eq!(controller.debug_counts().queued_turns, 0);
+        drop(blocker);
+    }
+
+    #[test]
+    fn rpm_and_tpm_wait_timeouts_report_remaining_budget_window_as_429() {
+        let cases = [
+            (
+                QuotaBudget {
+                    requests: Some(1),
+                    ..QuotaBudget::default()
+                },
+                UsageAmount {
+                    requests: 1,
+                    ..UsageAmount::default()
+                },
+                UsageAmount {
+                    requests: 1,
+                    ..UsageAmount::default()
+                },
+            ),
+            (
+                QuotaBudget {
+                    prompt_tokens: Some(10),
+                    ..QuotaBudget::default()
+                },
+                UsageAmount {
+                    prompt_tokens: 10,
+                    ..UsageAmount::default()
+                },
+                UsageAmount {
+                    requests: 1,
+                    prompt_tokens: 1,
+                    ..UsageAmount::default()
+                },
+            ),
+        ];
+
+        for (budget, completed, reservation) in cases {
+            let mut policy = test_policy(1);
+            policy.rolling_window = Duration::from_secs(60);
+            let quota_pool = CapacityPoolKey::ProviderModel(k3());
+            policy.quota_budgets.insert(quota_pool.clone(), budget);
+            let controller = controller(policy);
+            let started_at = Instant::now();
+            let timeout_at = started_at + Duration::from_secs(5);
+            let account = Uuid::new_v4();
+            let id = {
+                let mut inner = controller.lock();
+                inner
+                    .quota_pools
+                    .get_mut(&quota_pool)
+                    .unwrap()
+                    .ledger
+                    .completed
+                    .push_back(TimedUsage {
+                        started_at,
+                        amount: completed,
+                    });
+                let id = inner.allocate_id();
+                let (sender, _receiver) = oneshot::channel();
+                inner
+                    .quota_pools
+                    .get_mut(&quota_pool)
+                    .unwrap()
+                    .queue
+                    .push(TurnWaiter {
+                        id,
+                        account,
+                        route: k3(),
+                        reservation,
+                        deadline: timeout_at,
+                        sender,
+                    });
+                id
+            };
+
+            let rejection =
+                controller.timeout_turn_at(id, account, &quota_pool, reservation, timeout_at);
+            assert_eq!(rejection.kind, AdmissionRejectionKind::RateBudget);
+            assert_eq!(rejection.status_hint(), 429);
+            assert_eq!(rejection.retry_after, Duration::from_secs(55));
+            assert_eq!(controller.debug_counts().queued_turns, 0);
+        }
+    }
+
+    #[test]
+    fn retry_after_waits_until_enough_completed_usage_expires() {
+        let budget = QuotaBudget {
+            prompt_tokens: Some(100),
+            ..QuotaBudget::default()
+        };
+        let base = Instant::now();
+        let now = base + Duration::from_secs(40);
+        let mut ledger = QuotaLedger::default();
+        for offset in [0, 10, 20, 30] {
+            ledger.completed.push_back(TimedUsage {
+                started_at: base + Duration::from_secs(offset),
+                amount: UsageAmount {
+                    prompt_tokens: 30,
+                    ..UsageAmount::default()
+                },
+            });
+        }
+
+        let expiry = ledger
+            .earliest_budget_fit(
+                budget,
+                UsageAmount {
+                    prompt_tokens: 50,
+                    ..UsageAmount::default()
+                },
+                Duration::from_secs(100),
+                now,
+            )
+            .unwrap();
+        assert_eq!(expiry - now, Duration::from_secs(80));
+    }
+
+    #[test]
+    fn deployment_wait_timeout_remains_503_with_local_retry() {
+        let policy = test_policy(1);
+        let local_retry = policy.local_retry;
+        let controller = controller(policy);
+        let quota_pool = CapacityPoolKey::ProviderModel(k3());
+        let account = Uuid::new_v4();
+        let reservation = UsageAmount {
+            requests: 1,
+            ..UsageAmount::default()
+        };
+        let timeout_at = Instant::now();
+        let id = {
+            let mut inner = controller.lock();
+            inner.deployments.get_mut(&k3()).unwrap().in_flight = 1;
+            let id = inner.allocate_id();
+            let (sender, _receiver) = oneshot::channel();
+            inner
+                .quota_pools
+                .get_mut(&quota_pool)
+                .unwrap()
+                .queue
+                .push(TurnWaiter {
+                    id,
+                    account,
+                    route: k3(),
+                    reservation,
+                    deadline: timeout_at,
+                    sender,
+                });
+            id
+        };
+
+        let rejection =
+            controller.timeout_turn_at(id, account, &quota_pool, reservation, timeout_at);
+        assert_eq!(rejection.kind, AdmissionRejectionKind::WaitTimeout);
+        assert_eq!(rejection.status_hint(), 503);
+        assert_eq!(rejection.retry_after, local_retry);
+        assert_eq!(controller.debug_counts().queued_turns, 0);
+    }
+
+    #[tokio::test]
+    async fn provider_account_quota_is_shared_but_deployment_capacity_is_not() {
+        let mut policy = test_policy(1);
+        policy.quota_budgets.insert(
+            CapacityPoolKey::ProviderAccount(ProviderId::Continuum),
+            QuotaBudget {
+                requests: Some(1),
+                ..QuotaBudget::default()
+            },
+        );
+        let admission = controller(policy);
+        let first = admission
+            .acquire_turn(
+                &continuum_k2(),
+                Uuid::new_v4(),
+                WorkloadClass::Background,
+                AdmissionEstimate::new(1, Some(1)),
+                None,
+            )
+            .await
+            .unwrap();
+        first.settle(
+            Some(ActualUsage::complete(1, 1, None)),
+            TerminalDisposition::Completed,
+        );
+
+        let rejection = admission
+            .acquire_turn(
+                &continuum_glm(),
+                Uuid::new_v4(),
+                WorkloadClass::Background,
+                AdmissionEstimate::new(1, Some(1)),
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(rejection.kind, AdmissionRejectionKind::RateBudget);
+        assert_eq!(rejection.status_hint(), 429);
+
+        let no_quota = controller(test_policy(1));
+        let k2 = no_quota
+            .acquire_turn(
+                &continuum_k2(),
+                Uuid::new_v4(),
+                WorkloadClass::Interactive,
+                AdmissionEstimate::new(1, Some(1)),
+                None,
+            )
+            .await
+            .unwrap();
+        let glm = no_quota
+            .acquire_turn(
+                &continuum_glm(),
+                Uuid::new_v4(),
+                WorkloadClass::Interactive,
+                AdmissionEstimate::new(1, Some(1)),
+                None,
+            )
+            .await
+            .unwrap();
+        drop((k2, glm));
+    }
+
+    #[tokio::test]
+    async fn quota_and_deployment_reservations_are_atomic() {
+        let mut policy = test_policy(1);
+        policy.quota_budgets.insert(
+            CapacityPoolKey::ProviderModel(k3()),
+            QuotaBudget {
+                requests: Some(1),
+                ..QuotaBudget::default()
+            },
+        );
+        let controller = controller(policy);
+        let first = controller
+            .acquire_turn(
+                &k3(),
+                Uuid::new_v4(),
+                WorkloadClass::Interactive,
+                AdmissionEstimate::new(1, Some(1)),
+                None,
+            )
+            .await
+            .unwrap();
+        let blocked = controller
+            .acquire_turn(
+                &k3(),
+                Uuid::new_v4(),
+                WorkloadClass::Background,
+                AdmissionEstimate::new(1, Some(1)),
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(blocked.kind, AdmissionRejectionKind::RateBudget);
+        assert_eq!(controller.debug_counts().active_turns, 1);
+        first.settle(None, TerminalDisposition::ProvenPreAcceptance);
+        let second = controller
+            .acquire_turn(
+                &k3(),
+                Uuid::new_v4(),
+                WorkloadClass::Interactive,
+                AdmissionEstimate::new(1, Some(1)),
+                None,
+            )
+            .await
+            .unwrap();
+        drop(second);
+    }
+
+    #[tokio::test]
+    async fn reconciliation_refunds_only_proven_pre_acceptance_and_releases_once() {
+        let mut policy = test_policy(1);
+        policy.quota_budgets.insert(
+            CapacityPoolKey::ProviderModel(k3()),
+            QuotaBudget {
+                completion_tokens: Some(10),
+                ..QuotaBudget::default()
+            },
+        );
+        let controller = controller(policy);
+
+        let refunded = controller
+            .acquire_turn(
+                &k3(),
+                Uuid::new_v4(),
+                WorkloadClass::Interactive,
+                AdmissionEstimate::new(0, Some(10)),
+                None,
+            )
+            .await
+            .unwrap();
+        refunded.settle(None, TerminalDisposition::ProvenPreAcceptance);
+        assert_eq!(controller.debug_counts().active_turns, 0);
+
+        let reconciled = controller
+            .acquire_turn(
+                &k3(),
+                Uuid::new_v4(),
+                WorkloadClass::Interactive,
+                AdmissionEstimate::new(0, Some(10)),
+                None,
+            )
+            .await
+            .unwrap();
+        reconciled.settle(
+            Some(ActualUsage::complete(0, 4, None)),
+            TerminalDisposition::Completed,
+        );
+        let remaining = controller
+            .acquire_turn(
+                &k3(),
+                Uuid::new_v4(),
+                WorkloadClass::Interactive,
+                AdmissionEstimate::new(0, Some(6)),
+                None,
+            )
+            .await
+            .unwrap();
+        drop(remaining); // Ambiguous drop retains six: the budget is now full.
+        let rejected = controller
+            .acquire_turn(
+                &k3(),
+                Uuid::new_v4(),
+                WorkloadClass::Background,
+                AdmissionEstimate::new(0, Some(1)),
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(rejected.kind, AdmissionRejectionKind::RateBudget);
+        assert_eq!(controller.debug_counts().active_turns, 0);
+    }
+
+    #[test]
+    fn prompt_and_cached_usage_reconcile_as_independent_observations() {
+        fn reconciled(usage: ActualUsage) -> UsageAmount {
+            let budget = QuotaBudget {
+                prompt_tokens: Some(100),
+                cached_tokens: Some(100),
+                ..QuotaBudget::default()
+            };
+            let reserved = budget.charged(UsageAmount {
+                requests: 1,
+                prompt_tokens: 10,
+                completion_tokens: 5,
+                cached_tokens: 10,
+            });
+            let now = Instant::now();
+            let mut ledger = QuotaLedger::default();
+            ledger.reserve(1, now, reserved);
+            assert!(ledger.finish(
+                1,
+                budget,
+                Some(usage),
+                TerminalDisposition::Completed,
+                now,
+                Duration::from_secs(60),
+            ));
+            ledger.completed.front().unwrap().amount
+        }
+
+        let both = reconciled(ActualUsage {
+            prompt_tokens: Some(20),
+            completion_tokens: None,
+            cached_prompt_tokens: Some(7),
+        });
+        assert_eq!(both.prompt_tokens, 13);
+        assert_eq!(both.cached_tokens, 7);
+
+        let prompt_only = reconciled(ActualUsage {
+            prompt_tokens: Some(20),
+            completion_tokens: None,
+            cached_prompt_tokens: None,
+        });
+        assert_eq!(prompt_only.prompt_tokens, 20);
+        assert_eq!(prompt_only.cached_tokens, 20);
+
+        let cached_only = reconciled(ActualUsage {
+            prompt_tokens: None,
+            completion_tokens: None,
+            cached_prompt_tokens: Some(25),
+        });
+        assert_eq!(cached_only.prompt_tokens, 10);
+        assert_eq!(cached_only.cached_tokens, 25);
+
+        let neither = reconciled(ActualUsage::default());
+        assert_eq!(neither.prompt_tokens, 10);
+        assert_eq!(neither.cached_tokens, 10);
+    }
+
+    #[tokio::test]
+    async fn authoritative_cached_usage_reconciles_prompt_to_uncached_tokens() {
+        let mut policy = test_policy(1);
+        policy.quota_budgets.insert(
+            CapacityPoolKey::ProviderModel(k3()),
+            QuotaBudget {
+                prompt_tokens: Some(10),
+                cached_tokens: Some(10),
+                ..QuotaBudget::default()
+            },
+        );
+        let controller = controller(policy);
+
+        let first = controller
+            .acquire_turn(
+                &k3(),
+                Uuid::new_v4(),
+                WorkloadClass::Interactive,
+                AdmissionEstimate::new(10, Some(0)),
+                None,
+            )
+            .await
+            .unwrap();
+        first.settle(
+            Some(ActualUsage::complete(10, 0, Some(3))),
+            TerminalDisposition::Completed,
+        );
+
+        // The authoritative split charges seven uncached prompt tokens and
+        // three cached tokens, so a conservative three-token reservation fits
+        // both ten-token dimensions. Charging the full prompt plus cached
+        // tokens would reject this request.
+        let second = controller
+            .acquire_turn(
+                &k3(),
+                Uuid::new_v4(),
+                WorkloadClass::Background,
+                AdmissionEstimate::new(3, Some(0)),
+                None,
+            )
+            .await
+            .unwrap();
+        second.settle(None, TerminalDisposition::ProvenPreAcceptance);
+    }
+
+    #[tokio::test]
+    async fn rolling_budget_expiry_wakes_a_waiter_without_a_new_arrival() {
+        let mut policy = test_policy(1);
+        policy.rolling_window = Duration::from_millis(20);
+        policy.quota_budgets.insert(
+            CapacityPoolKey::ProviderModel(k3()),
+            QuotaBudget {
+                requests: Some(1),
+                ..QuotaBudget::default()
+            },
+        );
+        let controller = controller(policy);
+
+        let first = controller
+            .acquire_turn(
+                &k3(),
+                Uuid::new_v4(),
+                WorkloadClass::Interactive,
+                AdmissionEstimate::new(0, Some(0)),
+                None,
+            )
+            .await
+            .unwrap();
+        first.settle(
+            Some(ActualUsage::complete(0, 0, Some(0))),
+            TerminalDisposition::Completed,
+        );
+
+        let waiting = spawn_turn(controller.clone(), k3(), Uuid::new_v4());
+        tokio::task::yield_now().await;
+        assert!(!waiting.is_finished());
+        let permit = tokio::time::timeout(Duration::from_millis(250), waiting)
+            .await
+            .expect("rolling-window timer should wake the queue")
+            .unwrap()
+            .unwrap();
+        drop(permit);
+    }
+
+    #[tokio::test]
+    async fn unknown_routes_fail_closed_without_growing_fixed_topology() {
+        let controller = controller(test_policy(1));
+        let before = controller.debug_counts();
+        let rejection = controller
+            .acquire_turn(
+                &route(ProviderId::Tinfoil, "not-in-the-registry"),
+                Uuid::new_v4(),
+                WorkloadClass::Interactive,
+                AdmissionEstimate::new(1, None),
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(rejection.kind, AdmissionRejectionKind::UnknownRoute);
+        assert_eq!(rejection.status_hint(), 503);
+        assert_eq!(controller.debug_counts(), before);
+    }
+
+    #[test]
+    fn fixed_pool_cardinality_matches_registry_topology() {
+        let topology = Topology::from_registry(&PROVIDER_REGISTRY).unwrap();
+        let controller = controller(test_policy(4));
+        let counts = controller.debug_counts();
+        assert_eq!(counts.deployment_pools, topology.routes.len());
+        assert_eq!(counts.quota_pools, topology.quota_pools.len());
+        assert_eq!(counts.logical_accounts, 0);
+        assert_eq!(counts.queued_turns, 0);
+        assert_eq!(counts.active_turns, 0);
+    }
+}

--- a/src/inference/health.rs
+++ b/src/inference/health.rs
@@ -1,0 +1,1078 @@
+//! Enclave-local shadow health classification for inference routes.
+//!
+//! This module deliberately has no route-selection API. Stack 5 records what a
+//! versioned policy would do, while the legacy router and shadow planner remain
+//! the only sources of route decisions.
+
+use super::{AttemptFailureKind, AttemptTerminal, RouteKey};
+use crate::provider_registry::{ProviderId, ProviderRegistry, RateLimitScope, PROVIDER_REGISTRY};
+use std::collections::{HashMap, VecDeque};
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+
+pub(crate) const SHADOW_HEALTH_POLICY_VERSION: &str = "routing-v2-health-shadow-v1";
+
+// These are observation-only v1 hypotheses, not active product policy. Stack 5
+// intentionally versions and exercises them against real incidents before a
+// later stack may use any disposition during route selection.
+const ROUTE_FAILURE_WINDOW: Duration = Duration::from_secs(60);
+const ROUTE_FAILURES_TO_OPEN: u8 = 3;
+const ROUTE_OPEN_COOLDOWN: Duration = Duration::from_secs(30);
+const DEFAULT_CAPACITY_COOLDOWN: Duration = Duration::from_secs(1);
+const MAX_CAPACITY_COOLDOWN: Duration = Duration::from_secs(60 * 60);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShadowObservationMode {
+    Update,
+    TelemetryOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum CapacityPoolKey {
+    ProviderModel(RouteKey),
+    ProviderAccount(ProviderId),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShadowDisposition {
+    Healthy,
+    Watch { consecutive_failures: u8 },
+    WouldOpen { remaining: Duration },
+    WouldProbe,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ShadowRouteSnapshot {
+    pub(crate) route_health: ShadowDisposition,
+    pub(crate) deployment_capacity: ShadowDisposition,
+    pub(crate) rate_limit_capacity: ShadowDisposition,
+    pub(crate) effective: ShadowDisposition,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShadowSignal {
+    Completed,
+    CapacityRejected {
+        status: u16,
+    },
+    RouteFailure {
+        kind: AttemptFailureKind,
+        status: Option<u16>,
+    },
+    Neutral {
+        kind: AttemptFailureKind,
+        status: Option<u16>,
+    },
+    UnknownRoute,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ShadowObservationReport {
+    pub(crate) policy_version: &'static str,
+    pub(crate) mode: ShadowObservationMode,
+    pub(crate) route: RouteKey,
+    pub(crate) signal: ShadowSignal,
+    pub(crate) capacity_pool: Option<CapacityPoolKey>,
+    pub(crate) snapshot: Option<ShadowRouteSnapshot>,
+    pub(crate) mutated: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ShadowHealthPolicy {
+    route_failure_window: Duration,
+    route_failures_to_open: u8,
+    route_open_cooldown: Duration,
+    default_capacity_cooldown: Duration,
+    max_capacity_cooldown: Duration,
+}
+
+impl Default for ShadowHealthPolicy {
+    fn default() -> Self {
+        Self {
+            route_failure_window: ROUTE_FAILURE_WINDOW,
+            route_failures_to_open: ROUTE_FAILURES_TO_OPEN,
+            route_open_cooldown: ROUTE_OPEN_COOLDOWN,
+            default_capacity_cooldown: DEFAULT_CAPACITY_COOLDOWN,
+            max_capacity_cooldown: MAX_CAPACITY_COOLDOWN,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct RouteHealthState {
+    failure_times: VecDeque<Instant>,
+    open_until: Option<Instant>,
+}
+
+#[derive(Debug, Default)]
+struct CapacityState {
+    open_until: Option<Instant>,
+}
+
+#[derive(Debug)]
+struct ShadowHealthInner {
+    route_health: HashMap<RouteKey, RouteHealthState>,
+    capacity: HashMap<CapacityPoolKey, CapacityState>,
+}
+
+/// Fixed-topology, enclave-local shadow state.
+///
+/// Every key is pre-populated from the static provider registry. Observations
+/// for unknown routes are reported but can never grow the maps.
+#[derive(Debug)]
+pub(crate) struct ShadowHealthState {
+    policy: ShadowHealthPolicy,
+    rate_limit_pools: HashMap<RouteKey, CapacityPoolKey>,
+    inner: Mutex<ShadowHealthInner>,
+    #[cfg(test)]
+    observation_count: AtomicUsize,
+}
+
+impl Default for ShadowHealthState {
+    fn default() -> Self {
+        Self::new(&PROVIDER_REGISTRY)
+    }
+}
+
+impl ShadowHealthState {
+    pub(crate) fn new(registry: &'static ProviderRegistry) -> Self {
+        Self::new_with_policy(registry, ShadowHealthPolicy::default())
+    }
+
+    fn new_with_policy(registry: &'static ProviderRegistry, policy: ShadowHealthPolicy) -> Self {
+        let mut route_health = HashMap::new();
+        let mut capacity = HashMap::new();
+        let mut rate_limit_pools = HashMap::new();
+
+        for model in registry.completion_models() {
+            for route in model.routes {
+                let route_key = RouteKey {
+                    provider: route.provider,
+                    provider_model_id: route.provider_model_id.to_string(),
+                };
+                let deployment_pool = CapacityPoolKey::ProviderModel(route_key.clone());
+                let rate_limit_pool = match route.rate_limit_scope {
+                    RateLimitScope::ProviderModel => deployment_pool.clone(),
+                    RateLimitScope::ProviderAccount => {
+                        CapacityPoolKey::ProviderAccount(route.provider)
+                    }
+                };
+
+                route_health.entry(route_key.clone()).or_default();
+                capacity.entry(deployment_pool).or_default();
+                capacity.entry(rate_limit_pool.clone()).or_default();
+                rate_limit_pools.entry(route_key).or_insert(rate_limit_pool);
+            }
+        }
+
+        Self {
+            policy,
+            rate_limit_pools,
+            inner: Mutex::new(ShadowHealthInner {
+                route_health,
+                capacity,
+            }),
+            #[cfg(test)]
+            observation_count: AtomicUsize::new(0),
+        }
+    }
+
+    pub(crate) fn observe_terminal(
+        &self,
+        terminal: &AttemptTerminal,
+        mode: ShadowObservationMode,
+    ) -> ShadowObservationReport {
+        let mut inner = self.lock();
+        let now = Instant::now();
+        self.observe_terminal_locked(&mut inner, terminal, mode, now)
+    }
+
+    pub(crate) fn snapshot(&self, route: &RouteKey) -> Option<ShadowRouteSnapshot> {
+        let inner = self.lock();
+        self.snapshot_locked(&inner, route, Instant::now())
+    }
+
+    fn observe_terminal_locked(
+        &self,
+        inner: &mut ShadowHealthInner,
+        terminal: &AttemptTerminal,
+        mode: ShadowObservationMode,
+        now: Instant,
+    ) -> ShadowObservationReport {
+        #[cfg(test)]
+        self.observation_count.fetch_add(1, Ordering::Relaxed);
+
+        let route = terminal.attempt().route.route_key();
+        let Some(rate_limit_pool) = self.rate_limit_pools.get(&route).cloned() else {
+            return ShadowObservationReport {
+                policy_version: SHADOW_HEALTH_POLICY_VERSION,
+                mode,
+                route,
+                signal: ShadowSignal::UnknownRoute,
+                capacity_pool: None,
+                snapshot: None,
+                mutated: false,
+            };
+        };
+
+        let mut signal = ShadowSignal::Completed;
+        let mut capacity_pool = None;
+        let mut mutation = Mutation::Completed;
+
+        if let AttemptTerminal::Failed { failure, .. } = terminal {
+            let status = failure.status;
+            if failure.kind == AttemptFailureKind::CapacityRejected {
+                match status {
+                    Some(429) => {
+                        signal = ShadowSignal::CapacityRejected { status: 429 };
+                        capacity_pool = Some(rate_limit_pool.clone());
+                        mutation = Mutation::Capacity {
+                            pool: rate_limit_pool.clone(),
+                            retry_after: failure.retry_after,
+                        };
+                    }
+                    Some(status @ (503 | 529)) => {
+                        let pool = CapacityPoolKey::ProviderModel(route.clone());
+                        signal = ShadowSignal::CapacityRejected { status };
+                        capacity_pool = Some(pool.clone());
+                        mutation = Mutation::Capacity {
+                            pool,
+                            retry_after: failure.retry_after,
+                        };
+                    }
+                    _ => {
+                        signal = ShadowSignal::Neutral {
+                            kind: failure.kind,
+                            status,
+                        };
+                        mutation = Mutation::None;
+                    }
+                }
+            } else if failure.kind == AttemptFailureKind::HttpStatus {
+                if status.is_some_and(|status| (500..=599).contains(&status)) {
+                    signal = ShadowSignal::RouteFailure {
+                        kind: failure.kind,
+                        status,
+                    };
+                    mutation = Mutation::RouteFailure;
+                } else {
+                    signal = ShadowSignal::Neutral {
+                        kind: failure.kind,
+                        status,
+                    };
+                    mutation = Mutation::None;
+                }
+            } else if is_route_health_failure(failure.kind) {
+                signal = ShadowSignal::RouteFailure {
+                    kind: failure.kind,
+                    status,
+                };
+                mutation = Mutation::RouteFailure;
+            } else {
+                signal = ShadowSignal::Neutral {
+                    kind: failure.kind,
+                    status,
+                };
+                mutation = Mutation::None;
+            }
+        }
+
+        let mutated = mode == ShadowObservationMode::Update && mutation != Mutation::None;
+        if mutated {
+            self.apply_mutation(inner, &route, &rate_limit_pool, mutation, now);
+        }
+
+        ShadowObservationReport {
+            policy_version: SHADOW_HEALTH_POLICY_VERSION,
+            mode,
+            route: route.clone(),
+            signal,
+            capacity_pool,
+            snapshot: self.snapshot_locked(inner, &route, now),
+            mutated,
+        }
+    }
+
+    fn apply_mutation(
+        &self,
+        inner: &mut ShadowHealthInner,
+        route: &RouteKey,
+        rate_limit_pool: &CapacityPoolKey,
+        mutation: Mutation,
+        now: Instant,
+    ) {
+        match mutation {
+            Mutation::Completed => {
+                if let Some(state) = inner.route_health.get_mut(route) {
+                    apply_route_success(state, now);
+                }
+
+                let deployment_pool = CapacityPoolKey::ProviderModel(route.clone());
+                if let Some(state) = inner.capacity.get_mut(&deployment_pool) {
+                    apply_capacity_success(state, now);
+                }
+                if rate_limit_pool != &deployment_pool {
+                    if let Some(state) = inner.capacity.get_mut(rate_limit_pool) {
+                        apply_capacity_success(state, now);
+                    }
+                }
+            }
+            Mutation::Capacity { pool, retry_after } => {
+                if let Some(state) = inner.capacity.get_mut(&pool) {
+                    let cooldown = retry_after
+                        .unwrap_or(self.policy.default_capacity_cooldown)
+                        .min(self.policy.max_capacity_cooldown);
+                    extend_open_until(&mut state.open_until, now, cooldown);
+                }
+            }
+            Mutation::RouteFailure => {
+                if let Some(state) = inner.route_health.get_mut(route) {
+                    apply_route_failure(state, self.policy, now);
+                }
+            }
+            Mutation::None => {}
+        }
+    }
+
+    fn snapshot_locked(
+        &self,
+        inner: &ShadowHealthInner,
+        route: &RouteKey,
+        now: Instant,
+    ) -> Option<ShadowRouteSnapshot> {
+        let route_health = route_health_disposition(
+            inner.route_health.get(route)?,
+            self.policy.route_failure_window,
+            now,
+        );
+        let deployment_pool = CapacityPoolKey::ProviderModel(route.clone());
+        let deployment_capacity = capacity_disposition(inner.capacity.get(&deployment_pool)?, now);
+        let rate_limit_pool = self.rate_limit_pools.get(route)?;
+        let rate_limit_capacity = capacity_disposition(inner.capacity.get(rate_limit_pool)?, now);
+        let effective =
+            strongest_disposition([route_health, deployment_capacity, rate_limit_capacity]);
+
+        Some(ShadowRouteSnapshot {
+            route_health,
+            deployment_capacity,
+            rate_limit_capacity,
+            effective,
+        })
+    }
+
+    fn lock(&self) -> MutexGuard<'_, ShadowHealthInner> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    #[cfg(test)]
+    fn with_policy(policy: ShadowHealthPolicy) -> Self {
+        Self::new_with_policy(&PROVIDER_REGISTRY, policy)
+    }
+
+    #[cfg(test)]
+    fn observe_terminal_at(
+        &self,
+        terminal: &AttemptTerminal,
+        mode: ShadowObservationMode,
+        now: Instant,
+    ) -> ShadowObservationReport {
+        let mut inner = self.lock();
+        self.observe_terminal_locked(&mut inner, terminal, mode, now)
+    }
+
+    #[cfg(test)]
+    fn snapshot_at(&self, route: &RouteKey, now: Instant) -> Option<ShadowRouteSnapshot> {
+        let inner = self.lock();
+        self.snapshot_locked(&inner, route, now)
+    }
+
+    #[cfg(test)]
+    fn cardinality(&self) -> (usize, usize) {
+        let inner = self.lock();
+        (inner.route_health.len(), inner.capacity.len())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn observation_count(&self) -> usize {
+        self.observation_count.load(Ordering::Relaxed)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Mutation {
+    Completed,
+    Capacity {
+        pool: CapacityPoolKey,
+        retry_after: Option<Duration>,
+    },
+    RouteFailure,
+    None,
+}
+
+fn is_route_health_failure(kind: AttemptFailureKind) -> bool {
+    match kind {
+        AttemptFailureKind::Connect
+        | AttemptFailureKind::Transport
+        | AttemptFailureKind::ResponseStartTimeout
+        | AttemptFailureKind::ResponseBody
+        | AttemptFailureKind::InvalidResponse
+        | AttemptFailureKind::UpstreamResponseError
+        | AttemptFailureKind::UpstreamStreamError
+        | AttemptFailureKind::StreamTimeout
+        | AttemptFailureKind::UnexpectedEof => true,
+        AttemptFailureKind::ProviderUnavailable
+        | AttemptFailureKind::RequestBuild
+        | AttemptFailureKind::HttpStatus
+        | AttemptFailureKind::CapacityRejected
+        | AttemptFailureKind::ConsumerDropped => false,
+    }
+}
+
+fn apply_route_failure(state: &mut RouteHealthState, policy: ShadowHealthPolicy, now: Instant) {
+    if state.open_until.is_some_and(|until| now < until) {
+        extend_open_until(&mut state.open_until, now, policy.route_open_cooldown);
+        return;
+    }
+
+    state.failure_times.retain(|failure_at| {
+        now.checked_duration_since(*failure_at)
+            .is_none_or(|age| age <= policy.route_failure_window)
+    });
+    state.failure_times.push_back(now);
+
+    // The queue never needs more entries than the threshold. Keeping only the
+    // bounded recent tail makes the fixed-topology state safe even if a future
+    // shadow policy raises its observation volume.
+    let threshold = usize::from(policy.route_failures_to_open.max(1));
+    while state.failure_times.len() > threshold {
+        state.failure_times.pop_front();
+    }
+
+    if state.failure_times.len() >= threshold {
+        extend_open_until(&mut state.open_until, now, policy.route_open_cooldown);
+    } else {
+        state.open_until = None;
+    }
+}
+
+fn apply_route_success(state: &mut RouteHealthState, now: Instant) {
+    if state.open_until.is_some_and(|until| now < until) {
+        return;
+    }
+    state.failure_times.clear();
+    state.open_until = None;
+}
+
+fn apply_capacity_success(state: &mut CapacityState, now: Instant) {
+    if state.open_until.is_some_and(|until| now >= until) {
+        state.open_until = None;
+    }
+}
+
+fn extend_open_until(open_until: &mut Option<Instant>, now: Instant, cooldown: Duration) {
+    let candidate = now.checked_add(cooldown).unwrap_or(now);
+    *open_until = Some(open_until.map_or(candidate, |current| current.max(candidate)));
+}
+
+fn route_health_disposition(
+    state: &RouteHealthState,
+    failure_window: Duration,
+    now: Instant,
+) -> ShadowDisposition {
+    if let Some(until) = state.open_until {
+        return if now < until {
+            ShadowDisposition::WouldOpen {
+                remaining: until.duration_since(now),
+            }
+        } else {
+            ShadowDisposition::WouldProbe
+        };
+    }
+
+    let current_failures = state
+        .failure_times
+        .iter()
+        .filter(|failure_at| {
+            now.checked_duration_since(**failure_at)
+                .is_none_or(|age| age <= failure_window)
+        })
+        .count();
+    if current_failures > 0 {
+        ShadowDisposition::Watch {
+            consecutive_failures: u8::try_from(current_failures).unwrap_or(u8::MAX),
+        }
+    } else {
+        ShadowDisposition::Healthy
+    }
+}
+
+fn capacity_disposition(state: &CapacityState, now: Instant) -> ShadowDisposition {
+    match state.open_until {
+        Some(until) if now < until => ShadowDisposition::WouldOpen {
+            remaining: until.duration_since(now),
+        },
+        Some(_) => ShadowDisposition::WouldProbe,
+        None => ShadowDisposition::Healthy,
+    }
+}
+
+fn strongest_disposition(
+    dispositions: impl IntoIterator<Item = ShadowDisposition>,
+) -> ShadowDisposition {
+    dispositions
+        .into_iter()
+        .fold(ShadowDisposition::Healthy, stronger_disposition)
+}
+
+fn stronger_disposition(left: ShadowDisposition, right: ShadowDisposition) -> ShadowDisposition {
+    match (left, right) {
+        (
+            ShadowDisposition::WouldOpen {
+                remaining: left_remaining,
+            },
+            ShadowDisposition::WouldOpen {
+                remaining: right_remaining,
+            },
+        ) => ShadowDisposition::WouldOpen {
+            remaining: left_remaining.max(right_remaining),
+        },
+        (left @ ShadowDisposition::WouldOpen { .. }, _) => left,
+        (_, right @ ShadowDisposition::WouldOpen { .. }) => right,
+        (ShadowDisposition::WouldProbe, _) | (_, ShadowDisposition::WouldProbe) => {
+            ShadowDisposition::WouldProbe
+        }
+        (
+            ShadowDisposition::Watch {
+                consecutive_failures: left_failures,
+            },
+            ShadowDisposition::Watch {
+                consecutive_failures: right_failures,
+            },
+        ) => ShadowDisposition::Watch {
+            consecutive_failures: left_failures.max(right_failures),
+        },
+        (left @ ShadowDisposition::Watch { .. }, _) => left,
+        (_, right @ ShadowDisposition::Watch { .. }) => right,
+        (ShadowDisposition::Healthy, ShadowDisposition::Healthy) => ShadowDisposition::Healthy,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inference::{
+        AttemptFailure, AttemptStage, CompletionEvidence, InferenceExecution, ReplaySafety,
+        RouteIdentity,
+    };
+    use crate::provider_registry::RouteSelectionSource;
+    use std::sync::Arc;
+    use std::thread;
+
+    fn route(provider: ProviderId, public_model: &str, provider_model: &str) -> RouteIdentity {
+        RouteIdentity::new(
+            provider,
+            public_model,
+            provider_model,
+            public_model,
+            RouteSelectionSource::StaticSplit,
+            None,
+        )
+    }
+
+    fn completed(route: RouteIdentity) -> AttemptTerminal {
+        AttemptTerminal::Completed {
+            attempt: InferenceExecution {
+                request_id: super::super::InferenceRequestId::new(),
+                execution_id: super::super::InferenceExecutionId::new(),
+            }
+            .begin_attempt(route),
+            evidence: CompletionEvidence::ProviderDone,
+        }
+    }
+
+    fn failed(
+        route: RouteIdentity,
+        kind: AttemptFailureKind,
+        status: Option<u16>,
+        retry_after: Option<Duration>,
+    ) -> AttemptTerminal {
+        let mut failure = AttemptFailure::new(
+            kind,
+            AttemptStage::AwaitingResponse,
+            ReplaySafety::NotProvenPreAcceptance,
+        );
+        failure.status = status;
+        failure.retry_after = retry_after;
+        AttemptTerminal::Failed {
+            attempt: InferenceExecution {
+                request_id: super::super::InferenceRequestId::new(),
+                execution_id: super::super::InferenceExecutionId::new(),
+            }
+            .begin_attempt(route),
+            failure,
+        }
+    }
+
+    fn test_policy() -> ShadowHealthPolicy {
+        ShadowHealthPolicy {
+            route_failure_window: Duration::from_secs(10),
+            route_failures_to_open: 3,
+            route_open_cooldown: Duration::from_secs(5),
+            default_capacity_cooldown: Duration::from_secs(4),
+            max_capacity_cooldown: Duration::from_secs(10),
+        }
+    }
+
+    #[test]
+    fn classifier_is_exhaustive_and_only_provider_faults_penalize_health() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let now = Instant::now();
+        let kimi = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+
+        let route_failures = [
+            AttemptFailureKind::Connect,
+            AttemptFailureKind::Transport,
+            AttemptFailureKind::ResponseStartTimeout,
+            AttemptFailureKind::ResponseBody,
+            AttemptFailureKind::InvalidResponse,
+            AttemptFailureKind::UpstreamResponseError,
+            AttemptFailureKind::UpstreamStreamError,
+            AttemptFailureKind::StreamTimeout,
+            AttemptFailureKind::UnexpectedEof,
+        ];
+        for kind in route_failures {
+            let report = state.observe_terminal_at(
+                &failed(kimi.clone(), kind, None, None),
+                ShadowObservationMode::TelemetryOnly,
+                now,
+            );
+            assert!(matches!(
+                report.signal,
+                ShadowSignal::RouteFailure {
+                    kind: observed,
+                    status: None
+                } if observed == kind
+            ));
+            assert!(!report.mutated);
+        }
+
+        for kind in [
+            AttemptFailureKind::ProviderUnavailable,
+            AttemptFailureKind::RequestBuild,
+            AttemptFailureKind::ConsumerDropped,
+        ] {
+            let report = state.observe_terminal_at(
+                &failed(kimi.clone(), kind, None, None),
+                ShadowObservationMode::Update,
+                now,
+            );
+            assert!(matches!(report.signal, ShadowSignal::Neutral { .. }));
+            assert!(!report.mutated);
+        }
+
+        let server = state.observe_terminal_at(
+            &failed(
+                kimi.clone(),
+                AttemptFailureKind::HttpStatus,
+                Some(500),
+                None,
+            ),
+            ShadowObservationMode::TelemetryOnly,
+            now,
+        );
+        assert!(matches!(server.signal, ShadowSignal::RouteFailure { .. }));
+
+        let caller = state.observe_terminal_at(
+            &failed(
+                kimi.clone(),
+                AttemptFailureKind::HttpStatus,
+                Some(400),
+                None,
+            ),
+            ShadowObservationMode::Update,
+            now,
+        );
+        assert!(matches!(caller.signal, ShadowSignal::Neutral { .. }));
+        assert!(!caller.mutated);
+
+        let malformed_capacity = state.observe_terminal_at(
+            &failed(kimi, AttemptFailureKind::CapacityRejected, Some(500), None),
+            ShadowObservationMode::Update,
+            now,
+        );
+        assert!(matches!(
+            malformed_capacity.signal,
+            ShadowSignal::Neutral { .. }
+        ));
+        assert!(!malformed_capacity.mutated);
+    }
+
+    #[test]
+    fn provider_specific_rate_limit_scopes_and_deployment_capacity_are_isolated() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let now = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let quick = route(ProviderId::Tinfoil, "gpt-oss-120b", "gpt-oss-120b");
+        let k2 = route(ProviderId::Continuum, "kimi-k2-6", "kimi-k2.6");
+        let glm_continuum = route(ProviderId::Continuum, "glm-5-2", "glm-5.2");
+        let glm_tinfoil = route(ProviderId::Tinfoil, "glm-5-2", "glm-5-2");
+
+        let tinfoil = state.observe_terminal_at(
+            &failed(
+                k3.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(5)),
+            ),
+            ShadowObservationMode::Update,
+            now,
+        );
+        assert_eq!(
+            tinfoil.capacity_pool,
+            Some(CapacityPoolKey::ProviderModel(k3.route_key()))
+        );
+        assert!(matches!(
+            state.snapshot_at(&k3.route_key(), now).unwrap().effective,
+            ShadowDisposition::WouldOpen { .. }
+        ));
+        assert_eq!(
+            state
+                .snapshot_at(&quick.route_key(), now)
+                .unwrap()
+                .effective,
+            ShadowDisposition::Healthy
+        );
+
+        let continuum = state.observe_terminal_at(
+            &failed(
+                k2.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(5)),
+            ),
+            ShadowObservationMode::Update,
+            now,
+        );
+        assert_eq!(
+            continuum.capacity_pool,
+            Some(CapacityPoolKey::ProviderAccount(ProviderId::Continuum))
+        );
+        assert!(matches!(
+            state
+                .snapshot_at(&glm_continuum.route_key(), now)
+                .unwrap()
+                .effective,
+            ShadowDisposition::WouldOpen { .. }
+        ));
+        assert_eq!(
+            state
+                .snapshot_at(&glm_tinfoil.route_key(), now)
+                .unwrap()
+                .effective,
+            ShadowDisposition::Healthy
+        );
+
+        let state = ShadowHealthState::with_policy(test_policy());
+        state.observe_terminal_at(
+            &failed(
+                k2.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(503),
+                Some(Duration::from_secs(5)),
+            ),
+            ShadowObservationMode::Update,
+            now,
+        );
+        assert!(matches!(
+            state.snapshot_at(&k2.route_key(), now).unwrap().effective,
+            ShadowDisposition::WouldOpen { .. }
+        ));
+        assert_eq!(
+            state
+                .snapshot_at(&glm_continuum.route_key(), now)
+                .unwrap()
+                .effective,
+            ShadowDisposition::Healthy
+        );
+    }
+
+    #[test]
+    fn capacity_cooldowns_are_bounded_and_success_cannot_clear_them_early() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let start = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let key = k3.route_key();
+
+        state.observe_terminal_at(
+            &failed(
+                k3.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                None,
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+        assert_eq!(
+            state.snapshot_at(&key, start).unwrap().effective,
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(4)
+            }
+        );
+
+        state.observe_terminal_at(
+            &completed(k3.clone()),
+            ShadowObservationMode::Update,
+            start + Duration::from_secs(1),
+        );
+        assert!(matches!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(1))
+                .unwrap()
+                .effective,
+            ShadowDisposition::WouldOpen { .. }
+        ));
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(4))
+                .unwrap()
+                .effective,
+            ShadowDisposition::WouldProbe
+        );
+
+        state.observe_terminal_at(
+            &completed(k3.clone()),
+            ShadowObservationMode::Update,
+            start + Duration::from_secs(4),
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(4))
+                .unwrap()
+                .effective,
+            ShadowDisposition::Healthy
+        );
+
+        state.observe_terminal_at(
+            &failed(
+                k3,
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(100)),
+            ),
+            ShadowObservationMode::Update,
+            start + Duration::from_secs(20),
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(20))
+                .unwrap()
+                .effective,
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(10)
+            }
+        );
+    }
+
+    #[test]
+    fn route_health_uses_a_window_threshold_and_terminal_success_reset() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let start = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let key = k3.route_key();
+        let fault = || failed(k3.clone(), AttemptFailureKind::StreamTimeout, None, None);
+
+        state.observe_terminal_at(&fault(), ShadowObservationMode::Update, start);
+        assert_eq!(
+            state.snapshot_at(&key, start).unwrap().route_health,
+            ShadowDisposition::Watch {
+                consecutive_failures: 1
+            }
+        );
+
+        state.observe_terminal_at(
+            &completed(k3.clone()),
+            ShadowObservationMode::Update,
+            start + Duration::from_secs(1),
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(1))
+                .unwrap()
+                .route_health,
+            ShadowDisposition::Healthy
+        );
+
+        for offset in [2, 3, 4] {
+            state.observe_terminal_at(
+                &fault(),
+                ShadowObservationMode::Update,
+                start + Duration::from_secs(offset),
+            );
+        }
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(4))
+                .unwrap()
+                .route_health,
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(5)
+            }
+        );
+
+        state.observe_terminal_at(
+            &completed(k3.clone()),
+            ShadowObservationMode::Update,
+            start + Duration::from_secs(5),
+        );
+        assert!(matches!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(5))
+                .unwrap()
+                .route_health,
+            ShadowDisposition::WouldOpen { .. }
+        ));
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(9))
+                .unwrap()
+                .route_health,
+            ShadowDisposition::WouldProbe
+        );
+
+        state.observe_terminal_at(
+            &completed(k3.clone()),
+            ShadowObservationMode::Update,
+            start + Duration::from_secs(9),
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(9))
+                .unwrap()
+                .route_health,
+            ShadowDisposition::Healthy
+        );
+
+        state.observe_terminal_at(
+            &fault(),
+            ShadowObservationMode::Update,
+            start + Duration::from_secs(30),
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(30))
+                .unwrap()
+                .route_health,
+            ShadowDisposition::Watch {
+                consecutive_failures: 1
+            }
+        );
+    }
+
+    #[test]
+    fn route_health_threshold_uses_one_bounded_rolling_window() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let start = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let key = k3.route_key();
+        let fault = || failed(k3.clone(), AttemptFailureKind::StreamTimeout, None, None);
+
+        for offset in [0, 9, 18] {
+            state.observe_terminal_at(
+                &fault(),
+                ShadowObservationMode::Update,
+                start + Duration::from_secs(offset),
+            );
+        }
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(18))
+                .unwrap()
+                .route_health,
+            ShadowDisposition::Watch {
+                consecutive_failures: 2
+            }
+        );
+
+        state.observe_terminal_at(
+            &fault(),
+            ShadowObservationMode::Update,
+            start + Duration::from_secs(19),
+        );
+        assert!(matches!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(19))
+                .unwrap()
+                .route_health,
+            ShadowDisposition::WouldOpen { .. }
+        ));
+    }
+
+    #[test]
+    fn recovered_transport_attempts_are_telemetry_only() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let now = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let key = k3.route_key();
+
+        let recovered = state.observe_terminal_at(
+            &failed(k3.clone(), AttemptFailureKind::Connect, None, None),
+            ShadowObservationMode::TelemetryOnly,
+            now,
+        );
+        assert!(matches!(
+            recovered.signal,
+            ShadowSignal::RouteFailure {
+                kind: AttemptFailureKind::Connect,
+                ..
+            }
+        ));
+        assert!(!recovered.mutated);
+
+        state.observe_terminal_at(
+            &completed(k3),
+            ShadowObservationMode::Update,
+            now + Duration::from_millis(1),
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&key, now + Duration::from_millis(1))
+                .unwrap()
+                .effective,
+            ShadowDisposition::Healthy
+        );
+    }
+
+    #[test]
+    fn registry_topology_bounds_state_under_concurrent_observation() {
+        let state = Arc::new(ShadowHealthState::with_policy(test_policy()));
+        let cardinality = state.cardinality();
+        let terminal = completed(route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3"));
+
+        let threads = (0..32)
+            .map(|_| {
+                let state = Arc::clone(&state);
+                let terminal = terminal.clone();
+                thread::spawn(move || {
+                    state.observe_terminal(&terminal, ShadowObservationMode::Update)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for thread in threads {
+            let report = thread.join().expect("observation thread");
+            assert!(report.mutated);
+        }
+        assert_eq!(state.cardinality(), cardinality);
+
+        let unknown = completed(route(ProviderId::Tinfoil, "unknown", "unknown"));
+        let report = state.observe_terminal(&unknown, ShadowObservationMode::Update);
+        assert_eq!(report.signal, ShadowSignal::UnknownRoute);
+        assert!(!report.mutated);
+        assert_eq!(state.cardinality(), cardinality);
+    }
+}

--- a/src/inference/health.rs
+++ b/src/inference/health.rs
@@ -1,22 +1,22 @@
 //! Enclave-local health classification for inference routes.
 //!
-//! Stack 5 introduced this state observationally. Stack 6 consumes one coherent
-//! snapshot only for the explicit GLM 5.2 canary; every other route remains
-//! observational until its own rollout boundary.
+//! The state has a fixed registry-derived topology and is deliberately local to
+//! one enclave. Active routing reads coherent snapshots, and expired circuits
+//! are protected by fenced half-open probe leases so concurrent requests cannot
+//! create a probe herd.
 
 use super::{AttemptFailureKind, AttemptTerminal, RouteKey};
 use crate::provider_registry::{ProviderId, ProviderRegistry, RateLimitScope, PROVIDER_REGISTRY};
 use std::collections::{HashMap, VecDeque};
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 
 pub(crate) const SHADOW_HEALTH_POLICY_VERSION: &str = "routing-v2-health-shadow-v1";
 
-// These are observation-only v1 hypotheses, not active product policy. Stack 5
-// intentionally versions and exercises them against real incidents before a
-// later stack may use any disposition during route selection.
+// The identifier retains its original shadow-era name for telemetry continuity;
+// these thresholds now drive active circuit and capacity decisions.
 const ROUTE_FAILURE_WINDOW: Duration = Duration::from_secs(60);
 const ROUTE_FAILURES_TO_OPEN: u8 = 3;
 const ROUTE_OPEN_COOLDOWN: Duration = Duration::from_secs(30);
@@ -41,9 +41,19 @@ pub(crate) enum CapacityPoolKey {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ShadowDisposition {
     Healthy,
-    Watch { consecutive_failures: u8 },
-    WouldOpen { remaining: Duration },
+    Watch {
+        consecutive_failures: u8,
+    },
+    WouldOpen {
+        remaining: Duration,
+    },
     WouldProbe,
+    /// A half-open provider attempt is live. `retry_after` is only a bounded
+    /// recovery hint for callers; the lease itself has no timer and remains
+    /// live until its attempt terminalizes or its guard is dropped.
+    ProbeInFlight {
+        retry_after: Duration,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -82,6 +92,27 @@ pub(crate) struct ShadowObservationReport {
     pub(crate) mutated: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProbeRejectionReason {
+    CircuitOpen,
+    ProbeInFlight,
+    UnknownRoute,
+}
+
+/// Result of atomically checking every health gate for a selected route.
+///
+/// `Ready(None)` means no gate needs a probe. `Ready(Some(_))` owns every
+/// expired-open gate that must be probed as one composite decision. Rejections
+/// are replay-safe because this check happens before a provider attempt starts.
+#[derive(Debug)]
+pub(crate) enum ProbeClaimResult {
+    Ready(Option<ProbeLease>),
+    Rejected {
+        reason: ProbeRejectionReason,
+        retry_after: Duration,
+    },
+}
+
 #[derive(Debug, Clone, Copy)]
 struct ShadowHealthPolicy {
     route_failure_window: Duration,
@@ -103,24 +134,106 @@ impl Default for ShadowHealthPolicy {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ActiveProbe {
+    lease_id: ProbeLeaseId,
+    generation_at_claim: u64,
+}
+
 #[derive(Debug, Default)]
 struct RouteHealthState {
     failure_times: VecDeque<Instant>,
     open_until: Option<Instant>,
+    generation: u64,
+    active_probe: Option<ActiveProbe>,
 }
 
 #[derive(Debug, Default)]
 struct CapacityState {
     open_until: Option<Instant>,
+    generation: u64,
+    active_probe: Option<ActiveProbe>,
 }
 
 #[derive(Debug)]
 struct ShadowHealthInner {
     route_health: HashMap<RouteKey, RouteHealthState>,
     capacity: HashMap<CapacityPoolKey, CapacityState>,
+    next_probe_lease_id: u64,
 }
 
-/// Fixed-topology, enclave-local shadow state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct ProbeLeaseId(u64);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum ProbeGateKey {
+    RouteHealth(RouteKey),
+    Capacity(CapacityPoolKey),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProbeGateClaim {
+    gate: ProbeGateKey,
+    generation_at_claim: u64,
+}
+
+/// Non-cloneable ownership of a composite half-open probe.
+///
+/// Dropping an unresolved lease releases only matching fenced gates. It never
+/// heals a circuit, and a stale lease cannot release a newer probe.
+pub(crate) struct ProbeLease {
+    inner: Arc<Mutex<ShadowHealthInner>>,
+    route: RouteKey,
+    lease_id: ProbeLeaseId,
+    claims: Option<Box<[ProbeGateClaim]>>,
+}
+
+impl std::fmt::Debug for ProbeLease {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ProbeLease")
+            .field("route", &self.route)
+            .field("lease_id", &self.lease_id)
+            .field(
+                "claim_count",
+                &self.claims.as_ref().map_or(0, |claims| claims.len()),
+            )
+            .finish()
+    }
+}
+
+impl ProbeLease {
+    fn take_matching_claims(
+        &mut self,
+        owner: &Arc<Mutex<ShadowHealthInner>>,
+        route: &RouteKey,
+    ) -> Option<(ProbeLeaseId, Box<[ProbeGateClaim]>)> {
+        if !Arc::ptr_eq(&self.inner, owner) || &self.route != route {
+            return None;
+        }
+        self.claims.take().map(|claims| (self.lease_id, claims))
+    }
+
+    #[cfg(test)]
+    fn claim_count(&self) -> usize {
+        self.claims.as_ref().map_or(0, |claims| claims.len())
+    }
+}
+
+impl Drop for ProbeLease {
+    fn drop(&mut self) {
+        let Some(claims) = self.claims.take() else {
+            return;
+        };
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        release_probe_claims(&mut inner, self.lease_id, &claims);
+    }
+}
+
+/// Fixed-topology, enclave-local health state.
 ///
 /// Every key is pre-populated from the static provider registry. Observations
 /// for unknown routes are reported but can never grow the maps.
@@ -128,7 +241,7 @@ struct ShadowHealthInner {
 pub(crate) struct ShadowHealthState {
     policy: ShadowHealthPolicy,
     rate_limit_pools: HashMap<RouteKey, CapacityPoolKey>,
-    inner: Mutex<ShadowHealthInner>,
+    inner: Arc<Mutex<ShadowHealthInner>>,
     #[cfg(test)]
     observation_count: AtomicUsize,
 }
@@ -173,10 +286,11 @@ impl ShadowHealthState {
         Self {
             policy,
             rate_limit_pools,
-            inner: Mutex::new(ShadowHealthInner {
+            inner: Arc::new(Mutex::new(ShadowHealthInner {
                 route_health,
                 capacity,
-            }),
+                next_probe_lease_id: 0,
+            })),
             #[cfg(test)]
             observation_count: AtomicUsize::new(0),
         }
@@ -189,7 +303,28 @@ impl ShadowHealthState {
     ) -> ShadowObservationReport {
         let mut inner = self.lock();
         let now = Instant::now();
-        self.observe_terminal_locked(&mut inner, terminal, mode, now)
+        self.observe_terminal_locked(&mut inner, terminal, mode, None, now)
+    }
+
+    /// Records the terminal result of an attempt that may own a half-open
+    /// probe. The terminal health mutation and matching lease resolution occur
+    /// while holding one state lock.
+    ///
+    /// Telemetry-only recovered sub-attempts must use [`Self::observe_terminal`]
+    /// and leave the lease on the final attempt guard.
+    pub(crate) fn observe_terminal_with_probe(
+        &self,
+        terminal: &AttemptTerminal,
+        mode: ShadowObservationMode,
+        mut probe: Option<ProbeLease>,
+    ) -> ShadowObservationReport {
+        debug_assert!(
+            mode == ShadowObservationMode::Update || probe.is_none(),
+            "telemetry-only observations must not own a probe lease"
+        );
+        let mut inner = self.lock();
+        let now = Instant::now();
+        self.observe_terminal_locked(&mut inner, terminal, mode, probe.as_mut(), now)
     }
 
     pub(crate) fn snapshot(&self, route: &RouteKey) -> Option<ShadowRouteSnapshot> {
@@ -199,7 +334,7 @@ impl ShadowHealthState {
 
     /// Returns a point-in-time snapshot for every requested route while holding
     /// the state lock once. Active selection must not combine observations from
-    /// different instants when deciding whether all canary routes are open.
+    /// different instants when deciding whether candidate routes are open.
     pub(crate) fn snapshot_routes(&self, routes: &[RouteKey]) -> Option<Vec<ShadowRouteSnapshot>> {
         let inner = self.lock();
         let now = Instant::now();
@@ -209,11 +344,100 @@ impl ShadowHealthState {
             .collect()
     }
 
+    /// Atomically checks the route-health gate, deployment-capacity gate, and
+    /// registry-declared rate-limit gate for one already-selected route.
+    pub(crate) fn try_claim_probe(&self, route: &RouteKey) -> ProbeClaimResult {
+        let mut inner = self.lock();
+        self.try_claim_probe_locked(&mut inner, route, Instant::now())
+    }
+
+    fn try_claim_probe_locked(
+        &self,
+        inner: &mut ShadowHealthInner,
+        route: &RouteKey,
+        now: Instant,
+    ) -> ProbeClaimResult {
+        let Some(rate_limit_pool) = self.rate_limit_pools.get(route) else {
+            return ProbeClaimResult::Rejected {
+                reason: ProbeRejectionReason::UnknownRoute,
+                retry_after: self.policy.minimum_capacity_cooldown,
+            };
+        };
+
+        let deployment_pool = CapacityPoolKey::ProviderModel(route.clone());
+        let mut gates = Vec::with_capacity(3);
+        gates.push(ProbeGateKey::RouteHealth(route.clone()));
+        gates.push(ProbeGateKey::Capacity(deployment_pool.clone()));
+        if rate_limit_pool != &deployment_pool {
+            gates.push(ProbeGateKey::Capacity(rate_limit_pool.clone()));
+        }
+
+        let mut expired = Vec::with_capacity(gates.len());
+        let mut open_remaining = None;
+        let mut probe_in_flight = false;
+        for gate in &gates {
+            let Some(status) = probe_gate_status(inner, gate, now) else {
+                return ProbeClaimResult::Rejected {
+                    reason: ProbeRejectionReason::UnknownRoute,
+                    retry_after: self.policy.minimum_capacity_cooldown,
+                };
+            };
+            match status {
+                ProbeGateStatus::Healthy => {}
+                ProbeGateStatus::ExpiredOpen => expired.push(gate.clone()),
+                ProbeGateStatus::StillOpen { remaining } => {
+                    open_remaining = Some(
+                        open_remaining
+                            .map_or(remaining, |current: Duration| current.max(remaining)),
+                    );
+                }
+                ProbeGateStatus::ProbeInFlight => probe_in_flight = true,
+            }
+        }
+
+        if probe_in_flight {
+            return ProbeClaimResult::Rejected {
+                reason: ProbeRejectionReason::ProbeInFlight,
+                retry_after: open_remaining
+                    .unwrap_or(self.policy.minimum_capacity_cooldown)
+                    .max(self.policy.minimum_capacity_cooldown),
+            };
+        }
+        if let Some(retry_after) = open_remaining {
+            return ProbeClaimResult::Rejected {
+                reason: ProbeRejectionReason::CircuitOpen,
+                retry_after,
+            };
+        }
+        if expired.is_empty() {
+            return ProbeClaimResult::Ready(None);
+        }
+
+        let lease_id = next_probe_lease_id(inner);
+        let mut claims = Vec::with_capacity(expired.len());
+        for gate in expired {
+            let generation_at_claim = claim_probe_gate(inner, &gate, lease_id)
+                .expect("validated probe gate must remain claimable under the state lock");
+            claims.push(ProbeGateClaim {
+                gate,
+                generation_at_claim,
+            });
+        }
+
+        ProbeClaimResult::Ready(Some(ProbeLease {
+            inner: Arc::clone(&self.inner),
+            route: route.clone(),
+            lease_id,
+            claims: Some(claims.into_boxed_slice()),
+        }))
+    }
+
     fn observe_terminal_locked(
         &self,
         inner: &mut ShadowHealthInner,
         terminal: &AttemptTerminal,
         mode: ShadowObservationMode,
+        probe: Option<&mut ProbeLease>,
         now: Instant,
     ) -> ShadowObservationReport {
         #[cfg(test)]
@@ -294,9 +518,30 @@ impl ShadowHealthState {
             }
         }
 
-        let mutated = mode == ShadowObservationMode::Update && mutation != Mutation::None;
-        if mutated {
-            self.apply_mutation(inner, &route, &rate_limit_pool, mutation, now);
+        let mut mutated = mode == ShadowObservationMode::Update && mutation != Mutation::None;
+        if mode == ShadowObservationMode::Update {
+            let probe_claims =
+                probe.and_then(|probe| probe.take_matching_claims(&self.inner, &route));
+            if let Some((lease_id, claims)) = probe_claims {
+                match mutation.clone() {
+                    Mutation::Completed => {
+                        resolve_probe_success(inner, lease_id, &claims);
+                        if let Some(state) = inner.route_health.get_mut(&route) {
+                            apply_route_success(state, now);
+                        }
+                    }
+                    Mutation::None => {
+                        release_probe_claims(inner, lease_id, &claims);
+                    }
+                    mutation => {
+                        self.apply_mutation(inner, &route, mutation, now);
+                        release_probe_claims(inner, lease_id, &claims);
+                    }
+                }
+                mutated = true;
+            } else if mutated {
+                self.apply_mutation(inner, &route, mutation, now);
+            }
         }
 
         ShadowObservationReport {
@@ -314,7 +559,6 @@ impl ShadowHealthState {
         &self,
         inner: &mut ShadowHealthInner,
         route: &RouteKey,
-        rate_limit_pool: &CapacityPoolKey,
         mutation: Mutation,
         now: Instant,
     ) {
@@ -323,16 +567,8 @@ impl ShadowHealthState {
                 if let Some(state) = inner.route_health.get_mut(route) {
                     apply_route_success(state, now);
                 }
-
-                let deployment_pool = CapacityPoolKey::ProviderModel(route.clone());
-                if let Some(state) = inner.capacity.get_mut(&deployment_pool) {
-                    apply_capacity_success(state, now);
-                }
-                if rate_limit_pool != &deployment_pool {
-                    if let Some(state) = inner.capacity.get_mut(rate_limit_pool) {
-                        apply_capacity_success(state, now);
-                    }
-                }
+                // Ordinary success carries no authority to heal an opened
+                // capacity gate; only a matching probe lease can do that.
             }
             Mutation::Capacity { pool, retry_after } => {
                 if let Some(state) = inner.capacity.get_mut(&pool) {
@@ -340,6 +576,7 @@ impl ShadowHealthState {
                         .unwrap_or(self.policy.minimum_capacity_cooldown)
                         .max(self.policy.minimum_capacity_cooldown)
                         .min(self.policy.max_capacity_cooldown);
+                    advance_generation(&mut state.generation);
                     extend_open_until(&mut state.open_until, now, cooldown);
                 }
             }
@@ -361,12 +598,21 @@ impl ShadowHealthState {
         let route_health = route_health_disposition(
             inner.route_health.get(route)?,
             self.policy.route_failure_window,
+            self.policy.minimum_capacity_cooldown,
             now,
         );
         let deployment_pool = CapacityPoolKey::ProviderModel(route.clone());
-        let deployment_capacity = capacity_disposition(inner.capacity.get(&deployment_pool)?, now);
+        let deployment_capacity = capacity_disposition(
+            inner.capacity.get(&deployment_pool)?,
+            self.policy.minimum_capacity_cooldown,
+            now,
+        );
         let rate_limit_pool = self.rate_limit_pools.get(route)?;
-        let rate_limit_capacity = capacity_disposition(inner.capacity.get(rate_limit_pool)?, now);
+        let rate_limit_capacity = capacity_disposition(
+            inner.capacity.get(rate_limit_pool)?,
+            self.policy.minimum_capacity_cooldown,
+            now,
+        );
         let effective =
             strongest_disposition([route_health, deployment_capacity, rate_limit_capacity]);
 
@@ -397,7 +643,25 @@ impl ShadowHealthState {
         now: Instant,
     ) -> ShadowObservationReport {
         let mut inner = self.lock();
-        self.observe_terminal_locked(&mut inner, terminal, mode, now)
+        self.observe_terminal_locked(&mut inner, terminal, mode, None, now)
+    }
+
+    #[cfg(test)]
+    fn observe_terminal_with_probe_at(
+        &self,
+        terminal: &AttemptTerminal,
+        mode: ShadowObservationMode,
+        mut probe: Option<ProbeLease>,
+        now: Instant,
+    ) -> ShadowObservationReport {
+        let mut inner = self.lock();
+        self.observe_terminal_locked(&mut inner, terminal, mode, probe.as_mut(), now)
+    }
+
+    #[cfg(test)]
+    fn try_claim_probe_at(&self, route: &RouteKey, now: Instant) -> ProbeClaimResult {
+        let mut inner = self.lock();
+        self.try_claim_probe_locked(&mut inner, route, now)
     }
 
     #[cfg(test)]
@@ -415,6 +679,178 @@ impl ShadowHealthState {
     #[cfg(test)]
     pub(crate) fn observation_count(&self) -> usize {
         self.observation_count.load(Ordering::Relaxed)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProbeGateStatus {
+    Healthy,
+    StillOpen { remaining: Duration },
+    ExpiredOpen,
+    ProbeInFlight,
+}
+
+fn probe_gate_status(
+    inner: &ShadowHealthInner,
+    gate: &ProbeGateKey,
+    now: Instant,
+) -> Option<ProbeGateStatus> {
+    let (open_until, active_probe) = match gate {
+        ProbeGateKey::RouteHealth(route) => {
+            let state = inner.route_health.get(route)?;
+            (state.open_until, state.active_probe)
+        }
+        ProbeGateKey::Capacity(pool) => {
+            let state = inner.capacity.get(pool)?;
+            (state.open_until, state.active_probe)
+        }
+    };
+
+    if active_probe.is_some() {
+        return Some(ProbeGateStatus::ProbeInFlight);
+    }
+    match open_until {
+        Some(until) if now < until => Some(ProbeGateStatus::StillOpen {
+            remaining: until.duration_since(now),
+        }),
+        Some(_) => Some(ProbeGateStatus::ExpiredOpen),
+        None => Some(ProbeGateStatus::Healthy),
+    }
+}
+
+fn next_probe_lease_id(inner: &mut ShadowHealthInner) -> ProbeLeaseId {
+    loop {
+        inner.next_probe_lease_id = inner.next_probe_lease_id.wrapping_add(1);
+        if inner.next_probe_lease_id == 0 {
+            continue;
+        }
+        let candidate = ProbeLeaseId(inner.next_probe_lease_id);
+        let in_use = inner.route_health.values().any(|state| {
+            state
+                .active_probe
+                .is_some_and(|probe| probe.lease_id == candidate)
+        }) || inner.capacity.values().any(|state| {
+            state
+                .active_probe
+                .is_some_and(|probe| probe.lease_id == candidate)
+        });
+        if !in_use {
+            return candidate;
+        }
+    }
+}
+
+fn claim_probe_gate(
+    inner: &mut ShadowHealthInner,
+    gate: &ProbeGateKey,
+    lease_id: ProbeLeaseId,
+) -> Option<u64> {
+    let (generation, active_probe) = match gate {
+        ProbeGateKey::RouteHealth(route) => {
+            let state = inner.route_health.get_mut(route)?;
+            (&mut state.generation, &mut state.active_probe)
+        }
+        ProbeGateKey::Capacity(pool) => {
+            let state = inner.capacity.get_mut(pool)?;
+            (&mut state.generation, &mut state.active_probe)
+        }
+    };
+    debug_assert!(active_probe.is_none());
+    advance_generation(generation);
+    *active_probe = Some(ActiveProbe {
+        lease_id,
+        generation_at_claim: *generation,
+    });
+    Some(*generation)
+}
+
+fn release_probe_claims(
+    inner: &mut ShadowHealthInner,
+    lease_id: ProbeLeaseId,
+    claims: &[ProbeGateClaim],
+) {
+    for claim in claims {
+        match &claim.gate {
+            ProbeGateKey::RouteHealth(route) => {
+                if let Some(state) = inner.route_health.get_mut(route) {
+                    if active_probe_matches(state.active_probe, lease_id, claim.generation_at_claim)
+                    {
+                        state.active_probe = None;
+                    }
+                }
+            }
+            ProbeGateKey::Capacity(pool) => {
+                if let Some(state) = inner.capacity.get_mut(pool) {
+                    if active_probe_matches(state.active_probe, lease_id, claim.generation_at_claim)
+                    {
+                        state.active_probe = None;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn resolve_probe_success(
+    inner: &mut ShadowHealthInner,
+    lease_id: ProbeLeaseId,
+    claims: &[ProbeGateClaim],
+) {
+    for claim in claims {
+        match &claim.gate {
+            ProbeGateKey::RouteHealth(route) => {
+                if let Some(state) = inner.route_health.get_mut(route) {
+                    let matching_active = active_probe_matches(
+                        state.active_probe,
+                        lease_id,
+                        claim.generation_at_claim,
+                    );
+                    let matches = matching_active && state.generation == claim.generation_at_claim;
+                    if matches {
+                        state.failure_times.clear();
+                        state.open_until = None;
+                        state.active_probe = None;
+                        advance_generation(&mut state.generation);
+                    } else if matching_active {
+                        state.active_probe = None;
+                    }
+                }
+            }
+            ProbeGateKey::Capacity(pool) => {
+                if let Some(state) = inner.capacity.get_mut(pool) {
+                    let matching_active = active_probe_matches(
+                        state.active_probe,
+                        lease_id,
+                        claim.generation_at_claim,
+                    );
+                    let matches = matching_active && state.generation == claim.generation_at_claim;
+                    if matches {
+                        state.open_until = None;
+                        state.active_probe = None;
+                        advance_generation(&mut state.generation);
+                    } else if matching_active {
+                        state.active_probe = None;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn active_probe_matches(
+    active_probe: Option<ActiveProbe>,
+    lease_id: ProbeLeaseId,
+    generation_at_claim: u64,
+) -> bool {
+    active_probe.is_some_and(|active| {
+        active.lease_id == lease_id && active.generation_at_claim == generation_at_claim
+    })
+}
+
+fn advance_generation(generation: &mut u64) {
+    *generation = generation.wrapping_add(1);
+    if *generation == 0 {
+        *generation = 1;
     }
 }
 
@@ -449,7 +885,11 @@ fn is_route_health_failure(kind: AttemptFailureKind) -> bool {
 }
 
 fn apply_route_failure(state: &mut RouteHealthState, policy: ShadowHealthPolicy, now: Instant) {
-    if state.open_until.is_some_and(|until| now < until) {
+    advance_generation(&mut state.generation);
+    // Any failure while an opened route is awaiting or running its half-open
+    // probe reopens the circuit from this failure time. The probe deliberately
+    // has no timeout, so the original failure window may already have elapsed.
+    if state.open_until.is_some() {
         extend_open_until(&mut state.open_until, now, policy.route_open_cooldown);
         return;
     }
@@ -475,18 +915,17 @@ fn apply_route_failure(state: &mut RouteHealthState, policy: ShadowHealthPolicy,
     }
 }
 
-fn apply_route_success(state: &mut RouteHealthState, now: Instant) {
-    if state.open_until.is_some_and(|until| now < until) {
+fn apply_route_success(state: &mut RouteHealthState, _now: Instant) {
+    // Once a route has opened, only the matching fenced half-open probe may
+    // heal it. A late success from an attempt admitted before the open must not
+    // bypass probe ownership at or after the cooldown boundary.
+    if state.open_until.is_some() {
         return;
     }
-    state.failure_times.clear();
-    state.open_until = None;
-}
-
-fn apply_capacity_success(state: &mut CapacityState, now: Instant) {
-    if state.open_until.is_some_and(|until| now >= until) {
-        state.open_until = None;
+    if !state.failure_times.is_empty() {
+        advance_generation(&mut state.generation);
     }
+    state.failure_times.clear();
 }
 
 fn extend_open_until(open_until: &mut Option<Instant>, now: Instant, cooldown: Duration) {
@@ -497,8 +936,14 @@ fn extend_open_until(open_until: &mut Option<Instant>, now: Instant, cooldown: D
 fn route_health_disposition(
     state: &RouteHealthState,
     failure_window: Duration,
+    probe_retry_after: Duration,
     now: Instant,
 ) -> ShadowDisposition {
+    if state.active_probe.is_some() {
+        return ShadowDisposition::ProbeInFlight {
+            retry_after: probe_retry_after,
+        };
+    }
     if let Some(until) = state.open_until {
         return if now < until {
             ShadowDisposition::WouldOpen {
@@ -526,7 +971,16 @@ fn route_health_disposition(
     }
 }
 
-fn capacity_disposition(state: &CapacityState, now: Instant) -> ShadowDisposition {
+fn capacity_disposition(
+    state: &CapacityState,
+    probe_retry_after: Duration,
+    now: Instant,
+) -> ShadowDisposition {
+    if state.active_probe.is_some() {
+        return ShadowDisposition::ProbeInFlight {
+            retry_after: probe_retry_after,
+        };
+    }
     match state.open_until {
         Some(until) if now < until => ShadowDisposition::WouldOpen {
             remaining: until.duration_since(now),
@@ -546,6 +1000,28 @@ fn strongest_disposition(
 
 fn stronger_disposition(left: ShadowDisposition, right: ShadowDisposition) -> ShadowDisposition {
     match (left, right) {
+        (
+            ShadowDisposition::ProbeInFlight {
+                retry_after: left_retry_after,
+            },
+            ShadowDisposition::ProbeInFlight {
+                retry_after: right_retry_after,
+            },
+        ) => ShadowDisposition::ProbeInFlight {
+            retry_after: left_retry_after.max(right_retry_after),
+        },
+        (
+            ShadowDisposition::ProbeInFlight { retry_after },
+            ShadowDisposition::WouldOpen { remaining },
+        )
+        | (
+            ShadowDisposition::WouldOpen { remaining },
+            ShadowDisposition::ProbeInFlight { retry_after },
+        ) => ShadowDisposition::ProbeInFlight {
+            retry_after: retry_after.max(remaining),
+        },
+        (left @ ShadowDisposition::ProbeInFlight { .. }, _) => left,
+        (_, right @ ShadowDisposition::ProbeInFlight { .. }) => right,
         (
             ShadowDisposition::WouldOpen {
                 remaining: left_remaining,
@@ -585,7 +1061,7 @@ mod tests {
         RouteIdentity,
     };
     use crate::provider_registry::RouteSelectionSource;
-    use std::sync::Arc;
+    use std::sync::{Arc, Barrier};
     use std::thread;
 
     fn route(provider: ProviderId, public_model: &str, provider_model: &str) -> RouteIdentity {
@@ -640,6 +1116,23 @@ mod tests {
             route_open_cooldown: Duration::from_secs(5),
             minimum_capacity_cooldown: Duration::from_secs(4),
             max_capacity_cooldown: Duration::from_secs(10),
+        }
+    }
+
+    fn expect_probe(result: ProbeClaimResult) -> ProbeLease {
+        match result {
+            ProbeClaimResult::Ready(Some(lease)) => lease,
+            other => panic!("expected probe lease, got {other:?}"),
+        }
+    }
+
+    fn open_route_at(state: &ShadowHealthState, route: &RouteIdentity, now: Instant) {
+        for _ in 0..3 {
+            state.observe_terminal_at(
+                &failed(route.clone(), AttemptFailureKind::StreamTimeout, None, None),
+                ShadowObservationMode::Update,
+                now,
+            );
         }
     }
 
@@ -860,9 +1353,11 @@ mod tests {
             ShadowDisposition::WouldProbe
         );
 
-        state.observe_terminal_at(
+        let lease = expect_probe(state.try_claim_probe_at(&key, start + Duration::from_secs(4)));
+        state.observe_terminal_with_probe_at(
             &completed(k3.clone()),
             ShadowObservationMode::Update,
+            Some(lease),
             start + Duration::from_secs(4),
         );
         assert_eq!(
@@ -902,7 +1397,7 @@ mod tests {
 
         state.observe_terminal_at(
             &failed(
-                k3,
+                k3.clone(),
                 AttemptFailureKind::CapacityRejected,
                 Some(429),
                 Some(Duration::from_secs(100)),
@@ -1010,9 +1505,11 @@ mod tests {
             ShadowDisposition::WouldProbe
         );
 
-        state.observe_terminal_at(
+        let lease = expect_probe(state.try_claim_probe_at(&key, start + Duration::from_secs(9)));
+        state.observe_terminal_with_probe_at(
             &completed(k3.clone()),
             ShadowObservationMode::Update,
+            Some(lease),
             start + Duration::from_secs(9),
         );
         assert_eq!(
@@ -1114,6 +1611,632 @@ mod tests {
     }
 
     #[test]
+    fn half_open_probe_claim_is_atomic_with_one_winner_at_the_boundary() {
+        let state = Arc::new(ShadowHealthState::with_policy(test_policy()));
+        let start = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let key = k3.route_key();
+        state.observe_terminal_at(
+            &failed(
+                k3.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(4)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+
+        let boundary = start + Duration::from_secs(4);
+        match state.try_claim_probe_at(&key, boundary - Duration::from_nanos(1)) {
+            ProbeClaimResult::Rejected {
+                reason: ProbeRejectionReason::CircuitOpen,
+                retry_after,
+            } => assert_eq!(retry_after, Duration::from_nanos(1)),
+            other => panic!("circuit must remain closed immediately before boundary: {other:?}"),
+        }
+        let barrier = Arc::new(Barrier::new(33));
+        let late_success = {
+            let state = Arc::clone(&state);
+            let barrier = Arc::clone(&barrier);
+            let terminal = completed(k3);
+            thread::spawn(move || {
+                barrier.wait();
+                state.observe_terminal_at(&terminal, ShadowObservationMode::Update, boundary)
+            })
+        };
+        let threads = (0..32)
+            .map(|_| {
+                let state = Arc::clone(&state);
+                let key = key.clone();
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    state.try_claim_probe_at(&key, boundary)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let report = late_success.join().expect("late success thread");
+        assert_eq!(report.signal, ShadowSignal::Completed);
+
+        let mut leases = Vec::new();
+        let mut rejections = 0;
+        for thread in threads {
+            match thread.join().expect("probe claim thread") {
+                ProbeClaimResult::Ready(Some(lease)) => leases.push(lease),
+                ProbeClaimResult::Rejected {
+                    reason: ProbeRejectionReason::ProbeInFlight,
+                    retry_after,
+                } => {
+                    rejections += 1;
+                    assert_eq!(retry_after, Duration::from_secs(4));
+                }
+                other => panic!("unexpected concurrent claim result: {other:?}"),
+            }
+        }
+        assert_eq!(leases.len(), 1);
+        assert_eq!(rejections, 31);
+        assert_eq!(
+            state.snapshot_at(&key, boundary).unwrap().effective,
+            ShadowDisposition::ProbeInFlight {
+                retry_after: Duration::from_secs(4)
+            }
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&key, boundary + Duration::from_secs(60 * 60))
+                .unwrap()
+                .effective,
+            ShadowDisposition::ProbeInFlight {
+                retry_after: Duration::from_secs(4)
+            }
+        );
+
+        drop(leases);
+        assert_eq!(
+            state.snapshot_at(&key, boundary).unwrap().effective,
+            ShadowDisposition::WouldProbe
+        );
+    }
+
+    #[test]
+    fn shared_continuum_account_gate_allows_one_probe_across_models() {
+        let state = Arc::new(ShadowHealthState::with_policy(test_policy()));
+        let start = Instant::now();
+        let k2 = route(ProviderId::Continuum, "kimi-k2-6", "kimi-k2.6");
+        let glm = route(ProviderId::Continuum, "glm-5-2", "glm-5.2");
+        state.observe_terminal_at(
+            &failed(
+                k2.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(4)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+
+        let boundary = start + Duration::from_secs(4);
+        let barrier = Arc::new(Barrier::new(2));
+        let threads = [k2.route_key(), glm.route_key()]
+            .into_iter()
+            .map(|key| {
+                let state = Arc::clone(&state);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    state.try_claim_probe_at(&key, boundary)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let mut leases = Vec::new();
+        let mut rejected = 0;
+        for thread in threads {
+            match thread.join().expect("shared account probe thread") {
+                ProbeClaimResult::Ready(Some(lease)) => leases.push(lease),
+                ProbeClaimResult::Rejected {
+                    reason: ProbeRejectionReason::ProbeInFlight,
+                    ..
+                } => rejected += 1,
+                other => panic!("unexpected shared account claim result: {other:?}"),
+            }
+        }
+        assert_eq!(leases.len(), 1);
+        assert_eq!(rejected, 1);
+        assert!(matches!(
+            state
+                .snapshot_at(&k2.route_key(), boundary)
+                .unwrap()
+                .rate_limit_capacity,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+        assert!(matches!(
+            state
+                .snapshot_at(&glm.route_key(), boundary)
+                .unwrap()
+                .rate_limit_capacity,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+    }
+
+    #[test]
+    fn composite_probe_claims_are_all_or_none_and_deduplicate_capacity_gates() {
+        let start = Instant::now();
+        let k2 = route(ProviderId::Continuum, "kimi-k2-6", "kimi-k2.6");
+
+        let composite = ShadowHealthState::with_policy(test_policy());
+        open_route_at(&composite, &k2, start);
+        for status in [503, 429] {
+            composite.observe_terminal_at(
+                &failed(
+                    k2.clone(),
+                    AttemptFailureKind::CapacityRejected,
+                    Some(status),
+                    Some(Duration::from_secs(5)),
+                ),
+                ShadowObservationMode::Update,
+                start,
+            );
+        }
+        let boundary = start + Duration::from_secs(5);
+        let composite_lease = expect_probe(composite.try_claim_probe_at(&k2.route_key(), boundary));
+        assert_eq!(composite_lease.claim_count(), 3);
+        let snapshot = composite.snapshot_at(&k2.route_key(), boundary).unwrap();
+        assert!(matches!(
+            snapshot.route_health,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+        assert!(matches!(
+            snapshot.deployment_capacity,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+        assert!(matches!(
+            snapshot.rate_limit_capacity,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+        drop(composite_lease);
+
+        let tinfoil = ShadowHealthState::with_policy(test_policy());
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        open_route_at(&tinfoil, &k3, start);
+        tinfoil.observe_terminal_at(
+            &failed(
+                k3.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(5)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+        let deduplicated = expect_probe(tinfoil.try_claim_probe_at(&k3.route_key(), boundary));
+        assert_eq!(deduplicated.claim_count(), 2);
+        drop(deduplicated);
+
+        let blocked = ShadowHealthState::with_policy(test_policy());
+        open_route_at(&blocked, &k2, start);
+        blocked.observe_terminal_at(
+            &failed(
+                k2.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(503),
+                Some(Duration::from_secs(6)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+        match blocked.try_claim_probe_at(&k2.route_key(), boundary) {
+            ProbeClaimResult::Rejected {
+                reason: ProbeRejectionReason::CircuitOpen,
+                retry_after,
+            } => assert_eq!(retry_after, Duration::from_secs(1)),
+            other => panic!("expected all-or-none rejection, got {other:?}"),
+        }
+        let snapshot = blocked.snapshot_at(&k2.route_key(), boundary).unwrap();
+        assert_eq!(snapshot.route_health, ShadowDisposition::WouldProbe);
+        assert_eq!(
+            snapshot.deployment_capacity,
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(1)
+            }
+        );
+    }
+
+    #[test]
+    fn successful_probe_heals_claimed_gates_and_resets_route_watch() {
+        let start = Instant::now();
+        let k2 = route(ProviderId::Continuum, "kimi-k2-6", "kimi-k2.6");
+        let state = ShadowHealthState::with_policy(test_policy());
+        open_route_at(&state, &k2, start);
+        for status in [503, 429] {
+            state.observe_terminal_at(
+                &failed(
+                    k2.clone(),
+                    AttemptFailureKind::CapacityRejected,
+                    Some(status),
+                    Some(Duration::from_secs(5)),
+                ),
+                ShadowObservationMode::Update,
+                start,
+            );
+        }
+        let boundary = start + Duration::from_secs(5);
+        let lease = expect_probe(state.try_claim_probe_at(&k2.route_key(), boundary));
+        state.observe_terminal_with_probe_at(
+            &completed(k2.clone()),
+            ShadowObservationMode::Update,
+            Some(lease),
+            boundary,
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&k2.route_key(), boundary)
+                .unwrap()
+                .effective,
+            ShadowDisposition::Healthy
+        );
+
+        let only_account_open = ShadowHealthState::with_policy(test_policy());
+        only_account_open.observe_terminal_at(
+            &failed(k2.clone(), AttemptFailureKind::StreamTimeout, None, None),
+            ShadowObservationMode::Update,
+            start,
+        );
+        only_account_open.observe_terminal_at(
+            &failed(
+                k2.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(4)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+        let lease = expect_probe(
+            only_account_open.try_claim_probe_at(&k2.route_key(), start + Duration::from_secs(4)),
+        );
+        assert_eq!(lease.claim_count(), 1);
+        only_account_open.observe_terminal_with_probe_at(
+            &completed(k2.clone()),
+            ShadowObservationMode::Update,
+            Some(lease),
+            start + Duration::from_secs(4),
+        );
+        assert_eq!(
+            only_account_open
+                .snapshot_at(&k2.route_key(), start + Duration::from_secs(4))
+                .unwrap()
+                .route_health,
+            ShadowDisposition::Healthy
+        );
+    }
+
+    #[test]
+    fn unleased_success_cannot_heal_an_owned_route_gate() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let start = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let key = k3.route_key();
+        open_route_at(&state, &k3, start);
+
+        let boundary = start + Duration::from_secs(5);
+        let lease = expect_probe(state.try_claim_probe_at(&key, boundary));
+        state.observe_terminal_at(
+            &completed(k3.clone()),
+            ShadowObservationMode::Update,
+            boundary,
+        );
+        assert!(matches!(
+            state.snapshot_at(&key, boundary).unwrap().route_health,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+
+        state.observe_terminal_with_probe_at(
+            &completed(k3),
+            ShadowObservationMode::Update,
+            Some(lease),
+            boundary,
+        );
+        assert_eq!(
+            state.snapshot_at(&key, boundary).unwrap().route_health,
+            ShadowDisposition::Healthy
+        );
+    }
+
+    #[test]
+    fn failed_probes_reopen_only_the_classified_route_or_capacity_gate() {
+        let start = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let route_failure = ShadowHealthState::with_policy(test_policy());
+        open_route_at(&route_failure, &k3, start);
+        let boundary = start + Duration::from_secs(5);
+        let lease = expect_probe(route_failure.try_claim_probe_at(&k3.route_key(), boundary));
+        let late_terminal = boundary + Duration::from_secs(11);
+        route_failure.observe_terminal_with_probe_at(
+            &failed(k3.clone(), AttemptFailureKind::StreamTimeout, None, None),
+            ShadowObservationMode::Update,
+            Some(lease),
+            late_terminal,
+        );
+        assert_eq!(
+            route_failure
+                .snapshot_at(&k3.route_key(), late_terminal)
+                .unwrap()
+                .route_health,
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(5)
+            }
+        );
+
+        let k2 = route(ProviderId::Continuum, "kimi-k2-6", "kimi-k2.6");
+        let glm = route(ProviderId::Continuum, "glm-5-2", "glm-5.2");
+        let account_limit = ShadowHealthState::with_policy(test_policy());
+        account_limit.observe_terminal_at(
+            &failed(
+                k2.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(4)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+        let account_boundary = start + Duration::from_secs(4);
+        let lease =
+            expect_probe(account_limit.try_claim_probe_at(&k2.route_key(), account_boundary));
+        account_limit.observe_terminal_with_probe_at(
+            &failed(
+                k2.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                None,
+            ),
+            ShadowObservationMode::Update,
+            Some(lease),
+            account_boundary,
+        );
+        assert_eq!(
+            account_limit
+                .snapshot_at(&glm.route_key(), account_boundary)
+                .unwrap()
+                .rate_limit_capacity,
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(4)
+            }
+        );
+
+        let deployment_limit = ShadowHealthState::with_policy(test_policy());
+        deployment_limit.observe_terminal_at(
+            &failed(
+                k2.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(503),
+                Some(Duration::from_secs(4)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+        let lease =
+            expect_probe(deployment_limit.try_claim_probe_at(&k2.route_key(), account_boundary));
+        deployment_limit.observe_terminal_with_probe_at(
+            &failed(
+                k2.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(503),
+                None,
+            ),
+            ShadowObservationMode::Update,
+            Some(lease),
+            account_boundary,
+        );
+        assert_eq!(
+            deployment_limit
+                .snapshot_at(&k2.route_key(), account_boundary)
+                .unwrap()
+                .deployment_capacity,
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(4)
+            }
+        );
+        assert_eq!(
+            deployment_limit
+                .snapshot_at(&glm.route_key(), account_boundary)
+                .unwrap()
+                .effective,
+            ShadowDisposition::Healthy
+        );
+    }
+
+    #[test]
+    fn neutral_terminal_and_raii_drop_release_without_healing() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let start = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let key = k3.route_key();
+        state.observe_terminal_at(
+            &failed(
+                k3.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(4)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+        let boundary = start + Duration::from_secs(4);
+        let lease = expect_probe(state.try_claim_probe_at(&key, boundary));
+        state.observe_terminal_with_probe_at(
+            &failed(k3.clone(), AttemptFailureKind::HttpStatus, Some(400), None),
+            ShadowObservationMode::Update,
+            Some(lease),
+            boundary,
+        );
+        assert_eq!(
+            state.snapshot_at(&key, boundary).unwrap().effective,
+            ShadowDisposition::WouldProbe
+        );
+
+        let lease = expect_probe(state.try_claim_probe_at(&key, boundary));
+        state.observe_terminal_at(
+            &failed(k3, AttemptFailureKind::Connect, None, None),
+            ShadowObservationMode::TelemetryOnly,
+            boundary + Duration::from_secs(30),
+        );
+        assert!(matches!(
+            state
+                .snapshot_at(&key, boundary + Duration::from_secs(30))
+                .unwrap()
+                .effective,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+        drop(lease);
+        assert_eq!(
+            state.snapshot_at(&key, boundary).unwrap().effective,
+            ShadowDisposition::WouldProbe
+        );
+    }
+
+    #[test]
+    fn stale_or_duplicate_lease_cannot_release_a_newer_probe() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let start = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let key = k3.route_key();
+        state.observe_terminal_at(
+            &failed(
+                k3,
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(4)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+        let boundary = start + Duration::from_secs(4);
+        let first = expect_probe(state.try_claim_probe_at(&key, boundary));
+        let stale_one = ProbeLease {
+            inner: Arc::clone(&first.inner),
+            route: first.route.clone(),
+            lease_id: first.lease_id,
+            claims: first.claims.clone(),
+        };
+        let stale_two = ProbeLease {
+            inner: Arc::clone(&first.inner),
+            route: first.route.clone(),
+            lease_id: first.lease_id,
+            claims: first.claims.clone(),
+        };
+        drop(first);
+
+        // Force an ID reuse to prove the gate-local generation, not merely the
+        // monotonic ID, fences stale/double release.
+        {
+            let mut inner = state.lock();
+            inner.next_probe_lease_id = stale_one.lease_id.0.wrapping_sub(1);
+        }
+
+        let newer = expect_probe(state.try_claim_probe_at(&key, boundary));
+        assert_eq!(newer.lease_id, stale_one.lease_id);
+        assert!(matches!(
+            state.snapshot_at(&key, boundary).unwrap().effective,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+        drop(stale_one);
+        drop(stale_two);
+        assert!(matches!(
+            state.snapshot_at(&key, boundary).unwrap().effective,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+        drop(newer);
+        assert_eq!(
+            state.snapshot_at(&key, boundary).unwrap().effective,
+            ShadowDisposition::WouldProbe
+        );
+    }
+
+    #[test]
+    fn unrelated_success_cannot_heal_a_gate_with_a_live_probe() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let start = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let key = k3.route_key();
+        state.observe_terminal_at(
+            &failed(
+                k3.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(4)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+        let boundary = start + Duration::from_secs(4);
+        let lease = expect_probe(state.try_claim_probe_at(&key, boundary));
+
+        state.observe_terminal_at(
+            &completed(k3.clone()),
+            ShadowObservationMode::Update,
+            boundary,
+        );
+        assert!(matches!(
+            state.snapshot_at(&key, boundary).unwrap().effective,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+
+        state.observe_terminal_with_probe_at(
+            &completed(k3.clone()),
+            ShadowObservationMode::Update,
+            Some(lease),
+            boundary,
+        );
+        assert_eq!(
+            state.snapshot_at(&key, boundary).unwrap().effective,
+            ShadowDisposition::Healthy
+        );
+
+        let reopened_at = boundary + Duration::from_secs(10);
+        state.observe_terminal_at(
+            &failed(
+                k3.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(4)),
+            ),
+            ShadowObservationMode::Update,
+            reopened_at,
+        );
+        let second_boundary = reopened_at + Duration::from_secs(4);
+        let lease = expect_probe(state.try_claim_probe_at(&key, second_boundary));
+
+        // A distinct provider attempt can reopen a gate while its half-open
+        // probe is still live. Its generation fences the older probe success.
+        state.observe_terminal_at(
+            &failed(
+                k3.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                None,
+            ),
+            ShadowObservationMode::Update,
+            second_boundary,
+        );
+        state.observe_terminal_with_probe_at(
+            &completed(k3),
+            ShadowObservationMode::Update,
+            Some(lease),
+            second_boundary,
+        );
+        assert_eq!(
+            state.snapshot_at(&key, second_boundary).unwrap().effective,
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(4)
+            }
+        );
+    }
+
+    #[test]
     fn registry_topology_bounds_state_under_concurrent_observation() {
         let state = Arc::new(ShadowHealthState::with_policy(test_policy()));
         let cardinality = state.cardinality();
@@ -1139,6 +2262,16 @@ mod tests {
         let report = state.observe_terminal(&unknown, ShadowObservationMode::Update);
         assert_eq!(report.signal, ShadowSignal::UnknownRoute);
         assert!(!report.mutated);
+
+        for _ in 0..128 {
+            match state.try_claim_probe(&unknown.attempt().route.route_key()) {
+                ProbeClaimResult::Rejected {
+                    reason: ProbeRejectionReason::UnknownRoute,
+                    retry_after,
+                } => assert_eq!(retry_after, Duration::from_secs(4)),
+                other => panic!("unknown route must fail closed, got {other:?}"),
+            }
+        }
         assert_eq!(state.cardinality(), cardinality);
     }
 }

--- a/src/inference/health.rs
+++ b/src/inference/health.rs
@@ -1,8 +1,8 @@
-//! Enclave-local shadow health classification for inference routes.
+//! Enclave-local health classification for inference routes.
 //!
-//! This module deliberately has no route-selection API. Stack 5 records what a
-//! versioned policy would do, while the legacy router and shadow planner remain
-//! the only sources of route decisions.
+//! Stack 5 introduced this state observationally. Stack 6 consumes one coherent
+//! snapshot only for the explicit GLM 5.2 canary; every other route remains
+//! observational until its own rollout boundary.
 
 use super::{AttemptFailureKind, AttemptTerminal, RouteKey};
 use crate::provider_registry::{ProviderId, ProviderRegistry, RateLimitScope, PROVIDER_REGISTRY};
@@ -20,7 +20,10 @@ pub(crate) const SHADOW_HEALTH_POLICY_VERSION: &str = "routing-v2-health-shadow-
 const ROUTE_FAILURE_WINDOW: Duration = Duration::from_secs(60);
 const ROUTE_FAILURES_TO_OPEN: u8 = 3;
 const ROUTE_OPEN_COOLDOWN: Duration = Duration::from_secs(30);
-const DEFAULT_CAPACITY_COOLDOWN: Duration = Duration::from_secs(1);
+// A missing or zero upstream hint must not turn an active circuit into a hot
+// retry loop. Thirty seconds matches the route-health cooldown while remaining
+// bounded well below the one-hour maximum accepted from providers.
+pub(crate) const MIN_CAPACITY_COOLDOWN: Duration = Duration::from_secs(30);
 const MAX_CAPACITY_COOLDOWN: Duration = Duration::from_secs(60 * 60);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -84,7 +87,7 @@ struct ShadowHealthPolicy {
     route_failure_window: Duration,
     route_failures_to_open: u8,
     route_open_cooldown: Duration,
-    default_capacity_cooldown: Duration,
+    minimum_capacity_cooldown: Duration,
     max_capacity_cooldown: Duration,
 }
 
@@ -94,7 +97,7 @@ impl Default for ShadowHealthPolicy {
             route_failure_window: ROUTE_FAILURE_WINDOW,
             route_failures_to_open: ROUTE_FAILURES_TO_OPEN,
             route_open_cooldown: ROUTE_OPEN_COOLDOWN,
-            default_capacity_cooldown: DEFAULT_CAPACITY_COOLDOWN,
+            minimum_capacity_cooldown: MIN_CAPACITY_COOLDOWN,
             max_capacity_cooldown: MAX_CAPACITY_COOLDOWN,
         }
     }
@@ -192,6 +195,18 @@ impl ShadowHealthState {
     pub(crate) fn snapshot(&self, route: &RouteKey) -> Option<ShadowRouteSnapshot> {
         let inner = self.lock();
         self.snapshot_locked(&inner, route, Instant::now())
+    }
+
+    /// Returns a point-in-time snapshot for every requested route while holding
+    /// the state lock once. Active selection must not combine observations from
+    /// different instants when deciding whether all canary routes are open.
+    pub(crate) fn snapshot_routes(&self, routes: &[RouteKey]) -> Option<Vec<ShadowRouteSnapshot>> {
+        let inner = self.lock();
+        let now = Instant::now();
+        routes
+            .iter()
+            .map(|route| self.snapshot_locked(&inner, route, now))
+            .collect()
     }
 
     fn observe_terminal_locked(
@@ -322,7 +337,8 @@ impl ShadowHealthState {
             Mutation::Capacity { pool, retry_after } => {
                 if let Some(state) = inner.capacity.get_mut(&pool) {
                     let cooldown = retry_after
-                        .unwrap_or(self.policy.default_capacity_cooldown)
+                        .unwrap_or(self.policy.minimum_capacity_cooldown)
+                        .max(self.policy.minimum_capacity_cooldown)
                         .min(self.policy.max_capacity_cooldown);
                     extend_open_until(&mut state.open_until, now, cooldown);
                 }
@@ -622,7 +638,7 @@ mod tests {
             route_failure_window: Duration::from_secs(10),
             route_failures_to_open: 3,
             route_open_cooldown: Duration::from_secs(5),
-            default_capacity_cooldown: Duration::from_secs(4),
+            minimum_capacity_cooldown: Duration::from_secs(4),
             max_capacity_cooldown: Duration::from_secs(10),
         }
     }
@@ -859,6 +875,33 @@ mod tests {
 
         state.observe_terminal_at(
             &failed(
+                k3.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::ZERO),
+            ),
+            ShadowObservationMode::Update,
+            start + Duration::from_secs(10),
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(10))
+                .unwrap()
+                .effective,
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(4)
+            }
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&key, start + Duration::from_secs(14))
+                .unwrap()
+                .effective,
+            ShadowDisposition::WouldProbe
+        );
+
+        state.observe_terminal_at(
+            &failed(
                 k3,
                 AttemptFailureKind::CapacityRejected,
                 Some(429),
@@ -876,6 +919,29 @@ mod tests {
                 remaining: Duration::from_secs(10)
             }
         );
+    }
+
+    #[test]
+    fn route_snapshots_share_one_point_in_time_and_fail_closed_for_unknown_routes() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let glm_tinfoil = route(ProviderId::Tinfoil, "glm-5-2", "glm-5-2").route_key();
+        let glm_continuum = route(ProviderId::Continuum, "glm-5-2", "glm-5.2").route_key();
+
+        let snapshots = state
+            .snapshot_routes(&[glm_tinfoil.clone(), glm_continuum.clone()])
+            .expect("registered GLM routes");
+        assert_eq!(snapshots.len(), 2);
+        assert!(snapshots
+            .iter()
+            .all(|snapshot| snapshot.effective == ShadowDisposition::Healthy));
+
+        let unknown = RouteKey {
+            provider: ProviderId::Tinfoil,
+            provider_model_id: "not-registered".to_string(),
+        };
+        assert!(state
+            .snapshot_routes(&[glm_tinfoil, unknown, glm_continuum])
+            .is_none());
     }
 
     #[test]

--- a/src/inference_planning.rs
+++ b/src/inference_planning.rs
@@ -1,8 +1,9 @@
 //! Deterministic, credential-free completion route planning.
 //!
-//! The plan produced here is shadow-only. It describes route identity and
-//! ordered same-model candidates, but it cannot name or invoke an executable
-//! provider endpoint.
+//! The plan describes route identity and ordered same-model candidates without
+//! naming or invoking an executable endpoint. It remains the baseline shadow
+//! planner for every model and is also reused by Stack 6 after GLM's active
+//! canary has filtered its configured providers through one health snapshot.
 
 use crate::inference::{InferenceIntent, RouteIdentity};
 use crate::provider_registry::{

--- a/src/inference_planning.rs
+++ b/src/inference_planning.rs
@@ -1,11 +1,14 @@
 //! Deterministic, credential-free completion route planning.
 //!
-//! The plan describes route identity and ordered same-model candidates without
-//! naming or invoking an executable endpoint. It remains the baseline shadow
-//! planner for every model and is also reused by Stack 6 after GLM's active
-//! canary has filtered its configured providers through one health snapshot.
+//! The plan describes route identity and ordered candidates without naming or
+//! invoking an executable endpoint. The same-public-model planner remains the
+//! deterministic inner decision; Stack 7 composes it with the narrow ordered
+//! Auto Powerful K3/K2.6 model policy after one health snapshot.
 
-use crate::inference::{InferenceIntent, RouteIdentity};
+use crate::inference::{InferenceIntent, ModelSelectionMode, RouteIdentity};
+use crate::model_config::{
+    models_are_auto_substitution_compatible, KIMI_K3_MODEL_ID, POWERFUL_MODEL_ID,
+};
 use crate::provider_registry::{
     ProviderId, ProviderRegistry, RouteSelectionSource, SHADOW_ROUTING_POLICY_VERSION,
 };
@@ -24,6 +27,7 @@ impl ProviderPreference {
         }
     }
 
+    #[cfg(test)]
     pub(crate) const fn default_provider(provider: ProviderId) -> Self {
         Self {
             provider,
@@ -109,6 +113,21 @@ pub(crate) enum CandidateScope {
     SamePublicModelOnly,
 }
 
+pub(crate) const AUTO_MODEL_ROUTING_POLICY_VERSION: &str = "routing-v2-auto-model-v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ModelCandidateScope {
+    PreferredPublicModelOnly,
+    CompatibleAutoModels,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ModelCandidatePlan {
+    pub(crate) public_model_ids: Vec<String>,
+    pub(crate) candidate_scope: ModelCandidateScope,
+    pub(crate) policy_version: &'static str,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RoutePlan {
     pub(crate) selected: RouteIdentity,
@@ -127,6 +146,41 @@ pub(crate) enum RoutePlanningError {
 #[derive(Debug, Clone)]
 struct EligibleRoute {
     candidate: RouteCandidate,
+}
+
+/// Plans the ordered public-model candidates for one logical completion.
+///
+/// Only the original Auto selector can authorize a different public model.
+/// Stack 7 intentionally contains one compatible pair: paid Auto Powerful may
+/// move between Kimi K3 and Kimi K2.6. Auto Quick and every explicit request
+/// remain single-model plans.
+pub(crate) fn plan_completion_model_candidates(intent: &InferenceIntent) -> ModelCandidatePlan {
+    let mut public_model_ids = vec![intent.public_model_id.clone()];
+
+    if intent.selection_mode == ModelSelectionMode::AutoPowerful {
+        let alternate = match intent.public_model_id.as_str() {
+            KIMI_K3_MODEL_ID => Some(POWERFUL_MODEL_ID),
+            POWERFUL_MODEL_ID => Some(KIMI_K3_MODEL_ID),
+            _ => None,
+        };
+        if let Some(alternate) = alternate {
+            if intent.model_plan.allows_model(alternate)
+                && models_are_auto_substitution_compatible(&intent.public_model_id, alternate)
+            {
+                public_model_ids.push(alternate.to_string());
+            }
+        }
+    }
+
+    ModelCandidatePlan {
+        candidate_scope: if public_model_ids.len() > 1 {
+            ModelCandidateScope::CompatibleAutoModels
+        } else {
+            ModelCandidateScope::PreferredPublicModelOnly
+        },
+        public_model_ids,
+        policy_version: AUTO_MODEL_ROUTING_POLICY_VERSION,
+    }
 }
 
 pub(crate) fn plan_completion_route(
@@ -301,7 +355,10 @@ fn stable_account_bucket(account_uuid: uuid::Uuid) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model_config::{ModelPlan, AUTO_POWERFUL_MODEL_ID, GLM_5_2_MODEL_ID};
+    use crate::model_config::{
+        ModelPlan, AUTO_POWERFUL_MODEL_ID, AUTO_QUICK_MODEL_ID, DEEPSEEK_V4_FLASH_MODEL_ID,
+        GLM_5_2_MODEL_ID, KIMI_K3_MODEL_ID, POWERFUL_MODEL_ID, QUICK_MODEL_ID,
+    };
     use crate::provider_registry::{ProviderId, PROVIDER_REGISTRY};
     use uuid::Uuid;
 
@@ -314,6 +371,71 @@ mod tests {
             crate::inference::InferenceSurface::Responses,
             crate::inference::WorkloadClass::Interactive,
         )
+    }
+
+    fn intent_for_plan(
+        requested_model: &str,
+        public_model: &str,
+        model_plan: ModelPlan,
+    ) -> InferenceIntent {
+        InferenceIntent::new(
+            Uuid::from_u128(73),
+            requested_model,
+            public_model,
+            model_plan,
+            crate::inference::InferenceSurface::Responses,
+            crate::inference::WorkloadClass::Interactive,
+        )
+    }
+
+    #[test]
+    fn auto_model_policy_changes_only_paid_powerful_between_the_agreed_kimi_pair() {
+        let cases = [
+            (
+                intent(AUTO_POWERFUL_MODEL_ID, KIMI_K3_MODEL_ID),
+                vec![KIMI_K3_MODEL_ID, POWERFUL_MODEL_ID],
+                ModelCandidateScope::CompatibleAutoModels,
+            ),
+            (
+                intent(AUTO_POWERFUL_MODEL_ID, POWERFUL_MODEL_ID),
+                vec![POWERFUL_MODEL_ID, KIMI_K3_MODEL_ID],
+                ModelCandidateScope::CompatibleAutoModels,
+            ),
+            (
+                intent(AUTO_QUICK_MODEL_ID, DEEPSEEK_V4_FLASH_MODEL_ID),
+                vec![DEEPSEEK_V4_FLASH_MODEL_ID],
+                ModelCandidateScope::PreferredPublicModelOnly,
+            ),
+            (
+                intent_for_plan(AUTO_QUICK_MODEL_ID, QUICK_MODEL_ID, ModelPlan::Free),
+                vec![QUICK_MODEL_ID],
+                ModelCandidateScope::PreferredPublicModelOnly,
+            ),
+            (
+                intent(KIMI_K3_MODEL_ID, KIMI_K3_MODEL_ID),
+                vec![KIMI_K3_MODEL_ID],
+                ModelCandidateScope::PreferredPublicModelOnly,
+            ),
+        ];
+
+        for (intent, expected, scope) in cases {
+            let plan = plan_completion_model_candidates(&intent);
+            assert_eq!(plan.public_model_ids, expected);
+            assert_eq!(plan.candidate_scope, scope);
+            assert_eq!(plan.policy_version, AUTO_MODEL_ROUTING_POLICY_VERSION);
+        }
+    }
+
+    #[test]
+    fn free_powerful_policy_never_adds_a_paid_alternate() {
+        let intent = intent_for_plan(AUTO_POWERFUL_MODEL_ID, POWERFUL_MODEL_ID, ModelPlan::Free);
+        let plan = plan_completion_model_candidates(&intent);
+
+        assert_eq!(plan.public_model_ids, vec![POWERFUL_MODEL_ID]);
+        assert_eq!(
+            plan.candidate_scope,
+            ModelCandidateScope::PreferredPublicModelOnly
+        );
     }
 
     #[test]

--- a/src/inference_planning.rs
+++ b/src/inference_planning.rs
@@ -1,0 +1,424 @@
+//! Deterministic, credential-free completion route planning.
+//!
+//! The plan produced here is shadow-only. It describes route identity and
+//! ordered same-model candidates, but it cannot name or invoke an executable
+//! provider endpoint.
+
+use crate::inference::{InferenceIntent, RouteIdentity};
+use crate::provider_registry::{
+    ProviderId, ProviderRegistry, RouteSelectionSource, SHADOW_ROUTING_POLICY_VERSION,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProviderPreference {
+    provider: ProviderId,
+    source: RouteSelectionSource,
+}
+
+impl ProviderPreference {
+    pub(crate) const fn feature_flag(provider: ProviderId) -> Self {
+        Self {
+            provider,
+            source: RouteSelectionSource::FeatureFlag,
+        }
+    }
+
+    pub(crate) const fn default_provider(provider: ProviderId) -> Self {
+        Self {
+            provider,
+            source: RouteSelectionSource::DefaultProvider,
+        }
+    }
+
+    pub(crate) const fn provider(self) -> ProviderId {
+        self.provider
+    }
+
+    pub(crate) const fn source(self) -> RouteSelectionSource {
+        self.source
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct ConfiguredProviders {
+    tinfoil: bool,
+    continuum: bool,
+}
+
+impl ConfiguredProviders {
+    pub(crate) const fn none() -> Self {
+        Self {
+            tinfoil: false,
+            continuum: false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn all() -> Self {
+        Self {
+            tinfoil: true,
+            continuum: true,
+        }
+    }
+
+    pub(crate) fn with_provider(mut self, provider: ProviderId) -> Self {
+        match provider {
+            ProviderId::Tinfoil => self.tinfoil = true,
+            ProviderId::Continuum => self.continuum = true,
+        }
+        self
+    }
+
+    pub(crate) const fn contains(self, provider: ProviderId) -> bool {
+        match provider {
+            ProviderId::Tinfoil => self.tinfoil,
+            ProviderId::Continuum => self.continuum,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RoutePlanningInput<'a> {
+    pub(crate) intent: &'a InferenceIntent,
+    pub(crate) configured_providers: ConfiguredProviders,
+    pub(crate) provider_preference: Option<ProviderPreference>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RouteCandidate {
+    pub(crate) provider: ProviderId,
+    pub(crate) public_model_id: String,
+    pub(crate) provider_model_id: String,
+    pub(crate) response_model_id: String,
+    pub(crate) effective_weight: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PlanDecision {
+    FixedRoute,
+    StaticBucket,
+    DefaultProvider,
+    FeatureFlagPreference,
+    PreferredProviderUnavailable,
+    DefaultProviderUnavailable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CandidateScope {
+    SamePublicModelOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RoutePlan {
+    pub(crate) selected: RouteIdentity,
+    pub(crate) eligible_routes: Vec<RouteCandidate>,
+    pub(crate) decision: PlanDecision,
+    pub(crate) candidate_scope: CandidateScope,
+    pub(crate) policy_version: &'static str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RoutePlanningError {
+    UnsupportedModel(String),
+    NoEligibleRoute(String),
+}
+
+#[derive(Debug, Clone)]
+struct EligibleRoute {
+    candidate: RouteCandidate,
+}
+
+pub(crate) fn plan_completion_route(
+    registry: &ProviderRegistry,
+    input: RoutePlanningInput<'_>,
+) -> Result<RoutePlan, RoutePlanningError> {
+    let public_model_id = input.intent.public_model_id.as_str();
+    let model = registry
+        .completion_model(public_model_id)
+        .ok_or_else(|| RoutePlanningError::UnsupportedModel(public_model_id.to_string()))?;
+
+    let eligible_routes = model
+        .routes
+        .iter()
+        .filter_map(|route| {
+            if !route.enabled || route.weight == 0 {
+                return None;
+            }
+            let provider = registry.provider(route.provider)?;
+            if !provider.enabled
+                || provider.weight == 0
+                || !input.configured_providers.contains(route.provider)
+            {
+                return None;
+            }
+
+            Some(EligibleRoute {
+                candidate: RouteCandidate {
+                    provider: route.provider,
+                    public_model_id: model.public_model_id.to_string(),
+                    provider_model_id: route.provider_model_id.to_string(),
+                    response_model_id: route.response_model_id.to_string(),
+                    effective_weight: u32::from(provider.weight) * u32::from(route.weight),
+                },
+            })
+        })
+        .collect::<Vec<_>>();
+
+    if eligible_routes.is_empty() {
+        return Err(RoutePlanningError::NoEligibleRoute(
+            model.public_model_id.to_string(),
+        ));
+    }
+
+    if let Some(preference) = input.provider_preference {
+        if let Some(route) = eligible_routes
+            .iter()
+            .find(|route| route.candidate.provider == preference.provider())
+        {
+            return Ok(build_plan(
+                route,
+                &eligible_routes,
+                preference.source(),
+                None,
+                PlanDecision::FeatureFlagPreference,
+            ));
+        }
+    }
+
+    if let Some(default_provider) = model.default_provider {
+        if let Some(route) = eligible_routes
+            .iter()
+            .find(|route| route.candidate.provider == default_provider)
+        {
+            let (source, decision) = if input.provider_preference.is_some() {
+                (
+                    RouteSelectionSource::Fallback,
+                    PlanDecision::PreferredProviderUnavailable,
+                )
+            } else {
+                (
+                    RouteSelectionSource::DefaultProvider,
+                    PlanDecision::DefaultProvider,
+                )
+            };
+            return Ok(build_plan(route, &eligible_routes, source, None, decision));
+        }
+    }
+
+    let fallback_source = if input.provider_preference.is_some() || model.default_provider.is_some()
+    {
+        RouteSelectionSource::Fallback
+    } else {
+        RouteSelectionSource::StaticSplit
+    };
+    let missing_preference_decision = if input.provider_preference.is_some() {
+        Some(PlanDecision::PreferredProviderUnavailable)
+    } else if model.default_provider.is_some() {
+        Some(PlanDecision::DefaultProviderUnavailable)
+    } else {
+        None
+    };
+
+    if eligible_routes.len() == 1 {
+        return Ok(build_plan(
+            &eligible_routes[0],
+            &eligible_routes,
+            fallback_source,
+            None,
+            missing_preference_decision.unwrap_or(PlanDecision::FixedRoute),
+        ));
+    }
+
+    let bucket = stable_account_bucket(input.intent.account_uuid);
+    let selected = select_weighted_route(bucket, &eligible_routes)
+        .ok_or_else(|| RoutePlanningError::NoEligibleRoute(model.public_model_id.to_string()))?;
+    Ok(build_plan(
+        selected,
+        &eligible_routes,
+        fallback_source,
+        Some(bucket),
+        missing_preference_decision.unwrap_or(PlanDecision::StaticBucket),
+    ))
+}
+
+fn build_plan(
+    selected: &EligibleRoute,
+    eligible_routes: &[EligibleRoute],
+    selection_source: RouteSelectionSource,
+    bucket: Option<u8>,
+    decision: PlanDecision,
+) -> RoutePlan {
+    let selected = &selected.candidate;
+    RoutePlan {
+        selected: RouteIdentity::new(
+            selected.provider,
+            selected.public_model_id.clone(),
+            selected.provider_model_id.clone(),
+            selected.response_model_id.clone(),
+            selection_source,
+            bucket,
+        ),
+        eligible_routes: eligible_routes
+            .iter()
+            .map(|route| route.candidate.clone())
+            .collect(),
+        decision,
+        candidate_scope: CandidateScope::SamePublicModelOnly,
+        policy_version: SHADOW_ROUTING_POLICY_VERSION,
+    }
+}
+
+fn select_weighted_route(bucket: u8, routes: &[EligibleRoute]) -> Option<&EligibleRoute> {
+    let total_weight = routes
+        .iter()
+        .map(|route| route.candidate.effective_weight)
+        .sum::<u32>();
+    if total_weight == 0 {
+        return None;
+    }
+
+    let mut cumulative = 0u32;
+    for (index, route) in routes.iter().enumerate() {
+        let bucket_span = if index == routes.len() - 1 {
+            100u32.saturating_sub(cumulative)
+        } else {
+            (route.candidate.effective_weight * 100) / total_weight
+        };
+        cumulative = cumulative.saturating_add(bucket_span);
+
+        if u32::from(bucket) < cumulative || index == routes.len() - 1 {
+            return Some(route);
+        }
+    }
+    None
+}
+
+fn stable_account_bucket(account_uuid: uuid::Uuid) -> u8 {
+    (u128::from_be_bytes(*account_uuid.as_bytes()) % 100) as u8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model_config::{ModelPlan, AUTO_POWERFUL_MODEL_ID, GLM_5_2_MODEL_ID};
+    use crate::provider_registry::{ProviderId, PROVIDER_REGISTRY};
+    use uuid::Uuid;
+
+    fn intent(requested_model: &str, public_model: &str) -> InferenceIntent {
+        InferenceIntent::new(
+            Uuid::from_u128(73),
+            requested_model,
+            public_model,
+            ModelPlan::Paid,
+            crate::inference::InferenceSurface::Responses,
+            crate::inference::WorkloadClass::Interactive,
+        )
+    }
+
+    #[test]
+    fn planner_uses_resolved_public_model_without_resolving_auto_again() {
+        let intent = intent(AUTO_POWERFUL_MODEL_ID, "kimi-k3");
+        let plan = plan_completion_route(
+            &PROVIDER_REGISTRY,
+            RoutePlanningInput {
+                intent: &intent,
+                configured_providers: ConfiguredProviders::all(),
+                provider_preference: None,
+            },
+        )
+        .expect("shadow route");
+
+        assert_eq!(intent.requested_model_id, AUTO_POWERFUL_MODEL_ID);
+        assert_eq!(plan.selected.public_model_id, "kimi-k3");
+        assert_eq!(plan.selected.provider_model_id, "kimi-k3");
+        assert_eq!(plan.selected.provider, ProviderId::Tinfoil);
+        assert_eq!(plan.selected.bucket, None);
+        assert_eq!(plan.decision, PlanDecision::FixedRoute);
+    }
+
+    #[test]
+    fn planner_is_deterministic_and_candidates_never_cross_public_models() {
+        let intent = intent(GLM_5_2_MODEL_ID, GLM_5_2_MODEL_ID);
+        let input = RoutePlanningInput {
+            intent: &intent,
+            configured_providers: ConfiguredProviders::all(),
+            provider_preference: Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
+        };
+
+        let first = plan_completion_route(&PROVIDER_REGISTRY, input).expect("first plan");
+        let second = plan_completion_route(&PROVIDER_REGISTRY, input).expect("second plan");
+        assert_eq!(first, second);
+        assert_eq!(first.candidate_scope, CandidateScope::SamePublicModelOnly);
+        assert!(first
+            .eligible_routes
+            .iter()
+            .all(|route| route.public_model_id == intent.public_model_id));
+        assert_eq!(
+            first
+                .eligible_routes
+                .iter()
+                .map(|route| (route.provider, route.provider_model_id.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                (ProviderId::Tinfoil, GLM_5_2_MODEL_ID),
+                (ProviderId::Continuum, "glm-5.2"),
+            ]
+        );
+    }
+
+    #[test]
+    fn unavailable_preference_falls_back_without_authorizing_another_model() {
+        let intent = intent(GLM_5_2_MODEL_ID, GLM_5_2_MODEL_ID);
+        let configured = ConfiguredProviders::none().with_provider(ProviderId::Tinfoil);
+        let plan = plan_completion_route(
+            &PROVIDER_REGISTRY,
+            RoutePlanningInput {
+                intent: &intent,
+                configured_providers: configured,
+                provider_preference: Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
+            },
+        )
+        .expect("Tinfoil fallback plan");
+
+        assert_eq!(plan.selected.provider, ProviderId::Tinfoil);
+        assert_eq!(plan.selected.public_model_id, GLM_5_2_MODEL_ID);
+        assert_eq!(
+            plan.selected.selection_source,
+            RouteSelectionSource::Fallback
+        );
+        assert_eq!(plan.decision, PlanDecision::PreferredProviderUnavailable);
+        assert_eq!(plan.eligible_routes.len(), 1);
+    }
+
+    #[test]
+    fn planner_fails_closed_for_unknown_and_unconfigured_models() {
+        let unknown = intent("unknown-model", "unknown-model");
+        assert_eq!(
+            plan_completion_route(
+                &PROVIDER_REGISTRY,
+                RoutePlanningInput {
+                    intent: &unknown,
+                    configured_providers: ConfiguredProviders::all(),
+                    provider_preference: None,
+                },
+            ),
+            Err(RoutePlanningError::UnsupportedModel(
+                "unknown-model".to_string()
+            ))
+        );
+
+        let kimi = intent("kimi-k2-6", "kimi-k2-6");
+        let tinfoil_only = ConfiguredProviders::none().with_provider(ProviderId::Tinfoil);
+        assert_eq!(
+            plan_completion_route(
+                &PROVIDER_REGISTRY,
+                RoutePlanningInput {
+                    intent: &kimi,
+                    configured_providers: tinfoil_only,
+                    provider_preference: None,
+                },
+            ),
+            Err(RoutePlanningError::NoEligibleRoute("kimi-k2-6".to_string()))
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,10 +131,11 @@ mod web;
 mod aead_db_tamper_tests;
 
 use apple_signin::AppleJwtVerifier;
+use inference::admission::{AdmissionController, AdmissionPolicy};
 use inference_planning::ProviderPreference;
 use oauth::{AppleProvider, GithubProvider, GoogleProvider, OAuthManager};
 use provider_client::{ProviderClient, ProviderRequestError};
-use provider_registry::ProviderId;
+use provider_registry::{ProviderId, PROVIDER_REGISTRY};
 use provider_routing::ProviderRouter;
 use proxy_config::ProxyRouter;
 
@@ -865,6 +866,7 @@ pub struct AppState {
     provider_client: Arc<ProviderClient>,
     proxy_router: Arc<ProxyRouter>,
     provider_router: Arc<ProviderRouter>,
+    inference_admission: Arc<AdmissionController>,
     resend_api_key: Option<String>,
     ephemeral_keys: Arc<RwLock<BoundedTtlCache<PendingAttestationKey, EphemeralSecret>>>,
     session_states: Arc<tokio::sync::Mutex<LeaseAwareTtlCache<Uuid, SessionState>>>,
@@ -909,6 +911,7 @@ pub struct AppStateBuilder {
     os_flags_base_url: Option<String>,
     os_flags_api_key: Option<String>,
     kagi_api_key: Option<String>,
+    inference_admission_policy: Option<AdmissionPolicy>,
 }
 
 impl AppStateBuilder {
@@ -1031,6 +1034,14 @@ impl AppStateBuilder {
 
     pub fn kagi_api_key(mut self, kagi_api_key: Option<String>) -> Self {
         self.kagi_api_key = kagi_api_key;
+        self
+    }
+
+    pub(crate) fn inference_admission_policy(
+        mut self,
+        inference_admission_policy: AdmissionPolicy,
+    ) -> Self {
+        self.inference_admission_policy = Some(inference_admission_policy);
         self
     }
 
@@ -1168,6 +1179,18 @@ impl AppStateBuilder {
             provider_client.tinfoil_base_url(),
         ));
         let provider_router = Arc::new(ProviderRouter::default());
+        let inference_admission = Arc::new(
+            AdmissionController::new(
+                &PROVIDER_REGISTRY,
+                self.inference_admission_policy.unwrap_or_else(|| {
+                    AdmissionPolicy::baseline_for(&PROVIDER_REGISTRY)
+                        .expect("static provider registry has a valid admission policy")
+                }),
+            )
+            .map_err(|error| {
+                Error::BuilderError(format!("Invalid inference admission policy: {error}"))
+            })?,
+        );
 
         let (cancellation_tx, _) = tokio::sync::broadcast::channel(1024);
 
@@ -1200,6 +1223,7 @@ impl AppStateBuilder {
             provider_client,
             proxy_router,
             provider_router,
+            inference_admission,
             resend_api_key: self.resend_api_key,
             ephemeral_keys: Arc::new(RwLock::new(BoundedTtlCache::new(
                 NonZeroUsize::new(MAX_PENDING_ATTESTATIONS)
@@ -3900,6 +3924,11 @@ async fn main() -> Result<(), Error> {
         optional_env("OS_FLAGS_BASE_URL")
     };
 
+    let inference_admission_policy =
+        AdmissionPolicy::baseline_for(&PROVIDER_REGISTRY).map_err(|error| {
+            Error::BuilderError(format!("Invalid inference admission policy: {error}"))
+        })?;
+
     let app_state = AppStateBuilder::default()
         .app_mode(app_mode.clone())
         .db(db)
@@ -3920,6 +3949,7 @@ async fn main() -> Result<(), Error> {
         .os_flags_base_url(os_flags_base_url)
         .os_flags_api_key(os_flags_api_key)
         .kagi_api_key(kagi_api_key)
+        .inference_admission_policy(inference_admission_policy)
         .build()
         .await?;
     tracing::info!("App state created, app_mode: {:?}", app_mode);

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ use crate::{
 use crate::{encrypt::create_new_encryption_key, jwt::validate_jwt};
 use aws_credentials::{AwsCredentialManager, AwsCredentials};
 use axum::{
-    http::{HeaderName, HeaderValue, StatusCode},
+    http::{header, HeaderName, HeaderValue, StatusCode},
     middleware::{from_fn, from_fn_with_state, Next},
     response::{IntoResponse, Response},
     Json,
@@ -165,10 +165,13 @@ const ENCRYPTION_SESSION_IDLE_TTL: Duration = Duration::from_secs(65 * 60);
 
 pub(crate) const ERROR_CONTRACT_HEADER: &str = "x-opensecret-error-contract";
 pub(crate) const ERROR_CODE_HEADER: &str = "x-opensecret-error-code";
-const ERROR_CONTRACT_VERSION: &str = "1";
+pub(crate) const CLIENT_REPLAY_HEADER: &str = "x-opensecret-client-replay";
+pub(crate) const ERROR_CONTRACT_VERSION: &str = "1";
 const SESSION_NOT_FOUND_ERROR_CODE: &str = "session_not_found";
 const ACCESS_TOKEN_EXPIRED_ERROR_CODE: &str = "access_token_expired";
 const IMAGE_DESCRIPTION_UNAVAILABLE_ERROR_CODE: &str = "image_description_unavailable";
+pub(crate) const INFERENCE_CAPACITY_ERROR_CODE: &str = "inference_capacity";
+const CLIENT_REPLAY_SAFE: &str = "safe";
 
 type PendingAttestationKey = [u8; 32];
 pub(crate) type SessionLease = CacheLease<SessionState>;
@@ -375,6 +378,12 @@ pub enum ApiError {
 
     #[error("Upstream provider temporarily unavailable")]
     ImageDescriptionUnavailable,
+    #[error("Inference capacity is temporarily unavailable")]
+    InferenceCapacity {
+        status: StatusCode,
+        retry_after: Option<Duration>,
+        client_replay_safe: bool,
+    },
 
     #[error("Bad Request")]
     BadRequest,
@@ -437,6 +446,18 @@ pub enum ApiError {
     TooManyRequests,
 }
 
+impl ApiError {
+    pub(crate) fn with_client_replay_safe(mut self) -> Self {
+        if let Self::InferenceCapacity {
+            client_replay_safe, ..
+        } = &mut self
+        {
+            *client_replay_safe = true;
+        }
+        self
+    }
+}
+
 impl IntoResponse for ApiError {
     fn into_response(self) -> axum::response::Response {
         let status = match &self {
@@ -447,6 +468,7 @@ impl IntoResponse for ApiError {
             ApiError::InternalServerError => StatusCode::INTERNAL_SERVER_ERROR,
             ApiError::ServiceUnavailable => StatusCode::SERVICE_UNAVAILABLE,
             ApiError::ImageDescriptionUnavailable => StatusCode::SERVICE_UNAVAILABLE,
+            ApiError::InferenceCapacity { status, .. } => *status,
             ApiError::BadRequest => StatusCode::BAD_REQUEST,
             ApiError::SessionNotFound => StatusCode::BAD_REQUEST,
             ApiError::Conflict => StatusCode::CONFLICT,
@@ -471,6 +493,7 @@ impl IntoResponse for ApiError {
             ApiError::SessionNotFound => Some(SESSION_NOT_FOUND_ERROR_CODE),
             ApiError::AccessTokenExpired => Some(ACCESS_TOKEN_EXPIRED_ERROR_CODE),
             ApiError::ImageDescriptionUnavailable => Some(IMAGE_DESCRIPTION_UNAVAILABLE_ERROR_CODE),
+            ApiError::InferenceCapacity { .. } => Some(INFERENCE_CAPACITY_ERROR_CODE),
             _ => None,
         };
         let mut response = (
@@ -489,6 +512,24 @@ impl IntoResponse for ApiError {
             response
                 .headers_mut()
                 .insert(ERROR_CODE_HEADER, HeaderValue::from_static(error_code));
+        }
+        if let ApiError::InferenceCapacity {
+            retry_after,
+            client_replay_safe,
+            ..
+        } = self
+        {
+            if client_replay_safe {
+                response.headers_mut().insert(
+                    CLIENT_REPLAY_HEADER,
+                    HeaderValue::from_static(CLIENT_REPLAY_SAFE),
+                );
+            }
+            if let Some(retry_after) = retry_after {
+                if let Ok(value) = HeaderValue::from_str(&retry_after.as_secs().to_string()) {
+                    response.headers_mut().insert(header::RETRY_AFTER, value);
+                }
+            }
         }
         response
     }
@@ -626,6 +667,42 @@ mod api_error_contract_tests {
             None,
         )
         .await;
+    }
+
+    #[tokio::test]
+    async fn inference_capacity_contract_is_sanitized_and_replay_is_explicit() {
+        let response = ApiError::InferenceCapacity {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            retry_after: Some(Duration::from_secs(9)),
+            client_replay_safe: true,
+        }
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(response.headers()[ERROR_CONTRACT_HEADER], "1");
+        assert_eq!(
+            response.headers()[ERROR_CODE_HEADER],
+            INFERENCE_CAPACITY_ERROR_CODE
+        );
+        assert_eq!(response.headers()[CLIENT_REPLAY_HEADER], "safe");
+        assert_eq!(response.headers()[header::RETRY_AFTER], "9");
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(
+            body.as_ref(),
+            br#"{"status":429,"message":"Inference capacity is temporarily unavailable"}"#
+        );
+
+        let response = ApiError::InferenceCapacity {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            retry_after: None,
+            client_replay_safe: false,
+        }
+        .into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert!(response.headers().get(CLIENT_REPLAY_HEADER).is_none());
+        assert!(response.headers().get(header::RETRY_AFTER).is_none());
     }
 }
 
@@ -3868,6 +3945,8 @@ async fn main() -> Result<(), Error> {
         .expose_headers([
             HeaderName::from_static(ERROR_CONTRACT_HEADER),
             HeaderName::from_static(ERROR_CODE_HEADER),
+            HeaderName::from_static(CLIENT_REPLAY_HEADER),
+            header::RETRY_AFTER,
         ])
         // allow requests from any origin
         .allow_origin(Any);

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,7 @@ mod email;
 mod encrypt;
 mod http_client;
 mod inference;
+mod inference_planning;
 mod jwt;
 mod kagi;
 mod kv;
@@ -115,6 +116,7 @@ mod oauth;
 mod os_flags;
 mod private_key;
 mod provider_client;
+mod provider_registry;
 mod provider_routing;
 mod proxy_config;
 mod secret_cache_maintenance;
@@ -129,9 +131,11 @@ mod web;
 mod aead_db_tamper_tests;
 
 use apple_signin::AppleJwtVerifier;
+use inference_planning::ProviderPreference;
 use oauth::{AppleProvider, GithubProvider, GoogleProvider, OAuthManager};
 use provider_client::{ProviderClient, ProviderRequestError};
-use provider_routing::{ProviderName, ProviderPreference, ProviderRouter};
+use provider_registry::ProviderId;
+use provider_routing::ProviderRouter;
 use proxy_config::ProxyRouter;
 
 const ENCLAVE_KEY_NAME: &str = "enclave_key";
@@ -1189,8 +1193,8 @@ impl AppState {
         )
         .await
         {
-            Ok(Ok(Some(true))) => Some(ProviderPreference::feature_flag(ProviderName::Continuum)),
-            Ok(Ok(Some(false))) => Some(ProviderPreference::feature_flag(ProviderName::Tinfoil)),
+            Ok(Ok(Some(true))) => Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
+            Ok(Ok(Some(false))) => Some(ProviderPreference::feature_flag(ProviderId::Tinfoil)),
             Ok(Ok(None)) => {
                 debug!(
                     "os-flags provider routing flag missing (user_uuid={}, requested_model={}, flag_key={}); using default provider routing",

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,7 @@ mod db;
 mod email;
 mod encrypt;
 mod http_client;
+mod inference;
 mod jwt;
 mod kagi;
 mod kv;
@@ -504,7 +505,9 @@ impl From<ProviderRequestError> for ApiError {
             ProviderRequestError::TinfoilUnavailable => Self::ServiceUnavailable,
             ProviderRequestError::Timeout(_)
             | ProviderRequestError::Build(_)
-            | ProviderRequestError::Send(_) => Self::InternalServerError,
+            | ProviderRequestError::Connect(_)
+            | ProviderRequestError::Send(_)
+            | ProviderRequestError::Upstream(_) => Self::InternalServerError,
         }
     }
 }

--- a/src/model_config.rs
+++ b/src/model_config.rs
@@ -1057,6 +1057,124 @@ mod tests {
     }
 
     #[test]
+    fn test_golden_auto_alias_resolution_matrix_by_plan_and_paid_k3_flag() {
+        struct Case {
+            name: &'static str,
+            plan: ModelPlan,
+            powerful_kimi_k3: bool,
+            selector: &'static str,
+            expected_target: &'static str,
+        }
+
+        let cases = [
+            Case {
+                name: "free quick, flag off",
+                plan: ModelPlan::Free,
+                powerful_kimi_k3: false,
+                selector: AUTO_QUICK_MODEL_ID,
+                expected_target: QUICK_MODEL_ID,
+            },
+            Case {
+                name: "free quick, flag on",
+                plan: ModelPlan::Free,
+                powerful_kimi_k3: true,
+                selector: AUTO_QUICK_MODEL_ID,
+                expected_target: QUICK_MODEL_ID,
+            },
+            Case {
+                name: "free powerful, flag off",
+                plan: ModelPlan::Free,
+                powerful_kimi_k3: false,
+                selector: AUTO_POWERFUL_MODEL_ID,
+                expected_target: POWERFUL_MODEL_ID,
+            },
+            Case {
+                name: "free powerful, flag on",
+                plan: ModelPlan::Free,
+                powerful_kimi_k3: true,
+                selector: AUTO_POWERFUL_MODEL_ID,
+                expected_target: POWERFUL_MODEL_ID,
+            },
+            Case {
+                name: "paid quick, flag off",
+                plan: ModelPlan::Paid,
+                powerful_kimi_k3: false,
+                selector: AUTO_QUICK_MODEL_ID,
+                expected_target: DEEPSEEK_V4_FLASH_MODEL_ID,
+            },
+            Case {
+                name: "paid quick, flag on",
+                plan: ModelPlan::Paid,
+                powerful_kimi_k3: true,
+                selector: AUTO_QUICK_MODEL_ID,
+                expected_target: DEEPSEEK_V4_FLASH_MODEL_ID,
+            },
+            Case {
+                name: "paid powerful, flag off",
+                plan: ModelPlan::Paid,
+                powerful_kimi_k3: false,
+                selector: AUTO_POWERFUL_MODEL_ID,
+                expected_target: POWERFUL_MODEL_ID,
+            },
+            Case {
+                name: "paid powerful, flag on",
+                plan: ModelPlan::Paid,
+                powerful_kimi_k3: true,
+                selector: AUTO_POWERFUL_MODEL_ID,
+                expected_target: KIMI_K3_MODEL_ID,
+            },
+        ];
+
+        for case in cases {
+            let flags = HashMap::from([(
+                PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY.to_string(),
+                case.powerful_kimi_k3,
+            )]);
+            let targets = ModelAliasTargets::for_plan_with_overrides(
+                case.plan,
+                PaidModelAliasOverrides::from_flag_values(&flags),
+            );
+
+            assert_eq!(
+                targets.resolve(case.selector),
+                case.expected_target,
+                "{}",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_golden_explicit_model_resolution_is_plan_and_flag_invariant() {
+        for plan in [ModelPlan::Free, ModelPlan::Paid] {
+            for powerful_kimi_k3 in [false, true] {
+                let flags = HashMap::from([(
+                    PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY.to_string(),
+                    powerful_kimi_k3,
+                )]);
+                let targets = ModelAliasTargets::for_plan_with_overrides(
+                    plan,
+                    PaidModelAliasOverrides::from_flag_values(&flags),
+                );
+
+                for model in [
+                    QUICK_MODEL_ID,
+                    POWERFUL_MODEL_ID,
+                    KIMI_K3_MODEL_ID,
+                    GLM_5_2_MODEL_ID,
+                    DEEPSEEK_V4_FLASH_MODEL_ID,
+                ] {
+                    assert_eq!(
+                        targets.resolve(model),
+                        model,
+                        "explicit model changed for plan={plan:?}, powerful_kimi_k3={powerful_kimi_k3}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
     fn test_catalog_alias_metadata_tracks_paid_override_targets() {
         let flags = HashMap::from([(PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY.to_string(), true)]);
         let targets = ModelAliasTargets::for_plan_with_overrides(

--- a/src/model_config.rs
+++ b/src/model_config.rs
@@ -663,6 +663,14 @@ fn model_entry(model: &str) -> Option<ModelConfigEntry> {
         .copied()
 }
 
+#[cfg(test)]
+pub(crate) fn enabled_api_completion_model_ids() -> impl Iterator<Item = &'static str> {
+    MODEL_CONFIGS
+        .iter()
+        .filter(|entry| entry.api_listed && entry.enabled && entry.capabilities.chat)
+        .map(|entry| entry.id)
+}
+
 pub fn resolve_completion_model_id(model: &str) -> Option<&'static str> {
     let canonical = alias_target(model).unwrap_or(model);
     MODEL_CONFIGS

--- a/src/model_config.rs
+++ b/src/model_config.rs
@@ -41,6 +41,7 @@ impl SamplingConfig {
 #[derive(Debug, Clone, Copy)]
 struct ModelConfigEntry {
     id: &'static str,
+    #[cfg(test)]
     provider_id: &'static str,
     catalog_provider: &'static str,
     catalog_provider_id: &'static str,
@@ -174,6 +175,7 @@ impl ModelConfigEntry {
     ) -> Self {
         Self {
             id,
+            #[cfg(test)]
             provider_id: id,
             catalog_provider: "tinfoil",
             catalog_provider_id: id,
@@ -211,6 +213,7 @@ impl ModelConfigEntry {
     ) -> Self {
         Self {
             id,
+            #[cfg(test)]
             provider_id: id,
             catalog_provider: "tinfoil",
             catalog_provider_id: id,
@@ -246,6 +249,7 @@ impl ModelConfigEntry {
     ) -> Self {
         Self {
             id,
+            #[cfg(test)]
             provider_id: id,
             catalog_provider: "tinfoil",
             catalog_provider_id: id,
@@ -671,6 +675,7 @@ pub(crate) fn enabled_api_completion_model_ids() -> impl Iterator<Item = &'stati
         .map(|entry| entry.id)
 }
 
+#[cfg(test)]
 pub fn resolve_completion_model_id(model: &str) -> Option<&'static str> {
     let canonical = alias_target(model).unwrap_or(model);
     MODEL_CONFIGS
@@ -704,6 +709,36 @@ pub fn model_config(model: &str) -> ModelConfig {
 
 pub fn model_context_window(model: &str) -> usize {
     model_config(model).context_window
+}
+
+/// Returns whether `candidate` can safely replace `preferred` for an Auto
+/// request without narrowing the public capability contract.
+///
+/// Stack 7 deliberately keeps this strict: the substitute must be an enabled
+/// API completion model with the same access tier, capabilities, Responses
+/// behavior, and reasoning-history strategy, and it must not reduce the
+/// context window. A new model pair cannot enter the Auto policy merely by
+/// being added to the provider registry.
+pub(crate) fn models_are_auto_substitution_compatible(preferred: &str, candidate: &str) -> bool {
+    let Some(preferred) = model_entry(preferred) else {
+        return false;
+    };
+    let Some(candidate) = model_entry(candidate) else {
+        return false;
+    };
+
+    preferred.api_listed
+        && preferred.enabled
+        && preferred.capabilities.chat
+        && candidate.api_listed
+        && candidate.enabled
+        && candidate.capabilities.chat
+        && candidate.access == preferred.access
+        && candidate.capabilities == preferred.capabilities
+        && candidate.config.context_window >= preferred.config.context_window
+        && candidate.config.responses == preferred.config.responses
+        && model_reasoning_history_strategy(candidate.id)
+            == model_reasoning_history_strategy(preferred.id)
 }
 
 pub fn model_reasoning_history_strategy(model: &str) -> Option<ReasoningHistoryStrategy> {
@@ -929,6 +964,35 @@ mod tests {
             Some(ReasoningHistoryStrategy::GlmClearThinking)
         );
         assert_eq!(model_reasoning_history_strategy("gemma4-31b"), None);
+    }
+
+    #[test]
+    fn only_the_agreed_kimi_pair_is_auto_substitution_compatible() {
+        assert!(models_are_auto_substitution_compatible(
+            KIMI_K3_MODEL_ID,
+            POWERFUL_MODEL_ID
+        ));
+        assert!(models_are_auto_substitution_compatible(
+            POWERFUL_MODEL_ID,
+            KIMI_K3_MODEL_ID
+        ));
+
+        for candidate in [
+            GLM_5_2_MODEL_ID,
+            DEEPSEEK_V4_FLASH_MODEL_ID,
+            QUICK_MODEL_ID,
+            "gemma4-31b",
+            "llama3-3-70b",
+        ] {
+            assert!(
+                !models_are_auto_substitution_compatible(KIMI_K3_MODEL_ID, candidate),
+                "unexpected compatible Auto substitute: {candidate}"
+            );
+        }
+        assert!(!models_are_auto_substitution_compatible(
+            KIMI_K3_MODEL_ID,
+            "unknown-model"
+        ));
     }
 
     #[test]

--- a/src/models/responses.rs
+++ b/src/models/responses.rs
@@ -1070,6 +1070,23 @@ pub struct NewToolOutput {
     pub created_at: DateTime<Utc>,
 }
 
+impl ToolOutput {
+    pub fn get_by_uuid(
+        conn: &mut PgConnection,
+        uuid: Uuid,
+        user_id: Uuid,
+    ) -> Result<ToolOutput, ResponsesError> {
+        tool_outputs::table
+            .filter(tool_outputs::uuid.eq(uuid))
+            .filter(tool_outputs::user_id.eq(user_id))
+            .first::<ToolOutput>(conn)
+            .map_err(|e| match e {
+                diesel::result::Error::NotFound => ResponsesError::ToolOutputNotFound,
+                _ => ResponsesError::DatabaseError(e),
+            })
+    }
+}
+
 impl NewToolOutput {
     pub fn insert(&self, conn: &mut PgConnection) -> Result<ToolOutput, ResponsesError> {
         diesel::insert_into(tool_outputs::table)
@@ -1184,6 +1201,17 @@ pub struct NewReasoningItem {
 }
 
 impl ReasoningItem {
+    pub fn get_by_uuid(
+        conn: &mut PgConnection,
+        item_uuid: Uuid,
+    ) -> Result<Option<ReasoningItem>, ResponsesError> {
+        reasoning_items::table
+            .filter(reasoning_items::uuid.eq(item_uuid))
+            .first::<ReasoningItem>(conn)
+            .optional()
+            .map_err(ResponsesError::DatabaseError)
+    }
+
     pub fn update(
         conn: &mut PgConnection,
         item_uuid: Uuid,

--- a/src/provider_client.rs
+++ b/src/provider_client.rs
@@ -1,4 +1,4 @@
-use crate::provider_routing::ProviderName;
+use crate::provider_registry::ProviderId;
 use crate::proxy_config::ProxyConfig;
 use axum::http::{header, HeaderMap, HeaderName, HeaderValue};
 use bytes::Bytes;
@@ -624,7 +624,7 @@ impl ProviderClient {
         provider: &ProxyConfig,
         request: ProviderRequest<'_>,
     ) -> ProviderSendTrace {
-        if provider.provider_name != ProviderName::Tinfoil.as_str() {
+        if provider.provider_name != ProviderId::Tinfoil.as_str() {
             return ProviderSendTrace::terminal(self.send_standard(provider, request).await);
         }
 
@@ -745,7 +745,7 @@ impl ProviderClient {
         request: ProviderRequest<'_>,
         attempt: &TinfoilAttempt,
     ) -> Result<ReqwestRequest, ProviderRequestError> {
-        debug_assert_eq!(provider.provider_name, ProviderName::Tinfoil.as_str());
+        debug_assert_eq!(provider.provider_name, ProviderId::Tinfoil.as_str());
         let ProviderRequest {
             method,
             path,
@@ -940,7 +940,7 @@ mod tests {
         ProxyConfig {
             base_url: "http://ignored.invalid".to_string(),
             api_key: None,
-            provider_name: ProviderName::Tinfoil.as_str().to_string(),
+            provider_name: ProviderId::Tinfoil.as_str().to_string(),
         }
     }
 
@@ -1281,7 +1281,7 @@ mod tests {
         let provider = ProxyConfig {
             base_url: format!("http://{address}"),
             api_key: None,
-            provider_name: ProviderName::Continuum.as_str().to_string(),
+            provider_name: ProviderId::Continuum.as_str().to_string(),
         };
 
         let response = client
@@ -1339,7 +1339,7 @@ mod tests {
         let provider = ProxyConfig {
             base_url: format!("http://{redirect_address}"),
             api_key: None,
-            provider_name: ProviderName::Continuum.as_str().to_string(),
+            provider_name: ProviderId::Continuum.as_str().to_string(),
         };
         let body = Bytes::from_static(br#"{"model":"glm-5-2"}"#);
 
@@ -1388,7 +1388,7 @@ mod tests {
         let provider = ProxyConfig {
             base_url: format!("http://{address}"),
             api_key: Some("provider-key".to_string()),
-            provider_name: ProviderName::Continuum.as_str().to_string(),
+            provider_name: ProviderId::Continuum.as_str().to_string(),
         };
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -1592,7 +1592,7 @@ mod tests {
             // the enclave selected and attested by the SDK.
             base_url: client.tinfoil_base_url(),
             api_key: None,
-            provider_name: ProviderName::Tinfoil.as_str().to_string(),
+            provider_name: ProviderId::Tinfoil.as_str().to_string(),
         };
 
         let initialization_deadline = tokio::time::Instant::now() + Duration::from_secs(30);

--- a/src/provider_client.rs
+++ b/src/provider_client.rs
@@ -30,7 +30,7 @@ pub enum ProviderClientError {
     CryptoProvider,
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum ProviderRequestError {
     #[error(
         "Tinfoil is temporarily unavailable while router discovery and attestation retry in the background"
@@ -43,8 +43,35 @@ pub enum ProviderRequestError {
     #[error("failed to build provider request: {0}")]
     Build(String),
 
+    #[error("failed to connect to provider: {0}")]
+    Connect(String),
+
     #[error("provider request failed: {0}")]
     Send(String),
+
+    #[error("provider returned HTTP {}", .0.status)]
+    Upstream(UpstreamProviderError),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpstreamProviderError {
+    pub status: u16,
+    pub retry_after: Option<Duration>,
+    pub upstream_request_id: Option<String>,
+}
+
+pub(crate) struct ProviderSendTrace {
+    pub(crate) prior_failures: Vec<ProviderRequestError>,
+    pub(crate) result: Result<ProviderResponse, ProviderRequestError>,
+}
+
+impl ProviderSendTrace {
+    fn terminal(result: Result<ProviderResponse, ProviderRequestError>) -> Self {
+        Self {
+            prior_failures: Vec::new(),
+            result,
+        }
+    }
 }
 
 pub enum ProviderResponse {
@@ -118,6 +145,14 @@ impl ProviderResponse {
         }
     }
 
+    pub fn header_str(&self, name: &HeaderName) -> Option<&str> {
+        match self {
+            Self::Tinfoil(response) => response.headers().get(name),
+            Self::Standard(response) => response.headers().get(name),
+        }
+        .and_then(|value| value.to_str().ok())
+    }
+
     pub async fn bytes(self) -> Result<Bytes, String> {
         match self {
             Self::Tinfoil(response) => response.bytes().await.map_err(|error| error.to_string()),
@@ -140,6 +175,14 @@ impl ProviderResponse {
                     .map(|result| result.map_err(|e| e.to_string())),
             ),
         }
+    }
+}
+
+fn map_reqwest_send_error(error: reqwest::Error) -> ProviderRequestError {
+    if error.is_connect() {
+        ProviderRequestError::Connect(error.to_string())
+    } else {
+        ProviderRequestError::Send(error.to_string())
     }
 }
 
@@ -573,8 +616,16 @@ impl ProviderClient {
         provider: &ProxyConfig,
         request: ProviderRequest<'_>,
     ) -> Result<ProviderResponse, ProviderRequestError> {
+        self.send_traced(provider, request).await.result
+    }
+
+    pub(crate) async fn send_traced(
+        &self,
+        provider: &ProxyConfig,
+        request: ProviderRequest<'_>,
+    ) -> ProviderSendTrace {
         if provider.provider_name != ProviderName::Tinfoil.as_str() {
-            return self.send_standard(provider, request).await;
+            return ProviderSendTrace::terminal(self.send_standard(provider, request).await);
         }
 
         let response_start_timeout = request.response_start_timeout;
@@ -582,9 +633,18 @@ impl ProviderClient {
         // request path self-healing if construction behavior changes later;
         // the atomic claim prevents discovery herds.
         self.tinfoil.start_background_initialization();
-        let attempt = self.tinfoil.snapshot()?;
+        let attempt = match self.tinfoil.snapshot() {
+            Ok(attempt) => attempt,
+            Err(error) => return ProviderSendTrace::terminal(Err(error)),
+        };
         let first_request =
-            self.build_tinfoil_request_for_attempt(provider, request.clone(), &attempt)?;
+            match self.build_tinfoil_request_for_attempt(provider, request.clone(), &attempt) {
+                Ok(request) => request,
+                Err(error) => return ProviderSendTrace::terminal(Err(error)),
+            };
+
+        let prior_failures = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let prior_failures_for_send = Arc::clone(&prior_failures);
 
         let send = async {
             match attempt {
@@ -601,6 +661,10 @@ impl ProviderClient {
                         // Request/body/timeout failures are deliberately not replayed by this
                         // certificate-rotation layer.
                         Err(error) if error.is_connect() => {
+                            prior_failures_for_send
+                                .lock()
+                                .expect("provider attempt trace mutex poisoned")
+                                .push(ProviderRequestError::Connect(error.to_string()));
                             let refreshed = spawn_tinfoil_refresh_after_connect_failure(
                                 Arc::clone(self.tinfoil.secure()),
                                 failed_snapshot.clone(),
@@ -621,23 +685,42 @@ impl ProviderClient {
                                 .map_err(|error| ProviderRequestError::Send(error.to_string()))?
                                 .execute(retry_request)
                                 .await
-                                .map_err(|error| ProviderRequestError::Send(error.to_string()))
+                                .map_err(|error| {
+                                    if error.is_connect() {
+                                        ProviderRequestError::Connect(error.to_string())
+                                    } else {
+                                        ProviderRequestError::Send(error.to_string())
+                                    }
+                                })
                         }
-                        Err(error) => Err(ProviderRequestError::Send(error.to_string())),
+                        Err(error) => Err(if error.is_connect() {
+                            ProviderRequestError::Connect(error.to_string())
+                        } else {
+                            ProviderRequestError::Send(error.to_string())
+                        }),
                     }
                 }
                 #[cfg(test)]
                 TinfoilAttempt::Plain { client, .. } => client
                     .execute(first_request)
                     .await
-                    .map_err(|error| ProviderRequestError::Send(error.to_string())),
+                    .map_err(map_reqwest_send_error),
             }
         };
 
-        let response = tokio::time::timeout(response_start_timeout, send)
-            .await
-            .map_err(|_| ProviderRequestError::Timeout(response_start_timeout))??;
-        Ok(ProviderResponse::Tinfoil(response))
+        let result = match tokio::time::timeout(response_start_timeout, send).await {
+            Ok(result) => result.map(ProviderResponse::Tinfoil),
+            Err(_) => Err(ProviderRequestError::Timeout(response_start_timeout)),
+        };
+        let prior_failures = prior_failures
+            .lock()
+            .expect("provider attempt trace mutex poisoned")
+            .clone();
+
+        ProviderSendTrace {
+            prior_failures,
+            result,
+        }
     }
 
     #[cfg(test)]
@@ -757,7 +840,7 @@ impl ProviderClient {
         let response = tokio::time::timeout(response_start_timeout, request.send())
             .await
             .map_err(|_| ProviderRequestError::Timeout(response_start_timeout))?
-            .map_err(|error| ProviderRequestError::Send(error.to_string()))?;
+            .map_err(map_reqwest_send_error)?;
         Ok(ProviderResponse::Standard(response))
     }
 }

--- a/src/provider_registry.rs
+++ b/src/provider_registry.rs
@@ -1,8 +1,8 @@
 //! Credential-free provider topology for completion routing.
 //!
-//! This registry is intentionally independent from the legacy execution
-//! router. Stack 3 exercises it in shadow mode so the topology and planner can
-//! be validated before either is allowed to select an executable proxy.
+//! This registry is intentionally independent from executable credentials.
+//! Stack 3 introduced it in shadow mode; Stack 6 consumes it for the explicit
+//! GLM same-model provider canary while other active routes remain unchanged.
 
 use crate::model_config::{
     DEEPSEEK_V4_FLASH_MODEL_ID, GLM_5_2_MODEL_ID, KIMI_K3_MODEL_ID, POWERFUL_MODEL_ID,

--- a/src/provider_registry.rs
+++ b/src/provider_registry.rs
@@ -1,8 +1,9 @@
 //! Credential-free provider topology for completion routing.
 //!
 //! This registry is intentionally independent from executable credentials.
-//! Stack 3 introduced it in shadow mode; Stack 6 consumes it for the explicit
-//! GLM same-model provider canary while other active routes remain unchanged.
+//! Stack 3 introduced it in shadow mode. Stack 6 activated same-public-model
+//! provider selection for GLM, and Stack 7 uses the same topology for
+//! health-aware singleton routing plus the narrow Auto Powerful K3/K2.6 pool.
 
 use crate::model_config::{
     DEEPSEEK_V4_FLASH_MODEL_ID, GLM_5_2_MODEL_ID, KIMI_K3_MODEL_ID, POWERFUL_MODEL_ID,

--- a/src/provider_registry.rs
+++ b/src/provider_registry.rs
@@ -41,11 +41,24 @@ pub(crate) struct ProviderSpec {
     pub(crate) enabled: bool,
 }
 
+/// Scope of an upstream 429 for a configured completion route.
+///
+/// Tinfoil meters the shared OpenSecret credential per model, while
+/// Continuum/Edgeless documents organization-level limits. Keeping this in the
+/// credential-free registry prevents runtime error text or arbitrary model
+/// strings from defining health-state keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RateLimitScope {
+    ProviderModel,
+    ProviderAccount,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ModelRouteSpec {
     pub(crate) provider: ProviderId,
     pub(crate) provider_model_id: &'static str,
     pub(crate) response_model_id: &'static str,
+    pub(crate) rate_limit_scope: RateLimitScope,
     pub(crate) weight: u16,
     pub(crate) enabled: bool,
 }
@@ -78,7 +91,6 @@ impl ProviderRegistry {
             .find(|model| model.public_model_id == public_model_id)
     }
 
-    #[cfg(test)]
     pub(crate) fn completion_models(&self) -> &'static [CompletionModelSpec] {
         self.completion_models
     }
@@ -101,6 +113,7 @@ const GPT_OSS_120B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider: ProviderId::Tinfoil,
     provider_model_id: QUICK_MODEL_ID,
     response_model_id: QUICK_MODEL_ID,
+    rate_limit_scope: RateLimitScope::ProviderModel,
     weight: 100,
     enabled: true,
 }];
@@ -109,6 +122,7 @@ const GEMMA4_31B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider: ProviderId::Tinfoil,
     provider_model_id: "gemma4-31b",
     response_model_id: "gemma4-31b",
+    rate_limit_scope: RateLimitScope::ProviderModel,
     weight: 100,
     enabled: true,
 }];
@@ -117,6 +131,7 @@ const KIMI_K3_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider: ProviderId::Tinfoil,
     provider_model_id: KIMI_K3_MODEL_ID,
     response_model_id: KIMI_K3_MODEL_ID,
+    rate_limit_scope: RateLimitScope::ProviderModel,
     weight: 100,
     enabled: true,
 }];
@@ -125,6 +140,7 @@ const KIMI_K2_6_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider: ProviderId::Continuum,
     provider_model_id: "kimi-k2.6",
     response_model_id: POWERFUL_MODEL_ID,
+    rate_limit_scope: RateLimitScope::ProviderAccount,
     weight: 100,
     enabled: true,
 }];
@@ -134,6 +150,7 @@ const GLM_5_2_ROUTES: &[ModelRouteSpec] = &[
         provider: ProviderId::Tinfoil,
         provider_model_id: GLM_5_2_MODEL_ID,
         response_model_id: GLM_5_2_MODEL_ID,
+        rate_limit_scope: RateLimitScope::ProviderModel,
         weight: 100,
         enabled: true,
     },
@@ -141,6 +158,7 @@ const GLM_5_2_ROUTES: &[ModelRouteSpec] = &[
         provider: ProviderId::Continuum,
         provider_model_id: "glm-5.2",
         response_model_id: GLM_5_2_MODEL_ID,
+        rate_limit_scope: RateLimitScope::ProviderAccount,
         weight: 100,
         enabled: true,
     },
@@ -150,6 +168,7 @@ const DEEPSEEK_V4_FLASH_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider: ProviderId::Tinfoil,
     provider_model_id: DEEPSEEK_V4_FLASH_MODEL_ID,
     response_model_id: DEEPSEEK_V4_FLASH_MODEL_ID,
+    rate_limit_scope: RateLimitScope::ProviderModel,
     weight: 100,
     enabled: true,
 }];
@@ -158,6 +177,7 @@ const LLAMA3_3_70B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider: ProviderId::Tinfoil,
     provider_model_id: "llama3-3-70b",
     response_model_id: "llama3-3-70b",
+    rate_limit_scope: RateLimitScope::ProviderModel,
     weight: 100,
     enabled: true,
 }];
@@ -166,6 +186,7 @@ const GPT_OSS_SAFEGUARD_120B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider: ProviderId::Tinfoil,
     provider_model_id: "gpt-oss-safeguard-120b",
     response_model_id: "gpt-oss-safeguard-120b",
+    rate_limit_scope: RateLimitScope::ProviderModel,
     weight: 100,
     enabled: true,
 }];
@@ -374,5 +395,37 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    #[test]
+    fn registry_pins_provider_specific_rate_limit_scopes() {
+        let scopes = PROVIDER_REGISTRY
+            .completion_models()
+            .iter()
+            .flat_map(|model| {
+                model.routes.iter().map(move |route| {
+                    (
+                        route.provider,
+                        route.provider_model_id,
+                        route.rate_limit_scope,
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+
+        assert!(scopes.iter().all(|(provider, _, scope)| match provider {
+            ProviderId::Tinfoil => *scope == RateLimitScope::ProviderModel,
+            ProviderId::Continuum => *scope == RateLimitScope::ProviderAccount,
+        }));
+        assert!(scopes
+            .iter()
+            .any(|(provider, model, scope)| *provider == ProviderId::Tinfoil
+                && *model == KIMI_K3_MODEL_ID
+                && *scope == RateLimitScope::ProviderModel));
+        assert!(scopes.iter().any(
+            |(provider, model, scope)| *provider == ProviderId::Continuum
+                && *model == "glm-5.2"
+                && *scope == RateLimitScope::ProviderAccount
+        ));
     }
 }

--- a/src/provider_registry.rs
+++ b/src/provider_registry.rs
@@ -1,0 +1,378 @@
+//! Credential-free provider topology for completion routing.
+//!
+//! This registry is intentionally independent from the legacy execution
+//! router. Stack 3 exercises it in shadow mode so the topology and planner can
+//! be validated before either is allowed to select an executable proxy.
+
+use crate::model_config::{
+    DEEPSEEK_V4_FLASH_MODEL_ID, GLM_5_2_MODEL_ID, KIMI_K3_MODEL_ID, POWERFUL_MODEL_ID,
+    QUICK_MODEL_ID,
+};
+
+pub(crate) const SHADOW_ROUTING_POLICY_VERSION: &str = "routing-v2-shadow-v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum ProviderId {
+    Tinfoil,
+    Continuum,
+}
+
+impl ProviderId {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Tinfoil => "tinfoil",
+            Self::Continuum => "continuum",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RouteSelectionSource {
+    StaticSplit,
+    FeatureFlag,
+    DefaultProvider,
+    Fallback,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProviderSpec {
+    pub(crate) id: ProviderId,
+    pub(crate) weight: u16,
+    pub(crate) enabled: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ModelRouteSpec {
+    pub(crate) provider: ProviderId,
+    pub(crate) provider_model_id: &'static str,
+    pub(crate) response_model_id: &'static str,
+    pub(crate) weight: u16,
+    pub(crate) enabled: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CompletionModelSpec {
+    pub(crate) public_model_id: &'static str,
+    pub(crate) routes: &'static [ModelRouteSpec],
+    pub(crate) default_provider: Option<ProviderId>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ProviderRegistry {
+    providers: &'static [ProviderSpec],
+    completion_models: &'static [CompletionModelSpec],
+}
+
+impl ProviderRegistry {
+    pub(crate) fn provider(&self, id: ProviderId) -> Option<&ProviderSpec> {
+        self.providers.iter().find(|provider| provider.id == id)
+    }
+
+    pub(crate) fn providers(&self) -> &'static [ProviderSpec] {
+        self.providers
+    }
+
+    pub(crate) fn completion_model(&self, public_model_id: &str) -> Option<&CompletionModelSpec> {
+        self.completion_models
+            .iter()
+            .find(|model| model.public_model_id == public_model_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn completion_models(&self) -> &'static [CompletionModelSpec] {
+        self.completion_models
+    }
+}
+
+const PROVIDERS: &[ProviderSpec] = &[
+    ProviderSpec {
+        id: ProviderId::Tinfoil,
+        weight: 70,
+        enabled: true,
+    },
+    ProviderSpec {
+        id: ProviderId::Continuum,
+        weight: 30,
+        enabled: true,
+    },
+];
+
+const GPT_OSS_120B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
+    provider: ProviderId::Tinfoil,
+    provider_model_id: QUICK_MODEL_ID,
+    response_model_id: QUICK_MODEL_ID,
+    weight: 100,
+    enabled: true,
+}];
+
+const GEMMA4_31B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
+    provider: ProviderId::Tinfoil,
+    provider_model_id: "gemma4-31b",
+    response_model_id: "gemma4-31b",
+    weight: 100,
+    enabled: true,
+}];
+
+const KIMI_K3_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
+    provider: ProviderId::Tinfoil,
+    provider_model_id: KIMI_K3_MODEL_ID,
+    response_model_id: KIMI_K3_MODEL_ID,
+    weight: 100,
+    enabled: true,
+}];
+
+const KIMI_K2_6_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
+    provider: ProviderId::Continuum,
+    provider_model_id: "kimi-k2.6",
+    response_model_id: POWERFUL_MODEL_ID,
+    weight: 100,
+    enabled: true,
+}];
+
+const GLM_5_2_ROUTES: &[ModelRouteSpec] = &[
+    ModelRouteSpec {
+        provider: ProviderId::Tinfoil,
+        provider_model_id: GLM_5_2_MODEL_ID,
+        response_model_id: GLM_5_2_MODEL_ID,
+        weight: 100,
+        enabled: true,
+    },
+    ModelRouteSpec {
+        provider: ProviderId::Continuum,
+        provider_model_id: "glm-5.2",
+        response_model_id: GLM_5_2_MODEL_ID,
+        weight: 100,
+        enabled: true,
+    },
+];
+
+const DEEPSEEK_V4_FLASH_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
+    provider: ProviderId::Tinfoil,
+    provider_model_id: DEEPSEEK_V4_FLASH_MODEL_ID,
+    response_model_id: DEEPSEEK_V4_FLASH_MODEL_ID,
+    weight: 100,
+    enabled: true,
+}];
+
+const LLAMA3_3_70B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
+    provider: ProviderId::Tinfoil,
+    provider_model_id: "llama3-3-70b",
+    response_model_id: "llama3-3-70b",
+    weight: 100,
+    enabled: true,
+}];
+
+const GPT_OSS_SAFEGUARD_120B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
+    provider: ProviderId::Tinfoil,
+    provider_model_id: "gpt-oss-safeguard-120b",
+    response_model_id: "gpt-oss-safeguard-120b",
+    weight: 100,
+    enabled: true,
+}];
+
+const COMPLETION_MODELS: &[CompletionModelSpec] = &[
+    CompletionModelSpec {
+        public_model_id: QUICK_MODEL_ID,
+        routes: GPT_OSS_120B_ROUTES,
+        default_provider: None,
+    },
+    CompletionModelSpec {
+        public_model_id: "gemma4-31b",
+        routes: GEMMA4_31B_ROUTES,
+        default_provider: None,
+    },
+    CompletionModelSpec {
+        public_model_id: KIMI_K3_MODEL_ID,
+        routes: KIMI_K3_ROUTES,
+        default_provider: None,
+    },
+    CompletionModelSpec {
+        public_model_id: POWERFUL_MODEL_ID,
+        routes: KIMI_K2_6_ROUTES,
+        default_provider: Some(ProviderId::Continuum),
+    },
+    CompletionModelSpec {
+        public_model_id: GLM_5_2_MODEL_ID,
+        routes: GLM_5_2_ROUTES,
+        default_provider: Some(ProviderId::Tinfoil),
+    },
+    CompletionModelSpec {
+        public_model_id: DEEPSEEK_V4_FLASH_MODEL_ID,
+        routes: DEEPSEEK_V4_FLASH_ROUTES,
+        default_provider: None,
+    },
+    CompletionModelSpec {
+        public_model_id: "llama3-3-70b",
+        routes: LLAMA3_3_70B_ROUTES,
+        default_provider: None,
+    },
+    CompletionModelSpec {
+        public_model_id: "gpt-oss-safeguard-120b",
+        routes: GPT_OSS_SAFEGUARD_120B_ROUTES,
+        default_provider: None,
+    },
+];
+
+pub(crate) static PROVIDER_REGISTRY: ProviderRegistry = ProviderRegistry {
+    providers: PROVIDERS,
+    completion_models: COMPLETION_MODELS,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model_config::{
+        enabled_api_completion_model_ids, AUTO_POWERFUL_MODEL_ID, AUTO_QUICK_MODEL_ID,
+    };
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn registry_is_structurally_valid_and_deterministic() {
+        let registry = &PROVIDER_REGISTRY;
+        let provider_ids = registry
+            .providers()
+            .iter()
+            .map(|provider| provider.id)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(provider_ids.len(), registry.providers().len());
+
+        let model_ids = registry
+            .completion_models()
+            .iter()
+            .map(|model| model.public_model_id)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(model_ids.len(), registry.completion_models().len());
+
+        for model in registry.completion_models() {
+            assert!(!model.public_model_id.trim().is_empty());
+            assert!(!model.routes.is_empty(), "{}", model.public_model_id);
+            assert_ne!(model.public_model_id, AUTO_QUICK_MODEL_ID);
+            assert_ne!(model.public_model_id, AUTO_POWERFUL_MODEL_ID);
+
+            let mut route_providers = BTreeSet::new();
+            for route in model.routes {
+                assert!(registry.provider(route.provider).is_some());
+                assert!(route_providers.insert(route.provider));
+                assert!(!route.provider_model_id.trim().is_empty());
+                assert!(!route.response_model_id.trim().is_empty());
+                assert_eq!(route.response_model_id, model.public_model_id);
+            }
+
+            if let Some(default_provider) = model.default_provider {
+                assert!(model
+                    .routes
+                    .iter()
+                    .any(|route| route.provider == default_provider));
+            }
+        }
+
+        let ordered_model_ids = registry
+            .completion_models()
+            .iter()
+            .map(|model| model.public_model_id)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ordered_model_ids,
+            vec![
+                QUICK_MODEL_ID,
+                "gemma4-31b",
+                KIMI_K3_MODEL_ID,
+                POWERFUL_MODEL_ID,
+                GLM_5_2_MODEL_ID,
+                DEEPSEEK_V4_FLASH_MODEL_ID,
+                "llama3-3-70b",
+                "gpt-oss-safeguard-120b",
+            ]
+        );
+    }
+
+    #[test]
+    fn registry_covers_exactly_enabled_api_completion_models() {
+        let expected = enabled_api_completion_model_ids().collect::<BTreeSet<_>>();
+        let registered = PROVIDER_REGISTRY
+            .completion_models()
+            .iter()
+            .map(|model| model.public_model_id)
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(registered, expected);
+    }
+
+    #[test]
+    fn registry_pins_every_provider_model_translation() {
+        let routes = PROVIDER_REGISTRY
+            .completion_models()
+            .iter()
+            .flat_map(|model| {
+                model.routes.iter().map(move |route| {
+                    (
+                        model.public_model_id,
+                        route.provider,
+                        route.provider_model_id,
+                        route.response_model_id,
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            routes,
+            vec![
+                (
+                    QUICK_MODEL_ID,
+                    ProviderId::Tinfoil,
+                    QUICK_MODEL_ID,
+                    QUICK_MODEL_ID
+                ),
+                (
+                    "gemma4-31b",
+                    ProviderId::Tinfoil,
+                    "gemma4-31b",
+                    "gemma4-31b"
+                ),
+                (
+                    KIMI_K3_MODEL_ID,
+                    ProviderId::Tinfoil,
+                    KIMI_K3_MODEL_ID,
+                    KIMI_K3_MODEL_ID
+                ),
+                (
+                    POWERFUL_MODEL_ID,
+                    ProviderId::Continuum,
+                    "kimi-k2.6",
+                    POWERFUL_MODEL_ID
+                ),
+                (
+                    GLM_5_2_MODEL_ID,
+                    ProviderId::Tinfoil,
+                    GLM_5_2_MODEL_ID,
+                    GLM_5_2_MODEL_ID
+                ),
+                (
+                    GLM_5_2_MODEL_ID,
+                    ProviderId::Continuum,
+                    "glm-5.2",
+                    GLM_5_2_MODEL_ID
+                ),
+                (
+                    DEEPSEEK_V4_FLASH_MODEL_ID,
+                    ProviderId::Tinfoil,
+                    DEEPSEEK_V4_FLASH_MODEL_ID,
+                    DEEPSEEK_V4_FLASH_MODEL_ID
+                ),
+                (
+                    "llama3-3-70b",
+                    ProviderId::Tinfoil,
+                    "llama3-3-70b",
+                    "llama3-3-70b"
+                ),
+                (
+                    "gpt-oss-safeguard-120b",
+                    ProviderId::Tinfoil,
+                    "gpt-oss-safeguard-120b",
+                    "gpt-oss-safeguard-120b"
+                ),
+            ]
+        );
+    }
+}

--- a/src/provider_registry.rs
+++ b/src/provider_registry.rs
@@ -60,6 +60,9 @@ pub(crate) struct ModelRouteSpec {
     pub(crate) provider_model_id: &'static str,
     pub(crate) response_model_id: &'static str,
     pub(crate) rate_limit_scope: RateLimitScope,
+    /// Maximum prompt-token reservation for one image on this deployment.
+    /// Zero means the route is not advertised as accepting image input.
+    pub(crate) image_token_reservation: u64,
     pub(crate) weight: u16,
     pub(crate) enabled: bool,
 }
@@ -95,6 +98,19 @@ impl ProviderRegistry {
     pub(crate) fn completion_models(&self) -> &'static [CompletionModelSpec] {
         self.completion_models
     }
+
+    pub(crate) fn completion_route(
+        &self,
+        provider: ProviderId,
+        provider_model_id: &str,
+    ) -> Option<&ModelRouteSpec> {
+        self.completion_models
+            .iter()
+            .flat_map(|model| model.routes)
+            .find(|route| {
+                route.provider == provider && route.provider_model_id == provider_model_id
+            })
+    }
 }
 
 const PROVIDERS: &[ProviderSpec] = &[
@@ -115,6 +131,7 @@ const GPT_OSS_120B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider_model_id: QUICK_MODEL_ID,
     response_model_id: QUICK_MODEL_ID,
     rate_limit_scope: RateLimitScope::ProviderModel,
+    image_token_reservation: 0,
     weight: 100,
     enabled: true,
 }];
@@ -124,6 +141,7 @@ const GEMMA4_31B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider_model_id: "gemma4-31b",
     response_model_id: "gemma4-31b",
     rate_limit_scope: RateLimitScope::ProviderModel,
+    image_token_reservation: 16_384,
     weight: 100,
     enabled: true,
 }];
@@ -133,6 +151,7 @@ const KIMI_K3_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider_model_id: KIMI_K3_MODEL_ID,
     response_model_id: KIMI_K3_MODEL_ID,
     rate_limit_scope: RateLimitScope::ProviderModel,
+    image_token_reservation: 16_384,
     weight: 100,
     enabled: true,
 }];
@@ -142,6 +161,7 @@ const KIMI_K2_6_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider_model_id: "kimi-k2.6",
     response_model_id: POWERFUL_MODEL_ID,
     rate_limit_scope: RateLimitScope::ProviderAccount,
+    image_token_reservation: 4_096,
     weight: 100,
     enabled: true,
 }];
@@ -152,6 +172,7 @@ const GLM_5_2_ROUTES: &[ModelRouteSpec] = &[
         provider_model_id: GLM_5_2_MODEL_ID,
         response_model_id: GLM_5_2_MODEL_ID,
         rate_limit_scope: RateLimitScope::ProviderModel,
+        image_token_reservation: 0,
         weight: 100,
         enabled: true,
     },
@@ -160,6 +181,7 @@ const GLM_5_2_ROUTES: &[ModelRouteSpec] = &[
         provider_model_id: "glm-5.2",
         response_model_id: GLM_5_2_MODEL_ID,
         rate_limit_scope: RateLimitScope::ProviderAccount,
+        image_token_reservation: 0,
         weight: 100,
         enabled: true,
     },
@@ -170,6 +192,7 @@ const DEEPSEEK_V4_FLASH_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider_model_id: DEEPSEEK_V4_FLASH_MODEL_ID,
     response_model_id: DEEPSEEK_V4_FLASH_MODEL_ID,
     rate_limit_scope: RateLimitScope::ProviderModel,
+    image_token_reservation: 0,
     weight: 100,
     enabled: true,
 }];
@@ -179,6 +202,7 @@ const LLAMA3_3_70B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider_model_id: "llama3-3-70b",
     response_model_id: "llama3-3-70b",
     rate_limit_scope: RateLimitScope::ProviderModel,
+    image_token_reservation: 0,
     weight: 100,
     enabled: true,
 }];
@@ -188,6 +212,7 @@ const GPT_OSS_SAFEGUARD_120B_ROUTES: &[ModelRouteSpec] = &[ModelRouteSpec {
     provider_model_id: "gpt-oss-safeguard-120b",
     response_model_id: "gpt-oss-safeguard-120b",
     rate_limit_scope: RateLimitScope::ProviderModel,
+    image_token_reservation: 0,
     weight: 100,
     enabled: true,
 }];
@@ -318,6 +343,24 @@ mod tests {
             .collect::<BTreeSet<_>>();
 
         assert_eq!(registered, expected);
+    }
+
+    #[test]
+    fn registry_pins_known_image_accounting_bounds_per_deployment() {
+        assert_eq!(
+            PROVIDER_REGISTRY
+                .completion_route(ProviderId::Tinfoil, KIMI_K3_MODEL_ID)
+                .expect("K3 route")
+                .image_token_reservation,
+            16_384
+        );
+        assert_eq!(
+            PROVIDER_REGISTRY
+                .completion_route(ProviderId::Continuum, "kimi-k2.6")
+                .expect("K2.6 route")
+                .image_token_reservation,
+            4_096
+        );
     }
 
     #[test]

--- a/src/provider_routing.rs
+++ b/src/provider_routing.rs
@@ -1,6 +1,6 @@
 use crate::inference::health::{
-    ShadowDisposition, ShadowHealthState, ShadowObservationMode, ShadowObservationReport,
-    ShadowRouteSnapshot, MIN_CAPACITY_COOLDOWN,
+    ProbeClaimResult, ProbeLease, ShadowDisposition, ShadowHealthState, ShadowObservationMode,
+    ShadowObservationReport, ShadowRouteSnapshot, MIN_CAPACITY_COOLDOWN,
 };
 use crate::inference::{AttemptTerminal, InferenceIntent, RouteIdentity, RouteKey};
 use crate::inference_planning::{
@@ -17,6 +17,7 @@ use crate::provider_registry::{
 #[cfg(test)]
 use crate::proxy_config::canonicalize_tinfoil_model;
 use crate::proxy_config::{ProxyConfig, ProxyRouter};
+use std::collections::HashSet;
 use std::time::Duration;
 #[cfg(test)]
 use uuid::Uuid;
@@ -212,6 +213,20 @@ impl ProviderRouter {
         self.shadow_health.observe_terminal(terminal, mode)
     }
 
+    pub(crate) fn observe_attempt_terminal_with_probe(
+        &self,
+        terminal: &AttemptTerminal,
+        mode: ShadowObservationMode,
+        probe: Option<ProbeLease>,
+    ) -> ShadowObservationReport {
+        self.shadow_health
+            .observe_terminal_with_probe(terminal, mode, probe)
+    }
+
+    pub(crate) fn try_claim_probe(&self, route: &RouteKey) -> ProbeClaimResult {
+        self.shadow_health.try_claim_probe(route)
+    }
+
     pub(crate) fn shadow_health_snapshot(&self, route: &RouteKey) -> Option<ShadowRouteSnapshot> {
         self.shadow_health.snapshot(route)
     }
@@ -281,6 +296,32 @@ impl ProviderRouter {
             intent,
             &candidates,
             provider_preference,
+            &HashSet::new(),
+        )
+    }
+
+    /// Replans a not-yet-sent logical request while excluding route resources
+    /// that lost admission or half-open ownership races. This never retries an
+    /// upstream attempt; callers may use it only before the first send.
+    pub(crate) fn select_active_completion_route_excluding(
+        &self,
+        proxy_router: &ProxyRouter,
+        intent: &InferenceIntent,
+        provider_preference: Option<ProviderPreference>,
+        excluded_routes: &HashSet<RouteKey>,
+    ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
+        let model_plan = plan_completion_model_candidates(intent);
+        let candidates = model_plan
+            .public_model_ids
+            .iter()
+            .map(|public_model_id| intent.for_candidate_public_model(public_model_id.clone()))
+            .collect::<Vec<_>>();
+        self.select_health_aware_model_candidates(
+            proxy_router,
+            intent,
+            &candidates,
+            provider_preference,
+            excluded_routes,
         )
     }
 
@@ -317,6 +358,7 @@ impl ProviderRouter {
         preferred_intent: &InferenceIntent,
         candidates: &[InferenceIntent],
         provider_preference: Option<ProviderPreference>,
+        excluded_routes: &HashSet<RouteKey>,
     ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
         if candidates.is_empty() {
             return Err(ProviderRoutingError::NoEligibleRoute(
@@ -344,14 +386,14 @@ impl ProviderRouter {
                 {
                     continue;
                 }
-                configured_routes.push((
-                    candidate_index,
-                    route.provider,
-                    RouteKey {
-                        provider: route.provider,
-                        provider_model_id: route.provider_model_id.to_string(),
-                    },
-                ));
+                let route_key = RouteKey {
+                    provider: route.provider,
+                    provider_model_id: route.provider_model_id.to_string(),
+                };
+                if excluded_routes.contains(&route_key) {
+                    continue;
+                }
+                configured_routes.push((candidate_index, route.provider, route_key));
             }
         }
 
@@ -382,6 +424,13 @@ impl ProviderRouter {
                     earliest_recovery[*candidate_index] = Some(
                         earliest_recovery[*candidate_index]
                             .map_or(remaining, |current: Duration| current.min(remaining)),
+                    );
+                }
+                ShadowDisposition::ProbeInFlight { retry_after } => {
+                    let retry_after = ceil_retry_after(retry_after);
+                    earliest_recovery[*candidate_index] = Some(
+                        earliest_recovery[*candidate_index]
+                            .map_or(retry_after, |current: Duration| current.min(retry_after)),
                     );
                 }
                 disposition if route_is_available_for_new_request(disposition) => {
@@ -720,7 +769,10 @@ fn ceil_retry_after(duration: Duration) -> Duration {
 }
 
 fn route_is_available_for_new_request(disposition: ShadowDisposition) -> bool {
-    !matches!(disposition, ShadowDisposition::WouldOpen { .. })
+    !matches!(
+        disposition,
+        ShadowDisposition::WouldOpen { .. } | ShadowDisposition::ProbeInFlight { .. }
+    )
 }
 
 fn proxy_for_provider(proxy_router: &ProxyRouter, provider: ProviderId) -> Option<ProxyConfig> {

--- a/src/provider_routing.rs
+++ b/src/provider_routing.rs
@@ -416,6 +416,13 @@ fn proxy_for_provider(proxy_router: &ProxyRouter, provider: ProviderName) -> Opt
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model_config::{
+        ModelAliasTargets, ModelPlan, PaidModelAliasOverrides, AUTO_POWERFUL_MODEL_ID,
+        AUTO_QUICK_MODEL_ID, DEEPSEEK_V4_FLASH_MODEL_ID, KIMI_K3_MODEL_ID, POWERFUL_MODEL_ID,
+        QUICK_MODEL_ID,
+    };
+    use crate::os_flags::PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY;
+    use std::collections::HashMap;
 
     fn proxy_router_with_both_providers() -> ProxyRouter {
         ProxyRouter::new(
@@ -435,6 +442,225 @@ mod tests {
         assert_eq!(stable_account_bucket(uuid_for_bucket(49)), 49);
         assert_eq!(stable_account_bucket(uuid_for_bucket(50)), 50);
         assert_eq!(stable_account_bucket(uuid_for_bucket(99)), 99);
+    }
+
+    #[test]
+    fn test_golden_completion_route_matrix_by_selector_plan_and_provider_preference() {
+        #[derive(Clone, Copy)]
+        struct Case {
+            name: &'static str,
+            selector: &'static str,
+            plan: ModelPlan,
+            powerful_kimi_k3: bool,
+            provider_preference: Option<ProviderPreference>,
+            continuum_available: bool,
+            expected_access: bool,
+            expected_public_model: &'static str,
+            expected_provider: &'static str,
+            expected_provider_model: &'static str,
+            expected_source: ProviderSelectionSource,
+        }
+
+        let cases = [
+            Case {
+                name: "free auto quick",
+                selector: AUTO_QUICK_MODEL_ID,
+                plan: ModelPlan::Free,
+                powerful_kimi_k3: false,
+                provider_preference: None,
+                continuum_available: true,
+                expected_access: true,
+                expected_public_model: QUICK_MODEL_ID,
+                expected_provider: "tinfoil",
+                expected_provider_model: QUICK_MODEL_ID,
+                expected_source: ProviderSelectionSource::StaticSplit,
+            },
+            Case {
+                name: "free auto powerful remains unavailable when the paid flag is on",
+                selector: AUTO_POWERFUL_MODEL_ID,
+                plan: ModelPlan::Free,
+                powerful_kimi_k3: true,
+                provider_preference: None,
+                continuum_available: true,
+                expected_access: false,
+                expected_public_model: POWERFUL_MODEL_ID,
+                expected_provider: "continuum",
+                expected_provider_model: "kimi-k2.6",
+                expected_source: ProviderSelectionSource::DefaultProvider,
+            },
+            Case {
+                name: "paid auto quick",
+                selector: AUTO_QUICK_MODEL_ID,
+                plan: ModelPlan::Paid,
+                powerful_kimi_k3: false,
+                provider_preference: None,
+                continuum_available: true,
+                expected_access: true,
+                expected_public_model: DEEPSEEK_V4_FLASH_MODEL_ID,
+                expected_provider: "tinfoil",
+                expected_provider_model: DEEPSEEK_V4_FLASH_MODEL_ID,
+                expected_source: ProviderSelectionSource::StaticSplit,
+            },
+            Case {
+                name: "paid auto powerful, flag off",
+                selector: AUTO_POWERFUL_MODEL_ID,
+                plan: ModelPlan::Paid,
+                powerful_kimi_k3: false,
+                provider_preference: None,
+                continuum_available: true,
+                expected_access: true,
+                expected_public_model: POWERFUL_MODEL_ID,
+                expected_provider: "continuum",
+                expected_provider_model: "kimi-k2.6",
+                expected_source: ProviderSelectionSource::DefaultProvider,
+            },
+            Case {
+                name: "paid auto powerful, flag on",
+                selector: AUTO_POWERFUL_MODEL_ID,
+                plan: ModelPlan::Paid,
+                powerful_kimi_k3: true,
+                provider_preference: None,
+                continuum_available: true,
+                expected_access: true,
+                expected_public_model: KIMI_K3_MODEL_ID,
+                expected_provider: "tinfoil",
+                expected_provider_model: KIMI_K3_MODEL_ID,
+                expected_source: ProviderSelectionSource::StaticSplit,
+            },
+            Case {
+                name: "explicit K3 ignores the paid auto flag",
+                selector: KIMI_K3_MODEL_ID,
+                plan: ModelPlan::Paid,
+                powerful_kimi_k3: false,
+                provider_preference: None,
+                continuum_available: true,
+                expected_access: true,
+                expected_public_model: KIMI_K3_MODEL_ID,
+                expected_provider: "tinfoil",
+                expected_provider_model: KIMI_K3_MODEL_ID,
+                expected_source: ProviderSelectionSource::StaticSplit,
+            },
+            Case {
+                name: "explicit GLM default",
+                selector: GLM_5_2_MODEL_ID,
+                plan: ModelPlan::Paid,
+                powerful_kimi_k3: false,
+                provider_preference: None,
+                continuum_available: true,
+                expected_access: true,
+                expected_public_model: GLM_5_2_MODEL_ID,
+                expected_provider: "tinfoil",
+                expected_provider_model: GLM_5_2_MODEL_ID,
+                expected_source: ProviderSelectionSource::DefaultProvider,
+            },
+            Case {
+                name: "explicit GLM Tinfoil preference",
+                selector: GLM_5_2_MODEL_ID,
+                plan: ModelPlan::Paid,
+                powerful_kimi_k3: false,
+                provider_preference: Some(ProviderPreference::feature_flag(ProviderName::Tinfoil)),
+                continuum_available: true,
+                expected_access: true,
+                expected_public_model: GLM_5_2_MODEL_ID,
+                expected_provider: "tinfoil",
+                expected_provider_model: GLM_5_2_MODEL_ID,
+                expected_source: ProviderSelectionSource::FeatureFlag,
+            },
+            Case {
+                name: "explicit GLM Continuum preference",
+                selector: GLM_5_2_MODEL_ID,
+                plan: ModelPlan::Paid,
+                powerful_kimi_k3: false,
+                provider_preference: Some(ProviderPreference::feature_flag(
+                    ProviderName::Continuum,
+                )),
+                continuum_available: true,
+                expected_access: true,
+                expected_public_model: GLM_5_2_MODEL_ID,
+                expected_provider: "continuum",
+                expected_provider_model: "glm-5.2",
+                expected_source: ProviderSelectionSource::FeatureFlag,
+            },
+            Case {
+                name: "explicit GLM Continuum preference without a Continuum proxy",
+                selector: GLM_5_2_MODEL_ID,
+                plan: ModelPlan::Paid,
+                powerful_kimi_k3: false,
+                provider_preference: Some(ProviderPreference::feature_flag(
+                    ProviderName::Continuum,
+                )),
+                continuum_available: false,
+                expected_access: true,
+                expected_public_model: GLM_5_2_MODEL_ID,
+                expected_provider: "tinfoil",
+                expected_provider_model: GLM_5_2_MODEL_ID,
+                expected_source: ProviderSelectionSource::Fallback,
+            },
+        ];
+
+        let router = ProviderRouter::default();
+        for case in cases {
+            let flags = HashMap::from([(
+                PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY.to_string(),
+                case.powerful_kimi_k3,
+            )]);
+            let alias_targets = ModelAliasTargets::for_plan_with_overrides(
+                case.plan,
+                PaidModelAliasOverrides::from_flag_values(&flags),
+            );
+            let resolved_model = alias_targets.resolve(case.selector);
+            let access = case.plan.allows_model(resolved_model);
+
+            assert_eq!(access, case.expected_access, "{}", case.name);
+            if !case.expected_access {
+                continue;
+            }
+
+            let proxy_router = if case.continuum_available {
+                proxy_router_with_both_providers()
+            } else {
+                ProxyRouter::new(
+                    "https://api.openai.com".to_string(),
+                    None,
+                    "http://tinfoil.example.com".to_string(),
+                )
+            };
+            let selected = router
+                .select_completion_route_with_preference(
+                    &proxy_router,
+                    uuid_for_bucket(73),
+                    resolved_model,
+                    case.provider_preference,
+                )
+                .unwrap_or_else(|error| panic!("{}: {error:?}", case.name));
+
+            assert_eq!(
+                selected.public_model_id, case.expected_public_model,
+                "{}",
+                case.name
+            );
+            assert_eq!(
+                selected.provider_model_id, case.expected_provider_model,
+                "{}",
+                case.name
+            );
+            assert_eq!(
+                selected.response_model_id, case.expected_public_model,
+                "{}",
+                case.name
+            );
+            assert_eq!(
+                selected.proxy.provider_name, case.expected_provider,
+                "{}",
+                case.name
+            );
+            assert_eq!(
+                selected.selection_source, case.expected_source,
+                "{}",
+                case.name
+            );
+            assert_eq!(selected.bucket, None, "{}", case.name);
+        }
     }
 
     #[test]

--- a/src/provider_routing.rs
+++ b/src/provider_routing.rs
@@ -1,9 +1,10 @@
+use crate::inference::RouteIdentity;
 use crate::model_config::{resolve_completion_model_id, resolve_public_model_id, GLM_5_2_MODEL_ID};
 use crate::os_flags::GLM_5_2_CONTINUUM_FLAG_KEY;
 use crate::proxy_config::{canonicalize_tinfoil_model, ProxyConfig, ProxyRouter};
 use uuid::Uuid;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum ProviderName {
     Tinfoil,
     Continuum,
@@ -79,12 +80,26 @@ struct ProviderRoutingConfig {
 
 #[derive(Debug, Clone)]
 pub(crate) struct SelectedProviderRoute {
+    pub(crate) provider: ProviderName,
     pub(crate) proxy: ProxyConfig,
     pub(crate) public_model_id: String,
     pub(crate) provider_model_id: String,
     pub(crate) response_model_id: String,
     pub(crate) bucket: Option<u8>,
     pub(crate) selection_source: ProviderSelectionSource,
+}
+
+impl SelectedProviderRoute {
+    pub(crate) fn identity(&self) -> RouteIdentity {
+        RouteIdentity::new(
+            self.provider,
+            self.public_model_id.clone(),
+            self.provider_model_id.clone(),
+            self.response_model_id.clone(),
+            self.selection_source,
+            self.bucket,
+        )
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -298,6 +313,7 @@ impl ProviderRouter {
         };
 
         Ok(SelectedProviderRoute {
+            provider: selected.provider,
             proxy: selected.proxy.clone(),
             public_model_id: model_config.public_model_id.to_string(),
             provider_model_id: selected.provider_model_id.to_string(),
@@ -334,6 +350,7 @@ impl ProviderRouter {
         };
 
         Ok(SelectedProviderRoute {
+            provider: ProviderName::Tinfoil,
             proxy,
             public_model_id,
             provider_model_id,

--- a/src/provider_routing.rs
+++ b/src/provider_routing.rs
@@ -1,7 +1,10 @@
 use crate::inference::health::{
-    ShadowHealthState, ShadowObservationMode, ShadowObservationReport, ShadowRouteSnapshot,
+    ShadowDisposition, ShadowHealthState, ShadowObservationMode, ShadowObservationReport,
+    ShadowRouteSnapshot, MIN_CAPACITY_COOLDOWN,
 };
-use crate::inference::{AttemptTerminal, InferenceIntent, RouteIdentity, RouteKey};
+use crate::inference::{
+    AttemptTerminal, InferenceIntent, ModelSelectionMode, RouteIdentity, RouteKey,
+};
 use crate::inference_planning::{
     plan_completion_route, ConfiguredProviders, ProviderPreference, RoutePlan, RoutePlanningError,
     RoutePlanningInput,
@@ -12,6 +15,7 @@ use crate::provider_registry::{
     ProviderId, ProviderRegistry, RouteSelectionSource, PROVIDER_REGISTRY,
 };
 use crate::proxy_config::{canonicalize_tinfoil_model, ProxyConfig, ProxyRouter};
+use std::time::Duration;
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Copy)]
@@ -71,6 +75,10 @@ impl SelectedProviderRoute {
 pub(crate) enum ProviderRoutingError {
     UnsupportedModel(String),
     NoEligibleRoute(String),
+    CapacityUnavailable {
+        model: String,
+        retry_after: Duration,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -229,6 +237,31 @@ impl ProviderRouter {
         self.fallback_completion_route(proxy_router, requested_model)
     }
 
+    /// Selects the route used by a newly prepared logical request.
+    ///
+    /// Stack 6 activates health filtering only for explicit GLM 5.2 requests.
+    /// Auto aliases and every other public model deliberately retain the legacy
+    /// route decision until their own rollout stack.
+    pub(crate) fn select_active_completion_route(
+        &self,
+        proxy_router: &ProxyRouter,
+        intent: &InferenceIntent,
+        provider_preference: Option<ProviderPreference>,
+    ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
+        if intent.selection_mode == ModelSelectionMode::Explicit
+            && intent.public_model_id == GLM_5_2_MODEL_ID
+        {
+            return self.select_glm_canary_route(proxy_router, intent, provider_preference);
+        }
+
+        self.select_completion_route_with_preference(
+            proxy_router,
+            intent.account_uuid,
+            &intent.public_model_id,
+            provider_preference,
+        )
+    }
+
     pub(crate) fn shadow_completion_plan(
         &self,
         proxy_router: &ProxyRouter,
@@ -254,6 +287,110 @@ impl ProviderRouter {
                 provider_preference,
             },
         )
+    }
+
+    fn select_glm_canary_route(
+        &self,
+        proxy_router: &ProxyRouter,
+        intent: &InferenceIntent,
+        provider_preference: Option<ProviderPreference>,
+    ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
+        let model = self
+            .registry
+            .completion_model(&intent.public_model_id)
+            .ok_or_else(|| {
+                ProviderRoutingError::UnsupportedModel(intent.public_model_id.clone())
+            })?;
+
+        let configured_routes = model
+            .routes
+            .iter()
+            .filter_map(|route| {
+                let provider = self.registry.provider(route.provider)?;
+                if !route.enabled
+                    || route.weight == 0
+                    || !provider.enabled
+                    || provider.weight == 0
+                    || proxy_for_provider(proxy_router, route.provider).is_none()
+                {
+                    return None;
+                }
+
+                Some((
+                    route.provider,
+                    RouteKey {
+                        provider: route.provider,
+                        provider_model_id: route.provider_model_id.to_string(),
+                    },
+                ))
+            })
+            .collect::<Vec<_>>();
+
+        if configured_routes.is_empty() {
+            return Err(ProviderRoutingError::NoEligibleRoute(
+                intent.public_model_id.clone(),
+            ));
+        }
+
+        let route_keys = configured_routes
+            .iter()
+            .map(|(_, route)| route.clone())
+            .collect::<Vec<_>>();
+        let snapshots = self
+            .shadow_health
+            .snapshot_routes(&route_keys)
+            .ok_or_else(|| ProviderRoutingError::CapacityUnavailable {
+                model: intent.public_model_id.clone(),
+                retry_after: MIN_CAPACITY_COOLDOWN,
+            })?;
+
+        let mut available_providers = ConfiguredProviders::none();
+        let mut earliest_recovery = None;
+        for ((provider, _), snapshot) in configured_routes.iter().zip(snapshots) {
+            match snapshot.effective {
+                ShadowDisposition::WouldOpen { remaining } => {
+                    let remaining = ceil_retry_after(remaining);
+                    earliest_recovery = Some(
+                        earliest_recovery
+                            .map_or(remaining, |current: Duration| current.min(remaining)),
+                    );
+                }
+                disposition if route_is_available_for_new_request(disposition) => {
+                    available_providers = available_providers.with_provider(*provider);
+                }
+                _ => unreachable!("WouldOpen is handled above"),
+            }
+        }
+
+        if available_providers == ConfiguredProviders::none() {
+            return Err(ProviderRoutingError::CapacityUnavailable {
+                model: intent.public_model_id.clone(),
+                retry_after: earliest_recovery.unwrap_or(MIN_CAPACITY_COOLDOWN),
+            });
+        }
+
+        let plan = plan_completion_route(
+            self.registry,
+            RoutePlanningInput {
+                intent,
+                configured_providers: available_providers,
+                provider_preference,
+            },
+        )
+        .map_err(provider_routing_error_from_plan)?;
+
+        let selected = plan.selected;
+        let proxy = proxy_for_provider(proxy_router, selected.provider)
+            .ok_or_else(|| ProviderRoutingError::NoEligibleRoute(intent.public_model_id.clone()))?;
+        Ok(SelectedProviderRoute {
+            provider: selected.provider,
+            proxy,
+            public_model_id: selected.public_model_id,
+            provider_model_id: selected.provider_model_id,
+            response_model_id: selected.response_model_id,
+            bucket: selected.bucket,
+            selection_source: selected.selection_source,
+        })
     }
 
     pub(crate) fn continuum_flag_key_for_completion_model(
@@ -422,6 +559,9 @@ pub(crate) fn compare_shadow_route(
         Err(ProviderRoutingError::NoEligibleRoute(_)) => {
             CredentialFreeRouteOutcome::NoEligibleRoute
         }
+        Err(ProviderRoutingError::CapacityUnavailable { .. }) => {
+            CredentialFreeRouteOutcome::NoEligibleRoute
+        }
     };
     let (shadow_outcome, decision, candidate_count) = match shadow {
         Ok(plan) => (
@@ -498,6 +638,27 @@ fn stable_account_bucket(account_uuid: Uuid) -> u8 {
     (u128::from_be_bytes(*account_uuid.as_bytes()) % 100) as u8
 }
 
+fn provider_routing_error_from_plan(error: RoutePlanningError) -> ProviderRoutingError {
+    match error {
+        RoutePlanningError::UnsupportedModel(model) => {
+            ProviderRoutingError::UnsupportedModel(model)
+        }
+        RoutePlanningError::NoEligibleRoute(model) => ProviderRoutingError::NoEligibleRoute(model),
+    }
+}
+
+fn ceil_retry_after(duration: Duration) -> Duration {
+    let seconds = duration
+        .as_secs()
+        .saturating_add(u64::from(duration.subsec_nanos() > 0))
+        .max(1);
+    Duration::from_secs(seconds)
+}
+
+fn route_is_available_for_new_request(disposition: ShadowDisposition) -> bool {
+    !matches!(disposition, ShadowDisposition::WouldOpen { .. })
+}
+
 fn proxy_for_provider(proxy_router: &ProxyRouter, provider: ProviderId) -> Option<ProxyConfig> {
     match provider {
         ProviderId::Tinfoil => Some(proxy_router.get_tinfoil_proxy()),
@@ -535,6 +696,73 @@ mod tests {
 
     fn uuid_for_bucket(bucket: u8) -> Uuid {
         Uuid::from_u128(u128::from(bucket))
+    }
+
+    fn intent(requested_model: &str, public_model: &str) -> InferenceIntent {
+        InferenceIntent::new(
+            uuid_for_bucket(73),
+            requested_model,
+            public_model,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        )
+    }
+
+    fn capacity_terminal(
+        provider: ProviderId,
+        public_model: &str,
+        provider_model: &str,
+        status: u16,
+        retry_after: Duration,
+    ) -> AttemptTerminal {
+        let mut failure = AttemptFailure::new(
+            AttemptFailureKind::CapacityRejected,
+            AttemptStage::AwaitingResponse,
+            ReplaySafety::ProvenPreAcceptance,
+        );
+        failure.status = Some(status);
+        failure.retry_after = Some(retry_after);
+        let route = RouteIdentity::new(
+            provider,
+            public_model,
+            provider_model,
+            public_model,
+            RouteSelectionSource::DefaultProvider,
+            None,
+        );
+        AttemptTerminal::Failed {
+            attempt: intent(public_model, public_model)
+                .begin_execution()
+                .begin_attempt(route),
+            failure,
+        }
+    }
+
+    fn route_failure_terminal(
+        provider: ProviderId,
+        public_model: &str,
+        provider_model: &str,
+    ) -> AttemptTerminal {
+        let failure = AttemptFailure::new(
+            AttemptFailureKind::StreamTimeout,
+            AttemptStage::Stream,
+            ReplaySafety::NotProvenPreAcceptance,
+        );
+        let route = RouteIdentity::new(
+            provider,
+            public_model,
+            provider_model,
+            public_model,
+            RouteSelectionSource::DefaultProvider,
+            None,
+        );
+        AttemptTerminal::Failed {
+            attempt: intent(public_model, public_model)
+                .begin_execution()
+                .begin_attempt(route),
+            failure,
+        }
     }
 
     #[test]
@@ -861,7 +1089,7 @@ mod tests {
     }
 
     #[test]
-    fn hypothetical_open_capacity_never_changes_active_or_shadow_route_selection() {
+    fn legacy_selector_and_baseline_planner_remain_health_independent() {
         let router = ProviderRouter::default();
         let proxy_router = proxy_router_with_both_providers();
         let account_uuid = uuid_for_bucket(73);
@@ -924,6 +1152,273 @@ mod tests {
             compare_shadow_route(&Ok(active_after), &Ok(shadow_after)),
             ShadowRouteComparison::Match { .. }
         ));
+    }
+
+    #[test]
+    fn active_glm_canary_preserves_healthy_preferences_and_canonical_identity() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        let intent = intent(GLM_5_2_MODEL_ID, GLM_5_2_MODEL_ID);
+
+        let cases = [
+            (
+                None,
+                ProviderId::Tinfoil,
+                GLM_5_2_MODEL_ID,
+                RouteSelectionSource::DefaultProvider,
+            ),
+            (
+                Some(ProviderPreference::feature_flag(ProviderId::Tinfoil)),
+                ProviderId::Tinfoil,
+                GLM_5_2_MODEL_ID,
+                RouteSelectionSource::FeatureFlag,
+            ),
+            (
+                Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
+                ProviderId::Continuum,
+                "glm-5.2",
+                RouteSelectionSource::FeatureFlag,
+            ),
+        ];
+
+        for (preference, provider, provider_model, source) in cases {
+            let selected = router
+                .select_active_completion_route(&proxy_router, &intent, preference)
+                .expect("healthy GLM route");
+            assert_eq!(selected.provider, provider);
+            assert_eq!(selected.provider_model_id, provider_model);
+            assert_eq!(selected.public_model_id, GLM_5_2_MODEL_ID);
+            assert_eq!(selected.response_model_id, GLM_5_2_MODEL_ID);
+            assert_eq!(selected.selection_source, source);
+        }
+    }
+
+    #[test]
+    fn active_glm_canary_switches_only_new_requests_to_same_model_alternate() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        let intent = intent(GLM_5_2_MODEL_ID, GLM_5_2_MODEL_ID);
+
+        let pinned_before_failure = router
+            .select_active_completion_route(&proxy_router, &intent, None)
+            .expect("initial Tinfoil route");
+        assert_eq!(pinned_before_failure.provider, ProviderId::Tinfoil);
+
+        router.observe_attempt_terminal(
+            &capacity_terminal(
+                ProviderId::Tinfoil,
+                GLM_5_2_MODEL_ID,
+                GLM_5_2_MODEL_ID,
+                429,
+                Duration::from_secs(60),
+            ),
+            ShadowObservationMode::Update,
+        );
+
+        // The previously returned pin is immutable; only a fresh preparation
+        // observes the newly opened circuit.
+        assert_eq!(pinned_before_failure.provider, ProviderId::Tinfoil);
+        assert_eq!(pinned_before_failure.provider_model_id, GLM_5_2_MODEL_ID);
+
+        let selected_after_failure = router
+            .select_active_completion_route(&proxy_router, &intent, None)
+            .expect("Continuum GLM fallback");
+        assert_eq!(selected_after_failure.provider, ProviderId::Continuum);
+        assert_eq!(selected_after_failure.provider_model_id, "glm-5.2");
+        assert_eq!(selected_after_failure.public_model_id, GLM_5_2_MODEL_ID);
+        assert_eq!(
+            selected_after_failure.selection_source,
+            RouteSelectionSource::Fallback
+        );
+    }
+
+    #[test]
+    fn active_glm_canary_bypasses_an_open_feature_flag_preference() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        let intent = intent(GLM_5_2_MODEL_ID, GLM_5_2_MODEL_ID);
+
+        router.observe_attempt_terminal(
+            &capacity_terminal(
+                ProviderId::Continuum,
+                GLM_5_2_MODEL_ID,
+                "glm-5.2",
+                503,
+                Duration::from_secs(60),
+            ),
+            ShadowObservationMode::Update,
+        );
+
+        let selected = router
+            .select_active_completion_route(
+                &proxy_router,
+                &intent,
+                Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
+            )
+            .expect("Tinfoil GLM fallback");
+        assert_eq!(selected.provider, ProviderId::Tinfoil);
+        assert_eq!(selected.provider_model_id, GLM_5_2_MODEL_ID);
+        assert_eq!(selected.selection_source, RouteSelectionSource::Fallback);
+    }
+
+    #[test]
+    fn active_glm_canary_returns_typed_capacity_when_every_configured_route_is_open() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        let intent = intent(GLM_5_2_MODEL_ID, GLM_5_2_MODEL_ID);
+
+        for terminal in [
+            capacity_terminal(
+                ProviderId::Tinfoil,
+                GLM_5_2_MODEL_ID,
+                GLM_5_2_MODEL_ID,
+                429,
+                Duration::from_secs(40),
+            ),
+            capacity_terminal(
+                ProviderId::Continuum,
+                GLM_5_2_MODEL_ID,
+                "glm-5.2",
+                529,
+                Duration::from_secs(10),
+            ),
+        ] {
+            router.observe_attempt_terminal(&terminal, ShadowObservationMode::Update);
+        }
+
+        let error = router
+            .select_active_completion_route(&proxy_router, &intent, None)
+            .expect_err("both GLM routes are open");
+        match error {
+            ProviderRoutingError::CapacityUnavailable { model, retry_after } => {
+                assert_eq!(model, GLM_5_2_MODEL_ID);
+                assert_eq!(retry_after, Duration::from_secs(30));
+            }
+            other => panic!("unexpected route error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn active_glm_canary_uses_route_failure_threshold_but_not_watch_state() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        let intent = intent(GLM_5_2_MODEL_ID, GLM_5_2_MODEL_ID);
+        let failure =
+            || route_failure_terminal(ProviderId::Tinfoil, GLM_5_2_MODEL_ID, GLM_5_2_MODEL_ID);
+
+        for observed_failures in 1..=3 {
+            router.observe_attempt_terminal(&failure(), ShadowObservationMode::Update);
+            let selected = router
+                .select_active_completion_route(&proxy_router, &intent, None)
+                .expect("GLM route");
+            let expected = if observed_failures < 3 {
+                ProviderId::Tinfoil
+            } else {
+                ProviderId::Continuum
+            };
+            assert_eq!(selected.provider, expected, "failure {observed_failures}");
+        }
+    }
+
+    #[test]
+    fn active_glm_canary_consumes_continuum_account_429_without_changing_kimi_routing() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        router.observe_attempt_terminal(
+            &capacity_terminal(
+                ProviderId::Continuum,
+                POWERFUL_MODEL_ID,
+                "kimi-k2.6",
+                429,
+                Duration::from_secs(60),
+            ),
+            ShadowObservationMode::Update,
+        );
+
+        let glm = router
+            .select_active_completion_route(
+                &proxy_router,
+                &intent(GLM_5_2_MODEL_ID, GLM_5_2_MODEL_ID),
+                Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
+            )
+            .expect("Tinfoil GLM after Continuum account limit");
+        assert_eq!(glm.provider, ProviderId::Tinfoil);
+
+        let kimi = router
+            .select_active_completion_route(
+                &proxy_router,
+                &intent(POWERFUL_MODEL_ID, POWERFUL_MODEL_ID),
+                None,
+            )
+            .expect("Kimi remains on its legacy route in Stack 6");
+        assert_eq!(kimi.provider, ProviderId::Continuum);
+        assert_eq!(kimi.provider_model_id, "kimi-k2.6");
+    }
+
+    #[test]
+    fn active_glm_health_filter_is_inert_for_auto_and_other_models() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        router.observe_attempt_terminal(
+            &capacity_terminal(
+                ProviderId::Tinfoil,
+                GLM_5_2_MODEL_ID,
+                GLM_5_2_MODEL_ID,
+                429,
+                Duration::from_secs(60),
+            ),
+            ShadowObservationMode::Update,
+        );
+
+        let synthetic_auto_glm = intent(AUTO_POWERFUL_MODEL_ID, GLM_5_2_MODEL_ID);
+        let auto_route = router
+            .select_active_completion_route(&proxy_router, &synthetic_auto_glm, None)
+            .expect("Auto stays on legacy selection until Stack 7");
+        assert_eq!(auto_route.provider, ProviderId::Tinfoil);
+
+        for (requested, public, expected_provider) in [
+            (KIMI_K3_MODEL_ID, KIMI_K3_MODEL_ID, ProviderId::Tinfoil),
+            (POWERFUL_MODEL_ID, POWERFUL_MODEL_ID, ProviderId::Continuum),
+            (QUICK_MODEL_ID, QUICK_MODEL_ID, ProviderId::Tinfoil),
+        ] {
+            let selected = router
+                .select_active_completion_route(&proxy_router, &intent(requested, public), None)
+                .expect("non-canary route");
+            assert_eq!(selected.provider, expected_provider, "{requested}");
+        }
+    }
+
+    #[test]
+    fn only_would_open_blocks_a_new_canary_request() {
+        assert!(route_is_available_for_new_request(
+            ShadowDisposition::Healthy
+        ));
+        assert!(route_is_available_for_new_request(
+            ShadowDisposition::Watch {
+                consecutive_failures: 2
+            }
+        ));
+        assert!(route_is_available_for_new_request(
+            ShadowDisposition::WouldProbe
+        ));
+        assert!(!route_is_available_for_new_request(
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(1)
+            }
+        ));
+    }
+
+    #[test]
+    fn retry_after_rounds_up_and_never_returns_zero() {
+        assert_eq!(ceil_retry_after(Duration::ZERO), Duration::from_secs(1));
+        assert_eq!(
+            ceil_retry_after(Duration::from_nanos(1)),
+            Duration::from_secs(1)
+        );
+        assert_eq!(
+            ceil_retry_after(Duration::from_millis(1_001)),
+            Duration::from_secs(2)
+        );
     }
 
     #[test]

--- a/src/provider_routing.rs
+++ b/src/provider_routing.rs
@@ -2,22 +2,26 @@ use crate::inference::health::{
     ShadowDisposition, ShadowHealthState, ShadowObservationMode, ShadowObservationReport,
     ShadowRouteSnapshot, MIN_CAPACITY_COOLDOWN,
 };
-use crate::inference::{
-    AttemptTerminal, InferenceIntent, ModelSelectionMode, RouteIdentity, RouteKey,
-};
+use crate::inference::{AttemptTerminal, InferenceIntent, RouteIdentity, RouteKey};
 use crate::inference_planning::{
-    plan_completion_route, ConfiguredProviders, ProviderPreference, RoutePlan, RoutePlanningError,
-    RoutePlanningInput,
+    plan_completion_model_candidates, plan_completion_route, ConfiguredProviders,
+    ProviderPreference, RoutePlan, RoutePlanningError, RoutePlanningInput,
 };
-use crate::model_config::{resolve_completion_model_id, resolve_public_model_id, GLM_5_2_MODEL_ID};
+#[cfg(test)]
+use crate::model_config::resolve_completion_model_id;
+use crate::model_config::{resolve_public_model_id, GLM_5_2_MODEL_ID};
 use crate::os_flags::GLM_5_2_CONTINUUM_FLAG_KEY;
 use crate::provider_registry::{
     ProviderId, ProviderRegistry, RouteSelectionSource, PROVIDER_REGISTRY,
 };
-use crate::proxy_config::{canonicalize_tinfoil_model, ProxyConfig, ProxyRouter};
+#[cfg(test)]
+use crate::proxy_config::canonicalize_tinfoil_model;
+use crate::proxy_config::{ProxyConfig, ProxyRouter};
 use std::time::Duration;
+#[cfg(test)]
 use uuid::Uuid;
 
+#[cfg(test)]
 #[derive(Debug, Clone, Copy)]
 struct ProviderConfig {
     provider: ProviderId,
@@ -25,6 +29,7 @@ struct ProviderConfig {
     enabled: bool,
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, Copy)]
 struct ModelProviderRoute {
     provider: ProviderId,
@@ -33,14 +38,15 @@ struct ModelProviderRoute {
     enabled: bool,
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, Copy)]
 struct ModelRoutingConfig {
     public_model_id: &'static str,
     routes: &'static [ModelProviderRoute],
-    continuum_flag_key: Option<&'static str>,
     default_provider: Option<ProviderId>,
 }
 
+#[cfg(test)]
 #[derive(Debug)]
 struct ProviderRoutingConfig {
     providers: &'static [ProviderConfig],
@@ -56,6 +62,14 @@ pub(crate) struct SelectedProviderRoute {
     pub(crate) response_model_id: String,
     pub(crate) bucket: Option<u8>,
     pub(crate) selection_source: RouteSelectionSource,
+    pub(crate) model_selection_source: ModelSelectionSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ModelSelectionSource {
+    Explicit,
+    AutoPrimary,
+    AutoFallback,
 }
 
 impl SelectedProviderRoute {
@@ -105,11 +119,13 @@ pub(crate) enum ShadowRouteComparison {
 
 #[derive(Debug)]
 pub(crate) struct ProviderRouter {
+    #[cfg(test)]
     config: &'static ProviderRoutingConfig,
     registry: &'static ProviderRegistry,
     shadow_health: ShadowHealthState,
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone)]
 struct EligibleRoute {
     provider: ProviderId,
@@ -118,6 +134,7 @@ struct EligibleRoute {
     effective_weight: u32,
 }
 
+#[cfg(test)]
 const PROVIDERS: &[ProviderConfig] = &[
     ProviderConfig {
         provider: ProviderId::Tinfoil,
@@ -131,6 +148,7 @@ const PROVIDERS: &[ProviderConfig] = &[
     },
 ];
 
+#[cfg(test)]
 const KIMI_K2_6_ROUTES: &[ModelProviderRoute] = &[ModelProviderRoute {
     provider: ProviderId::Continuum,
     provider_model_id: "kimi-k2.6",
@@ -138,6 +156,7 @@ const KIMI_K2_6_ROUTES: &[ModelProviderRoute] = &[ModelProviderRoute {
     enabled: true,
 }];
 
+#[cfg(test)]
 const GLM_5_2_ROUTES: &[ModelProviderRoute] = &[
     ModelProviderRoute {
         provider: ProviderId::Tinfoil,
@@ -153,21 +172,21 @@ const GLM_5_2_ROUTES: &[ModelProviderRoute] = &[
     },
 ];
 
+#[cfg(test)]
 const MODEL_ROUTES: &[ModelRoutingConfig] = &[
     ModelRoutingConfig {
         public_model_id: "kimi-k2-6",
         routes: KIMI_K2_6_ROUTES,
-        continuum_flag_key: None,
         default_provider: Some(ProviderId::Continuum),
     },
     ModelRoutingConfig {
         public_model_id: GLM_5_2_MODEL_ID,
         routes: GLM_5_2_ROUTES,
-        continuum_flag_key: Some(GLM_5_2_CONTINUUM_FLAG_KEY),
         default_provider: Some(ProviderId::Tinfoil),
     },
 ];
 
+#[cfg(test)]
 static DEFAULT_PROVIDER_ROUTING_CONFIG: ProviderRoutingConfig = ProviderRoutingConfig {
     providers: PROVIDERS,
     models: MODEL_ROUTES,
@@ -176,6 +195,7 @@ static DEFAULT_PROVIDER_ROUTING_CONFIG: ProviderRoutingConfig = ProviderRoutingC
 impl Default for ProviderRouter {
     fn default() -> Self {
         Self {
+            #[cfg(test)]
             config: &DEFAULT_PROVIDER_ROUTING_CONFIG,
             registry: &PROVIDER_REGISTRY,
             shadow_health: ShadowHealthState::new(&PROVIDER_REGISTRY),
@@ -216,6 +236,7 @@ impl ProviderRouter {
         )
     }
 
+    #[cfg(test)]
     pub(crate) fn select_completion_route_with_preference(
         &self,
         proxy_router: &ProxyRouter,
@@ -239,25 +260,26 @@ impl ProviderRouter {
 
     /// Selects the route used by a newly prepared logical request.
     ///
-    /// Stack 6 activates health filtering only for explicit GLM 5.2 requests.
-    /// Auto aliases and every other public model deliberately retain the legacy
-    /// route decision until their own rollout stack.
+    /// Stack 6 activated the first explicit GLM canary. Stack 7 applies the
+    /// same future-request-only circuit filtering to every completion model and
+    /// composes it with the narrow Auto Powerful K3/K2.6 candidate policy.
+    /// Explicit requests and Auto Quick still contain exactly one public model.
     pub(crate) fn select_active_completion_route(
         &self,
         proxy_router: &ProxyRouter,
         intent: &InferenceIntent,
         provider_preference: Option<ProviderPreference>,
     ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
-        if intent.selection_mode == ModelSelectionMode::Explicit
-            && intent.public_model_id == GLM_5_2_MODEL_ID
-        {
-            return self.select_glm_canary_route(proxy_router, intent, provider_preference);
-        }
-
-        self.select_completion_route_with_preference(
+        let model_plan = plan_completion_model_candidates(intent);
+        let candidates = model_plan
+            .public_model_ids
+            .iter()
+            .map(|public_model_id| intent.for_candidate_public_model(public_model_id.clone()))
+            .collect::<Vec<_>>();
+        self.select_health_aware_model_candidates(
             proxy_router,
-            intent.account_uuid,
-            &intent.public_model_id,
+            intent,
+            &candidates,
             provider_preference,
         )
     }
@@ -289,107 +311,140 @@ impl ProviderRouter {
         )
     }
 
-    fn select_glm_canary_route(
+    fn select_health_aware_model_candidates(
         &self,
         proxy_router: &ProxyRouter,
-        intent: &InferenceIntent,
+        preferred_intent: &InferenceIntent,
+        candidates: &[InferenceIntent],
         provider_preference: Option<ProviderPreference>,
     ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
-        let model = self
-            .registry
-            .completion_model(&intent.public_model_id)
-            .ok_or_else(|| {
-                ProviderRoutingError::UnsupportedModel(intent.public_model_id.clone())
-            })?;
+        if candidates.is_empty() {
+            return Err(ProviderRoutingError::NoEligibleRoute(
+                preferred_intent.public_model_id.clone(),
+            ));
+        }
 
-        let configured_routes = model
-            .routes
-            .iter()
-            .filter_map(|route| {
-                let provider = self.registry.provider(route.provider)?;
+        let mut configured_routes = Vec::new();
+        for (candidate_index, candidate) in candidates.iter().enumerate() {
+            let model = self
+                .registry
+                .completion_model(&candidate.public_model_id)
+                .ok_or_else(|| {
+                    ProviderRoutingError::UnsupportedModel(candidate.public_model_id.clone())
+                })?;
+            for route in model.routes {
+                let Some(provider) = self.registry.provider(route.provider) else {
+                    continue;
+                };
                 if !route.enabled
                     || route.weight == 0
                     || !provider.enabled
                     || provider.weight == 0
                     || proxy_for_provider(proxy_router, route.provider).is_none()
                 {
-                    return None;
+                    continue;
                 }
-
-                Some((
+                configured_routes.push((
+                    candidate_index,
                     route.provider,
                     RouteKey {
                         provider: route.provider,
                         provider_model_id: route.provider_model_id.to_string(),
                     },
-                ))
-            })
-            .collect::<Vec<_>>();
+                ));
+            }
+        }
 
         if configured_routes.is_empty() {
             return Err(ProviderRoutingError::NoEligibleRoute(
-                intent.public_model_id.clone(),
+                preferred_intent.public_model_id.clone(),
             ));
         }
 
         let route_keys = configured_routes
             .iter()
-            .map(|(_, route)| route.clone())
+            .map(|(_, _, route)| route.clone())
             .collect::<Vec<_>>();
         let snapshots = self
             .shadow_health
             .snapshot_routes(&route_keys)
             .ok_or_else(|| ProviderRoutingError::CapacityUnavailable {
-                model: intent.public_model_id.clone(),
+                model: preferred_intent.public_model_id.clone(),
                 retry_after: MIN_CAPACITY_COOLDOWN,
             })?;
 
-        let mut available_providers = ConfiguredProviders::none();
-        let mut earliest_recovery = None;
-        for ((provider, _), snapshot) in configured_routes.iter().zip(snapshots) {
+        let mut available_providers = vec![ConfiguredProviders::none(); candidates.len()];
+        let mut earliest_recovery = vec![None; candidates.len()];
+        for ((candidate_index, provider, _), snapshot) in configured_routes.iter().zip(snapshots) {
             match snapshot.effective {
                 ShadowDisposition::WouldOpen { remaining } => {
                     let remaining = ceil_retry_after(remaining);
-                    earliest_recovery = Some(
-                        earliest_recovery
+                    earliest_recovery[*candidate_index] = Some(
+                        earliest_recovery[*candidate_index]
                             .map_or(remaining, |current: Duration| current.min(remaining)),
                     );
                 }
                 disposition if route_is_available_for_new_request(disposition) => {
-                    available_providers = available_providers.with_provider(*provider);
+                    available_providers[*candidate_index] =
+                        available_providers[*candidate_index].with_provider(*provider);
                 }
                 _ => unreachable!("WouldOpen is handled above"),
             }
         }
 
-        if available_providers == ConfiguredProviders::none() {
-            return Err(ProviderRoutingError::CapacityUnavailable {
-                model: intent.public_model_id.clone(),
-                retry_after: earliest_recovery.unwrap_or(MIN_CAPACITY_COOLDOWN),
+        for (candidate_index, candidate) in candidates.iter().enumerate() {
+            let configured = available_providers[candidate_index];
+            if configured == ConfiguredProviders::none() {
+                continue;
+            }
+
+            let candidate_preference = (candidate_index == 0)
+                .then_some(provider_preference)
+                .flatten();
+            let plan = plan_completion_route(
+                self.registry,
+                RoutePlanningInput {
+                    intent: candidate,
+                    configured_providers: configured,
+                    provider_preference: candidate_preference,
+                },
+            )
+            .map_err(provider_routing_error_from_plan)?;
+
+            let selected = plan.selected;
+            let proxy = proxy_for_provider(proxy_router, selected.provider).ok_or_else(|| {
+                ProviderRoutingError::NoEligibleRoute(candidate.public_model_id.clone())
+            })?;
+            return Ok(SelectedProviderRoute {
+                provider: selected.provider,
+                proxy,
+                public_model_id: selected.public_model_id,
+                provider_model_id: selected.provider_model_id,
+                response_model_id: selected.response_model_id,
+                bucket: selected.bucket,
+                // Provider-route provenance remains independent from model
+                // substitution provenance. AutoFallback below is the only
+                // signal that a different public model was selected.
+                selection_source: selected.selection_source,
+                model_selection_source: match (
+                    preferred_intent.selection_mode.is_auto(),
+                    candidate_index,
+                ) {
+                    (false, _) => ModelSelectionSource::Explicit,
+                    (true, 0) => ModelSelectionSource::AutoPrimary,
+                    (true, _) => ModelSelectionSource::AutoFallback,
+                },
             });
         }
 
-        let plan = plan_completion_route(
-            self.registry,
-            RoutePlanningInput {
-                intent,
-                configured_providers: available_providers,
-                provider_preference,
-            },
-        )
-        .map_err(provider_routing_error_from_plan)?;
-
-        let selected = plan.selected;
-        let proxy = proxy_for_provider(proxy_router, selected.provider)
-            .ok_or_else(|| ProviderRoutingError::NoEligibleRoute(intent.public_model_id.clone()))?;
-        Ok(SelectedProviderRoute {
-            provider: selected.provider,
-            proxy,
-            public_model_id: selected.public_model_id,
-            provider_model_id: selected.provider_model_id,
-            response_model_id: selected.response_model_id,
-            bucket: selected.bucket,
-            selection_source: selected.selection_source,
+        let retry_after = earliest_recovery
+            .into_iter()
+            .flatten()
+            .min()
+            .unwrap_or(MIN_CAPACITY_COOLDOWN);
+        Err(ProviderRoutingError::CapacityUnavailable {
+            model: preferred_intent.public_model_id.clone(),
+            retry_after,
         })
     }
 
@@ -398,9 +453,10 @@ impl ProviderRouter {
         requested_model: &str,
     ) -> Option<&'static str> {
         let public_model_id = resolve_public_model_id(requested_model)?;
-        self.model_config(public_model_id)?.continuum_flag_key
+        (public_model_id == GLM_5_2_MODEL_ID).then_some(GLM_5_2_CONTINUUM_FLAG_KEY)
     }
 
+    #[cfg(test)]
     fn select_configured_route(
         &self,
         proxy_router: &ProxyRouter,
@@ -492,9 +548,11 @@ impl ProviderRouter {
             response_model_id: model_config.public_model_id.to_string(),
             bucket,
             selection_source,
+            model_selection_source: ModelSelectionSource::Explicit,
         })
     }
 
+    #[cfg(test)]
     fn fallback_completion_route(
         &self,
         proxy_router: &ProxyRouter,
@@ -529,9 +587,11 @@ impl ProviderRouter {
             response_model_id,
             bucket: None,
             selection_source: RouteSelectionSource::StaticSplit,
+            model_selection_source: ModelSelectionSource::Explicit,
         })
     }
 
+    #[cfg(test)]
     fn provider_config(&self, provider: ProviderId) -> Option<&ProviderConfig> {
         self.config
             .providers
@@ -539,6 +599,7 @@ impl ProviderRouter {
             .find(|config| config.provider == provider)
     }
 
+    #[cfg(test)]
     fn model_config(&self, public_model_id: &str) -> Option<&ModelRoutingConfig> {
         self.config
             .models
@@ -593,12 +654,14 @@ pub(crate) fn compare_shadow_route(
     }
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone)]
 struct WeightedSelection<'a> {
     route: &'a EligibleRoute,
     bucket: u8,
 }
 
+#[cfg(test)]
 fn select_weighted_route<'a>(
     account_uuid: Uuid,
     routes: &'a [EligibleRoute],
@@ -634,6 +697,7 @@ fn select_weighted_route<'a>(
     None
 }
 
+#[cfg(test)]
 fn stable_account_bucket(account_uuid: Uuid) -> u8 {
     (u128::from_be_bytes(*account_uuid.as_bytes()) % 100) as u8
 }
@@ -1321,7 +1385,7 @@ mod tests {
     }
 
     #[test]
-    fn active_glm_canary_consumes_continuum_account_429_without_changing_kimi_routing() {
+    fn continuum_account_429_blocks_explicit_kimi_and_auto_falls_back_to_k3() {
         let router = ProviderRouter::default();
         let proxy_router = proxy_router_with_both_providers();
         router.observe_attempt_terminal(
@@ -1344,47 +1408,200 @@ mod tests {
             .expect("Tinfoil GLM after Continuum account limit");
         assert_eq!(glm.provider, ProviderId::Tinfoil);
 
-        let kimi = router
+        let explicit_kimi_error = router
             .select_active_completion_route(
                 &proxy_router,
                 &intent(POWERFUL_MODEL_ID, POWERFUL_MODEL_ID),
                 None,
             )
-            .expect("Kimi remains on its legacy route in Stack 6");
-        assert_eq!(kimi.provider, ProviderId::Continuum);
-        assert_eq!(kimi.provider_model_id, "kimi-k2.6");
+            .expect_err("explicit Kimi never changes public model");
+        assert!(matches!(
+            explicit_kimi_error,
+            ProviderRoutingError::CapacityUnavailable { model, .. }
+                if model == POWERFUL_MODEL_ID
+        ));
+
+        let auto_kimi = router
+            .select_active_completion_route(
+                &proxy_router,
+                &intent(AUTO_POWERFUL_MODEL_ID, POWERFUL_MODEL_ID),
+                None,
+            )
+            .expect("Auto Powerful may use the compatible K3 model");
+        assert_eq!(auto_kimi.provider, ProviderId::Tinfoil);
+        assert_eq!(auto_kimi.public_model_id, KIMI_K3_MODEL_ID);
+        assert_eq!(auto_kimi.provider_model_id, KIMI_K3_MODEL_ID);
+        assert_eq!(
+            auto_kimi.model_selection_source,
+            ModelSelectionSource::AutoFallback
+        );
     }
 
     #[test]
-    fn active_glm_health_filter_is_inert_for_auto_and_other_models() {
+    fn singleton_model_plans_circuit_break_without_crossing_public_identity() {
         let router = ProviderRouter::default();
         let proxy_router = proxy_router_with_both_providers();
         router.observe_attempt_terminal(
             &capacity_terminal(
                 ProviderId::Tinfoil,
-                GLM_5_2_MODEL_ID,
-                GLM_5_2_MODEL_ID,
+                KIMI_K3_MODEL_ID,
+                KIMI_K3_MODEL_ID,
                 429,
                 Duration::from_secs(60),
             ),
             ShadowObservationMode::Update,
         );
 
-        let synthetic_auto_glm = intent(AUTO_POWERFUL_MODEL_ID, GLM_5_2_MODEL_ID);
-        let auto_route = router
-            .select_active_completion_route(&proxy_router, &synthetic_auto_glm, None)
-            .expect("Auto stays on legacy selection until Stack 7");
-        assert_eq!(auto_route.provider, ProviderId::Tinfoil);
+        let explicit_error = router
+            .select_active_completion_route(
+                &proxy_router,
+                &intent(KIMI_K3_MODEL_ID, KIMI_K3_MODEL_ID),
+                None,
+            )
+            .expect_err("explicit K3 circuit is open");
+        assert!(matches!(
+            explicit_error,
+            ProviderRoutingError::CapacityUnavailable { model, .. }
+                if model == KIMI_K3_MODEL_ID
+        ));
 
-        for (requested, public, expected_provider) in [
-            (KIMI_K3_MODEL_ID, KIMI_K3_MODEL_ID, ProviderId::Tinfoil),
-            (POWERFUL_MODEL_ID, POWERFUL_MODEL_ID, ProviderId::Continuum),
-            (QUICK_MODEL_ID, QUICK_MODEL_ID, ProviderId::Tinfoil),
+        // A healthy compatible model cannot broaden an explicit request.
+        let explicit_k2 = router
+            .select_active_completion_route(
+                &proxy_router,
+                &intent(POWERFUL_MODEL_ID, POWERFUL_MODEL_ID),
+                None,
+            )
+            .expect("explicit K2.6 remains K2.6");
+        assert_eq!(explicit_k2.public_model_id, POWERFUL_MODEL_ID);
+        assert_eq!(
+            explicit_k2.model_selection_source,
+            ModelSelectionSource::Explicit
+        );
+
+        // Auto Quick is also a singleton model plan in Stack 7.
+        router.observe_attempt_terminal(
+            &capacity_terminal(
+                ProviderId::Tinfoil,
+                QUICK_MODEL_ID,
+                QUICK_MODEL_ID,
+                429,
+                Duration::from_secs(60),
+            ),
+            ShadowObservationMode::Update,
+        );
+        let auto_quick_error = router
+            .select_active_completion_route(
+                &proxy_router,
+                &intent(AUTO_QUICK_MODEL_ID, QUICK_MODEL_ID),
+                None,
+            )
+            .expect_err("Auto Quick has no alternate public model");
+        assert!(matches!(
+            auto_quick_error,
+            ProviderRoutingError::CapacityUnavailable { model, .. }
+                if model == QUICK_MODEL_ID
+        ));
+    }
+
+    #[test]
+    fn auto_powerful_falls_back_in_both_flag_selected_directions() {
+        let proxy_router = proxy_router_with_both_providers();
+
+        let k3_preferred = ProviderRouter::default();
+        k3_preferred.observe_attempt_terminal(
+            &capacity_terminal(
+                ProviderId::Tinfoil,
+                KIMI_K3_MODEL_ID,
+                KIMI_K3_MODEL_ID,
+                429,
+                Duration::from_secs(60),
+            ),
+            ShadowObservationMode::Update,
+        );
+        let selected = k3_preferred
+            .select_active_completion_route(
+                &proxy_router,
+                &intent(AUTO_POWERFUL_MODEL_ID, KIMI_K3_MODEL_ID),
+                None,
+            )
+            .expect("flag-on Auto Powerful falls back to K2.6");
+        assert_eq!(selected.public_model_id, POWERFUL_MODEL_ID);
+        assert_eq!(selected.provider, ProviderId::Continuum);
+        assert_eq!(selected.provider_model_id, "kimi-k2.6");
+        assert_eq!(
+            selected.selection_source,
+            RouteSelectionSource::DefaultProvider
+        );
+        assert_eq!(
+            selected.model_selection_source,
+            ModelSelectionSource::AutoFallback
+        );
+
+        let k2_preferred = ProviderRouter::default();
+        k2_preferred.observe_attempt_terminal(
+            &capacity_terminal(
+                ProviderId::Continuum,
+                POWERFUL_MODEL_ID,
+                "kimi-k2.6",
+                429,
+                Duration::from_secs(60),
+            ),
+            ShadowObservationMode::Update,
+        );
+        let selected = k2_preferred
+            .select_active_completion_route(
+                &proxy_router,
+                &intent(AUTO_POWERFUL_MODEL_ID, POWERFUL_MODEL_ID),
+                None,
+            )
+            .expect("flag-off Auto Powerful falls back to K3");
+        assert_eq!(selected.public_model_id, KIMI_K3_MODEL_ID);
+        assert_eq!(selected.provider, ProviderId::Tinfoil);
+        assert_eq!(selected.provider_model_id, KIMI_K3_MODEL_ID);
+        assert_eq!(selected.selection_source, RouteSelectionSource::StaticSplit);
+        assert_eq!(
+            selected.model_selection_source,
+            ModelSelectionSource::AutoFallback
+        );
+    }
+
+    #[test]
+    fn auto_powerful_returns_earliest_capacity_when_both_kimi_candidates_are_open() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        for terminal in [
+            capacity_terminal(
+                ProviderId::Tinfoil,
+                KIMI_K3_MODEL_ID,
+                KIMI_K3_MODEL_ID,
+                429,
+                Duration::from_secs(50),
+            ),
+            capacity_terminal(
+                ProviderId::Continuum,
+                POWERFUL_MODEL_ID,
+                "kimi-k2.6",
+                429,
+                Duration::from_secs(10),
+            ),
         ] {
-            let selected = router
-                .select_active_completion_route(&proxy_router, &intent(requested, public), None)
-                .expect("non-canary route");
-            assert_eq!(selected.provider, expected_provider, "{requested}");
+            router.observe_attempt_terminal(&terminal, ShadowObservationMode::Update);
+        }
+
+        let error = router
+            .select_active_completion_route(
+                &proxy_router,
+                &intent(AUTO_POWERFUL_MODEL_ID, KIMI_K3_MODEL_ID),
+                None,
+            )
+            .expect_err("both compatible Auto Powerful models are open");
+        match error {
+            ProviderRoutingError::CapacityUnavailable { model, retry_after } => {
+                assert_eq!(model, KIMI_K3_MODEL_ID);
+                assert_eq!(retry_after, Duration::from_secs(30));
+            }
+            other => panic!("unexpected route error: {other:?}"),
         }
     }
 

--- a/src/provider_routing.rs
+++ b/src/provider_routing.rs
@@ -1,64 +1,26 @@
-use crate::inference::RouteIdentity;
+use crate::inference::{InferenceIntent, RouteIdentity};
+use crate::inference_planning::{
+    plan_completion_route, ConfiguredProviders, ProviderPreference, RoutePlan, RoutePlanningError,
+    RoutePlanningInput,
+};
 use crate::model_config::{resolve_completion_model_id, resolve_public_model_id, GLM_5_2_MODEL_ID};
 use crate::os_flags::GLM_5_2_CONTINUUM_FLAG_KEY;
+use crate::provider_registry::{
+    ProviderId, ProviderRegistry, RouteSelectionSource, PROVIDER_REGISTRY,
+};
 use crate::proxy_config::{canonicalize_tinfoil_model, ProxyConfig, ProxyRouter};
 use uuid::Uuid;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) enum ProviderName {
-    Tinfoil,
-    Continuum,
-}
-
-impl ProviderName {
-    pub(crate) const fn as_str(self) -> &'static str {
-        match self {
-            Self::Tinfoil => "tinfoil",
-            Self::Continuum => "continuum",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ProviderSelectionSource {
-    StaticSplit,
-    FeatureFlag,
-    DefaultProvider,
-    Fallback,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct ProviderPreference {
-    provider: ProviderName,
-    source: ProviderSelectionSource,
-}
-
-impl ProviderPreference {
-    pub(crate) const fn feature_flag(provider: ProviderName) -> Self {
-        Self {
-            provider,
-            source: ProviderSelectionSource::FeatureFlag,
-        }
-    }
-
-    const fn default_provider(provider: ProviderName) -> Self {
-        Self {
-            provider,
-            source: ProviderSelectionSource::DefaultProvider,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy)]
 struct ProviderConfig {
-    provider: ProviderName,
+    provider: ProviderId,
     weight: u16,
     enabled: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
 struct ModelProviderRoute {
-    provider: ProviderName,
+    provider: ProviderId,
     provider_model_id: &'static str,
     weight: u16,
     enabled: bool,
@@ -69,7 +31,7 @@ struct ModelRoutingConfig {
     public_model_id: &'static str,
     routes: &'static [ModelProviderRoute],
     continuum_flag_key: Option<&'static str>,
-    default_provider: Option<ProviderName>,
+    default_provider: Option<ProviderId>,
 }
 
 #[derive(Debug)]
@@ -80,13 +42,13 @@ struct ProviderRoutingConfig {
 
 #[derive(Debug, Clone)]
 pub(crate) struct SelectedProviderRoute {
-    pub(crate) provider: ProviderName,
+    pub(crate) provider: ProviderId,
     pub(crate) proxy: ProxyConfig,
     pub(crate) public_model_id: String,
     pub(crate) provider_model_id: String,
     pub(crate) response_model_id: String,
     pub(crate) bucket: Option<u8>,
-    pub(crate) selection_source: ProviderSelectionSource,
+    pub(crate) selection_source: RouteSelectionSource,
 }
 
 impl SelectedProviderRoute {
@@ -108,14 +70,37 @@ pub(crate) enum ProviderRoutingError {
     NoEligibleRoute(String),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CredentialFreeRouteOutcome {
+    Selected(RouteIdentity),
+    UnsupportedModel,
+    NoEligibleRoute,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ShadowRouteComparison {
+    Match {
+        outcome: CredentialFreeRouteOutcome,
+        decision: Option<crate::inference_planning::PlanDecision>,
+        candidate_count: usize,
+    },
+    Mismatch {
+        active: CredentialFreeRouteOutcome,
+        shadow: CredentialFreeRouteOutcome,
+        decision: Option<crate::inference_planning::PlanDecision>,
+        candidate_count: usize,
+    },
+}
+
 #[derive(Debug)]
 pub(crate) struct ProviderRouter {
     config: &'static ProviderRoutingConfig,
+    registry: &'static ProviderRegistry,
 }
 
 #[derive(Debug, Clone)]
 struct EligibleRoute {
-    provider: ProviderName,
+    provider: ProviderId,
     proxy: ProxyConfig,
     provider_model_id: &'static str,
     effective_weight: u32,
@@ -123,19 +108,19 @@ struct EligibleRoute {
 
 const PROVIDERS: &[ProviderConfig] = &[
     ProviderConfig {
-        provider: ProviderName::Tinfoil,
+        provider: ProviderId::Tinfoil,
         weight: 70,
         enabled: true,
     },
     ProviderConfig {
-        provider: ProviderName::Continuum,
+        provider: ProviderId::Continuum,
         weight: 30,
         enabled: true,
     },
 ];
 
 const KIMI_K2_6_ROUTES: &[ModelProviderRoute] = &[ModelProviderRoute {
-    provider: ProviderName::Continuum,
+    provider: ProviderId::Continuum,
     provider_model_id: "kimi-k2.6",
     weight: 100,
     enabled: true,
@@ -143,13 +128,13 @@ const KIMI_K2_6_ROUTES: &[ModelProviderRoute] = &[ModelProviderRoute {
 
 const GLM_5_2_ROUTES: &[ModelProviderRoute] = &[
     ModelProviderRoute {
-        provider: ProviderName::Tinfoil,
+        provider: ProviderId::Tinfoil,
         provider_model_id: GLM_5_2_MODEL_ID,
         weight: 100,
         enabled: true,
     },
     ModelProviderRoute {
-        provider: ProviderName::Continuum,
+        provider: ProviderId::Continuum,
         provider_model_id: "glm-5.2",
         weight: 100,
         enabled: true,
@@ -161,13 +146,13 @@ const MODEL_ROUTES: &[ModelRoutingConfig] = &[
         public_model_id: "kimi-k2-6",
         routes: KIMI_K2_6_ROUTES,
         continuum_flag_key: None,
-        default_provider: Some(ProviderName::Continuum),
+        default_provider: Some(ProviderId::Continuum),
     },
     ModelRoutingConfig {
         public_model_id: GLM_5_2_MODEL_ID,
         routes: GLM_5_2_ROUTES,
         continuum_flag_key: Some(GLM_5_2_CONTINUUM_FLAG_KEY),
-        default_provider: Some(ProviderName::Tinfoil),
+        default_provider: Some(ProviderId::Tinfoil),
     },
 ];
 
@@ -180,6 +165,7 @@ impl Default for ProviderRouter {
     fn default() -> Self {
         Self {
             config: &DEFAULT_PROVIDER_ROUTING_CONFIG,
+            registry: &PROVIDER_REGISTRY,
         }
     }
 }
@@ -219,6 +205,33 @@ impl ProviderRouter {
         }
 
         self.fallback_completion_route(proxy_router, requested_model)
+    }
+
+    pub(crate) fn shadow_completion_plan(
+        &self,
+        proxy_router: &ProxyRouter,
+        intent: &InferenceIntent,
+        provider_preference: Option<ProviderPreference>,
+    ) -> Result<RoutePlan, RoutePlanningError> {
+        let configured_providers = self.registry.providers().iter().fold(
+            ConfiguredProviders::none(),
+            |configured, provider| {
+                if proxy_for_provider(proxy_router, provider.id).is_some() {
+                    configured.with_provider(provider.id)
+                } else {
+                    configured
+                }
+            },
+        );
+
+        plan_completion_route(
+            self.registry,
+            RoutePlanningInput {
+                intent,
+                configured_providers,
+                provider_preference,
+            },
+        )
     }
 
     pub(crate) fn continuum_flag_key_for_completion_model(
@@ -275,18 +288,18 @@ impl ProviderRouter {
         let provider_preference_route = provider_preference.and_then(|preference| {
             eligible_routes
                 .iter()
-                .find(|route| route.provider == preference.provider)
-                .map(|route| (route, preference.source))
+                .find(|route| route.provider == preference.provider())
+                .map(|route| (route, preference.source()))
         });
         let default_preference_route = default_preference.and_then(|preference| {
             eligible_routes
                 .iter()
-                .find(|route| route.provider == preference.provider)
+                .find(|route| route.provider == preference.provider())
                 .map(|route| {
                     let source = if provider_preference.is_some() {
-                        ProviderSelectionSource::Fallback
+                        RouteSelectionSource::Fallback
                     } else {
-                        preference.source
+                        preference.source()
                     };
                     (route, source)
                 })
@@ -305,9 +318,9 @@ impl ProviderRouter {
                 selected.route,
                 Some(selected.bucket),
                 if provider_preference.is_some() || default_preference.is_some() {
-                    ProviderSelectionSource::Fallback
+                    RouteSelectionSource::Fallback
                 } else {
-                    ProviderSelectionSource::StaticSplit
+                    RouteSelectionSource::StaticSplit
                 },
             )
         };
@@ -331,7 +344,7 @@ impl ProviderRouter {
         let proxy = proxy_router.get_completion_proxy();
         let resolved_public_model_id =
             resolve_public_model_id(requested_model).map(ToOwned::to_owned);
-        let provider_model_id = if proxy.provider_name == ProviderName::Tinfoil.as_str() {
+        let provider_model_id = if proxy.provider_name == ProviderId::Tinfoil.as_str() {
             resolve_completion_model_id(requested_model)
                 .ok_or_else(|| ProviderRoutingError::UnsupportedModel(requested_model.into()))?
                 .to_string()
@@ -343,24 +356,24 @@ impl ProviderRouter {
 
         let public_model_id = resolved_public_model_id.unwrap_or_else(|| provider_model_id.clone());
 
-        let response_model_id = if proxy.provider_name == ProviderName::Tinfoil.as_str() {
+        let response_model_id = if proxy.provider_name == ProviderId::Tinfoil.as_str() {
             canonicalize_tinfoil_model(&provider_model_id)
         } else {
             public_model_id.clone()
         };
 
         Ok(SelectedProviderRoute {
-            provider: ProviderName::Tinfoil,
+            provider: ProviderId::Tinfoil,
             proxy,
             public_model_id,
             provider_model_id,
             response_model_id,
             bucket: None,
-            selection_source: ProviderSelectionSource::StaticSplit,
+            selection_source: RouteSelectionSource::StaticSplit,
         })
     }
 
-    fn provider_config(&self, provider: ProviderName) -> Option<&ProviderConfig> {
+    fn provider_config(&self, provider: ProviderId) -> Option<&ProviderConfig> {
         self.config
             .providers
             .iter()
@@ -372,6 +385,49 @@ impl ProviderRouter {
             .models
             .iter()
             .find(|config| config.public_model_id == public_model_id)
+    }
+}
+
+pub(crate) fn compare_shadow_route(
+    active: &Result<SelectedProviderRoute, ProviderRoutingError>,
+    shadow: &Result<RoutePlan, RoutePlanningError>,
+) -> ShadowRouteComparison {
+    let active_outcome = match active {
+        Ok(route) => CredentialFreeRouteOutcome::Selected(route.identity()),
+        Err(ProviderRoutingError::UnsupportedModel(_)) => {
+            CredentialFreeRouteOutcome::UnsupportedModel
+        }
+        Err(ProviderRoutingError::NoEligibleRoute(_)) => {
+            CredentialFreeRouteOutcome::NoEligibleRoute
+        }
+    };
+    let (shadow_outcome, decision, candidate_count) = match shadow {
+        Ok(plan) => (
+            CredentialFreeRouteOutcome::Selected(plan.selected.clone()),
+            Some(plan.decision),
+            plan.eligible_routes.len(),
+        ),
+        Err(RoutePlanningError::UnsupportedModel(_)) => {
+            (CredentialFreeRouteOutcome::UnsupportedModel, None, 0)
+        }
+        Err(RoutePlanningError::NoEligibleRoute(_)) => {
+            (CredentialFreeRouteOutcome::NoEligibleRoute, None, 0)
+        }
+    };
+
+    if active_outcome == shadow_outcome {
+        ShadowRouteComparison::Match {
+            outcome: active_outcome,
+            decision,
+            candidate_count,
+        }
+    } else {
+        ShadowRouteComparison::Mismatch {
+            active: active_outcome,
+            shadow: shadow_outcome,
+            decision,
+            candidate_count,
+        }
     }
 }
 
@@ -420,12 +476,12 @@ fn stable_account_bucket(account_uuid: Uuid) -> u8 {
     (u128::from_be_bytes(*account_uuid.as_bytes()) % 100) as u8
 }
 
-fn proxy_for_provider(proxy_router: &ProxyRouter, provider: ProviderName) -> Option<ProxyConfig> {
+fn proxy_for_provider(proxy_router: &ProxyRouter, provider: ProviderId) -> Option<ProxyConfig> {
     match provider {
-        ProviderName::Tinfoil => Some(proxy_router.get_tinfoil_proxy()),
-        ProviderName::Continuum => {
+        ProviderId::Tinfoil => Some(proxy_router.get_tinfoil_proxy()),
+        ProviderId::Continuum => {
             let proxy = proxy_router.get_default_proxy();
-            (proxy.provider_name == ProviderName::Continuum.as_str()).then_some(proxy)
+            (proxy.provider_name == ProviderId::Continuum.as_str()).then_some(proxy)
         }
     }
 }
@@ -433,6 +489,7 @@ fn proxy_for_provider(proxy_router: &ProxyRouter, provider: ProviderName) -> Opt
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::inference::{InferenceSurface, WorkloadClass};
     use crate::model_config::{
         ModelAliasTargets, ModelPlan, PaidModelAliasOverrides, AUTO_POWERFUL_MODEL_ID,
         AUTO_QUICK_MODEL_ID, DEEPSEEK_V4_FLASH_MODEL_ID, KIMI_K3_MODEL_ID, POWERFUL_MODEL_ID,
@@ -475,7 +532,7 @@ mod tests {
             expected_public_model: &'static str,
             expected_provider: &'static str,
             expected_provider_model: &'static str,
-            expected_source: ProviderSelectionSource,
+            expected_source: RouteSelectionSource,
         }
 
         let cases = [
@@ -490,7 +547,7 @@ mod tests {
                 expected_public_model: QUICK_MODEL_ID,
                 expected_provider: "tinfoil",
                 expected_provider_model: QUICK_MODEL_ID,
-                expected_source: ProviderSelectionSource::StaticSplit,
+                expected_source: RouteSelectionSource::StaticSplit,
             },
             Case {
                 name: "free auto powerful remains unavailable when the paid flag is on",
@@ -503,7 +560,7 @@ mod tests {
                 expected_public_model: POWERFUL_MODEL_ID,
                 expected_provider: "continuum",
                 expected_provider_model: "kimi-k2.6",
-                expected_source: ProviderSelectionSource::DefaultProvider,
+                expected_source: RouteSelectionSource::DefaultProvider,
             },
             Case {
                 name: "paid auto quick",
@@ -516,7 +573,7 @@ mod tests {
                 expected_public_model: DEEPSEEK_V4_FLASH_MODEL_ID,
                 expected_provider: "tinfoil",
                 expected_provider_model: DEEPSEEK_V4_FLASH_MODEL_ID,
-                expected_source: ProviderSelectionSource::StaticSplit,
+                expected_source: RouteSelectionSource::StaticSplit,
             },
             Case {
                 name: "paid auto powerful, flag off",
@@ -529,7 +586,7 @@ mod tests {
                 expected_public_model: POWERFUL_MODEL_ID,
                 expected_provider: "continuum",
                 expected_provider_model: "kimi-k2.6",
-                expected_source: ProviderSelectionSource::DefaultProvider,
+                expected_source: RouteSelectionSource::DefaultProvider,
             },
             Case {
                 name: "paid auto powerful, flag on",
@@ -542,7 +599,7 @@ mod tests {
                 expected_public_model: KIMI_K3_MODEL_ID,
                 expected_provider: "tinfoil",
                 expected_provider_model: KIMI_K3_MODEL_ID,
-                expected_source: ProviderSelectionSource::StaticSplit,
+                expected_source: RouteSelectionSource::StaticSplit,
             },
             Case {
                 name: "explicit K3 ignores the paid auto flag",
@@ -555,7 +612,7 @@ mod tests {
                 expected_public_model: KIMI_K3_MODEL_ID,
                 expected_provider: "tinfoil",
                 expected_provider_model: KIMI_K3_MODEL_ID,
-                expected_source: ProviderSelectionSource::StaticSplit,
+                expected_source: RouteSelectionSource::StaticSplit,
             },
             Case {
                 name: "explicit GLM default",
@@ -568,50 +625,46 @@ mod tests {
                 expected_public_model: GLM_5_2_MODEL_ID,
                 expected_provider: "tinfoil",
                 expected_provider_model: GLM_5_2_MODEL_ID,
-                expected_source: ProviderSelectionSource::DefaultProvider,
+                expected_source: RouteSelectionSource::DefaultProvider,
             },
             Case {
                 name: "explicit GLM Tinfoil preference",
                 selector: GLM_5_2_MODEL_ID,
                 plan: ModelPlan::Paid,
                 powerful_kimi_k3: false,
-                provider_preference: Some(ProviderPreference::feature_flag(ProviderName::Tinfoil)),
+                provider_preference: Some(ProviderPreference::feature_flag(ProviderId::Tinfoil)),
                 continuum_available: true,
                 expected_access: true,
                 expected_public_model: GLM_5_2_MODEL_ID,
                 expected_provider: "tinfoil",
                 expected_provider_model: GLM_5_2_MODEL_ID,
-                expected_source: ProviderSelectionSource::FeatureFlag,
+                expected_source: RouteSelectionSource::FeatureFlag,
             },
             Case {
                 name: "explicit GLM Continuum preference",
                 selector: GLM_5_2_MODEL_ID,
                 plan: ModelPlan::Paid,
                 powerful_kimi_k3: false,
-                provider_preference: Some(ProviderPreference::feature_flag(
-                    ProviderName::Continuum,
-                )),
+                provider_preference: Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
                 continuum_available: true,
                 expected_access: true,
                 expected_public_model: GLM_5_2_MODEL_ID,
                 expected_provider: "continuum",
                 expected_provider_model: "glm-5.2",
-                expected_source: ProviderSelectionSource::FeatureFlag,
+                expected_source: RouteSelectionSource::FeatureFlag,
             },
             Case {
                 name: "explicit GLM Continuum preference without a Continuum proxy",
                 selector: GLM_5_2_MODEL_ID,
                 plan: ModelPlan::Paid,
                 powerful_kimi_k3: false,
-                provider_preference: Some(ProviderPreference::feature_flag(
-                    ProviderName::Continuum,
-                )),
+                provider_preference: Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
                 continuum_available: false,
                 expected_access: true,
                 expected_public_model: GLM_5_2_MODEL_ID,
                 expected_provider: "tinfoil",
                 expected_provider_model: GLM_5_2_MODEL_ID,
-                expected_source: ProviderSelectionSource::Fallback,
+                expected_source: RouteSelectionSource::Fallback,
             },
         ];
 
@@ -677,6 +730,106 @@ mod tests {
                 case.name
             );
             assert_eq!(selected.bucket, None, "{}", case.name);
+
+            let intent = InferenceIntent::new(
+                uuid_for_bucket(73),
+                case.selector,
+                resolved_model,
+                case.plan,
+                InferenceSurface::ChatCompletions,
+                WorkloadClass::Interactive,
+            );
+            let active = Ok(selected.clone());
+            let shadow =
+                router.shadow_completion_plan(&proxy_router, &intent, case.provider_preference);
+            assert!(
+                matches!(
+                    compare_shadow_route(&active, &shadow),
+                    ShadowRouteComparison::Match { .. }
+                ),
+                "{}: active={active:?}, shadow={shadow:?}",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn shadow_planner_matches_legacy_for_every_registered_model_and_topology() {
+        let router = ProviderRouter::default();
+        let both = proxy_router_with_both_providers();
+        let tinfoil_only = ProxyRouter::new(
+            "https://api.openai.com".to_string(),
+            None,
+            "http://tinfoil.example.com".to_string(),
+        );
+
+        for proxy_router in [&both, &tinfoil_only] {
+            for model in PROVIDER_REGISTRY.completion_models() {
+                for bucket in [0, 29, 30, 69, 70, 99] {
+                    let account_uuid = uuid_for_bucket(bucket);
+                    let intent = InferenceIntent::new(
+                        account_uuid,
+                        model.public_model_id,
+                        model.public_model_id,
+                        ModelPlan::Paid,
+                        InferenceSurface::Responses,
+                        WorkloadClass::Interactive,
+                    );
+                    let active = router.select_completion_route_with_preference(
+                        proxy_router,
+                        account_uuid,
+                        model.public_model_id,
+                        None,
+                    );
+                    let shadow = router.shadow_completion_plan(proxy_router, &intent, None);
+                    assert!(
+                        matches!(
+                            compare_shadow_route(&active, &shadow),
+                            ShadowRouteComparison::Match { .. }
+                        ),
+                        "model={}, bucket={bucket}, active={active:?}, shadow={shadow:?}",
+                        model.public_model_id
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn shadow_planner_matches_legacy_error_classes_for_unknown_models() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+
+        for model in [
+            "unknown-model",
+            "kimi-k-3",
+            "kimi-k3-latest",
+            "deepseek-v4-flash-0731",
+        ] {
+            let account_uuid = uuid_for_bucket(50);
+            let intent = InferenceIntent::new(
+                account_uuid,
+                model,
+                model,
+                ModelPlan::Paid,
+                InferenceSurface::ChatCompletions,
+                WorkloadClass::Interactive,
+            );
+            let active = router.select_completion_route_with_preference(
+                &proxy_router,
+                account_uuid,
+                model,
+                None,
+            );
+            let shadow = router.shadow_completion_plan(&proxy_router, &intent, None);
+
+            assert!(matches!(
+                compare_shadow_route(&active, &shadow),
+                ShadowRouteComparison::Match {
+                    outcome: CredentialFreeRouteOutcome::UnsupportedModel,
+                    ..
+                }
+            ));
         }
     }
 
@@ -697,7 +850,7 @@ mod tests {
             assert_eq!(selected.bucket, None);
             assert_eq!(
                 selected.selection_source,
-                ProviderSelectionSource::DefaultProvider
+                RouteSelectionSource::DefaultProvider
             );
         }
     }
@@ -730,7 +883,7 @@ mod tests {
                 &proxy_router,
                 uuid_for_bucket(1),
                 GLM_5_2_MODEL_ID,
-                Some(ProviderPreference::feature_flag(ProviderName::Continuum)),
+                Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
             )
             .expect("route");
 
@@ -739,10 +892,7 @@ mod tests {
         assert_eq!(selected.provider_model_id, "glm-5.2");
         assert_eq!(selected.response_model_id, GLM_5_2_MODEL_ID);
         assert_eq!(selected.bucket, None);
-        assert_eq!(
-            selected.selection_source,
-            ProviderSelectionSource::FeatureFlag
-        );
+        assert_eq!(selected.selection_source, RouteSelectionSource::FeatureFlag);
     }
 
     #[test]
@@ -755,17 +905,14 @@ mod tests {
                 &proxy_router,
                 uuid_for_bucket(99),
                 GLM_5_2_MODEL_ID,
-                Some(ProviderPreference::feature_flag(ProviderName::Tinfoil)),
+                Some(ProviderPreference::feature_flag(ProviderId::Tinfoil)),
             )
             .expect("route");
 
         assert_eq!(selected.proxy.provider_name, "tinfoil");
         assert_eq!(selected.provider_model_id, GLM_5_2_MODEL_ID);
         assert_eq!(selected.bucket, None);
-        assert_eq!(
-            selected.selection_source,
-            ProviderSelectionSource::FeatureFlag
-        );
+        assert_eq!(selected.selection_source, RouteSelectionSource::FeatureFlag);
     }
 
     #[test]
@@ -782,14 +929,14 @@ mod tests {
                 &tinfoil_only,
                 uuid_for_bucket(70),
                 GLM_5_2_MODEL_ID,
-                Some(ProviderPreference::feature_flag(ProviderName::Continuum)),
+                Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
             )
             .expect("route");
 
         assert_eq!(selected.proxy.provider_name, "tinfoil");
         assert_eq!(selected.provider_model_id, GLM_5_2_MODEL_ID);
         assert_eq!(selected.bucket, None);
-        assert_eq!(selected.selection_source, ProviderSelectionSource::Fallback);
+        assert_eq!(selected.selection_source, RouteSelectionSource::Fallback);
     }
 
     #[test]
@@ -809,7 +956,7 @@ mod tests {
             assert_eq!(selected.bucket, None);
             assert_eq!(
                 selected.selection_source,
-                ProviderSelectionSource::DefaultProvider
+                RouteSelectionSource::DefaultProvider
             );
         }
     }

--- a/src/provider_routing.rs
+++ b/src/provider_routing.rs
@@ -1,4 +1,7 @@
-use crate::inference::{InferenceIntent, RouteIdentity};
+use crate::inference::health::{
+    ShadowHealthState, ShadowObservationMode, ShadowObservationReport, ShadowRouteSnapshot,
+};
+use crate::inference::{AttemptTerminal, InferenceIntent, RouteIdentity, RouteKey};
 use crate::inference_planning::{
     plan_completion_route, ConfiguredProviders, ProviderPreference, RoutePlan, RoutePlanningError,
     RoutePlanningInput,
@@ -96,6 +99,7 @@ pub(crate) enum ShadowRouteComparison {
 pub(crate) struct ProviderRouter {
     config: &'static ProviderRoutingConfig,
     registry: &'static ProviderRegistry,
+    shadow_health: ShadowHealthState,
 }
 
 #[derive(Debug, Clone)]
@@ -166,11 +170,29 @@ impl Default for ProviderRouter {
         Self {
             config: &DEFAULT_PROVIDER_ROUTING_CONFIG,
             registry: &PROVIDER_REGISTRY,
+            shadow_health: ShadowHealthState::new(&PROVIDER_REGISTRY),
         }
     }
 }
 
 impl ProviderRouter {
+    pub(crate) fn observe_attempt_terminal(
+        &self,
+        terminal: &AttemptTerminal,
+        mode: ShadowObservationMode,
+    ) -> ShadowObservationReport {
+        self.shadow_health.observe_terminal(terminal, mode)
+    }
+
+    pub(crate) fn shadow_health_snapshot(&self, route: &RouteKey) -> Option<ShadowRouteSnapshot> {
+        self.shadow_health.snapshot(route)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn shadow_observation_count(&self) -> usize {
+        self.shadow_health.observation_count()
+    }
+
     #[cfg(test)]
     pub(crate) fn select_completion_route(
         &self,
@@ -489,7 +511,11 @@ fn proxy_for_provider(proxy_router: &ProxyRouter, provider: ProviderId) -> Optio
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::inference::{InferenceSurface, WorkloadClass};
+    use crate::inference::health::{ShadowDisposition, ShadowObservationMode};
+    use crate::inference::{
+        AttemptFailure, AttemptFailureKind, AttemptStage, AttemptTerminal, InferenceSurface,
+        ReplaySafety, WorkloadClass,
+    };
     use crate::model_config::{
         ModelAliasTargets, ModelPlan, PaidModelAliasOverrides, AUTO_POWERFUL_MODEL_ID,
         AUTO_QUICK_MODEL_ID, DEEPSEEK_V4_FLASH_MODEL_ID, KIMI_K3_MODEL_ID, POWERFUL_MODEL_ID,
@@ -497,6 +523,7 @@ mod tests {
     };
     use crate::os_flags::PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY;
     use std::collections::HashMap;
+    use std::time::Duration;
 
     fn proxy_router_with_both_providers() -> ProxyRouter {
         ProxyRouter::new(
@@ -831,6 +858,72 @@ mod tests {
                 }
             ));
         }
+    }
+
+    #[test]
+    fn hypothetical_open_capacity_never_changes_active_or_shadow_route_selection() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        let account_uuid = uuid_for_bucket(73);
+        let provider_preference = Some(ProviderPreference::feature_flag(ProviderId::Continuum));
+        let intent = InferenceIntent::new(
+            account_uuid,
+            GLM_5_2_MODEL_ID,
+            GLM_5_2_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+
+        let active_before = router
+            .select_completion_route_with_preference(
+                &proxy_router,
+                account_uuid,
+                GLM_5_2_MODEL_ID,
+                provider_preference,
+            )
+            .expect("active route before shadow health");
+        let shadow_before = router
+            .shadow_completion_plan(&proxy_router, &intent, provider_preference)
+            .expect("shadow route before shadow health");
+
+        let mut failure = AttemptFailure::new(
+            AttemptFailureKind::CapacityRejected,
+            AttemptStage::AwaitingResponse,
+            ReplaySafety::ProvenPreAcceptance,
+        );
+        failure.status = Some(429);
+        failure.retry_after = Some(Duration::from_secs(60));
+        let terminal = AttemptTerminal::Failed {
+            attempt: intent
+                .begin_execution()
+                .begin_attempt(active_before.identity()),
+            failure,
+        };
+        let report = router.observe_attempt_terminal(&terminal, ShadowObservationMode::Update);
+        assert!(matches!(
+            report.snapshot.expect("known route").effective,
+            ShadowDisposition::WouldOpen { .. }
+        ));
+
+        let active_after = router
+            .select_completion_route_with_preference(
+                &proxy_router,
+                account_uuid,
+                GLM_5_2_MODEL_ID,
+                provider_preference,
+            )
+            .expect("active route after shadow health");
+        let shadow_after = router
+            .shadow_completion_plan(&proxy_router, &intent, provider_preference)
+            .expect("shadow route after shadow health");
+
+        assert_eq!(active_after.identity(), active_before.identity());
+        assert_eq!(shadow_after, shadow_before);
+        assert!(matches!(
+            compare_shadow_route(&Ok(active_after), &Ok(shadow_after)),
+            ShadowRouteComparison::Match { .. }
+        ));
     }
 
     #[test]

--- a/src/proxy_config.rs
+++ b/src/proxy_config.rs
@@ -11,6 +11,7 @@ pub struct ProxyRouter {
     tinfoil_proxy: ProxyConfig,
 }
 
+#[cfg(test)]
 pub fn canonicalize_tinfoil_model(model: &str) -> String {
     match model {
         "whisper-large-v3-turbo" => "whisper-large-v3".to_string(),

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -1,10 +1,14 @@
-use crate::inference::health::ShadowObservationMode;
+use crate::inference::admission::{
+    ActualUsage, AdmissionEstimate, AdmissionRejection, LogicalAdmissionTicket, RouteTurnPermit,
+    TerminalDisposition,
+};
+use crate::inference::health::{ProbeClaimResult, ProbeLease, ShadowObservationMode};
 use crate::inference::{
     AttemptFailure, AttemptFailureKind, AttemptOutcome, AttemptStage, AttemptTerminal,
     CompletionEvidence, InferenceAttempt, InferenceExecution, InferenceIntent, InferenceSurface,
     ReplaySafety, WorkloadClass,
 };
-use crate::inference_planning::{RoutePlan, RoutePlanningError};
+use crate::inference_planning::{ProviderPreference, RoutePlan, RoutePlanningError};
 use crate::model_config::{
     model_alias_requires_flag_lookup, model_catalog_response, openai_models_response,
     ModelAliasTargets, ModelPlan,
@@ -15,7 +19,7 @@ use crate::provider_client::{
     ProviderClient, ProviderRequest, ProviderRequestError, ProviderResponse, ProviderSendTrace,
     UpstreamProviderError,
 };
-use crate::provider_registry::{ProviderId, SHADOW_ROUTING_POLICY_VERSION};
+use crate::provider_registry::{ProviderId, PROVIDER_REGISTRY, SHADOW_ROUTING_POLICY_VERSION};
 use crate::provider_routing::{
     compare_shadow_route, ProviderRouter, ProviderRoutingError, SelectedProviderRoute,
     ShadowRouteComparison,
@@ -43,8 +47,8 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::str::FromStr;
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tokio::time::{sleep, timeout};
 use tracing::{debug, error, info, trace, warn};
@@ -56,6 +60,15 @@ const MAX_AUDIO_SIZE: usize = 100 * 1024 * 1024;
 // Timeout constants for provider requests
 const REQUEST_TIMEOUT_SECS: u64 = 120; // Request timeout (generous for large non-streaming responses)
 const STREAM_CHUNK_TIMEOUT_SECS: u64 = 120; // Per-chunk timeout for streaming reads
+const UNKNOWN_ROUTE_IMAGE_TOKEN_RESERVATION: u64 = 16_384;
+const COMPLETION_PROMPT_BASE_TOKEN_OVERHEAD: u64 = 512;
+const COMPLETION_PROMPT_MESSAGE_TOKEN_OVERHEAD: u64 = 64;
+const COMPLETION_PROMPT_TOOL_TOKEN_OVERHEAD: u64 = 256;
+const COMPLETION_PROMPT_TOOL_CALL_TOKEN_OVERHEAD: u64 = 64;
+const COMPLETION_PROMPT_ARGUMENT_ENTRY_TOKEN_OVERHEAD: u64 = 16;
+const COMPLETION_PROMPT_LINE_PREFIX_TOKEN_OVERHEAD: u64 = 4;
+const MAX_COMPLETION_NAME_BYTES: usize = 64;
+const MAX_COMPLETION_TOOL_ARGUMENT_BYTES: usize = 1024 * 1024;
 const TTS_BILLING_CHECK_TIMEOUT: Duration = Duration::from_secs(5);
 const TTS_PROVIDER_TIMEOUT: Duration = Duration::from_secs(120);
 const MAX_TTS_INPUT_CHARS: usize = 100_000;
@@ -63,6 +76,16 @@ const MAX_BOUNDED_PROVIDER_RESPONSE_BYTES: usize = 256 * 1024;
 
 const PROVIDER_MANAGED_CACHE_SALT_FIELD: &str = "cache_salt";
 const PROVIDER_MANAGED_USER_CACHE_SECRET_FIELD: &str = "user_cache_secret";
+const PROVIDER_MANAGED_KV_TRANSFER_PARAMS_FIELD: &str = "kv_transfer_params";
+const TINFOIL_TOOL_AUTO_CONTINUE_FIELD: &str = "x-tinfoil-tool-auto-continue";
+const TINFOIL_ROUTER_EXECUTION_FIELDS: &[&str] = &[
+    "auto_model_options",
+    "code_execution_options",
+    "filters",
+    "pii_check_options",
+    "prompt_injection_check_options",
+    "web_search_options",
+];
 
 #[derive(Clone, Default)]
 struct CompletionRequestLogMetadata {
@@ -539,10 +562,46 @@ impl BillingContext {
     }
 }
 
+/// A single, move-only billing settlement for one logical provider model turn.
+///
+/// `request_id` can span a complete Responses tool loop, while `execution_id`
+/// identifies exactly one model turn. Reusing the execution UUID as the SQS
+/// event id makes an accidentally repeated publish idempotent at the billing
+/// consumer without introducing distributed coordination in OpenSecret.
+#[derive(Debug)]
+struct UsageSettlement {
+    event_id: Uuid,
+    request_id: crate::inference::InferenceRequestId,
+    execution_id: crate::inference::InferenceExecutionId,
+    attempt_id: crate::inference::InferenceAttemptId,
+    requested_model_id: String,
+    public_model_id: String,
+    provider_name: String,
+    auth_method: AuthMethod,
+}
+
+impl UsageSettlement {
+    fn new(billing_context: BillingContext, attempt: &InferenceAttempt) -> Self {
+        Self {
+            event_id: attempt.execution_id.as_uuid(),
+            request_id: attempt.request_id,
+            execution_id: attempt.execution_id,
+            attempt_id: attempt.attempt_id,
+            requested_model_id: billing_context.model_name,
+            public_model_id: attempt.route.public_model_id.clone(),
+            provider_name: attempt.route.provider.as_str().to_string(),
+            auth_method: billing_context.auth_method,
+        }
+    }
+}
+
 /// Usage statistics extracted from a completion
 #[derive(Debug, Clone)]
 pub struct CompletionUsage {
     pub prompt_tokens: i32,
+    /// Whether the provider explicitly reported a prompt-token total.
+    /// A synthesized zero is not sufficient for refunding reserved input capacity.
+    pub prompt_tokens_observed: bool,
     pub completion_tokens: i32,
     /// Whether the provider explicitly reported a completion-token total.
     /// A synthesized zero is not sufficient for enforcing aggregate output budgets.
@@ -642,6 +701,11 @@ impl StreamUsageAccumulator {
             .unwrap_or(0);
         self.latest_usage = Some(CompletionUsage {
             prompt_tokens,
+            prompt_tokens_observed: observed.prompt_tokens.is_some()
+                || self
+                    .latest_usage
+                    .as_ref()
+                    .is_some_and(|usage| usage.prompt_tokens_observed),
             completion_tokens,
             completion_tokens_observed: observed.completion_tokens.is_some()
                 || self
@@ -667,10 +731,15 @@ impl StreamUsageAccumulator {
 
         self.finalized = true;
         let mut usage = self.latest_usage.take()?;
-        usage.cached_prompt_tokens = usage
-            .cached_prompt_tokens
-            .map(|cached| cached.min(usage.prompt_tokens));
-        (usage.prompt_tokens > 0 || usage.completion_tokens > 0).then_some(usage)
+        if usage.prompt_tokens_observed {
+            usage.cached_prompt_tokens = usage
+                .cached_prompt_tokens
+                .map(|cached| cached.min(usage.prompt_tokens));
+        }
+        (usage.prompt_tokens_observed
+            || usage.completion_tokens_observed
+            || usage.cached_prompt_tokens.is_some())
+        .then_some(usage)
     }
 }
 
@@ -707,7 +776,11 @@ pub struct CompletionStream {
 #[derive(Debug, Clone)]
 pub(crate) struct PinnedCompletionRequest {
     intent: InferenceIntent,
+    /// A pure provisional decision used for model-compatible validation and
+    /// context construction before scarce admission is acquired.
     route: SelectedProviderRoute,
+    provider_preference: Option<ProviderPreference>,
+    finalized_route: Arc<OnceLock<SelectedProviderRoute>>,
 }
 
 impl PinnedCompletionRequest {
@@ -716,11 +789,19 @@ impl PinnedCompletionRequest {
     }
 
     pub(crate) fn public_model_id(&self) -> &str {
-        &self.route.public_model_id
+        &self.selected_route().public_model_id
     }
 
     fn begin_execution(&self) -> InferenceExecution {
         self.intent.begin_execution()
+    }
+
+    fn selected_route(&self) -> &SelectedProviderRoute {
+        self.finalized_route.get().unwrap_or(&self.route)
+    }
+
+    fn finalize_route(&self, route: SelectedProviderRoute) -> bool {
+        self.finalized_route.set(route).is_ok()
     }
 }
 
@@ -772,6 +853,7 @@ impl From<ApiError> for CompletionExecutionError {
     }
 }
 
+#[cfg(test)]
 fn failed_completion_execution(
     provider_router: &ProviderRouter,
     attempt: InferenceAttempt,
@@ -923,51 +1005,69 @@ fn record_attempt_outcome(
             );
         }
         AttemptOutcome::Terminal(terminal) => {
-            let attempt = terminal.attempt();
             let shadow_report = provider_router.observe_attempt_terminal(terminal, shadow_mode);
-            debug!(
-                "Inference shadow health observation: request_id={}, execution_id={}, attempt_id={}, policy_version={}, mode={:?}, route_provider={}, route_model={}, signal={:?}, capacity_pool={:?}, snapshot={:?}, mutated={}",
-                attempt.request_id,
-                attempt.execution_id,
-                attempt.attempt_id,
-                shadow_report.policy_version,
-                shadow_report.mode,
-                shadow_report.route.provider.as_str(),
-                shadow_report.route.provider_model_id,
-                shadow_report.signal,
-                shadow_report.capacity_pool,
-                shadow_report.snapshot,
-                shadow_report.mutated
-            );
-            match terminal {
-                AttemptTerminal::Completed { evidence, .. } => debug!(
-                    "Inference attempt completed: request_id={}, execution_id={}, attempt_id={}, provider={}, public_model={}, provider_model={}, evidence={:?}",
-                    attempt.request_id,
-                    attempt.execution_id,
-                    attempt.attempt_id,
-                    attempt.route.provider.as_str(),
-                    attempt.route.public_model_id,
-                    attempt.route.provider_model_id,
-                    evidence
-                ),
-                AttemptTerminal::Failed { failure, .. } => warn!(
-                    "Inference attempt failed: request_id={}, execution_id={}, attempt_id={}, provider={}, public_model={}, provider_model={}, kind={:?}, stage={:?}, replay_safety={:?}, status={:?}, retry_after_ms={:?}, upstream_request_id={:?}, upstream_code={:?}",
-                    attempt.request_id,
-                    attempt.execution_id,
-                    attempt.attempt_id,
-                    attempt.route.provider.as_str(),
-                    attempt.route.public_model_id,
-                    attempt.route.provider_model_id,
-                    failure.kind,
-                    failure.stage,
-                    failure.replay_safety,
-                    failure.status,
-                    failure.retry_after.map(|duration| duration.as_millis()),
-                    failure.upstream_request_id,
-                    failure.upstream_code
-                ),
-            }
+            log_attempt_terminal(terminal, &shadow_report);
         }
+    }
+}
+
+fn record_attempt_terminal_with_probe(
+    provider_router: &ProviderRouter,
+    terminal: &AttemptTerminal,
+    shadow_mode: ShadowObservationMode,
+    probe: Option<ProbeLease>,
+) {
+    let shadow_report =
+        provider_router.observe_attempt_terminal_with_probe(terminal, shadow_mode, probe);
+    log_attempt_terminal(terminal, &shadow_report);
+}
+
+fn log_attempt_terminal(
+    terminal: &AttemptTerminal,
+    shadow_report: &crate::inference::health::ShadowObservationReport,
+) {
+    let attempt = terminal.attempt();
+    debug!(
+        "Inference shadow health observation: request_id={}, execution_id={}, attempt_id={}, policy_version={}, mode={:?}, route_provider={}, route_model={}, signal={:?}, capacity_pool={:?}, snapshot={:?}, mutated={}",
+        attempt.request_id,
+        attempt.execution_id,
+        attempt.attempt_id,
+        shadow_report.policy_version,
+        shadow_report.mode,
+        shadow_report.route.provider.as_str(),
+        shadow_report.route.provider_model_id,
+        shadow_report.signal,
+        shadow_report.capacity_pool,
+        shadow_report.snapshot,
+        shadow_report.mutated
+    );
+    match terminal {
+        AttemptTerminal::Completed { evidence, .. } => debug!(
+            "Inference attempt completed: request_id={}, execution_id={}, attempt_id={}, provider={}, public_model={}, provider_model={}, evidence={:?}",
+            attempt.request_id,
+            attempt.execution_id,
+            attempt.attempt_id,
+            attempt.route.provider.as_str(),
+            attempt.route.public_model_id,
+            attempt.route.provider_model_id,
+            evidence
+        ),
+        AttemptTerminal::Failed { failure, .. } => warn!(
+            "Inference attempt failed: request_id={}, execution_id={}, attempt_id={}, provider={}, public_model={}, provider_model={}, kind={:?}, stage={:?}, replay_safety={:?}, status={:?}, retry_after_ms={:?}, upstream_request_id={:?}, upstream_code={:?}",
+            attempt.request_id,
+            attempt.execution_id,
+            attempt.attempt_id,
+            attempt.route.provider.as_str(),
+            attempt.route.public_model_id,
+            attempt.route.provider_model_id,
+            failure.kind,
+            failure.stage,
+            failure.replay_safety,
+            failure.status,
+            failure.retry_after.map(|duration| duration.as_millis()),
+            failure.upstream_request_id,
+            failure.upstream_code
+        ),
     }
 }
 
@@ -1062,42 +1162,63 @@ async fn read_non_streaming_completion_response(
     response_model_id: &str,
     attempt: &InferenceAttempt,
     body_limit: Option<usize>,
+    body_timeout: Duration,
 ) -> Result<Value, AttemptFailure> {
-    let body_bytes = match body_limit {
-        Some(limit_bytes) => bytes::Bytes::from(
-            collect_bounded_provider_response_body(response.bytes_stream(), limit_bytes)
-                .await
-                .map_err(|error| {
-                    error!(
-                        "Failed to read bounded inference response body: request_id={}, execution_id={}, attempt_id={}, error={}",
-                        attempt.request_id, attempt.execution_id, attempt.attempt_id, error
-                    );
-                    let kind = match error {
-                        BoundedProviderResponseBodyError::Read => {
-                            AttemptFailureKind::ResponseBody
-                        }
-                        BoundedProviderResponseBodyError::TooLarge { .. } => {
-                            AttemptFailureKind::InvalidResponse
-                        }
-                    };
-                    AttemptFailure::new(
-                        kind,
-                        AttemptStage::ResponseBody,
-                        ReplaySafety::NotProvenPreAcceptance,
-                    )
-                })?,
-        ),
-        None => response.bytes().await.map_err(|error| {
-            error!(
-                "Failed to read inference response body: request_id={}, execution_id={}, attempt_id={}, error={}",
-                attempt.request_id, attempt.execution_id, attempt.attempt_id, error
+    let body_bytes = match timeout(body_timeout, async move {
+        match body_limit {
+            Some(limit_bytes) => collect_bounded_provider_response_body(
+                response.bytes_stream(),
+                limit_bytes,
+            )
+            .await
+            .map(bytes::Bytes::from)
+            .map_err(|error| {
+                error!(
+                    "Failed to read bounded inference response body: request_id={}, execution_id={}, attempt_id={}, error={}",
+                    attempt.request_id, attempt.execution_id, attempt.attempt_id, error
+                );
+                let kind = match error {
+                    BoundedProviderResponseBodyError::Read => AttemptFailureKind::ResponseBody,
+                    BoundedProviderResponseBodyError::TooLarge { .. } => {
+                        AttemptFailureKind::InvalidResponse
+                    }
+                };
+                AttemptFailure::new(
+                    kind,
+                    AttemptStage::ResponseBody,
+                    ReplaySafety::NotProvenPreAcceptance,
+                )
+            }),
+            None => response.bytes().await.map_err(|error| {
+                error!(
+                    "Failed to read inference response body: request_id={}, execution_id={}, attempt_id={}, error={}",
+                    attempt.request_id, attempt.execution_id, attempt.attempt_id, error
+                );
+                AttemptFailure::new(
+                    AttemptFailureKind::ResponseBody,
+                    AttemptStage::ResponseBody,
+                    ReplaySafety::NotProvenPreAcceptance,
+                )
+            }),
+        }
+    })
+    .await
+    {
+        Ok(result) => result?,
+        Err(_) => {
+            warn!(
+                "Inference response body timed out: request_id={}, execution_id={}, attempt_id={}, timeout_ms={}",
+                attempt.request_id,
+                attempt.execution_id,
+                attempt.attempt_id,
+                body_timeout.as_millis()
             );
-            AttemptFailure::new(
+            return Err(AttemptFailure::new(
                 AttemptFailureKind::ResponseBody,
                 AttemptStage::ResponseBody,
                 ReplaySafety::NotProvenPreAcceptance,
-            )
-        })?,
+            ));
+        }
     };
 
     let mut response_json: Value = serde_json::from_slice(&body_bytes).map_err(|error| {
@@ -1220,11 +1341,14 @@ async fn process_completion_stream(
                     usage_accumulator.observe(&json);
                     canonicalize_response_model(&mut json, response_model_id);
 
-                    if tx_consumer
-                        .send(CompletionChunk::StreamChunk(json))
-                        .await
-                        .is_err()
-                    {
+                    if !matches!(
+                        timeout(
+                            chunk_timeout,
+                            tx_consumer.send(CompletionChunk::StreamChunk(json))
+                        )
+                        .await,
+                        Ok(Ok(()))
+                    ) {
                         return finish_stream_processing(
                             &mut usage_accumulator,
                             StreamUsageFinalization::ConsumerDropped,
@@ -1301,8 +1425,7 @@ async fn publish_stream_usage(
     finalization: StreamUsageFinalization,
     state: &Arc<AppState>,
     user: &User,
-    billing_context: &BillingContext,
-    provider: &str,
+    settlement: UsageSettlement,
     tx_consumer: &mpsc::Sender<CompletionChunk>,
 ) {
     let Some(usage) = usage else {
@@ -1312,11 +1435,11 @@ async fn publish_stream_usage(
     if !finalization.is_provider_done() {
         warn!(
             "Finalizing streaming usage from terminal fallback: trigger={:?}, provider={}, model={}",
-            finalization, provider, billing_context.model_name
+            finalization, settlement.provider_name, settlement.public_model_id
         );
     }
 
-    publish_usage_event_internal(state, user, billing_context, usage.clone(), provider).await;
+    settle_completion_usage(state, user, settlement, usage.clone()).await;
 
     // Billing is independent from the consumer. If it has gone away after a
     // terminal provider signal, the usage event must still be emitted once.
@@ -1438,6 +1561,12 @@ async fn proxy_openai(
     }
     pin_chat_request_model(&mut body, &pinned_completion);
 
+    let logical_ticket: LogicalAdmissionTicket = state
+        .inference_admission
+        .acquire_logical(user.uuid, WorkloadClass::Interactive)
+        .await
+        .map_err(admission_api_error)?;
+
     // Create billing context
     let billing_context = BillingContext::new(auth_method, requested_model_name);
 
@@ -1473,6 +1602,7 @@ async fn proxy_openai(
             // Billing already happened in get_chat_completion_response!
             // Just encrypt and return
             let encrypted_response = encrypt_response(&state, &session_id, &response_json).await?;
+            drop(logical_ticket);
             return Ok(encrypted_response.into_response());
         } else {
             error!("Expected FullResponse chunk but got something else");
@@ -1485,6 +1615,7 @@ async fn proxy_openai(
     let mut rx = completion.stream;
 
     let stream = async_stream::stream! {
+        let _logical_ticket = logical_ticket;
         while let Some(chunk) = rx.recv().await {
             match chunk {
                 CompletionChunk::StreamChunk(json) => {
@@ -1718,7 +1849,682 @@ pub(crate) async fn prepare_completion_request(
         route.selection_source
     );
 
-    Ok(PinnedCompletionRequest { intent, route })
+    Ok(PinnedCompletionRequest {
+        intent,
+        route,
+        provider_preference,
+        finalized_route: Arc::new(OnceLock::new()),
+    })
+}
+
+#[derive(Debug)]
+struct AdmittedProviderTurn {
+    route: SelectedProviderRoute,
+    permit: RouteTurnPermit,
+    probe: Option<ProbeLease>,
+}
+
+fn admission_api_error(rejection: AdmissionRejection) -> ApiError {
+    let status = if rejection.status_hint() == 429 {
+        StatusCode::TOO_MANY_REQUESTS
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    ApiError::InferenceCapacity {
+        status,
+        retry_after: Some(rejection.retry_after),
+        client_replay_safe: false,
+    }
+}
+
+fn probe_api_error(retry_after: Duration) -> ApiError {
+    ApiError::InferenceCapacity {
+        status: StatusCode::SERVICE_UNAVAILABLE,
+        retry_after: Some(retry_after),
+        client_replay_safe: false,
+    }
+}
+
+fn route_image_token_reservation(route: &SelectedProviderRoute) -> u64 {
+    PROVIDER_REGISTRY
+        .completion_route(route.provider, &route.provider_model_id)
+        .map_or(UNKNOWN_ROUTE_IMAGE_TOKEN_RESERVATION, |route| {
+            route.image_token_reservation
+        })
+}
+
+/// Ensures every accepted request has a provider-visible output bound that
+/// matches admission's reservation. This bounds provider extensions such as
+/// `ignore_eos` and token allowlists without trying to enumerate every option
+/// that can suppress ordinary generation termination.
+fn ensure_bounded_completion_generation(
+    body: &mut serde_json::Map<String, Value>,
+    completion_default_reservation: u64,
+) {
+    for field in ["max_completion_tokens", "max_tokens"] {
+        if body.get(field).is_some_and(Value::is_null) {
+            body.remove(field);
+        }
+    }
+
+    let has_explicit_maximum = ["max_completion_tokens", "max_tokens"]
+        .into_iter()
+        .any(|field| body.contains_key(field));
+    if !has_explicit_maximum {
+        let requested_minimum = body.get("min_tokens").and_then(Value::as_u64).unwrap_or(0);
+        body.insert(
+            "max_tokens".to_string(),
+            json!(completion_default_reservation.max(requested_minimum)),
+        );
+    }
+}
+
+fn validate_completion_request_controls(
+    body: &serde_json::Map<String, Value>,
+    max_completion_choices: u64,
+) -> Result<(), ApiError> {
+    for field in ["max_completion_tokens", "max_tokens"] {
+        let Some(value) = body.get(field) else {
+            continue;
+        };
+        if value.is_null() {
+            continue;
+        }
+        if value.as_u64().is_none_or(|tokens| tokens == 0) {
+            warn!(field, "Rejected non-canonical completion maximum");
+            return Err(ApiError::BadRequest);
+        }
+    }
+
+    if let Some(value) = body.get("n") {
+        if !value.is_null() {
+            let Some(count) = value.as_u64().filter(|count| *count > 0) else {
+                warn!("Rejected non-canonical completion choice count");
+                return Err(ApiError::BadRequest);
+            };
+            if count > max_completion_choices {
+                warn!(
+                    count,
+                    max_completion_choices, "Rejected excessive completion choice count"
+                );
+                return Err(ApiError::BadRequest);
+            }
+        }
+    }
+    if let Some(value) = body.get("min_tokens") {
+        if value.as_u64().is_none() {
+            warn!("Rejected non-canonical minimum completion tokens");
+            return Err(ApiError::BadRequest);
+        }
+    }
+    if let Some(value) = body.get("stream") {
+        if !value.is_null() && !value.is_boolean() {
+            warn!("Rejected non-canonical completion stream flag");
+            return Err(ApiError::BadRequest);
+        }
+    }
+
+    validate_completion_names(body)?;
+    validate_completion_tool_arguments(body)?;
+
+    Ok(())
+}
+
+fn validate_completion_name(value: &Value, field: &'static str) -> Result<(), ApiError> {
+    let Some(name) = value.as_str() else {
+        warn!(field, "Rejected non-string completion name");
+        return Err(ApiError::BadRequest);
+    };
+    if name.is_empty()
+        || name.len() > MAX_COMPLETION_NAME_BYTES
+        || !name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+    {
+        warn!(field, "Rejected non-canonical completion name");
+        return Err(ApiError::BadRequest);
+    }
+    Ok(())
+}
+
+fn validate_nested_completion_name(
+    value: &Value,
+    container: &str,
+    field: &'static str,
+) -> Result<(), ApiError> {
+    if let Some(name) = value.get(container).and_then(|nested| nested.get("name")) {
+        validate_completion_name(name, field)?;
+    }
+    Ok(())
+}
+
+fn validate_completion_names(body: &serde_json::Map<String, Value>) -> Result<(), ApiError> {
+    if let Some(messages) = body.get("messages").and_then(Value::as_array) {
+        for message in messages {
+            if let Some(name) = message.get("name") {
+                validate_completion_name(name, "messages[].name")?;
+            }
+            validate_nested_completion_name(
+                message,
+                "function_call",
+                "messages[].function_call.name",
+            )?;
+            if let Some(tool_calls) = message.get("tool_calls").and_then(Value::as_array) {
+                for tool_call in tool_calls {
+                    validate_nested_completion_name(
+                        tool_call,
+                        "function",
+                        "messages[].tool_calls[].function.name",
+                    )?;
+                }
+            }
+        }
+    }
+
+    if let Some(tools) = body.get("tools").and_then(Value::as_array) {
+        for tool in tools {
+            validate_nested_completion_name(tool, "function", "tools[].function.name")?;
+            validate_nested_completion_name(tool, "custom", "tools[].custom.name")?;
+        }
+    }
+    if let Some(tool_choice) = body.get("tool_choice") {
+        validate_nested_completion_name(tool_choice, "function", "tool_choice.function.name")?;
+        validate_nested_completion_name(tool_choice, "custom", "tool_choice.custom.name")?;
+    }
+
+    Ok(())
+}
+
+fn validate_completion_tool_arguments(
+    body: &serde_json::Map<String, Value>,
+) -> Result<(), ApiError> {
+    let Some(messages) = body.get("messages").and_then(Value::as_array) else {
+        return Ok(());
+    };
+    for message in messages {
+        let calls = message
+            .get("tool_calls")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .chain(message.get("function_call"));
+        for call in calls {
+            let Some(arguments) = call.get("function").unwrap_or(call).get("arguments") else {
+                continue;
+            };
+            let Some(arguments) = arguments.as_str() else {
+                warn!("Rejected non-string historical tool arguments");
+                return Err(ApiError::BadRequest);
+            };
+            if arguments.len() > MAX_COMPLETION_TOOL_ARGUMENT_BYTES
+                || serde_json::from_str::<Value>(arguments).is_err()
+            {
+                warn!("Rejected invalid or oversized historical tool arguments");
+                return Err(ApiError::BadRequest);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn is_unsupported_completion_media_part(value: &Value) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    object
+        .get("type")
+        .and_then(Value::as_str)
+        .is_some_and(|kind| {
+            matches!(
+                kind,
+                "video_url" | "input_video" | "image_pil" | "image_embeds" | "prompt_embeds"
+            )
+        })
+        || ["video_url", "image_pil", "image_embeds", "prompt_embeds"]
+            .into_iter()
+            .any(|field| object.contains_key(field))
+}
+
+fn completion_contains_unsupported_media(body: &serde_json::Map<String, Value>) -> bool {
+    body.get("messages")
+        .and_then(Value::as_array)
+        .is_some_and(|messages| {
+            messages.iter().any(|message| {
+                let Some(content) = message.get("content") else {
+                    return false;
+                };
+                content.as_array().map_or_else(
+                    || is_unsupported_completion_media_part(content),
+                    |parts| parts.iter().any(is_unsupported_completion_media_part),
+                )
+            })
+        })
+}
+
+fn strip_provider_internal_request_fields(body: &mut serde_json::Map<String, Value>) {
+    if body
+        .remove(PROVIDER_MANAGED_KV_TRANSFER_PARAMS_FIELD)
+        .is_some()
+    {
+        debug!("Stripped provider-internal KV transfer parameters");
+    }
+}
+
+fn estimate_completion_admission(
+    body: &serde_json::Map<String, Value>,
+    route: &SelectedProviderRoute,
+    completion_default_reservation: u64,
+) -> AdmissionEstimate {
+    let image_token_reservation = route_image_token_reservation(route);
+    let prompt_tokens = estimate_json_prompt_tokens(body, image_token_reservation);
+    let completion_count = body
+        .get("n")
+        .and_then(Value::as_u64)
+        .filter(|count| *count > 0)
+        .unwrap_or(1);
+    let requested_maximum = ["max_completion_tokens", "max_tokens"]
+        .into_iter()
+        .find_map(|field| body.get(field).and_then(Value::as_u64))
+        .filter(|tokens| *tokens > 0)
+        .unwrap_or(completion_default_reservation);
+    let requested_minimum = body.get("min_tokens").and_then(Value::as_u64).unwrap_or(0);
+    let completion_tokens = requested_maximum
+        .max(requested_minimum)
+        .saturating_mul(completion_count);
+    AdmissionEstimate::new(prompt_tokens, Some(completion_tokens))
+}
+
+fn is_completion_image_content_part(value: &Value) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    let explicit_image = object
+        .get("type")
+        .and_then(Value::as_str)
+        .is_some_and(|kind| matches!(kind, "image_url" | "input_image"));
+    let shorthand_image = object.contains_key("image_url");
+    explicit_image || shorthand_image
+}
+
+fn sanitize_completion_message_content(value: &Value, image_count: &mut u64) -> Value {
+    let sanitize_part = |part: &Value, image_count: &mut u64| {
+        if !is_completion_image_content_part(part) {
+            return part.clone();
+        }
+
+        *image_count = image_count.saturating_add(1);
+        let mut sanitized = part.clone();
+        if let Some(object) = sanitized.as_object_mut() {
+            if object.contains_key("image_url") {
+                object.insert("image_url".to_string(), json!("[image]"));
+            }
+        }
+        sanitized
+    };
+
+    match value {
+        Value::Array(parts) => Value::Array(
+            parts
+                .iter()
+                .map(|part| sanitize_part(part, image_count))
+                .collect(),
+        ),
+        part => sanitize_part(part, image_count),
+    }
+}
+
+/// Returns messages with only actual content-part images replaced by a small
+/// sentinel, plus the number of images removed. Restricting recognition to
+/// `messages[*].content[*]` ensures a tool or response JSON schema containing
+/// keys such as `type: image_url` is still counted in full.
+fn sanitize_completion_messages(value: &Value, image_count: &mut u64) -> Value {
+    let Value::Array(messages) = value else {
+        return value.clone();
+    };
+    Value::Array(
+        messages
+            .iter()
+            .map(|message| {
+                let Some(message) = message.as_object() else {
+                    return message.clone();
+                };
+                let mut sanitized = message.clone();
+                if let Some(content) = sanitized.get_mut("content") {
+                    *content = sanitize_completion_message_content(content, image_count);
+                }
+                Value::Object(sanitized)
+            })
+            .collect(),
+    )
+}
+
+fn count_json_object_entries(value: &Value) -> u64 {
+    match value {
+        Value::Array(values) => values.iter().fold(0_u64, |total, value| {
+            total.saturating_add(count_json_object_entries(value))
+        }),
+        Value::Object(object) => object.values().fold(
+            u64::try_from(object.len()).unwrap_or(u64::MAX),
+            |total, value| total.saturating_add(count_json_object_entries(value)),
+        ),
+        _ => 0,
+    }
+}
+
+fn completion_tool_argument_shape(body: &serde_json::Map<String, Value>) -> (u64, u64, u64) {
+    let mut tool_calls = 0_u64;
+    let mut argument_entries = 0_u64;
+    let mut normalized_argument_bytes = 0_u64;
+    let Some(messages) = body.get("messages").and_then(Value::as_array) else {
+        return (tool_calls, argument_entries, normalized_argument_bytes);
+    };
+
+    for message in messages {
+        let calls = message
+            .get("tool_calls")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .chain(message.get("function_call"));
+        for call in calls {
+            tool_calls = tool_calls.saturating_add(1);
+            let Some(arguments) = call.get("function").unwrap_or(call).get("arguments") else {
+                continue;
+            };
+            if let Some(arguments) = arguments.as_str() {
+                argument_entries = argument_entries.saturating_add(
+                    u64::try_from(arguments.bytes().filter(|byte| *byte == b':').count())
+                        .unwrap_or(u64::MAX),
+                );
+                if let Ok(arguments) = serde_json::from_str::<Value>(arguments) {
+                    normalized_argument_bytes = normalized_argument_bytes.saturating_add(
+                        serde_json::to_string(&arguments)
+                            .map(|arguments| u64::try_from(arguments.len()).unwrap_or(u64::MAX))
+                            .unwrap_or(u64::MAX),
+                    );
+                }
+            } else {
+                argument_entries =
+                    argument_entries.saturating_add(count_json_object_entries(arguments));
+            }
+        }
+    }
+    (tool_calls, argument_entries, normalized_argument_bytes)
+}
+
+fn count_prompt_line_breaks(value: &Value) -> u64 {
+    match value {
+        Value::String(text) => text.chars().fold(0_u64, |total, ch| {
+            total.saturating_add(u64::from(matches!(
+                ch,
+                '\n' | '\r' | '\u{000B}' | '\u{000C}' | '\u{0085}' | '\u{2028}' | '\u{2029}'
+            )))
+        }),
+        Value::Array(values) => values.iter().fold(0_u64, |total, value| {
+            total.saturating_add(count_prompt_line_breaks(value))
+        }),
+        Value::Object(object) => object.values().fold(0_u64, |total, value| {
+            total.saturating_add(count_prompt_line_breaks(value))
+        }),
+        _ => 0,
+    }
+}
+
+fn estimate_json_prompt_tokens(
+    body: &serde_json::Map<String, Value>,
+    image_token_reservation: u64,
+) -> u64 {
+    let mut image_count = 0_u64;
+    let mut sanitized_body = body.clone();
+    if let Some(messages) = sanitized_body.get_mut("messages") {
+        *messages = sanitize_completion_messages(messages, &mut image_count);
+    }
+    let sanitized_body = Value::Object(sanitized_body);
+    let prompt_line_break_count = count_prompt_line_breaks(&sanitized_body);
+    let serialized = serde_json::to_string(&sanitized_body)
+        .expect("serde_json::Value serialization is infallible");
+    let message_count = body
+        .get("messages")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+    let tool_count = body
+        .get("tools")
+        .and_then(Value::as_array)
+        .map_or(0, Vec::len);
+    let attribute_escape_expansion = serialized.bytes().fold(0_u64, |total, byte| {
+        total.saturating_add(match byte {
+            b'&' => 4, // `&` -> `&amp;`
+            b'"' => 5, // `"` -> `&quot;` after JSON decoding
+            _ => 0,
+        })
+    });
+    let normalized_json_separator_expansion = u64::try_from(
+        serialized
+            .bytes()
+            .filter(|byte| matches!(byte, b',' | b':'))
+            .count(),
+    )
+    .unwrap_or(u64::MAX);
+    let normalized_json_unicode_expansion = serialized.chars().fold(0_u64, |total, ch| {
+        if ch.is_ascii() {
+            return total;
+        }
+        let escaped_bytes = if ch.len_utf8() == 4 { 12 } else { 6 };
+        total.saturating_add(u64::try_from(escaped_bytes - ch.len_utf8()).unwrap_or(u64::MAX))
+    });
+    let (tool_call_count, argument_entry_count, normalized_argument_bytes) =
+        completion_tool_argument_shape(body);
+
+    // Provider tokenizers are not interchangeable: K3 can split ordinary
+    // ASCII nearly eleven times more finely than cl100k. UTF-8 bytes are a
+    // tokenizer-independent upper bound for the byte-level provider
+    // tokenizers on these routes; explicit structural allowances cover prompt
+    // markers and template text that are not present verbatim in the JSON.
+    u64::try_from(serialized.len())
+        .unwrap_or(u64::MAX)
+        .saturating_add(attribute_escape_expansion)
+        .saturating_add(normalized_json_separator_expansion)
+        .saturating_add(normalized_json_unicode_expansion)
+        .saturating_add(normalized_argument_bytes)
+        .saturating_add(COMPLETION_PROMPT_BASE_TOKEN_OVERHEAD)
+        .saturating_add(
+            u64::try_from(message_count)
+                .unwrap_or(u64::MAX)
+                .saturating_mul(COMPLETION_PROMPT_MESSAGE_TOKEN_OVERHEAD),
+        )
+        .saturating_add(
+            u64::try_from(tool_count)
+                .unwrap_or(u64::MAX)
+                .saturating_mul(COMPLETION_PROMPT_TOOL_TOKEN_OVERHEAD),
+        )
+        .saturating_add(tool_call_count.saturating_mul(COMPLETION_PROMPT_TOOL_CALL_TOKEN_OVERHEAD))
+        .saturating_add(
+            argument_entry_count.saturating_mul(COMPLETION_PROMPT_ARGUMENT_ENTRY_TOKEN_OVERHEAD),
+        )
+        .saturating_add(
+            prompt_line_break_count.saturating_mul(COMPLETION_PROMPT_LINE_PREFIX_TOKEN_OVERHEAD),
+        )
+        .saturating_add(image_count.saturating_mul(image_token_reservation))
+}
+
+fn replan_completion_route_excluding(
+    state: &AppState,
+    pinned: &PinnedCompletionRequest,
+    excluded_routes: &mut HashSet<crate::inference::RouteKey>,
+) -> Result<SelectedProviderRoute, ApiError> {
+    loop {
+        let route = state
+            .provider_router
+            .select_active_completion_route_excluding(
+                &state.proxy_router,
+                &pinned.intent,
+                pinned.provider_preference,
+                excluded_routes,
+            )
+            .map_err(provider_routing_api_error)?;
+
+        // Model substitution is finalized during request preparation, before
+        // Responses builds model-specific context and defaults. Admission may
+        // still move a request to another provider for that public model, but
+        // it must never change the public model behind an already-built body.
+        if route.public_model_id == pinned.route.public_model_id {
+            return Ok(route);
+        }
+        excluded_routes.insert(route.identity().route_key());
+    }
+}
+
+/// Acquires one fair provider-turn reservation, then atomically claims any
+/// expired health/capacity gates. A first turn may replan to another provider
+/// for the prepared public model only before its first upstream send. Once
+/// finalized, Responses tool turns reacquire admission on the identical route
+/// and never consult health or switch provider/model.
+async fn admit_completion_turn(
+    state: &Arc<AppState>,
+    pinned: &PinnedCompletionRequest,
+    body: &serde_json::Map<String, Value>,
+    allow_replan: bool,
+) -> Result<AdmittedProviderTurn, ApiError> {
+    let completion_default_reservation = state
+        .inference_admission
+        .policy()
+        .completion_default_reservation();
+    if let Some(route) = pinned.finalized_route.get() {
+        let estimate = estimate_completion_admission(body, route, completion_default_reservation);
+        let permit = state
+            .inference_admission
+            .acquire_turn(
+                &route.identity().route_key(),
+                pinned.intent.account_uuid,
+                pinned.intent.workload_class,
+                estimate,
+                None,
+            )
+            .await
+            .map_err(admission_api_error)?;
+        return Ok(AdmittedProviderTurn {
+            route: route.clone(),
+            permit,
+            probe: None,
+        });
+    }
+
+    let admission_deadline = Instant::now()
+        .checked_add(match pinned.intent.workload_class {
+            WorkloadClass::Interactive => state.inference_admission.policy().interactive_wait(),
+            WorkloadClass::Background => state.inference_admission.policy().background_wait(),
+        })
+        .unwrap_or_else(Instant::now);
+    let mut excluded_routes = HashSet::new();
+    let mut route = pinned.route.clone();
+
+    loop {
+        let route_key = route.identity().route_key();
+        let estimate = estimate_completion_admission(body, &route, completion_default_reservation);
+        let permit = match state
+            .inference_admission
+            .acquire_turn(
+                &route_key,
+                pinned.intent.account_uuid,
+                pinned.intent.workload_class,
+                estimate,
+                Some(admission_deadline),
+            )
+            .await
+        {
+            Ok(permit) => permit,
+            Err(rejection) => {
+                debug!(
+                    "Inference route lost local admission before send: request_id={}, provider={}, provider_model={}, kind={:?}",
+                    pinned.intent.request_id,
+                    route.provider.as_str(),
+                    route.provider_model_id,
+                    rejection.kind
+                );
+                let local_error = admission_api_error(rejection);
+                if !allow_replan {
+                    return Err(local_error);
+                }
+                excluded_routes.insert(route_key);
+                match replan_completion_route_excluding(state, pinned, &mut excluded_routes) {
+                    Ok(replanned) => {
+                        route = replanned;
+                        continue;
+                    }
+                    Err(_) => return Err(local_error),
+                }
+            }
+        };
+
+        let probe = match state.provider_router.try_claim_probe(&route_key) {
+            ProbeClaimResult::Ready(probe) => probe,
+            ProbeClaimResult::Rejected {
+                reason,
+                retry_after,
+            } => {
+                debug!(
+                    "Inference route lost half-open claim before send: request_id={}, provider={}, provider_model={}, reason={:?}",
+                    pinned.intent.request_id,
+                    route.provider.as_str(),
+                    route.provider_model_id,
+                    reason
+                );
+                permit.settle(None, TerminalDisposition::ProvenPreAcceptance);
+                let local_error = probe_api_error(retry_after);
+                if !allow_replan {
+                    return Err(local_error);
+                }
+                excluded_routes.insert(route_key);
+                match replan_completion_route_excluding(state, pinned, &mut excluded_routes) {
+                    Ok(replanned) => {
+                        route = replanned;
+                        continue;
+                    }
+                    Err(_) => return Err(local_error),
+                }
+            }
+        };
+
+        match pinned.finalize_route(route.clone()) {
+            true => {
+                return Ok(AdmittedProviderTurn {
+                    route,
+                    permit,
+                    probe,
+                });
+            }
+            false => {
+                // Pinned requests are not started concurrently today, but fail
+                // safely if that invariant changes: refund before sending and
+                // reacquire the already-finalized route on the next iteration.
+                drop(probe);
+                permit.settle(None, TerminalDisposition::ProvenPreAcceptance);
+                let finalized = pinned
+                    .finalized_route
+                    .get()
+                    .expect("failed OnceLock set means another route was finalized")
+                    .clone();
+                let estimate =
+                    estimate_completion_admission(body, &finalized, completion_default_reservation);
+                let permit = state
+                    .inference_admission
+                    .acquire_turn(
+                        &finalized.identity().route_key(),
+                        pinned.intent.account_uuid,
+                        pinned.intent.workload_class,
+                        estimate,
+                        Some(admission_deadline),
+                    )
+                    .await
+                    .map_err(admission_api_error)?;
+                return Ok(AdmittedProviderTurn {
+                    route: finalized,
+                    permit,
+                    probe: None,
+                });
+            }
+        }
+    }
 }
 
 /// Ensures cancellation or panic cannot make an in-flight attempt disappear
@@ -1728,10 +2534,13 @@ struct AttemptObservationGuard {
     attempt: InferenceAttempt,
     provider_router: Arc<ProviderRouter>,
     stage: AttemptStage,
+    turn_permit: Option<RouteTurnPermit>,
+    probe: Option<ProbeLease>,
     armed: bool,
 }
 
 impl AttemptObservationGuard {
+    #[cfg(test)]
     fn new(
         attempt: InferenceAttempt,
         provider_router: Arc<ProviderRouter>,
@@ -1741,6 +2550,25 @@ impl AttemptObservationGuard {
             attempt,
             provider_router,
             stage,
+            turn_permit: None,
+            probe: None,
+            armed: true,
+        }
+    }
+
+    fn new_admitted(
+        attempt: InferenceAttempt,
+        provider_router: Arc<ProviderRouter>,
+        stage: AttemptStage,
+        turn_permit: RouteTurnPermit,
+        probe: Option<ProbeLease>,
+    ) -> Self {
+        Self {
+            attempt,
+            provider_router,
+            stage,
+            turn_permit: Some(turn_permit),
+            probe,
             armed: true,
         }
     }
@@ -1758,12 +2586,37 @@ impl AttemptObservationGuard {
     }
 
     fn record_terminal(&mut self, terminal: &AttemptTerminal) {
+        self.record_terminal_with_usage(terminal, None);
+    }
+
+    fn record_terminal_with_usage(
+        &mut self,
+        terminal: &AttemptTerminal,
+        usage: Option<&CompletionUsage>,
+    ) {
         debug_assert_eq!(terminal.attempt(), &self.attempt);
-        record_attempt_outcome(
+        let (actual, disposition) = match terminal {
+            AttemptTerminal::Completed { .. } => (
+                usage.map(completion_actual_usage),
+                TerminalDisposition::Completed,
+            ),
+            AttemptTerminal::Failed { failure, .. }
+                if failure.replay_safety == ReplaySafety::ProvenPreAcceptance =>
+            {
+                (None, TerminalDisposition::ProvenPreAcceptance)
+            }
+            AttemptTerminal::Failed { .. } => (None, TerminalDisposition::Ambiguous),
+        };
+        record_attempt_terminal_with_probe(
             &self.provider_router,
-            &AttemptOutcome::Terminal(terminal.clone()),
+            terminal,
             ShadowObservationMode::Update,
+            self.probe.take(),
         );
+        // Commit health/probe state before admission can wake another waiter.
+        if let Some(permit) = self.turn_permit.take() {
+            permit.settle(actual, disposition);
+        }
         self.disarm();
     }
 
@@ -1779,6 +2632,22 @@ impl AttemptObservationGuard {
     }
 }
 
+fn completion_actual_usage(usage: &CompletionUsage) -> ActualUsage {
+    ActualUsage {
+        prompt_tokens: usage
+            .prompt_tokens_observed
+            .then(|| u64::try_from(usage.prompt_tokens).ok())
+            .flatten(),
+        completion_tokens: usage
+            .completion_tokens_observed
+            .then(|| u64::try_from(usage.completion_tokens).ok())
+            .flatten(),
+        cached_prompt_tokens: usage
+            .cached_prompt_tokens
+            .and_then(|tokens| u64::try_from(tokens).ok()),
+    }
+}
+
 impl Drop for AttemptObservationGuard {
     fn drop(&mut self) {
         if !self.armed {
@@ -1786,11 +2655,16 @@ impl Drop for AttemptObservationGuard {
         }
 
         let terminal = self.cancellation_terminal();
-        record_attempt_outcome(
+        record_attempt_terminal_with_probe(
             &self.provider_router,
-            &AttemptOutcome::Terminal(terminal),
+            &terminal,
             ShadowObservationMode::Update,
+            self.probe.take(),
         );
+        // Commit the neutral terminal before admission can wake a waiter.
+        if let Some(permit) = self.turn_permit.take() {
+            permit.settle(None, TerminalDisposition::Ambiguous);
+        }
         warn!(
             "Inference attempt abandoned before terminal processing: request_id={}, execution_id={}, attempt_id={}, stage={:?}",
             self.attempt.request_id,
@@ -1819,9 +2693,10 @@ pub(crate) struct StartedCompletion {
     attempt: InferenceAttempt,
     terminal_guard: Option<AttemptObservationGuard>,
     response_model_id: String,
+    public_model_id: String,
     is_streaming: bool,
-    billing_context: BillingContext,
     non_streaming_body_limit: Option<usize>,
+    usage_settlement: Option<UsageSettlement>,
 }
 
 /// Starts one model turn against a route pinned for the logical inference
@@ -1937,7 +2812,7 @@ async fn get_chat_completion_response_with_options(
     user: &User,
     body: Value,
     headers: &HeaderMap,
-    mut billing_context: BillingContext,
+    billing_context: BillingContext,
     pinned: &PinnedCompletionRequest,
     options: CompletionExecutionOptions,
 ) -> Result<StartedCompletion, CompletionExecutionError> {
@@ -1954,6 +2829,17 @@ async fn get_chat_completion_response_with_options(
         })?
         .clone();
 
+    validate_completion_request_controls(
+        &modified_body,
+        state.inference_admission.policy().max_completion_choices(),
+    )
+    .map_err(CompletionExecutionError::from)?;
+    if completion_contains_unsupported_media(&modified_body) {
+        warn!("Rejected unsupported media content in completion request");
+        return Err(ApiError::BadRequest.into());
+    }
+    strip_provider_internal_request_fields(&mut modified_body);
+
     // Check if streaming is requested (default to false if not specified)
     let is_streaming = modified_body
         .get("stream")
@@ -1969,23 +2855,74 @@ async fn get_chat_completion_response_with_options(
         })?
         .to_string();
 
-    if body_model_name != pinned.route.public_model_id {
+    if body_model_name != pinned.public_model_id() {
         error!(
             "Prepared inference model did not match execution body: request_id={}, preferred_model={}, prepared_model={}, body_model={}",
             pinned.intent.request_id,
             pinned.intent.public_model_id,
-            pinned.route.public_model_id,
+            pinned.public_model_id(),
             body_model_name
         );
         return Err(ApiError::InternalServerError.into());
     }
 
     ensure_completion_model_access(&pinned.route.public_model_id, pinned.intent.model_plan)?;
-    let selected_route = pinned.route.clone();
+    if let Some(expected_route) = &options.exact_route {
+        if !completion_route_matches_exact_constraint(&pinned.route, expected_route) {
+            error!(
+                "Completion route did not match the server-selected constraint: request_id={}, public_model={}, expected_provider={}, expected_provider_model={}, selected_provider={}, selected_proxy_provider={}, selected_provider_model={}",
+                pinned.intent.request_id,
+                pinned.route.public_model_id,
+                expected_route.provider_name,
+                expected_route.provider_model_id,
+                pinned.route.provider.as_str(),
+                pinned.route.proxy.provider_name,
+                pinned.route.provider_model_id
+            );
+            return Err(CompletionExecutionError::Request(
+                ApiError::ServiceUnavailable,
+            ));
+        }
+    }
+    ensure_bounded_completion_generation(
+        &mut modified_body,
+        state
+            .inference_admission
+            .policy()
+            .completion_default_reservation(),
+    );
+
+    let AdmittedProviderTurn {
+        route: selected_route,
+        permit,
+        probe,
+    } = admit_completion_turn(state, pinned, &modified_body, options.exact_route.is_none())
+        .await
+        .map_err(CompletionExecutionError::from)?;
+    if selected_route.public_model_id != body_model_name {
+        error!(
+            "Admission changed the prepared public model: request_id={}, prepared_model={}, admitted_model={}",
+            pinned.intent.request_id,
+            body_model_name,
+            selected_route.public_model_id
+        );
+        drop(probe);
+        permit.settle(None, TerminalDisposition::ProvenPreAcceptance);
+        return Err(CompletionExecutionError::Request(
+            ApiError::InternalServerError,
+        ));
+    }
+    if let Err(error) =
+        ensure_completion_model_access(&selected_route.public_model_id, pinned.intent.model_plan)
+    {
+        drop(probe);
+        permit.settle(None, TerminalDisposition::ProvenPreAcceptance);
+        return Err(CompletionExecutionError::Request(error));
+    }
     if let Some(expected_route) = &options.exact_route {
         if !completion_route_matches_exact_constraint(&selected_route, expected_route) {
             error!(
-                "Completion route did not match the server-selected constraint: request_id={}, public_model={}, expected_provider={}, expected_provider_model={}, selected_provider={}, selected_proxy_provider={}, selected_provider_model={}",
+                "Admitted completion route did not match the server-selected constraint: request_id={}, public_model={}, expected_provider={}, expected_provider_model={}, selected_provider={}, selected_proxy_provider={}, selected_provider_model={}",
                 pinned.intent.request_id,
                 selected_route.public_model_id,
                 expected_route.provider_name,
@@ -1994,6 +2931,8 @@ async fn get_chat_completion_response_with_options(
                 selected_route.proxy.provider_name,
                 selected_route.provider_model_id
             );
+            drop(probe);
+            permit.settle(None, TerminalDisposition::ProvenPreAcceptance);
             return Err(CompletionExecutionError::Request(
                 ApiError::ServiceUnavailable,
             ));
@@ -2011,14 +2950,16 @@ async fn get_chat_completion_response_with_options(
         user.uuid,
     );
     if options.exact_route.is_some() {
-        apply_server_selected_cache_isolation(
+        if let Err(error) = apply_server_selected_cache_isolation(
             &mut modified_body,
             &selected_route.proxy.provider_name,
             options.continuum_cache_salt.as_deref(),
-        )?;
+        ) {
+            drop(probe);
+            permit.settle(None, TerminalDisposition::ProvenPreAcceptance);
+            return Err(CompletionExecutionError::Request(error));
+        }
     }
-    billing_context.model_name = selected_route.public_model_id.clone();
-
     // Prepare one logical model-turn execution. The provider transport may
     // report more than one attempt when Tinfoil safely refreshes a stale
     // attested route after a proven pre-connect failure.
@@ -2039,10 +2980,17 @@ async fn get_chat_completion_response_with_options(
         ensure_stream_usage(&mut request_body);
 
         let request_body_value = Value::Object(request_body);
+        let attempt = execution.begin_attempt(route_identity.clone());
+        let mut terminal_guard = AttemptObservationGuard::new_admitted(
+            attempt.clone(),
+            Arc::clone(&state.provider_router),
+            AttemptStage::BeforeSend,
+            permit,
+            probe,
+        );
         let request_body_json = match serde_json::to_string(&request_body_value) {
             Ok(json) => json,
             Err(error) => {
-                let attempt = execution.begin_attempt(route_identity.clone());
                 let failure = AttemptFailure::new(
                     AttemptFailureKind::RequestBuild,
                     AttemptStage::BeforeSend,
@@ -2052,12 +3000,12 @@ async fn get_chat_completion_response_with_options(
                     "Failed to serialize inference request: request_id={}, execution_id={}, attempt_id={}, error={:?}",
                     attempt.request_id, attempt.execution_id, attempt.attempt_id, error
                 );
-                return Err(failed_completion_execution(
-                    &state.provider_router,
-                    attempt,
-                    failure,
-                    ApiError::InternalServerError,
-                ));
+                let terminal = AttemptTerminal::Failed { attempt, failure };
+                terminal_guard.record_terminal(&terminal);
+                return Err(CompletionExecutionError::Attempt {
+                    terminal,
+                    public_error: ApiError::InternalServerError,
+                });
             }
         };
         let request_log_metadata =
@@ -2072,11 +3020,7 @@ async fn get_chat_completion_response_with_options(
             request_log_metadata
         );
 
-        let terminal_guard = AttemptObservationGuard::new(
-            execution.begin_attempt(route_identity.clone()),
-            Arc::clone(&state.provider_router),
-            AttemptStage::AwaitingResponse,
-        );
+        terminal_guard.set_stage(AttemptStage::AwaitingResponse);
         let (
             ProviderSendTrace {
                 prior_failures,
@@ -2135,14 +3079,13 @@ async fn get_chat_completion_response_with_options(
                     failure.stage,
                     request_log_metadata
                 );
-                let execution_error = failed_completion_execution(
-                    &state.provider_router,
-                    attempt,
-                    failure.clone(),
-                    public_completion_error(&err, &failure),
-                );
-                terminal_guard.disarm();
-                return Err(execution_error);
+                let public_error = public_completion_error(&err, &failure);
+                let terminal = AttemptTerminal::Failed { attempt, failure };
+                terminal_guard.record_terminal(&terminal);
+                return Err(CompletionExecutionError::Attempt {
+                    terminal,
+                    public_error,
+                });
             }
         }
     };
@@ -2155,11 +3098,12 @@ async fn get_chat_completion_response_with_options(
     Ok(StartedCompletion {
         response: Some(response),
         successful_provider,
+        usage_settlement: Some(UsageSettlement::new(billing_context, &attempt)),
         attempt,
         terminal_guard: Some(terminal_guard),
         response_model_id: selected_route.response_model_id,
+        public_model_id: selected_route.public_model_id,
         is_streaming,
-        billing_context,
         non_streaming_body_limit: options.non_streaming_body_limit,
     })
 }
@@ -2182,9 +3126,13 @@ pub(crate) async fn finish_started_completion(
     let successful_provider = started.successful_provider.clone();
     let attempt = started.attempt.clone();
     let response_model_id = started.response_model_id.clone();
+    let public_model_id = started.public_model_id.clone();
     let is_streaming = started.is_streaming;
-    let billing_context = started.billing_context.clone();
     let non_streaming_body_limit = started.non_streaming_body_limit;
+    let usage_settlement = started
+        .usage_settlement
+        .take()
+        .expect("started completion usage settlement can only be consumed once");
 
     // NOW: Process the response internally and handle billing
     if !is_streaming {
@@ -2197,38 +3145,34 @@ pub(crate) async fn finish_started_completion(
             &response_model_id,
             &attempt,
             non_streaming_body_limit,
+            Duration::from_secs(REQUEST_TIMEOUT_SECS),
         )
         .await
         {
             Ok(response_json) => response_json,
             Err(failure) => {
-                let execution_error = failed_completion_execution(
-                    &state.provider_router,
-                    attempt.clone(),
+                let terminal = AttemptTerminal::Failed {
+                    attempt: attempt.clone(),
                     failure,
-                    ApiError::InternalServerError,
-                );
-                terminal_guard.disarm();
-                return Err(execution_error);
+                };
+                terminal_guard.record_terminal(&terminal);
+                return Err(CompletionExecutionError::Attempt {
+                    terminal,
+                    public_error: ApiError::InternalServerError,
+                });
             }
         };
 
+        let usage = extract_usage(&response_json);
         let terminal = AttemptTerminal::Completed {
             attempt: attempt.clone(),
             evidence: CompletionEvidence::NonStreamingResponse,
         };
-        terminal_guard.record_terminal(&terminal);
+        terminal_guard.record_terminal_with_usage(&terminal, usage.as_ref());
 
         // ✅ Handle billing HERE, inside completions API
-        if let Some(usage) = extract_usage(&response_json) {
-            publish_usage_event_internal(
-                state,
-                user,
-                &billing_context,
-                usage,
-                &successful_provider,
-            )
-            .await;
+        if let Some(usage) = usage {
+            settle_completion_usage(state, user, usage_settlement, usage).await;
         }
 
         // Return the full response as a single chunk
@@ -2240,7 +3184,7 @@ pub(crate) async fn finish_started_completion(
             stream: rx,
             metadata: CompletionMetadata {
                 provider_name: successful_provider,
-                model_name: billing_context.model_name.clone(),
+                model_name: public_model_id,
                 is_streaming: false,
                 attempt,
             },
@@ -2254,8 +3198,6 @@ pub(crate) async fn finish_started_completion(
     // Spawn INTERNAL task that handles billing
     let state_clone = state.clone();
     let user_clone = user.clone();
-    let billing_ctx = billing_context.clone();
-    let provider = successful_provider.clone();
     let stream_attempt = attempt.clone();
     terminal_guard.set_stage(AttemptStage::Stream);
 
@@ -2269,14 +3211,13 @@ pub(crate) async fn finish_started_completion(
         )
         .await;
         let terminal = result.terminal.clone();
-        terminal_guard.record_terminal(&terminal);
+        terminal_guard.record_terminal_with_usage(&terminal, result.usage.as_ref());
         publish_stream_usage(
             result.usage,
             result.finalization,
             &state_clone,
             &user_clone,
-            &billing_ctx,
-            &provider,
+            usage_settlement,
             &tx_consumer,
         )
         .await;
@@ -2287,7 +3228,7 @@ pub(crate) async fn finish_started_completion(
         stream: rx_consumer,
         metadata: CompletionMetadata {
             provider_name: successful_provider,
-            model_name: billing_context.model_name.clone(),
+            model_name: public_model_id,
             is_streaming: true,
             attempt,
         },
@@ -2335,11 +3276,14 @@ fn extract_usage(json: &Value) -> Option<CompletionUsage> {
 
     Some(CompletionUsage {
         prompt_tokens,
+        prompt_tokens_observed: observed.prompt_tokens.is_some(),
         completion_tokens: observed.completion_tokens.unwrap_or(0),
         completion_tokens_observed: observed.completion_tokens.is_some(),
-        cached_prompt_tokens: observed
-            .cached_prompt_tokens
-            .map(|tokens| tokens.min(prompt_tokens)),
+        cached_prompt_tokens: observed.cached_prompt_tokens.map(|cached| {
+            observed
+                .prompt_tokens
+                .map_or(cached, |prompt| cached.min(prompt))
+        }),
     })
 }
 
@@ -2398,11 +3342,37 @@ fn tinfoil_user_cache_secret(user_uuid: Uuid) -> String {
     hex::encode(Sha256::digest(user_uuid.as_bytes()))
 }
 
+fn strip_tinfoil_router_execution_controls(body: &mut serde_json::Map<String, Value>) {
+    for field in TINFOIL_ROUTER_EXECUTION_FIELDS {
+        if body.remove(*field).is_some() {
+            debug!(field, "Stripped Tinfoil router-owned execution field");
+        }
+    }
+
+    let Some(tools) = body.get_mut("tools").and_then(Value::as_array_mut) else {
+        return;
+    };
+    for tool in tools {
+        let Some(tool) = tool.as_object_mut() else {
+            continue;
+        };
+        let mut stripped = tool.remove(TINFOIL_TOOL_AUTO_CONTINUE_FIELD).is_some();
+        stripped |= tool
+            .get_mut("function")
+            .and_then(Value::as_object_mut)
+            .is_some_and(|function| function.remove(TINFOIL_TOOL_AUTO_CONTINUE_FIELD).is_some());
+        if stripped {
+            debug!("Stripped Tinfoil router-owned tool auto-continue flag");
+        }
+    }
+}
+
 fn apply_provider_managed_request_fields(
     body: &mut serde_json::Map<String, Value>,
     provider_name: &str,
     user_uuid: Uuid,
 ) {
+    strip_provider_internal_request_fields(body);
     if body.remove(PROVIDER_MANAGED_CACHE_SALT_FIELD).is_some() {
         debug!("Stripped provider-managed completion request field: cache_salt");
     }
@@ -2412,6 +3382,10 @@ fn apply_provider_managed_request_fields(
         .is_some();
 
     if provider_name == ProviderId::Tinfoil.as_str() {
+        // OpenSecret owns tool loops, admission, and model routing. Tinfoil's
+        // router-only controls can otherwise fan one admitted request into
+        // several hidden upstream generations.
+        strip_tinfoil_router_execution_controls(body);
         body.insert(
             PROVIDER_MANAGED_USER_CACHE_SECRET_FIELD.to_string(),
             json!(tinfoil_user_cache_secret(user_uuid)),
@@ -2528,7 +3502,36 @@ fn find_sse_frame_boundary(buffer: &[u8]) -> Option<(usize, usize)> {
 }
 
 /// Internal billing function - NEVER exposed outside this module
-/// This function publishes usage events to both the database and SQS
+/// Settles one completion execution with a stable idempotency key.
+async fn settle_completion_usage(
+    state: &Arc<AppState>,
+    user: &User,
+    settlement: UsageSettlement,
+    usage: CompletionUsage,
+) {
+    debug!(
+        "Settling inference usage exactly once: request_id={}, execution_id={}, attempt_id={}, requested_model={}, public_model={}, provider={}",
+        settlement.request_id,
+        settlement.execution_id,
+        settlement.attempt_id,
+        settlement.requested_model_id,
+        settlement.public_model_id,
+        settlement.provider_name
+    );
+    publish_usage_record(
+        state,
+        user,
+        settlement.event_id,
+        settlement.auth_method == AuthMethod::ApiKey,
+        settlement.provider_name,
+        settlement.public_model_id,
+        usage,
+    )
+    .await;
+}
+
+/// Legacy settlement seam for modalities that have not migrated to routing-v2.
+/// Stack 9 owns moving those callers onto execution-scoped identifiers.
 async fn publish_usage_event_internal(
     state: &Arc<AppState>,
     user: &User,
@@ -2536,9 +3539,45 @@ async fn publish_usage_event_internal(
     usage: CompletionUsage,
     provider_name: &str,
 ) {
+    publish_usage_record(
+        state,
+        user,
+        Uuid::new_v4(),
+        billing_context.auth_method == AuthMethod::ApiKey,
+        provider_name.to_string(),
+        billing_context.model_name.clone(),
+        usage,
+    )
+    .await;
+}
+
+/// Publishes one already-identified usage record to the legacy local table and
+/// the authoritative billing queue. Callers own idempotency before this seam.
+#[allow(clippy::too_many_arguments)]
+async fn publish_usage_record(
+    state: &Arc<AppState>,
+    user: &User,
+    event_id: Uuid,
+    is_api_request: bool,
+    provider_name: String,
+    model_name: String,
+    mut usage: CompletionUsage,
+) {
     if usage.prompt_tokens == 0 && usage.completion_tokens == 0 {
         return;
     }
+
+    // Partial provider usage can still carry a raw cached-token observation for
+    // conservative admission settlement. Billing requires cached input to be a
+    // subset of an observed prompt total, so omit it when that total is absent.
+    usage.cached_prompt_tokens = usage
+        .prompt_tokens_observed
+        .then(|| {
+            usage
+                .cached_prompt_tokens
+                .map(|cached| cached.min(usage.prompt_tokens))
+        })
+        .flatten();
 
     // Local token_usage keeps the legacy rough estimate for observability.
     // The billing server recomputes authoritative provider cost from SQS tokens.
@@ -2551,7 +3590,7 @@ async fn publish_usage_event_internal(
     info!(
         "Chat completion usage for user {}: model={}, provider={}, prompt_tokens={}, cached_prompt_tokens={}, completion_tokens={}, total_tokens={}, estimated_cost={}",
         user.uuid,
-        billing_context.model_name,
+        model_name,
         provider_name,
         usage.prompt_tokens,
         usage.cached_prompt_tokens.unwrap_or(0),
@@ -2563,9 +3602,6 @@ async fn publish_usage_event_internal(
     // Spawn background task for DB + SQS
     let state_clone = state.clone();
     let user_id = user.uuid;
-    let is_api_request = billing_context.auth_method == AuthMethod::ApiKey;
-    let provider_name = provider_name.to_string();
-    let model_name = billing_context.model_name.clone();
 
     tokio::spawn(async move {
         // Create and store token usage record
@@ -2585,6 +3621,7 @@ async fn publish_usage_event_internal(
         // Post event to SQS if configured
         if let Some(publisher) = &state_clone.sqs_publisher {
             let event = build_usage_event(
+                event_id,
                 user_id,
                 usage,
                 total_cost,
@@ -2617,6 +3654,7 @@ async fn publish_usage_event_internal(
 }
 
 fn build_usage_event(
+    event_id: Uuid,
     user_id: Uuid,
     usage: CompletionUsage,
     estimated_cost: BigDecimal,
@@ -2625,7 +3663,7 @@ fn build_usage_event(
     model_name: String,
 ) -> UsageEvent {
     UsageEvent {
-        event_id: Uuid::new_v4(),
+        event_id,
         user_id,
         input_tokens: usage.prompt_tokens,
         output_tokens: usage.completion_tokens,
@@ -3451,6 +4489,7 @@ async fn proxy_embeddings(
                 BillingContext::new(_auth_method, embedding_request.model.clone());
             let embedding_usage = CompletionUsage {
                 prompt_tokens,
+                prompt_tokens_observed: true,
                 completion_tokens: 0, // Embeddings don't have completion tokens
                 completion_tokens_observed: false,
                 cached_prompt_tokens: None,
@@ -3714,6 +4753,8 @@ mod tests {
                 selection_source: crate::provider_registry::RouteSelectionSource::StaticSplit,
                 model_selection_source: crate::provider_routing::ModelSelectionSource::AutoPrimary,
             },
+            provider_preference: None,
+            finalized_route: Arc::new(OnceLock::new()),
         }
     }
 
@@ -3772,7 +4813,673 @@ mod tests {
                 selection_source: crate::provider_registry::RouteSelectionSource::DefaultProvider,
                 model_selection_source: crate::provider_routing::ModelSelectionSource::AutoFallback,
             },
+            provider_preference: None,
+            finalized_route: Arc::new(OnceLock::new()),
         }
+    }
+
+    #[test]
+    fn admission_estimate_sanitizes_images_and_uses_selected_deployment_bounds() {
+        let body = json!({
+            "model": "kimi-k3",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "hello admission"},
+                    {"type": "image_url", "image_url": {"url": format!("data:image/png;base64,{}", "A".repeat(100_000))}},
+                    {"type": "input_image", "image_url": "data:image/png;base64,BBBB"},
+                    {"image_url": "https://example.com/shorthand.png"},
+                    {"type": null, "image_url": "https://example.com/null-shorthand.png"},
+                    {"type": "garbage", "image_url": "https://example.com/coerced-shorthand.png"}
+                ]
+            }],
+            "max_completion_tokens": 321,
+            "n": 4
+        });
+
+        let k3 = pinned_test_completion();
+        let k2 = pinned_auto_fallback_completion();
+        let k3_estimate =
+            estimate_completion_admission(body.as_object().expect("object"), &k3.route, 4_096);
+        let k2_estimate =
+            estimate_completion_admission(body.as_object().expect("object"), &k2.route, 4_096);
+
+        assert_eq!(k3_estimate.completion_tokens, Some(1_284));
+        assert_eq!(k2_estimate.completion_tokens, Some(1_284));
+        assert_eq!(
+            k3_estimate.prompt_tokens - k2_estimate.prompt_tokens,
+            5 * (16_384 - 4_096)
+        );
+        assert!(k3_estimate.prompt_tokens >= 5 * 16_384);
+        assert!(k3_estimate.prompt_tokens < 90_000);
+
+        let compact_body = json!({
+            "model": "kimi-k3",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "hello admission"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,A"}},
+                    {"type": "input_image", "image_url": "data:image/png;base64,B"},
+                    {"image_url": "https://example.com/short.png"},
+                    {"type": null, "image_url": "https://example.com/null-short.png"},
+                    {"type": false, "image_url": "https://example.com/coerced-short.png"}
+                ]
+            }],
+            "max_completion_tokens": 321,
+            "n": 4
+        });
+        let compact_estimate = estimate_completion_admission(
+            compact_body.as_object().expect("object"),
+            &k3.route,
+            4_096,
+        );
+        assert!(
+            k3_estimate
+                .prompt_tokens
+                .abs_diff(compact_estimate.prompt_tokens)
+                < 16
+        );
+    }
+
+    #[test]
+    fn missing_completion_max_is_bounded_and_reserved_per_choice() {
+        let mut body = json!({
+            "messages": [{"role": "user", "content": "hello"}],
+            "ignore_eos": true,
+            "allowed_token_ids": [1, 2],
+            "n": 3
+        })
+        .as_object()
+        .expect("object")
+        .clone();
+        let pinned = pinned_test_completion();
+
+        ensure_bounded_completion_generation(&mut body, 4_096);
+        let estimate = estimate_completion_admission(&body, &pinned.route, 4_096);
+
+        assert_eq!(body["max_tokens"], 4_096);
+        assert_eq!(body["ignore_eos"], true);
+        assert_eq!(body["allowed_token_ids"], json!([1, 2]));
+        assert_eq!(estimate.completion_tokens, Some(12_288));
+    }
+
+    #[test]
+    fn null_completion_maxima_are_replaced_by_the_bounded_minimum() {
+        let mut body = json!({
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_completion_tokens": null,
+            "max_tokens": null,
+            "min_tokens": 8_192
+        })
+        .as_object()
+        .expect("object")
+        .clone();
+
+        validate_completion_request_controls(&body, 8).expect("canonical controls");
+        ensure_bounded_completion_generation(&mut body, 4_096);
+
+        assert!(!body.contains_key("max_completion_tokens"));
+        assert_eq!(body["max_tokens"], 8_192);
+    }
+
+    #[test]
+    fn completion_controls_reject_provider_coercible_json_types() {
+        for (field, value) in [
+            ("max_completion_tokens", json!("20000")),
+            ("max_tokens", json!(20_000.0)),
+            ("n", json!("4")),
+            ("min_tokens", json!("20000")),
+            ("stream", json!("true")),
+            ("stream", json!(1)),
+        ] {
+            let body = serde_json::Map::from_iter([(field.to_string(), value)]);
+            assert!(matches!(
+                validate_completion_request_controls(&body, 8),
+                Err(ApiError::BadRequest)
+            ));
+        }
+
+        let canonical = json!({
+            "max_completion_tokens": 20_000,
+            "max_tokens": null,
+            "n": 4,
+            "min_tokens": 0,
+            "stream": true
+        });
+        assert!(
+            validate_completion_request_controls(canonical.as_object().expect("object"), 8).is_ok()
+        );
+
+        let excessive = json!({"n": 9});
+        assert!(matches!(
+            validate_completion_request_controls(excessive.as_object().expect("object"), 8),
+            Err(ApiError::BadRequest)
+        ));
+    }
+
+    #[test]
+    fn completion_names_bound_derived_tool_attribute_expansion() {
+        let mut messages = vec![json!({
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [{
+                "id": "shared-call",
+                "type": "function",
+                "function": {"name": "&".repeat(65), "arguments": "{}"}
+            }]
+        })];
+        messages.extend(
+            (0..128)
+                .map(|_| json!({"role": "tool", "tool_call_id": "shared-call", "content": "ok"})),
+        );
+        let repeated = json!({"messages": messages, "max_tokens": 64});
+        assert!(matches!(
+            validate_completion_request_controls(repeated.as_object().expect("object"), 8),
+            Err(ApiError::BadRequest)
+        ));
+
+        for body in [
+            json!({"messages": [{"role": "user", "name": "bad&name", "content": "x"}]}),
+            json!({"tools": [{"type": "function", "function": {"name": "bad name"}}]}),
+            json!({"tool_choice": {"type": "function", "function": {"name": "bad\"name"}}}),
+        ] {
+            assert!(matches!(
+                validate_completion_request_controls(body.as_object().expect("object"), 8),
+                Err(ApiError::BadRequest)
+            ));
+        }
+
+        let canonical = json!({
+            "messages": [{
+                "role": "assistant",
+                "tool_calls": [{"function": {"name": "open_urls-2"}}]
+            }],
+            "tools": [{"type": "function", "function": {"name": "open_urls-2"}}],
+            "tool_choice": {"type": "function", "function": {"name": "open_urls-2"}}
+        });
+        assert!(
+            validate_completion_request_controls(canonical.as_object().expect("object"), 8).is_ok()
+        );
+    }
+
+    #[test]
+    fn historical_tool_arguments_must_be_bounded_valid_json_strings() {
+        for arguments in [
+            Value::String("{invalid".to_string()),
+            Value::String(format!(
+                "\"{}\"",
+                "x".repeat(MAX_COMPLETION_TOOL_ARGUMENT_BYTES)
+            )),
+            json!({"not": "a string"}),
+        ] {
+            let body = json!({
+                "messages": [{
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "type": "function",
+                        "function": {"name": "bounded_tool", "arguments": arguments}
+                    }]
+                }]
+            });
+            assert!(matches!(
+                validate_completion_request_controls(body.as_object().expect("object"), 8),
+                Err(ApiError::BadRequest)
+            ));
+        }
+    }
+
+    #[test]
+    fn admission_estimate_reserves_forwarded_min_tokens_per_choice() {
+        let mut body = json!({
+            "messages": [{"role": "user", "content": "hello"}],
+            "min_tokens": 20_000,
+            "n": 2
+        })
+        .as_object()
+        .expect("object")
+        .clone();
+        let pinned = pinned_test_completion();
+
+        ensure_bounded_completion_generation(&mut body, 4_096);
+        let estimate = estimate_completion_admission(&body, &pinned.route, 4_096);
+
+        assert_eq!(body["max_tokens"], 20_000);
+        assert_eq!(estimate.completion_tokens, Some(40_000));
+    }
+
+    #[test]
+    fn admission_estimate_counts_schema_keys_numbers_and_structure() {
+        let mut properties = serde_json::Map::new();
+        for index in 0..256 {
+            properties.insert(
+                format!("property_{index:04}_{}", "x".repeat(48)),
+                json!({"type": "integer", "enum": [index, index + 1, index + 2]}),
+            );
+        }
+        let body = json!({
+            "messages": [{"role": "user", "content": "return structured data"}],
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "large_schema",
+                    "parameters": {"type": "object", "properties": properties}
+                }
+            }],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "numeric_schema",
+                    "schema": {"type": "integer", "enum": (0..512).collect::<Vec<_>>()}
+                }
+            },
+            "max_tokens": 64
+        });
+        let baseline = json!({
+            "messages": [{"role": "user", "content": "return structured data"}],
+            "max_tokens": 64
+        });
+        let pinned = pinned_test_completion();
+
+        let estimate =
+            estimate_completion_admission(body.as_object().expect("object"), &pinned.route, 4_096);
+        let baseline_estimate = estimate_completion_admission(
+            baseline.as_object().expect("object"),
+            &pinned.route,
+            4_096,
+        );
+
+        assert!(estimate.prompt_tokens > baseline_estimate.prompt_tokens + 1_000);
+    }
+
+    #[test]
+    fn prompt_bound_is_tokenizer_independent_and_preserves_text_with_image_key() {
+        let adversarial_text = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".repeat(4_000);
+        let body = json!({
+            "messages": [{
+                "role": "user",
+                "content": [{
+                    "type": "text",
+                    "text": adversarial_text,
+                    "image_url": null
+                }]
+            }],
+            "max_tokens": 64
+        });
+        let pinned = pinned_test_completion();
+
+        let estimate =
+            estimate_completion_admission(body.as_object().expect("object"), &pinned.route, 4_096);
+
+        assert!(estimate.prompt_tokens >= u64::try_from(adversarial_text.len()).unwrap() + 16_384);
+    }
+
+    #[test]
+    fn prompt_bound_accounts_for_provider_attribute_entity_expansion() {
+        let attribute = "&\"".repeat(5_000);
+        let body = json!({
+            "messages": [{"role": "user", "name": attribute, "content": "hello"}],
+            "max_tokens": 64
+        });
+        let pinned = pinned_test_completion();
+
+        let estimate =
+            estimate_completion_admission(body.as_object().expect("object"), &pinned.route, 4_096);
+
+        // Each pair expands from two decoded bytes to eleven entity bytes.
+        assert!(estimate.prompt_tokens >= 55_000);
+    }
+
+    #[test]
+    fn prompt_bound_accounts_for_tool_argument_normalization_and_tags() {
+        let array_arguments = json!({"a": vec![0; 10_000]}).to_string();
+        let array_body = json!({
+            "messages": [{
+                "role": "assistant",
+                "tool_calls": [{
+                    "id": "call-array",
+                    "type": "function",
+                    "function": {"name": "array_tool", "arguments": array_arguments}
+                }]
+            }],
+            "max_tokens": 64
+        });
+        let mut object_arguments = serde_json::Map::new();
+        for index in 0..1_000 {
+            object_arguments.insert(format!("a{index}"), Value::Null);
+        }
+        let object_body = json!({
+            "messages": [{
+                "role": "assistant",
+                "tool_calls": [{
+                    "id": "call-object",
+                    "type": "function",
+                    "function": {
+                        "name": "object_tool",
+                        "arguments": Value::Object(object_arguments).to_string()
+                    }
+                }]
+            }],
+            "max_tokens": 64
+        });
+        let pinned = pinned_test_completion();
+
+        let array_estimate = estimate_completion_admission(
+            array_body.as_object().expect("object"),
+            &pinned.route,
+            4_096,
+        );
+        let object_estimate = estimate_completion_admission(
+            object_body.as_object().expect("object"),
+            &pinned.route,
+            4_096,
+        );
+
+        assert!(array_estimate.prompt_tokens >= 30_000);
+        assert!(object_estimate.prompt_tokens >= 17_000);
+
+        let exponent_arguments = format!(
+            r#"{{"x":[{}]}}"#,
+            std::iter::repeat_n("1e15", 10_000)
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        let exponent_body = json!({
+            "messages": [{
+                "role": "assistant",
+                "tool_calls": [{
+                    "id": "call-exponent",
+                    "type": "function",
+                    "function": {"name": "exponent_tool", "arguments": exponent_arguments}
+                }]
+            }],
+            "max_tokens": 64
+        });
+        validate_completion_request_controls(exponent_body.as_object().expect("object"), 8)
+            .expect("bounded valid arguments");
+        let exponent_estimate = estimate_completion_admission(
+            exponent_body.as_object().expect("object"),
+            &pinned.route,
+            4_096,
+        );
+        assert!(exponent_estimate.prompt_tokens >= 100_134);
+    }
+
+    #[test]
+    fn prompt_bound_accounts_for_multiline_tool_schema_formatting() {
+        let description = format!("{}x", "x\n".repeat(10_000));
+        let body = json!({
+            "messages": [{"role": "user", "content": "use the tool"}],
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "multiline_tool",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "value": {"type": "string", "description": description}
+                        }
+                    }
+                }
+            }],
+            "max_tokens": 64
+        });
+        let pinned = pinned_auto_fallback_completion();
+
+        let estimate =
+            estimate_completion_admission(body.as_object().expect("object"), &pinned.route, 4_096);
+
+        assert!(estimate.prompt_tokens >= 40_044);
+    }
+
+    #[test]
+    fn message_tool_schema_named_image_url_is_counted_not_sanitized() {
+        let large_description = "schema detail ".repeat(2_000);
+        let body = json!({
+            "messages": [{
+                "role": "developer",
+                "content": "use the provided schema",
+                "tools": [{
+                    "type": "function",
+                    "function": {
+                        "name": "schema_tool",
+                        "parameters": {
+                            "type": "image_url",
+                            "description": large_description
+                        }
+                    }
+                }]
+            }],
+            "max_tokens": 64
+        });
+        let baseline = json!({
+            "messages": [{"role": "developer", "content": "use the provided schema"}],
+            "max_tokens": 64
+        });
+        let pinned = pinned_test_completion();
+
+        let estimate =
+            estimate_completion_admission(body.as_object().expect("object"), &pinned.route, 4_096);
+        let baseline_estimate = estimate_completion_admission(
+            baseline.as_object().expect("object"),
+            &pinned.route,
+            4_096,
+        );
+
+        assert!(estimate.prompt_tokens > baseline_estimate.prompt_tokens + 2_000);
+    }
+
+    #[test]
+    fn unsupported_media_is_rejected_in_explicit_shorthand_and_cached_shapes() {
+        for part in [
+            json!({"type": "video_url", "video_url": {"url": "https://example.com/a.mp4"}}),
+            json!({"video_url": "https://example.com/a.mp4"}),
+            json!({"type": null, "video_url": "https://example.com/a.mp4"}),
+            json!({"type": "garbage", "video_url": "https://example.com/a.mp4"}),
+            json!({"type": "input_video", "video_url": "data:video/mp4;base64,AAAA"}),
+            json!({"type": "image_pil", "image_pil": null, "uuid": "cached-image"}),
+            json!({"image_embeds": null, "uuid": "cached-image"}),
+            json!({"type": "prompt_embeds", "prompt_embeds": null}),
+        ] {
+            let body = json!({
+                "messages": [{"role": "user", "content": [part]}],
+                "max_tokens": 64
+            });
+            assert!(completion_contains_unsupported_media(
+                body.as_object().expect("object")
+            ));
+        }
+
+        let image = json!({
+            "messages": [{
+                "role": "user",
+                "content": [{"image_url": "https://example.com/a.png"}]
+            }]
+        });
+        assert!(!completion_contains_unsupported_media(
+            image.as_object().expect("object")
+        ));
+    }
+
+    #[test]
+    fn usage_settlement_uses_one_stable_id_per_execution() {
+        let pinned = pinned_test_completion();
+        let route = pinned.route.identity();
+        let first_execution = pinned.begin_execution();
+        let first_attempt = first_execution.begin_attempt(route.clone());
+        let recovered_attempt = first_execution.begin_attempt(route.clone());
+        let next_attempt = pinned.begin_execution().begin_attempt(route);
+        let billing = || BillingContext::new(AuthMethod::Jwt, "auto-powerful".to_string());
+
+        let first = UsageSettlement::new(billing(), &first_attempt);
+        let recovered = UsageSettlement::new(billing(), &recovered_attempt);
+        let next = UsageSettlement::new(billing(), &next_attempt);
+
+        assert_eq!(first.event_id, recovered.event_id);
+        assert_eq!(first.event_id, first_execution.execution_id.as_uuid());
+        assert_ne!(first.attempt_id, recovered.attempt_id);
+        assert_ne!(first.event_id, next.event_id);
+    }
+
+    #[tokio::test]
+    async fn attempt_guard_holds_admission_until_authoritative_terminal() {
+        let policy =
+            crate::inference::admission::AdmissionPolicy::with_deployment_in_flight_for_test(
+                &crate::provider_registry::PROVIDER_REGISTRY,
+                1,
+            )
+            .expect("one-slot policy");
+        let controller = crate::inference::admission::AdmissionController::new(
+            &crate::provider_registry::PROVIDER_REGISTRY,
+            policy,
+        )
+        .expect("controller");
+        let pinned = pinned_test_completion();
+        let route_key = pinned.route.identity().route_key();
+        let permit = controller
+            .acquire_turn(
+                &route_key,
+                Uuid::nil(),
+                WorkloadClass::Interactive,
+                AdmissionEstimate::new(10, Some(5)),
+                None,
+            )
+            .await
+            .expect("first permit");
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let mut guard = AttemptObservationGuard::new_admitted(
+            attempt.clone(),
+            Arc::new(ProviderRouter::default()),
+            AttemptStage::ResponseBody,
+            permit,
+            None,
+        );
+
+        let rejection = controller
+            .acquire_turn(
+                &route_key,
+                Uuid::from_u128(1),
+                WorkloadClass::Background,
+                AdmissionEstimate::new(1, Some(1)),
+                None,
+            )
+            .await
+            .expect_err("response headers must not release the permit");
+        assert_eq!(
+            rejection.kind,
+            crate::inference::admission::AdmissionRejectionKind::DeploymentBusy
+        );
+
+        let terminal = AttemptTerminal::Completed {
+            attempt,
+            evidence: CompletionEvidence::NonStreamingResponse,
+        };
+        let usage = CompletionUsage {
+            prompt_tokens: 8,
+            prompt_tokens_observed: true,
+            completion_tokens: 4,
+            completion_tokens_observed: true,
+            cached_prompt_tokens: Some(2),
+        };
+        guard.record_terminal_with_usage(&terminal, Some(&usage));
+
+        let next = controller
+            .acquire_turn(
+                &route_key,
+                Uuid::from_u128(1),
+                WorkloadClass::Background,
+                AdmissionEstimate::new(1, Some(1)),
+                None,
+            )
+            .await
+            .expect("terminal releases the deployment slot");
+        next.settle(None, TerminalDisposition::ProvenPreAcceptance);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn terminal_health_is_visible_before_a_queued_waiter_is_released() {
+        let policy =
+            crate::inference::admission::AdmissionPolicy::with_deployment_in_flight_for_test(
+                &PROVIDER_REGISTRY,
+                1,
+            )
+            .expect("one-slot policy");
+        let controller =
+            crate::inference::admission::AdmissionController::new(&PROVIDER_REGISTRY, policy)
+                .expect("controller");
+        let provider_router = Arc::new(ProviderRouter::default());
+        let pinned = pinned_test_completion();
+        let route_key = pinned.route.identity().route_key();
+        let permit = controller
+            .acquire_turn(
+                &route_key,
+                Uuid::nil(),
+                WorkloadClass::Interactive,
+                AdmissionEstimate::new(1, Some(1)),
+                None,
+            )
+            .await
+            .expect("first permit");
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let mut guard = AttemptObservationGuard::new_admitted(
+            attempt.clone(),
+            provider_router.clone(),
+            AttemptStage::ResponseBody,
+            permit,
+            None,
+        );
+
+        let waiter_controller = controller.clone();
+        let waiter_router = provider_router.clone();
+        let waiter_route = route_key.clone();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let waiter = tokio::spawn(async move {
+            let _ = started_tx.send(());
+            let permit = waiter_controller
+                .acquire_turn(
+                    &waiter_route,
+                    Uuid::from_u128(1),
+                    WorkloadClass::Interactive,
+                    AdmissionEstimate::new(1, Some(1)),
+                    None,
+                )
+                .await
+                .expect("queued waiter should acquire after release");
+            let circuit_is_open = matches!(
+                waiter_router.try_claim_probe(&waiter_route),
+                ProbeClaimResult::Rejected {
+                    reason: crate::inference::health::ProbeRejectionReason::CircuitOpen,
+                    ..
+                }
+            );
+            permit.settle(None, TerminalDisposition::ProvenPreAcceptance);
+            circuit_is_open
+        });
+        started_rx.await.expect("waiter started");
+        tokio::task::yield_now().await;
+
+        let terminal = AttemptTerminal::Failed {
+            attempt,
+            failure: AttemptFailure::new(
+                AttemptFailureKind::CapacityRejected,
+                AttemptStage::ResponseBody,
+                ReplaySafety::NotProvenPreAcceptance,
+            )
+            .with_upstream_response(503, Some(Duration::from_secs(30)), None),
+        };
+        guard.record_terminal(&terminal);
+
+        assert!(
+            timeout(Duration::from_secs(1), waiter)
+                .await
+                .expect("waiter should wake")
+                .expect("waiter task"),
+            "the circuit-opening terminal must be visible before admission wakes the waiter"
+        );
     }
 
     #[test]
@@ -3864,15 +5571,20 @@ mod tests {
             Arc::clone(&provider_router),
             AttemptStage::ResponseBody,
         );
+        let usage_settlement = UsageSettlement::new(
+            BillingContext::new(AuthMethod::Jwt, "kimi-k3".to_string()),
+            &attempt,
+        );
         let mut started = StartedCompletion {
             response: Some(response),
             successful_provider: ProviderId::Tinfoil.as_str().to_string(),
             attempt,
             terminal_guard: Some(terminal_guard),
             response_model_id: "kimi-k3".to_string(),
+            public_model_id: "kimi-k3".to_string(),
             is_streaming: false,
-            billing_context: BillingContext::new(AuthMethod::Jwt, "kimi-k3".to_string()),
             non_streaming_body_limit: None,
+            usage_settlement: Some(usage_settlement),
         };
 
         drop(started.response.take());
@@ -4216,6 +5928,7 @@ mod tests {
             &second_route.response_model_id,
             &second_attempt,
             None,
+            Duration::from_secs(1),
         )
         .await
         .expect("canonical Continuum response");
@@ -4405,6 +6118,7 @@ mod tests {
             &second_route.response_model_id,
             &second_attempt,
             None,
+            Duration::from_secs(1),
         )
         .await
         .expect("canonical K2.6 response");
@@ -4499,7 +6213,12 @@ mod tests {
             baseline,
         )
         .expect("initial GLM route");
-        let pinned = PinnedCompletionRequest { intent, route };
+        let pinned = PinnedCompletionRequest {
+            intent,
+            route,
+            provider_preference: None,
+            finalized_route: Arc::new(OnceLock::new()),
+        };
 
         let send_pinned_turn = |content: &'static str| {
             let provider_client = &provider_client;
@@ -4526,6 +6245,7 @@ mod tests {
                     &pinned.route.response_model_id,
                     &attempt,
                     None,
+                    Duration::from_secs(1),
                 )
                 .await
                 .expect("canonical pinned response");
@@ -4657,7 +6377,12 @@ mod tests {
             route.model_selection_source,
             crate::provider_routing::ModelSelectionSource::AutoPrimary
         );
-        let pinned = PinnedCompletionRequest { intent, route };
+        let pinned = PinnedCompletionRequest {
+            intent,
+            route,
+            provider_preference: None,
+            finalized_route: Arc::new(OnceLock::new()),
+        };
 
         let send_pinned_turn = |content: &'static str| {
             let provider_client = &provider_client;
@@ -4684,6 +6409,7 @@ mod tests {
                     &pinned.route.response_model_id,
                     &attempt,
                     None,
+                    Duration::from_secs(1),
                 )
                 .await
                 .expect("canonical pinned K3 response");
@@ -5163,9 +6889,15 @@ mod tests {
         let attempt = pinned
             .begin_execution()
             .begin_attempt(pinned.route.identity());
-        let failure = read_non_streaming_completion_response(response, "kimi-k3", &attempt, None)
-            .await
-            .expect_err("top-level provider error payload must fail the attempt");
+        let failure = read_non_streaming_completion_response(
+            response,
+            "kimi-k3",
+            &attempt,
+            None,
+            Duration::from_secs(1),
+        )
+        .await
+        .expect_err("top-level provider error payload must fail the attempt");
         server.abort();
 
         assert_eq!(failure.kind, AttemptFailureKind::UpstreamResponseError);
@@ -5208,10 +6940,15 @@ mod tests {
         let attempt = pinned
             .begin_execution()
             .begin_attempt(pinned.route.identity());
-        let failure =
-            read_non_streaming_completion_response(response, "kimi-k3", &attempt, Some(8))
-                .await
-                .expect_err("response over the descriptor cap must fail");
+        let failure = read_non_streaming_completion_response(
+            response,
+            "kimi-k3",
+            &attempt,
+            Some(8),
+            Duration::from_secs(1),
+        )
+        .await
+        .expect_err("response over the descriptor cap must fail");
         server.abort();
 
         assert_eq!(failure.kind, AttemptFailureKind::InvalidResponse);
@@ -5257,6 +6994,42 @@ mod tests {
             .decrypt(ciphertext, &nonce)
             .expect("Maple SDK AEAD contract");
         assert_eq!(decrypted, plaintext.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn mock_provider_pending_non_streaming_body_times_out() {
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(|| async {
+                let pending = futures::stream::pending::<Result<bytes::Bytes, std::io::Error>>();
+                axum::http::Response::builder()
+                    .status(axum::http::StatusCode::OK)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(axum::body::Body::from_stream(pending))
+                    .expect("mock pending response")
+            }),
+        );
+        let (trace, server) = call_mock_provider(app).await;
+        let response = trace.result.expect("mock provider response start");
+        let pinned = pinned_test_completion();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+
+        let failure = read_non_streaming_completion_response(
+            response,
+            "kimi-k3",
+            &attempt,
+            None,
+            Duration::from_millis(20),
+        )
+        .await
+        .expect_err("pending non-streaming body must time out");
+        server.abort();
+
+        assert_eq!(failure.kind, AttemptFailureKind::ResponseBody);
+        assert_eq!(failure.stage, AttemptStage::ResponseBody);
+        assert_eq!(failure.replay_safety, ReplaySafety::NotProvenPreAcceptance);
     }
 
     #[tokio::test]
@@ -5307,6 +7080,51 @@ mod tests {
                 consecutive_failures: 1
             }
         );
+    }
+
+    #[tokio::test]
+    async fn slow_stream_consumer_cannot_hold_the_processor_forever() {
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(|| async {
+                axum::http::Response::builder()
+                    .status(axum::http::StatusCode::OK)
+                    .header(header::CONTENT_TYPE, "text/event-stream")
+                    .body(axum::body::Body::from(concat!(
+                        "data: {\"choices\":[{\"delta\":{\"content\":\"one\"},\"finish_reason\":null}]}\n\n",
+                        "data: {\"choices\":[{\"delta\":{\"content\":\"two\"},\"finish_reason\":null}]}\n\n",
+                        "data: [DONE]\n\n"
+                    )))
+                    .expect("mock streaming response")
+            }),
+        );
+        let (trace, server) = call_mock_provider(app).await;
+        let response = trace.result.expect("mock provider response start");
+        let pinned = pinned_test_completion();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let (tx, _rx) = mpsc::channel(1);
+
+        let result = timeout(
+            Duration::from_millis(200),
+            process_completion_stream(response, "kimi-k3", attempt, &tx, Duration::from_millis(20)),
+        )
+        .await
+        .expect("slow consumer must be bounded");
+        server.abort();
+
+        assert!(matches!(
+            result.terminal,
+            AttemptTerminal::Failed {
+                failure: AttemptFailure {
+                    kind: AttemptFailureKind::ConsumerDropped,
+                    stage: AttemptStage::Stream,
+                    ..
+                },
+                ..
+            }
+        ));
     }
 
     #[tokio::test]
@@ -6113,10 +7931,70 @@ mod tests {
     }
 
     #[test]
+    fn strips_tinfoil_router_execution_controls_but_preserves_tool_schema() {
+        let mut body = serde_json::Map::from_iter([
+            ("web_search_options".to_string(), json!({"enabled": true})),
+            (
+                "code_execution_options".to_string(),
+                json!({"accessToken": "client-controlled"}),
+            ),
+            ("pii_check_options".to_string(), json!({})),
+            (
+                "auto_model_options".to_string(),
+                json!([{"model": "different-model"}]),
+            ),
+            (
+                "tools".to_string(),
+                json!([{
+                    "type": "function",
+                    "function": {
+                        "name": "render_preview",
+                        "description": "Render a preview",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"title": {"type": "string"}}
+                        },
+                        "x-tinfoil-tool-auto-continue": true
+                    }
+                }]),
+            ),
+            (
+                "tool_choice".to_string(),
+                json!({"type": "function", "function": {"name": "render_preview"}}),
+            ),
+        ]);
+
+        apply_provider_managed_request_fields(
+            &mut body,
+            ProviderId::Tinfoil.as_str(),
+            Uuid::from_u128(42),
+        );
+
+        for field in TINFOIL_ROUTER_EXECUTION_FIELDS {
+            assert!(!body.contains_key(*field));
+        }
+        let function = body["tools"][0]["function"]
+            .as_object()
+            .expect("ordinary function schema remains");
+        assert!(!function.contains_key(TINFOIL_TOOL_AUTO_CONTINUE_FIELD));
+        assert_eq!(function["name"], "render_preview");
+        assert_eq!(function["description"], "Render a preview");
+        assert_eq!(
+            function["parameters"]["properties"]["title"]["type"],
+            "string"
+        );
+        assert_eq!(body["tool_choice"]["function"]["name"], "render_preview");
+    }
+
+    #[test]
     fn strips_tinfoil_cache_fields_from_non_tinfoil_requests() {
         let mut body = serde_json::Map::from_iter([
             ("cache_salt".to_string(), json!("user-supplied")),
             ("user_cache_secret".to_string(), json!("client-controlled")),
+            (
+                "kv_transfer_params".to_string(),
+                json!({"prompt_token_ids": [1, 2, 3]}),
+            ),
         ]);
 
         apply_provider_managed_request_fields(
@@ -6127,6 +8005,7 @@ mod tests {
 
         assert!(!body.contains_key(PROVIDER_MANAGED_CACHE_SALT_FIELD));
         assert!(!body.contains_key(PROVIDER_MANAGED_USER_CACHE_SECRET_FIELD));
+        assert!(!body.contains_key(PROVIDER_MANAGED_KV_TRANSFER_PARAMS_FIELD));
     }
 
     #[test]
@@ -6174,6 +8053,7 @@ mod tests {
         let usage = extract_usage(&response).expect("usage should parse");
 
         assert_eq!(usage.prompt_tokens, 100);
+        assert!(usage.prompt_tokens_observed);
         assert_eq!(usage.completion_tokens, 20);
         assert!(usage.completion_tokens_observed);
         assert_eq!(usage.cached_prompt_tokens, Some(42));
@@ -6190,8 +8070,33 @@ mod tests {
         let usage = extract_usage(&response).expect("usage should parse");
 
         assert_eq!(usage.prompt_tokens, 100);
+        assert!(usage.prompt_tokens_observed);
         assert_eq!(usage.completion_tokens, 0);
         assert!(!usage.completion_tokens_observed);
+    }
+
+    #[test]
+    fn completion_only_usage_preserves_missing_prompt_token_signal() {
+        let response = json!({
+            "usage": {
+                "completion_tokens": 7,
+                "prompt_tokens_details": {
+                    "cached_tokens": 5
+                }
+            }
+        });
+
+        let usage = extract_usage(&response).expect("usage should parse");
+        let actual = completion_actual_usage(&usage);
+
+        assert_eq!(usage.prompt_tokens, 0);
+        assert!(!usage.prompt_tokens_observed);
+        assert_eq!(usage.completion_tokens, 7);
+        assert!(usage.completion_tokens_observed);
+        assert_eq!(usage.cached_prompt_tokens, Some(5));
+        assert_eq!(actual.prompt_tokens, None);
+        assert_eq!(actual.completion_tokens, Some(7));
+        assert_eq!(actual.cached_prompt_tokens, Some(5));
     }
 
     #[test]
@@ -6262,12 +8167,14 @@ mod tests {
     fn cached_prompt_tokens_are_mapped_to_sqs_cached_input_tokens() {
         let usage = CompletionUsage {
             prompt_tokens: 100,
+            prompt_tokens_observed: true,
             completion_tokens: 20,
             completion_tokens_observed: true,
             cached_prompt_tokens: Some(42),
         };
 
         let event = build_usage_event(
+            Uuid::parse_str("dca25195-ae0a-4c49-aa7a-bd2ba21a7d2b").unwrap(),
             Uuid::parse_str("6142db59-fc0c-413d-8792-579fc1457fe2").unwrap(),
             usage,
             BigDecimal::from_str("0.001").unwrap(),
@@ -6288,6 +8195,7 @@ mod tests {
     fn route_identity_is_preserved_in_usage_events() {
         let usage = CompletionUsage {
             prompt_tokens: 100,
+            prompt_tokens_observed: true,
             completion_tokens: 20,
             completion_tokens_observed: true,
             cached_prompt_tokens: Some(42),
@@ -6302,6 +8210,7 @@ mod tests {
             ("continuum", "glm-5-2"),
         ] {
             let event = build_usage_event(
+                Uuid::parse_str("dca25195-ae0a-4c49-aa7a-bd2ba21a7d2b").unwrap(),
                 Uuid::parse_str("6142db59-fc0c-413d-8792-579fc1457fe2").unwrap(),
                 usage.clone(),
                 BigDecimal::from_str("0.001").unwrap(),
@@ -6384,6 +8293,7 @@ mod tests {
         cached_prompt_tokens: Option<i32>,
     ) {
         assert_eq!(usage.prompt_tokens, prompt_tokens);
+        assert!(usage.prompt_tokens_observed);
         assert_eq!(usage.completion_tokens, completion_tokens);
         assert!(usage.completion_tokens_observed);
         assert_eq!(usage.cached_prompt_tokens, cached_prompt_tokens);
@@ -6579,6 +8489,17 @@ mod tests {
     }
 
     #[test]
+    fn authoritative_zero_usage_is_not_dropped() {
+        let mut accumulator = StreamUsageAccumulator::default();
+        accumulator.observe(&stream_usage_chunk(0, 0, None, None, true));
+
+        let usage = accumulator
+            .take_final_usage(StreamUsageFinalization::ProviderDone)
+            .expect("explicit zero totals are authoritative usage");
+        assert_usage(usage, 0, 0, None);
+    }
+
+    #[test]
     fn stream_prompt_only_usage_keeps_completion_tokens_unobserved() {
         let mut accumulator = StreamUsageAccumulator::default();
         accumulator.observe(&json!({
@@ -6590,8 +8511,32 @@ mod tests {
             .take_final_usage(StreamUsageFinalization::ProviderDone)
             .expect("non-zero prompt usage should be retained");
         assert_eq!(usage.prompt_tokens, 33);
+        assert!(usage.prompt_tokens_observed);
         assert_eq!(usage.completion_tokens, 0);
         assert!(!usage.completion_tokens_observed);
+    }
+
+    #[test]
+    fn stream_cached_usage_without_prompt_total_keeps_cached_tokens_unobserved() {
+        let mut accumulator = StreamUsageAccumulator::default();
+        accumulator.observe(&json!({
+            "choices": [{ "finish_reason": "stop" }],
+            "usage": {
+                "completion_tokens": 7,
+                "prompt_tokens_details": { "cached_tokens": 5 }
+            }
+        }));
+
+        let usage = accumulator
+            .take_final_usage(StreamUsageFinalization::ProviderDone)
+            .expect("observed completion usage should be retained");
+        let actual = completion_actual_usage(&usage);
+        assert!(!usage.prompt_tokens_observed);
+        assert!(usage.completion_tokens_observed);
+        assert_eq!(usage.cached_prompt_tokens, Some(5));
+        assert_eq!(actual.prompt_tokens, None);
+        assert_eq!(actual.completion_tokens, Some(7));
+        assert_eq!(actual.cached_prompt_tokens, Some(5));
     }
 
     #[test]

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -1459,7 +1459,7 @@ async fn proxy_openai(
         &pinned_completion,
     )
     .await
-    .map_err(CompletionExecutionError::into_api_error)?;
+    .map_err(CompletionExecutionError::into_pre_persistence_api_error)?;
 
     debug!(
         "Received completion stream: request_id={}, execution_id={}, attempt_id={}, provider={}, streaming={}",
@@ -3757,6 +3757,36 @@ mod tests {
                 }
             ));
         }
+    }
+
+    #[tokio::test]
+    async fn pre_persistence_capacity_failure_marks_client_replay_safe() {
+        let provider_error = ProviderRequestError::Upstream(UpstreamProviderError {
+            status: 429,
+            retry_after: Some(Duration::from_secs(7)),
+            upstream_request_id: None,
+        });
+        let failure = attempt_failure_from_provider_error(&provider_error);
+        let pinned = pinned_test_completion();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let response = failed_completion_execution(
+            attempt,
+            failure.clone(),
+            public_completion_error(&provider_error, &failure),
+        )
+        .into_pre_persistence_api_error()
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(response.headers()[crate::CLIENT_REPLAY_HEADER], "safe");
+        assert_eq!(response.headers()[crate::ERROR_CONTRACT_HEADER], "1");
+        assert_eq!(
+            response.headers()[crate::ERROR_CODE_HEADER],
+            crate::INFERENCE_CAPACITY_ERROR_CODE
+        );
+        assert_eq!(response.headers()[header::RETRY_AFTER], "7");
     }
 
     #[tokio::test]

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -3139,6 +3139,64 @@ mod tests {
         assert_eq!(event.model_name, "kimi-k2-6");
     }
 
+    #[test]
+    fn route_identity_is_preserved_in_usage_events() {
+        let usage = CompletionUsage {
+            prompt_tokens: 100,
+            completion_tokens: 20,
+            cached_prompt_tokens: Some(42),
+        };
+
+        for (provider, public_model) in [
+            ("tinfoil", "gpt-oss-120b"),
+            ("tinfoil", "deepseek-v4-flash"),
+            ("tinfoil", "kimi-k3"),
+            ("tinfoil", "glm-5-2"),
+            ("continuum", "kimi-k2-6"),
+            ("continuum", "glm-5-2"),
+        ] {
+            let event = build_usage_event(
+                Uuid::parse_str("6142db59-fc0c-413d-8792-579fc1457fe2").unwrap(),
+                usage.clone(),
+                BigDecimal::from_str("0.001").unwrap(),
+                false,
+                provider.to_string(),
+                public_model.to_string(),
+            );
+
+            assert_eq!(event.provider_name, provider);
+            assert_eq!(event.model_name, public_model);
+            assert_eq!(event.input_tokens, 100);
+            assert_eq!(event.output_tokens, 20);
+            assert_eq!(event.cached_input_tokens, Some(42));
+        }
+    }
+
+    #[test]
+    fn provider_model_ids_are_canonicalized_in_client_responses() {
+        for (provider_model, public_model) in [
+            ("kimi-k2.6", "kimi-k2-6"),
+            ("glm-5.2", "glm-5-2"),
+            ("kimi-k3", "kimi-k3"),
+        ] {
+            let mut response = json!({
+                "id": "completion-id",
+                "model": provider_model,
+                "choices": [],
+            });
+
+            canonicalize_response_model(&mut response, public_model);
+
+            assert_eq!(response["model"], public_model);
+            assert_eq!(response["id"], "completion-id");
+            assert_eq!(response["choices"], json!([]));
+        }
+
+        let mut response_without_model = json!({"choices": []});
+        canonicalize_response_model(&mut response_without_model, "glm-5-2");
+        assert!(response_without_model.get("model").is_none());
+    }
+
     fn stream_usage_chunk(
         prompt_tokens: i32,
         completion_tokens: i32,

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -3,6 +3,7 @@ use crate::inference::{
     CompletionEvidence, InferenceAttempt, InferenceExecution, InferenceIntent, InferenceSurface,
     ReplaySafety, WorkloadClass,
 };
+use crate::inference_planning::{RoutePlan, RoutePlanningError};
 use crate::model_config::{
     model_alias_requires_flag_lookup, model_catalog_response, openai_models_response,
     ModelAliasTargets, ModelPlan,
@@ -13,7 +14,10 @@ use crate::provider_client::{
     ProviderClient, ProviderRequest, ProviderRequestError, ProviderResponse, ProviderSendTrace,
     UpstreamProviderError,
 };
-use crate::provider_routing::{ProviderName, ProviderRoutingError, SelectedProviderRoute};
+use crate::provider_registry::{ProviderId, SHADOW_ROUTING_POLICY_VERSION};
+use crate::provider_routing::{
+    compare_shadow_route, ProviderRoutingError, SelectedProviderRoute, ShadowRouteComparison,
+};
 use crate::proxy_config::ProxyConfig;
 use crate::sqs::UsageEvent;
 use crate::web::audio_utils::{merge_transcriptions, AudioSplitter, TINFOIL_MAX_SIZE};
@@ -1467,6 +1471,40 @@ async fn proxy_openai(
     Ok(Sse::new(stream).into_response())
 }
 
+fn retain_active_route_after_shadow_observation(
+    intent: &InferenceIntent,
+    active: Result<SelectedProviderRoute, ProviderRoutingError>,
+    shadow: Result<RoutePlan, RoutePlanningError>,
+) -> Result<SelectedProviderRoute, ProviderRoutingError> {
+    let comparison = compare_shadow_route(&active, &shadow);
+    let policy_version = shadow
+        .as_ref()
+        .map(|plan| plan.policy_version)
+        .unwrap_or(SHADOW_ROUTING_POLICY_VERSION);
+    let candidate_scope = shadow.as_ref().ok().map(|plan| plan.candidate_scope);
+
+    match &comparison {
+        ShadowRouteComparison::Match { .. } => debug!(
+            "Shadow route matched active route: request_id={}, public_model={}, policy_version={}, candidate_scope={:?}, comparison={:?}",
+            intent.request_id,
+            intent.public_model_id,
+            policy_version,
+            candidate_scope,
+            comparison
+        ),
+        ShadowRouteComparison::Mismatch { .. } => warn!(
+            "Shadow route differed from active route; retaining active route: request_id={}, public_model={}, policy_version={}, candidate_scope={:?}, comparison={:?}",
+            intent.request_id,
+            intent.public_model_id,
+            policy_version,
+            candidate_scope,
+            comparison
+        ),
+    }
+
+    active
+}
+
 pub(crate) async fn prepare_completion_request(
     state: &Arc<AppState>,
     user: &User,
@@ -1481,22 +1519,30 @@ pub(crate) async fn prepare_completion_request(
     let provider_preference = state
         .provider_routing_preference(user.uuid, &intent.public_model_id)
         .await;
-    let route = state
+    let shadow = state.provider_router.shadow_completion_plan(
+        &state.proxy_router,
+        &intent,
+        provider_preference,
+    );
+    let active = state
         .provider_router
         .select_completion_route_with_preference(
             &state.proxy_router,
             user.uuid,
             &intent.public_model_id,
             provider_preference,
-        )
-        .map_err(|err| match err {
-            ProviderRoutingError::UnsupportedModel(model) => {
-                error!("Unsupported completion model requested: {}", model);
-                ApiError::BadRequest
-            }
-            ProviderRoutingError::NoEligibleRoute(model) => {
-                error!("No eligible provider route for completion model: {}", model);
-                ApiError::InternalServerError
+        );
+    let route =
+        retain_active_route_after_shadow_observation(&intent, active, shadow).map_err(|err| {
+            match err {
+                ProviderRoutingError::UnsupportedModel(model) => {
+                    error!("Unsupported completion model requested: {}", model);
+                    ApiError::BadRequest
+                }
+                ProviderRoutingError::NoEligibleRoute(model) => {
+                    error!("No eligible provider route for completion model: {}", model);
+                    ApiError::InternalServerError
+                }
             }
         })?;
 
@@ -1576,7 +1622,7 @@ pub(crate) async fn get_chat_completion_response_for_expected_route(
             CompletionExecutionError::Request(ApiError::ServiceUnavailable)
         })?;
 
-    let continuum_cache_salt = (route.provider_name == ProviderName::Continuum.as_str())
+    let continuum_cache_salt = (route.provider_name == ProviderId::Continuum.as_str())
         .then(|| format!("server-selected-{}", Uuid::new_v4().simple()));
     get_chat_completion_response_with_options(
         state,
@@ -2026,7 +2072,7 @@ fn apply_provider_managed_request_fields(
         .remove(PROVIDER_MANAGED_USER_CACHE_SECRET_FIELD)
         .is_some();
 
-    if provider_name == ProviderName::Tinfoil.as_str() {
+    if provider_name == ProviderId::Tinfoil.as_str() {
         body.insert(
             PROVIDER_MANAGED_USER_CACHE_SECRET_FIELD.to_string(),
             json!(tinfoil_user_cache_secret(user_uuid)),
@@ -2044,7 +2090,7 @@ fn apply_server_selected_cache_isolation(
     provider_name: &str,
     continuum_cache_salt: Option<&str>,
 ) -> Result<(), ApiError> {
-    if provider_name != ProviderName::Continuum.as_str() {
+    if provider_name != ProviderId::Continuum.as_str() {
         return Ok(());
     }
 
@@ -3246,7 +3292,7 @@ mod tests {
         let proxy = ProxyConfig {
             base_url,
             api_key: None,
-            provider_name: ProviderName::Tinfoil.as_str().to_string(),
+            provider_name: ProviderId::Tinfoil.as_str().to_string(),
         };
         let trace = try_provider(
             &client,
@@ -3310,7 +3356,7 @@ mod tests {
                 WorkloadClass::Interactive,
             ),
             route: SelectedProviderRoute {
-                provider: ProviderName::Tinfoil,
+                provider: ProviderId::Tinfoil,
                 proxy: ProxyConfig {
                     base_url: "http://tinfoil.example.com".to_string(),
                     api_key: None,
@@ -3320,7 +3366,7 @@ mod tests {
                 provider_model_id: "kimi-k3".to_string(),
                 response_model_id: "kimi-k3".to_string(),
                 bucket: None,
-                selection_source: crate::provider_routing::ProviderSelectionSource::StaticSplit,
+                selection_source: crate::provider_registry::RouteSelectionSource::StaticSplit,
             },
         }
     }
@@ -3719,7 +3765,7 @@ mod tests {
         let proxy = ProxyConfig {
             base_url,
             api_key: None,
-            provider_name: ProviderName::Tinfoil.as_str().to_string(),
+            provider_name: ProviderId::Tinfoil.as_str().to_string(),
         };
         let trace = try_provider(
             &client,
@@ -3779,6 +3825,64 @@ mod tests {
             crate::model_config::AUTO_POWERFUL_MODEL_ID
         );
         assert!(pinned.intent().selection_mode.is_auto());
+    }
+
+    #[test]
+    fn shadow_mismatch_or_error_never_changes_the_active_route() {
+        use crate::inference_planning::{CandidateScope, PlanDecision};
+
+        let mut pinned = pinned_test_completion();
+        pinned.route.proxy.base_url = "https://active-route.example".to_string();
+        pinned.route.proxy.api_key = Some("sentinel-active-api-key".to_string());
+        let active = pinned.route.clone();
+        let shadow = RoutePlan {
+            selected: crate::inference::RouteIdentity::new(
+                ProviderId::Continuum,
+                "kimi-k3",
+                "shadow-provider-model",
+                "kimi-k3",
+                crate::provider_registry::RouteSelectionSource::Fallback,
+                Some(73),
+            ),
+            eligible_routes: Vec::new(),
+            decision: PlanDecision::PreferredProviderUnavailable,
+            candidate_scope: CandidateScope::SamePublicModelOnly,
+            policy_version: SHADOW_ROUTING_POLICY_VERSION,
+        };
+
+        let comparison = compare_shadow_route(&Ok(active.clone()), &Ok(shadow.clone()));
+        let comparison_debug = format!("{comparison:?}");
+        assert!(!comparison_debug.contains("active-route.example"));
+        assert!(!comparison_debug.contains("sentinel-active-api-key"));
+
+        let retained = retain_active_route_after_shadow_observation(
+            pinned.intent(),
+            Ok(active.clone()),
+            Ok(shadow.clone()),
+        )
+        .expect("shadow mismatch must retain active route");
+        assert_eq!(retained.identity(), active.identity());
+        assert_eq!(retained.proxy, active.proxy);
+
+        let retained = retain_active_route_after_shadow_observation(
+            pinned.intent(),
+            Ok(active.clone()),
+            Err(RoutePlanningError::NoEligibleRoute("kimi-k3".to_string())),
+        )
+        .expect("shadow error must retain active route");
+        assert_eq!(retained.identity(), active.identity());
+        assert_eq!(retained.proxy, active.proxy);
+
+        let active_error = ProviderRoutingError::NoEligibleRoute("kimi-k3".to_string());
+        let result = retain_active_route_after_shadow_observation(
+            pinned.intent(),
+            Err(active_error.clone()),
+            Ok(shadow),
+        );
+        assert_eq!(
+            result.expect_err("shadow success cannot rescue active failure"),
+            active_error
+        );
     }
 
     #[test]
@@ -4267,7 +4371,7 @@ mod tests {
             ("messages".to_string(), json!([])),
         ]);
 
-        apply_provider_managed_request_fields(&mut body, ProviderName::Tinfoil.as_str(), user_uuid);
+        apply_provider_managed_request_fields(&mut body, ProviderId::Tinfoil.as_str(), user_uuid);
 
         assert_eq!(body.get("model"), Some(&json!("kimi-k2-6")));
         assert_eq!(body.get("messages"), Some(&json!([])));
@@ -4287,7 +4391,7 @@ mod tests {
 
         apply_provider_managed_request_fields(
             &mut body,
-            ProviderName::Continuum.as_str(),
+            ProviderId::Continuum.as_str(),
             Uuid::from_u128(42),
         );
 
@@ -4303,17 +4407,13 @@ mod tests {
             ("messages".to_string(), json!([])),
         ]);
 
-        apply_provider_managed_request_fields(
-            &mut body,
-            ProviderName::Continuum.as_str(),
-            user_uuid,
-        );
+        apply_provider_managed_request_fields(&mut body, ProviderId::Continuum.as_str(), user_uuid);
         assert!(!body.contains_key(PROVIDER_MANAGED_CACHE_SALT_FIELD));
 
         let server_salt = format!("server-selected-{}", Uuid::new_v4().simple());
         apply_server_selected_cache_isolation(
             &mut body,
-            ProviderName::Continuum.as_str(),
+            ProviderId::Continuum.as_str(),
             Some(&server_salt),
         )
         .expect("server-selected Continuum salt should be accepted");

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -20,7 +20,7 @@ use crate::provider_routing::{
     compare_shadow_route, ProviderRouter, ProviderRoutingError, SelectedProviderRoute,
     ShadowRouteComparison,
 };
-use crate::proxy_config::ProxyConfig;
+use crate::proxy_config::{ProxyConfig, ProxyRouter};
 use crate::sqs::UsageEvent;
 use crate::web::audio_utils::{merge_transcriptions, AudioSplitter, TINFOIL_MAX_SIZE};
 use crate::web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse};
@@ -1552,6 +1552,33 @@ fn retain_active_route_after_shadow_observation(
             candidate_scope,
             comparison
         ),
+        ShadowRouteComparison::Mismatch { .. }
+            if matches!(
+                active,
+                Err(ProviderRoutingError::CapacityUnavailable { .. })
+            ) =>
+        {
+            debug!(
+                "GLM canary found every configured same-model route open: request_id={}, public_model={}, policy_version={}, candidate_scope={:?}",
+                intent.request_id,
+                intent.public_model_id,
+                policy_version,
+                candidate_scope
+            )
+        }
+        ShadowRouteComparison::Mismatch { .. }
+            if !intent.selection_mode.is_auto()
+                && intent.public_model_id == crate::model_config::GLM_5_2_MODEL_ID =>
+        {
+            debug!(
+            "Health-aware route differed from the baseline plan; retaining the active route: request_id={}, public_model={}, policy_version={}, candidate_scope={:?}, comparison={:?}",
+            intent.request_id,
+            intent.public_model_id,
+            policy_version,
+            candidate_scope,
+            comparison
+            )
+        }
         ShadowRouteComparison::Mismatch { .. } => warn!(
             "Shadow route differed from active route; retaining active route: request_id={}, public_model={}, policy_version={}, candidate_scope={:?}, comparison={:?}",
             intent.request_id,
@@ -1563,6 +1590,44 @@ fn retain_active_route_after_shadow_observation(
     }
 
     active
+}
+
+fn provider_routing_api_error(error: ProviderRoutingError) -> ApiError {
+    match error {
+        ProviderRoutingError::UnsupportedModel(model) => {
+            error!("Unsupported completion model requested: {}", model);
+            ApiError::BadRequest
+        }
+        ProviderRoutingError::NoEligibleRoute(model) => {
+            error!("No eligible provider route for completion model: {}", model);
+            ApiError::InternalServerError
+        }
+        ProviderRoutingError::CapacityUnavailable { model, retry_after } => {
+            debug!(
+                "All configured same-model routes are temporarily unavailable: public_model={}, retry_after_seconds={}",
+                model,
+                retry_after.as_secs()
+            );
+            ApiError::InferenceCapacity {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                retry_after: Some(retry_after),
+                client_replay_safe: true,
+            }
+        }
+    }
+}
+
+fn select_prepared_completion_route(
+    provider_router: &ProviderRouter,
+    proxy_router: &ProxyRouter,
+    intent: &InferenceIntent,
+    provider_preference: Option<crate::inference_planning::ProviderPreference>,
+    baseline_plan: Result<RoutePlan, RoutePlanningError>,
+) -> Result<SelectedProviderRoute, ApiError> {
+    let active =
+        provider_router.select_active_completion_route(proxy_router, intent, provider_preference);
+    retain_active_route_after_shadow_observation(intent, active, baseline_plan)
+        .map_err(provider_routing_api_error)
 }
 
 pub(crate) async fn prepare_completion_request(
@@ -1608,27 +1673,13 @@ pub(crate) async fn prepare_completion_request(
             candidate_health
         );
     }
-    let active = state
-        .provider_router
-        .select_completion_route_with_preference(
-            &state.proxy_router,
-            user.uuid,
-            &intent.public_model_id,
-            provider_preference,
-        );
-    let route =
-        retain_active_route_after_shadow_observation(&intent, active, shadow).map_err(|err| {
-            match err {
-                ProviderRoutingError::UnsupportedModel(model) => {
-                    error!("Unsupported completion model requested: {}", model);
-                    ApiError::BadRequest
-                }
-                ProviderRoutingError::NoEligibleRoute(model) => {
-                    error!("No eligible provider route for completion model: {}", model);
-                    ApiError::InternalServerError
-                }
-            }
-        })?;
+    let route = select_prepared_completion_route(
+        &state.provider_router,
+        &state.proxy_router,
+        &intent,
+        provider_preference,
+        shadow,
+    )?;
 
     debug!(
         "Pinned inference route: request_id={}, selection_mode={:?}, auto={}, surface={:?}, workload={:?}, requested_model={}, public_model={}, provider={}, provider_model={}, bucket={:?}, source={:?}",
@@ -3513,6 +3564,7 @@ fn is_safe_identifier_char(character: char) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[tokio::test]
     async fn bounded_provider_response_body_accepts_exact_limit_across_chunks() {
@@ -3541,7 +3593,7 @@ mod tests {
         );
     }
 
-    async fn call_mock_provider(app: Router) -> (ProviderSendTrace, tokio::task::JoinHandle<()>) {
+    async fn start_mock_provider(app: Router) -> (String, tokio::task::JoinHandle<()>) {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind mock provider");
@@ -3551,7 +3603,11 @@ mod tests {
                 .await
                 .expect("serve mock provider");
         });
-        let base_url = format!("http://{address}");
+        (format!("http://{address}"), server)
+    }
+
+    async fn call_mock_provider(app: Router) -> (ProviderSendTrace, tokio::task::JoinHandle<()>) {
+        let (base_url, server) = start_mock_provider(app).await;
         let client = ProviderClient::for_test(base_url.clone()).expect("mock provider client");
         let proxy = ProxyConfig {
             base_url,
@@ -3934,6 +3990,333 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn glm_capacity_failure_switches_only_the_next_request_to_the_mock_alternate() {
+        let tinfoil_count = Arc::new(AtomicUsize::new(0));
+        let tinfoil_bodies = Arc::new(std::sync::Mutex::new(Vec::<Value>::new()));
+        let tinfoil_app = {
+            let count = Arc::clone(&tinfoil_count);
+            let bodies = Arc::clone(&tinfoil_bodies);
+            Router::new().route(
+                "/v1/chat/completions",
+                post(move |Json(body): Json<Value>| {
+                    let count = Arc::clone(&count);
+                    let bodies = Arc::clone(&bodies);
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        bodies.lock().expect("Tinfoil body lock").push(body);
+                        axum::http::Response::builder()
+                            .status(StatusCode::TOO_MANY_REQUESTS)
+                            .header(header::RETRY_AFTER, "60")
+                            .body(axum::body::Body::empty())
+                            .expect("mock Tinfoil 429")
+                    }
+                }),
+            )
+        };
+        let continuum_count = Arc::new(AtomicUsize::new(0));
+        let continuum_bodies = Arc::new(std::sync::Mutex::new(Vec::<Value>::new()));
+        let continuum_app = {
+            let count = Arc::clone(&continuum_count);
+            let bodies = Arc::clone(&continuum_bodies);
+            Router::new().route(
+                "/v1/chat/completions",
+                post(move |Json(body): Json<Value>| {
+                    let count = Arc::clone(&count);
+                    let bodies = Arc::clone(&bodies);
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        bodies.lock().expect("Continuum body lock").push(body);
+                        axum::http::Response::builder()
+                            .status(StatusCode::OK)
+                            .header(header::CONTENT_TYPE, "application/json")
+                            .body(axum::body::Body::from(
+                                r#"{"model":"glm-5.2","choices":[{"message":{"role":"assistant","content":"ok"}}]}"#,
+                            ))
+                            .expect("mock Continuum success")
+                    }
+                }),
+            )
+        };
+
+        let (tinfoil_url, tinfoil_server) = start_mock_provider(tinfoil_app).await;
+        let (continuum_url, continuum_server) = start_mock_provider(continuum_app).await;
+        let provider_client =
+            ProviderClient::for_test(tinfoil_url.clone()).expect("test provider client");
+        let proxy_router = crate::proxy_config::ProxyRouter::new(continuum_url, None, tinfoil_url);
+        let provider_router = ProviderRouter::default();
+        let intent = InferenceIntent::new(
+            Uuid::nil(),
+            crate::model_config::GLM_5_2_MODEL_ID,
+            crate::model_config::GLM_5_2_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+
+        let first_baseline = provider_router.shadow_completion_plan(&proxy_router, &intent, None);
+        let first_route = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &intent,
+            None,
+            first_baseline,
+        )
+        .expect("initial GLM route");
+        assert_eq!(first_route.provider, ProviderId::Tinfoil);
+        let first_trace = try_provider(
+            &provider_client,
+            &first_route.proxy,
+            json!({
+                "model": first_route.provider_model_id,
+                "messages": [{"role": "user", "content": "one"}]
+            })
+            .to_string(),
+            &HeaderMap::new(),
+        )
+        .await;
+        assert!(first_trace.prior_failures.is_empty());
+        let first_error = match first_trace.result {
+            Err(error) => error,
+            Ok(_) => panic!("mock Tinfoil unexpectedly succeeded"),
+        };
+        let first_failure = attempt_failure_from_provider_error(&first_error);
+        let first_attempt = intent
+            .begin_execution()
+            .begin_attempt(first_route.identity());
+        let surfaced = public_completion_error(&first_error, &first_failure);
+        let _ =
+            failed_completion_execution(&provider_router, first_attempt, first_failure, surfaced);
+
+        // The triggering logical request made exactly one provider call and did
+        // not replay or fail over to Continuum.
+        assert_eq!(tinfoil_count.load(Ordering::SeqCst), 1);
+        assert_eq!(continuum_count.load(Ordering::SeqCst), 0);
+
+        let second_intent = InferenceIntent::new(
+            Uuid::nil(),
+            crate::model_config::GLM_5_2_MODEL_ID,
+            crate::model_config::GLM_5_2_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+        assert_ne!(second_intent.request_id, intent.request_id);
+        let second_baseline =
+            provider_router.shadow_completion_plan(&proxy_router, &second_intent, None);
+        let second_route = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &second_intent,
+            None,
+            second_baseline,
+        )
+        .expect("next request uses Continuum GLM");
+        assert_eq!(second_route.provider, ProviderId::Continuum);
+        assert_eq!(second_route.provider_model_id, "glm-5.2");
+        assert_eq!(
+            second_route.response_model_id,
+            crate::model_config::GLM_5_2_MODEL_ID
+        );
+        let second_trace = try_provider(
+            &provider_client,
+            &second_route.proxy,
+            json!({
+                "model": second_route.provider_model_id,
+                "messages": [{"role": "user", "content": "two"}]
+            })
+            .to_string(),
+            &HeaderMap::new(),
+        )
+        .await;
+        assert!(second_trace.prior_failures.is_empty());
+        let response = second_trace.result.expect("mock Continuum succeeds");
+        let second_attempt = second_intent
+            .begin_execution()
+            .begin_attempt(second_route.identity());
+        let canonical_response = read_non_streaming_completion_response(
+            response,
+            &second_route.response_model_id,
+            &second_attempt,
+            None,
+        )
+        .await
+        .expect("canonical Continuum response");
+        assert_eq!(
+            canonical_response["model"],
+            crate::model_config::GLM_5_2_MODEL_ID
+        );
+        assert_eq!(
+            second_attempt.route.public_model_id,
+            crate::model_config::GLM_5_2_MODEL_ID
+        );
+        assert_eq!(second_attempt.route.provider, ProviderId::Continuum);
+
+        assert_eq!(tinfoil_count.load(Ordering::SeqCst), 1);
+        assert_eq!(continuum_count.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            tinfoil_bodies.lock().expect("Tinfoil bodies")[0]["model"],
+            crate::model_config::GLM_5_2_MODEL_ID
+        );
+        assert_eq!(
+            continuum_bodies.lock().expect("Continuum bodies")[0]["model"],
+            "glm-5.2"
+        );
+
+        tinfoil_server.abort();
+        continuum_server.abort();
+    }
+
+    #[tokio::test]
+    async fn glm_tool_turns_keep_the_original_mock_provider_after_health_opens() {
+        let tinfoil_count = Arc::new(AtomicUsize::new(0));
+        let tinfoil_app = {
+            let count = Arc::clone(&tinfoil_count);
+            Router::new().route(
+                "/v1/chat/completions",
+                post(move |Json(_body): Json<Value>| {
+                    let count = Arc::clone(&count);
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        Json(json!({
+                            "model": "glm-5-2",
+                            "choices": [{"message": {"role": "assistant", "content": "ok"}}]
+                        }))
+                    }
+                }),
+            )
+        };
+        let continuum_count = Arc::new(AtomicUsize::new(0));
+        let continuum_app = {
+            let count = Arc::clone(&continuum_count);
+            Router::new().route(
+                "/v1/chat/completions",
+                post(move |Json(_body): Json<Value>| {
+                    let count = Arc::clone(&count);
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        Json(json!({
+                            "model": "glm-5.2",
+                            "choices": [{"message": {"role": "assistant", "content": "ok"}}]
+                        }))
+                    }
+                }),
+            )
+        };
+        let (tinfoil_url, tinfoil_server) = start_mock_provider(tinfoil_app).await;
+        let (continuum_url, continuum_server) = start_mock_provider(continuum_app).await;
+        let provider_client =
+            ProviderClient::for_test(tinfoil_url.clone()).expect("test provider client");
+        let proxy_router = ProxyRouter::new(continuum_url, None, tinfoil_url);
+        let provider_router = ProviderRouter::default();
+        let intent = InferenceIntent::new(
+            Uuid::nil(),
+            crate::model_config::GLM_5_2_MODEL_ID,
+            crate::model_config::GLM_5_2_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+        let baseline = provider_router.shadow_completion_plan(&proxy_router, &intent, None);
+        let route = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &intent,
+            None,
+            baseline,
+        )
+        .expect("initial GLM route");
+        let pinned = PinnedCompletionRequest { intent, route };
+
+        let send_pinned_turn = |content: &'static str| {
+            let provider_client = &provider_client;
+            let pinned = &pinned;
+            async move {
+                let trace = try_provider(
+                    provider_client,
+                    &pinned.route.proxy,
+                    json!({
+                        "model": pinned.route.provider_model_id,
+                        "messages": [{"role": "user", "content": content}]
+                    })
+                    .to_string(),
+                    &HeaderMap::new(),
+                )
+                .await;
+                assert!(trace.prior_failures.is_empty());
+                let response = trace.result.expect("pinned mock turn succeeds");
+                let attempt = pinned
+                    .begin_execution()
+                    .begin_attempt(pinned.route.identity());
+                let response = read_non_streaming_completion_response(
+                    response,
+                    &pinned.route.response_model_id,
+                    &attempt,
+                    None,
+                )
+                .await
+                .expect("canonical pinned response");
+                assert_eq!(response["model"], crate::model_config::GLM_5_2_MODEL_ID);
+                attempt
+            }
+        };
+
+        let first_attempt = send_pinned_turn("first tool turn").await;
+        let external_error = ProviderRequestError::Upstream(UpstreamProviderError {
+            status: 429,
+            retry_after: Some(Duration::from_secs(60)),
+            upstream_request_id: None,
+        });
+        let external_failure = attempt_failure_from_provider_error(&external_error);
+        let external_intent = InferenceIntent::new(
+            Uuid::from_u128(1),
+            crate::model_config::GLM_5_2_MODEL_ID,
+            crate::model_config::GLM_5_2_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+        let _ = failed_completion_execution(
+            &provider_router,
+            external_intent
+                .begin_execution()
+                .begin_attempt(pinned.route.identity()),
+            external_failure.clone(),
+            public_completion_error(&external_error, &external_failure),
+        );
+
+        let second_attempt = send_pinned_turn("second tool turn").await;
+        assert_eq!(first_attempt.request_id, second_attempt.request_id);
+        assert_ne!(first_attempt.execution_id, second_attempt.execution_id);
+        assert_eq!(first_attempt.route, second_attempt.route);
+        assert_eq!(tinfoil_count.load(Ordering::SeqCst), 2);
+        assert_eq!(continuum_count.load(Ordering::SeqCst), 0);
+
+        let next_intent = InferenceIntent::new(
+            Uuid::nil(),
+            crate::model_config::GLM_5_2_MODEL_ID,
+            crate::model_config::GLM_5_2_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+        let next_baseline =
+            provider_router.shadow_completion_plan(&proxy_router, &next_intent, None);
+        let next_route = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &next_intent,
+            None,
+            next_baseline,
+        )
+        .expect("next logical request switches providers");
+        assert_eq!(next_route.provider, ProviderId::Continuum);
+        assert_eq!(next_route.provider_model_id, "glm-5.2");
+
+        tinfoil_server.abort();
+        continuum_server.abort();
+    }
+
+    #[tokio::test]
     async fn mock_provider_429_does_not_wait_for_pending_error_body() {
         let app = Router::new().route(
             "/v1/chat/completions",
@@ -4050,6 +4433,132 @@ mod tests {
             crate::INFERENCE_CAPACITY_ERROR_CODE
         );
         assert_eq!(response.headers()[header::RETRY_AFTER], "7");
+    }
+
+    #[tokio::test]
+    async fn prepared_all_open_glm_route_sends_zero_requests_and_returns_capacity_contract() {
+        let tinfoil_count = Arc::new(AtomicUsize::new(0));
+        let tinfoil_app = {
+            let count = Arc::clone(&tinfoil_count);
+            Router::new().route(
+                "/v1/chat/completions",
+                post(move || {
+                    let count = Arc::clone(&count);
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        StatusCode::OK
+                    }
+                }),
+            )
+        };
+        let continuum_count = Arc::new(AtomicUsize::new(0));
+        let continuum_app = {
+            let count = Arc::clone(&continuum_count);
+            Router::new().route(
+                "/v1/chat/completions",
+                post(move || {
+                    let count = Arc::clone(&count);
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        StatusCode::OK
+                    }
+                }),
+            )
+        };
+        let (tinfoil_url, tinfoil_server) = start_mock_provider(tinfoil_app).await;
+        let (continuum_url, continuum_server) = start_mock_provider(continuum_app).await;
+        let proxy_router = ProxyRouter::new(continuum_url, None, tinfoil_url);
+        let provider_router = ProviderRouter::default();
+
+        let new_intent = || {
+            InferenceIntent::new(
+                Uuid::nil(),
+                crate::model_config::GLM_5_2_MODEL_ID,
+                crate::model_config::GLM_5_2_MODEL_ID,
+                ModelPlan::Paid,
+                InferenceSurface::Responses,
+                WorkloadClass::Interactive,
+            )
+        };
+        let first_intent = new_intent();
+        let first_baseline =
+            provider_router.shadow_completion_plan(&proxy_router, &first_intent, None);
+        let first_route = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &first_intent,
+            None,
+            first_baseline,
+        )
+        .expect("initial Tinfoil GLM route");
+        let first_error = ProviderRequestError::Upstream(UpstreamProviderError {
+            status: 429,
+            retry_after: Some(Duration::from_secs(40)),
+            upstream_request_id: None,
+        });
+        let first_failure = attempt_failure_from_provider_error(&first_error);
+        let _ = failed_completion_execution(
+            &provider_router,
+            first_intent
+                .begin_execution()
+                .begin_attempt(first_route.identity()),
+            first_failure.clone(),
+            public_completion_error(&first_error, &first_failure),
+        );
+
+        let second_intent = new_intent();
+        let second_baseline =
+            provider_router.shadow_completion_plan(&proxy_router, &second_intent, None);
+        let second_route = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &second_intent,
+            None,
+            second_baseline,
+        )
+        .expect("Continuum GLM route while Tinfoil is open");
+        assert_eq!(second_route.provider, ProviderId::Continuum);
+        let second_error = ProviderRequestError::Upstream(UpstreamProviderError {
+            status: 503,
+            retry_after: Some(Duration::from_secs(10)),
+            upstream_request_id: None,
+        });
+        let second_failure = attempt_failure_from_provider_error(&second_error);
+        let _ = failed_completion_execution(
+            &provider_router,
+            second_intent
+                .begin_execution()
+                .begin_attempt(second_route.identity()),
+            second_failure.clone(),
+            public_completion_error(&second_error, &second_failure),
+        );
+
+        let third_intent = new_intent();
+        let third_baseline =
+            provider_router.shadow_completion_plan(&proxy_router, &third_intent, None);
+        let error = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &third_intent,
+            None,
+            third_baseline,
+        )
+        .expect_err("both GLM routes are open");
+        let response = error.into_response();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response.headers()[crate::CLIENT_REPLAY_HEADER], "safe");
+        assert_eq!(response.headers()[crate::ERROR_CONTRACT_HEADER], "1");
+        assert_eq!(
+            response.headers()[crate::ERROR_CODE_HEADER],
+            crate::INFERENCE_CAPACITY_ERROR_CODE
+        );
+        assert_eq!(response.headers()[header::RETRY_AFTER], "30");
+        assert_eq!(tinfoil_count.load(Ordering::SeqCst), 0);
+        assert_eq!(continuum_count.load(Ordering::SeqCst), 0);
+
+        tinfoil_server.abort();
+        continuum_server.abort();
     }
 
     #[tokio::test]

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -715,9 +715,19 @@ impl PinnedCompletionRequest {
         &self.intent
     }
 
+    pub(crate) fn public_model_id(&self) -> &str {
+        &self.route.public_model_id
+    }
+
     fn begin_execution(&self) -> InferenceExecution {
         self.intent.begin_execution()
     }
+}
+
+fn pin_chat_request_model(body: &mut Value, pinned: &PinnedCompletionRequest) {
+    body.as_object_mut()
+        .expect("model was read from a JSON object")
+        .insert("model".to_string(), json!(pinned.public_model_id()));
 }
 
 #[derive(Debug)]
@@ -1419,15 +1429,14 @@ async fn proxy_openai(
         WorkloadClass::Interactive,
     );
     let pinned_completion = prepare_completion_request(&state, &user, intent).await?;
-    if requested_model_name != model_name {
+    let served_model_name = pinned_completion.public_model_id().to_string();
+    if requested_model_name != served_model_name {
         debug!(
-            "Resolved chat model {} to {}",
-            requested_model_name, model_name
+            "Resolved chat model {} to preferred {} and pinned {}",
+            requested_model_name, model_name, served_model_name
         );
-        body.as_object_mut()
-            .expect("model was read from a JSON object")
-            .insert("model".to_string(), json!(model_name));
     }
+    pin_chat_request_model(&mut body, &pinned_completion);
 
     // Create billing context
     let billing_context = BillingContext::new(auth_method, requested_model_name);
@@ -1559,7 +1568,7 @@ fn retain_active_route_after_shadow_observation(
             ) =>
         {
             debug!(
-                "GLM canary found every configured same-model route open: request_id={}, public_model={}, policy_version={}, candidate_scope={:?}",
+                "Health-aware routing found every configured policy candidate open: request_id={}, preferred_public_model={}, policy_version={}, candidate_scope={:?}",
                 intent.request_id,
                 intent.public_model_id,
                 policy_version,
@@ -1567,18 +1576,28 @@ fn retain_active_route_after_shadow_observation(
             )
         }
         ShadowRouteComparison::Mismatch { .. }
-            if !intent.selection_mode.is_auto()
-                && intent.public_model_id == crate::model_config::GLM_5_2_MODEL_ID =>
+            if active.as_ref().is_ok_and(|route| {
+                route.model_selection_source
+                    == crate::provider_routing::ModelSelectionSource::AutoFallback
+            }) =>
         {
             debug!(
-            "Health-aware route differed from the baseline plan; retaining the active route: request_id={}, public_model={}, policy_version={}, candidate_scope={:?}, comparison={:?}",
+                "Auto policy selected a compatible fallback model: request_id={}, preferred_public_model={}, selected_public_model={}, policy_version={}, comparison={:?}",
+                intent.request_id,
+                intent.public_model_id,
+                active.as_ref().map(|route| route.public_model_id.as_str()).unwrap_or("unavailable"),
+                crate::inference_planning::AUTO_MODEL_ROUTING_POLICY_VERSION,
+                comparison
+            )
+        }
+        ShadowRouteComparison::Mismatch { .. } if active.is_ok() => debug!(
+            "Health-aware route differed from the baseline plan; retaining the active route: request_id={}, preferred_public_model={}, policy_version={}, candidate_scope={:?}, comparison={:?}",
             intent.request_id,
             intent.public_model_id,
             policy_version,
             candidate_scope,
             comparison
-            )
-        }
+        ),
         ShadowRouteComparison::Mismatch { .. } => warn!(
             "Shadow route differed from active route; retaining active route: request_id={}, public_model={}, policy_version={}, candidate_scope={:?}, comparison={:?}",
             intent.request_id,
@@ -1604,7 +1623,7 @@ fn provider_routing_api_error(error: ProviderRoutingError) -> ApiError {
         }
         ProviderRoutingError::CapacityUnavailable { model, retry_after } => {
             debug!(
-                "All configured same-model routes are temporarily unavailable: public_model={}, retry_after_seconds={}",
+                "All configured policy-permitted routes are temporarily unavailable: preferred_public_model={}, retry_after_seconds={}",
                 model,
                 retry_after.as_secs()
             );
@@ -1666,7 +1685,7 @@ pub(crate) async fn prepare_completion_request(
             })
             .collect::<Vec<_>>();
         debug!(
-            "Shadow route health remained observational: request_id={}, public_model={}, routing_policy_version={}, candidate_health={:?}",
+            "Baseline route candidate health before active selection: request_id={}, public_model={}, routing_policy_version={}, candidate_health={:?}",
             intent.request_id,
             intent.public_model_id,
             plan.policy_version,
@@ -1680,15 +1699,18 @@ pub(crate) async fn prepare_completion_request(
         provider_preference,
         shadow,
     )?;
+    ensure_completion_model_access(&route.public_model_id, intent.model_plan)?;
 
     debug!(
-        "Pinned inference route: request_id={}, selection_mode={:?}, auto={}, surface={:?}, workload={:?}, requested_model={}, public_model={}, provider={}, provider_model={}, bucket={:?}, source={:?}",
+        "Pinned inference route: request_id={}, selection_mode={:?}, model_selection={:?}, auto={}, surface={:?}, workload={:?}, requested_model={}, preferred_public_model={}, public_model={}, provider={}, provider_model={}, bucket={:?}, source={:?}",
         intent.request_id,
         intent.selection_mode,
+        route.model_selection_source,
         intent.selection_mode.is_auto(),
         intent.surface,
         intent.workload_class,
         intent.requested_model_id,
+        intent.public_model_id,
         route.public_model_id,
         route.provider.as_str(),
         route.provider_model_id,
@@ -1947,15 +1969,18 @@ async fn get_chat_completion_response_with_options(
         })?
         .to_string();
 
-    if body_model_name != pinned.intent.public_model_id {
+    if body_model_name != pinned.route.public_model_id {
         error!(
-            "Prepared inference model did not match execution body: request_id={}, prepared_model={}, body_model={}",
-            pinned.intent.request_id, pinned.intent.public_model_id, body_model_name
+            "Prepared inference model did not match execution body: request_id={}, preferred_model={}, prepared_model={}, body_model={}",
+            pinned.intent.request_id,
+            pinned.intent.public_model_id,
+            pinned.route.public_model_id,
+            body_model_name
         );
         return Err(ApiError::InternalServerError.into());
     }
 
-    ensure_completion_model_access(&pinned.intent.public_model_id, pinned.intent.model_plan)?;
+    ensure_completion_model_access(&pinned.route.public_model_id, pinned.intent.model_plan)?;
     let selected_route = pinned.route.clone();
     if let Some(expected_route) = &options.exact_route {
         if !completion_route_matches_exact_constraint(&selected_route, expected_route) {
@@ -3687,6 +3712,7 @@ mod tests {
                 response_model_id: "kimi-k3".to_string(),
                 bucket: None,
                 selection_source: crate::provider_registry::RouteSelectionSource::StaticSplit,
+                model_selection_source: crate::provider_routing::ModelSelectionSource::AutoPrimary,
             },
         }
     }
@@ -3720,6 +3746,58 @@ mod tests {
             &pinned.route,
             &wrong_model
         ));
+    }
+
+    fn pinned_auto_fallback_completion() -> PinnedCompletionRequest {
+        PinnedCompletionRequest {
+            intent: InferenceIntent::new(
+                Uuid::nil(),
+                crate::model_config::AUTO_POWERFUL_MODEL_ID,
+                crate::model_config::KIMI_K3_MODEL_ID,
+                ModelPlan::Paid,
+                InferenceSurface::ChatCompletions,
+                WorkloadClass::Interactive,
+            ),
+            route: SelectedProviderRoute {
+                provider: ProviderId::Continuum,
+                proxy: ProxyConfig {
+                    base_url: "http://continuum.example.com".to_string(),
+                    api_key: None,
+                    provider_name: "continuum".to_string(),
+                },
+                public_model_id: crate::model_config::POWERFUL_MODEL_ID.to_string(),
+                provider_model_id: "kimi-k2.6".to_string(),
+                response_model_id: crate::model_config::POWERFUL_MODEL_ID.to_string(),
+                bucket: None,
+                selection_source: crate::provider_registry::RouteSelectionSource::DefaultProvider,
+                model_selection_source: crate::provider_routing::ModelSelectionSource::AutoFallback,
+            },
+        }
+    }
+
+    #[test]
+    fn chat_body_uses_the_pinned_auto_fallback_public_model() {
+        let pinned = pinned_auto_fallback_completion();
+        let mut body = json!({
+            "model": crate::model_config::AUTO_POWERFUL_MODEL_ID,
+            "messages": [{"role": "user", "content": "hello"}]
+        });
+
+        pin_chat_request_model(&mut body, &pinned);
+
+        assert_eq!(body["model"], crate::model_config::POWERFUL_MODEL_ID);
+        assert_eq!(
+            pinned.intent().public_model_id,
+            crate::model_config::KIMI_K3_MODEL_ID
+        );
+        assert_eq!(
+            pinned.public_model_id(),
+            crate::model_config::POWERFUL_MODEL_ID
+        );
+        assert_eq!(
+            pinned.intent().requested_model_id,
+            crate::model_config::AUTO_POWERFUL_MODEL_ID
+        );
     }
 
     async fn record_terminal_once(
@@ -4167,6 +4245,202 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn auto_powerful_capacity_failure_switches_only_a_distinct_request_to_k2_6() {
+        let tinfoil_count = Arc::new(AtomicUsize::new(0));
+        let tinfoil_bodies = Arc::new(std::sync::Mutex::new(Vec::<Value>::new()));
+        let tinfoil_app = {
+            let count = Arc::clone(&tinfoil_count);
+            let bodies = Arc::clone(&tinfoil_bodies);
+            Router::new().route(
+                "/v1/chat/completions",
+                post(move |Json(body): Json<Value>| {
+                    let count = Arc::clone(&count);
+                    let bodies = Arc::clone(&bodies);
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        bodies.lock().expect("Tinfoil body lock").push(body);
+                        axum::http::Response::builder()
+                            .status(StatusCode::TOO_MANY_REQUESTS)
+                            .header(header::RETRY_AFTER, "60")
+                            .body(axum::body::Body::empty())
+                            .expect("mock K3 429")
+                    }
+                }),
+            )
+        };
+        let continuum_count = Arc::new(AtomicUsize::new(0));
+        let continuum_bodies = Arc::new(std::sync::Mutex::new(Vec::<Value>::new()));
+        let continuum_app = {
+            let count = Arc::clone(&continuum_count);
+            let bodies = Arc::clone(&continuum_bodies);
+            Router::new().route(
+                "/v1/chat/completions",
+                post(move |Json(body): Json<Value>| {
+                    let count = Arc::clone(&count);
+                    let bodies = Arc::clone(&bodies);
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        bodies.lock().expect("Continuum body lock").push(body);
+                        axum::http::Response::builder()
+                            .status(StatusCode::OK)
+                            .header(header::CONTENT_TYPE, "application/json")
+                            .body(axum::body::Body::from(
+                                r#"{"model":"kimi-k2.6","choices":[{"message":{"role":"assistant","content":"ok"}}]}"#,
+                            ))
+                            .expect("mock K2.6 success")
+                    }
+                }),
+            )
+        };
+
+        let (tinfoil_url, tinfoil_server) = start_mock_provider(tinfoil_app).await;
+        let (continuum_url, continuum_server) = start_mock_provider(continuum_app).await;
+        let provider_client =
+            ProviderClient::for_test(tinfoil_url.clone()).expect("test provider client");
+        let proxy_router = ProxyRouter::new(continuum_url, None, tinfoil_url);
+        let provider_router = ProviderRouter::default();
+        let first_intent = InferenceIntent::new(
+            Uuid::nil(),
+            crate::model_config::AUTO_POWERFUL_MODEL_ID,
+            crate::model_config::KIMI_K3_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+        let first_baseline =
+            provider_router.shadow_completion_plan(&proxy_router, &first_intent, None);
+        let first_route = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &first_intent,
+            None,
+            first_baseline,
+        )
+        .expect("healthy Auto Powerful prefers K3");
+        assert_eq!(first_route.provider, ProviderId::Tinfoil);
+        assert_eq!(
+            first_route.public_model_id,
+            crate::model_config::KIMI_K3_MODEL_ID
+        );
+        assert_eq!(
+            first_route.model_selection_source,
+            crate::provider_routing::ModelSelectionSource::AutoPrimary
+        );
+
+        let user_content = json!("hello");
+        let first_trace = try_provider(
+            &provider_client,
+            &first_route.proxy,
+            json!({
+                "model": first_route.provider_model_id,
+                "messages": [{"role": "user", "content": user_content.clone()}]
+            })
+            .to_string(),
+            &HeaderMap::new(),
+        )
+        .await;
+        assert!(first_trace.prior_failures.is_empty());
+        let first_error = match first_trace.result {
+            Err(error) => error,
+            Ok(_) => panic!("mock K3 unexpectedly succeeded"),
+        };
+        let first_failure = attempt_failure_from_provider_error(&first_error);
+        let first_attempt = first_intent
+            .begin_execution()
+            .begin_attempt(first_route.identity());
+        let surfaced = public_completion_error(&first_error, &first_failure);
+        let _ =
+            failed_completion_execution(&provider_router, first_attempt, first_failure, surfaced);
+
+        assert_eq!(tinfoil_count.load(Ordering::SeqCst), 1);
+        assert_eq!(continuum_count.load(Ordering::SeqCst), 0);
+
+        let second_intent = InferenceIntent::new(
+            Uuid::nil(),
+            crate::model_config::AUTO_POWERFUL_MODEL_ID,
+            crate::model_config::KIMI_K3_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+        assert_ne!(second_intent.request_id, first_intent.request_id);
+        let second_baseline =
+            provider_router.shadow_completion_plan(&proxy_router, &second_intent, None);
+        let second_route = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &second_intent,
+            None,
+            second_baseline,
+        )
+        .expect("later Auto Powerful request uses compatible K2.6");
+        assert_eq!(second_route.provider, ProviderId::Continuum);
+        assert_eq!(
+            second_route.public_model_id,
+            crate::model_config::POWERFUL_MODEL_ID
+        );
+        assert_eq!(second_route.provider_model_id, "kimi-k2.6");
+        assert_eq!(
+            second_route.model_selection_source,
+            crate::provider_routing::ModelSelectionSource::AutoFallback
+        );
+        let second_trace = try_provider(
+            &provider_client,
+            &second_route.proxy,
+            json!({
+                "model": second_route.provider_model_id,
+                "messages": [{"role": "user", "content": user_content.clone()}]
+            })
+            .to_string(),
+            &HeaderMap::new(),
+        )
+        .await;
+        assert!(second_trace.prior_failures.is_empty());
+        let response = second_trace.result.expect("mock K2.6 succeeds");
+        let second_attempt = second_intent
+            .begin_execution()
+            .begin_attempt(second_route.identity());
+        let canonical_response = read_non_streaming_completion_response(
+            response,
+            &second_route.response_model_id,
+            &second_attempt,
+            None,
+        )
+        .await
+        .expect("canonical K2.6 response");
+
+        assert_eq!(
+            canonical_response["model"],
+            crate::model_config::POWERFUL_MODEL_ID
+        );
+        assert_eq!(
+            second_intent.requested_model_id,
+            crate::model_config::AUTO_POWERFUL_MODEL_ID
+        );
+        assert_eq!(
+            second_attempt.route.public_model_id,
+            crate::model_config::POWERFUL_MODEL_ID
+        );
+        assert_eq!(tinfoil_count.load(Ordering::SeqCst), 1);
+        assert_eq!(continuum_count.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            tinfoil_bodies.lock().expect("Tinfoil bodies")[0]["model"],
+            crate::model_config::KIMI_K3_MODEL_ID
+        );
+        assert_eq!(
+            continuum_bodies.lock().expect("Continuum bodies")[0]["model"],
+            "kimi-k2.6"
+        );
+        assert_eq!(
+            continuum_bodies.lock().expect("Continuum bodies")[0]["messages"][0]["content"],
+            user_content
+        );
+
+        tinfoil_server.abort();
+        continuum_server.abort();
+    }
+
+    #[tokio::test]
     async fn glm_tool_turns_keep_the_original_mock_provider_after_health_opens() {
         let tinfoil_count = Arc::new(AtomicUsize::new(0));
         let tinfoil_app = {
@@ -4311,6 +4585,181 @@ mod tests {
         .expect("next logical request switches providers");
         assert_eq!(next_route.provider, ProviderId::Continuum);
         assert_eq!(next_route.provider_model_id, "glm-5.2");
+
+        tinfoil_server.abort();
+        continuum_server.abort();
+    }
+
+    #[tokio::test]
+    async fn auto_powerful_tool_turns_keep_the_pinned_k3_after_health_opens() {
+        let tinfoil_count = Arc::new(AtomicUsize::new(0));
+        let tinfoil_bodies = Arc::new(std::sync::Mutex::new(Vec::<Value>::new()));
+        let tinfoil_app = {
+            let count = Arc::clone(&tinfoil_count);
+            let bodies = Arc::clone(&tinfoil_bodies);
+            Router::new().route(
+                "/v1/chat/completions",
+                post(move |Json(body): Json<Value>| {
+                    let count = Arc::clone(&count);
+                    let bodies = Arc::clone(&bodies);
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        bodies.lock().expect("Tinfoil body lock").push(body);
+                        Json(json!({
+                            "model": "kimi-k3",
+                            "choices": [{"message": {"role": "assistant", "content": "ok"}}]
+                        }))
+                    }
+                }),
+            )
+        };
+        let continuum_count = Arc::new(AtomicUsize::new(0));
+        let continuum_app = {
+            let count = Arc::clone(&continuum_count);
+            Router::new().route(
+                "/v1/chat/completions",
+                post(move |Json(_body): Json<Value>| {
+                    let count = Arc::clone(&count);
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        Json(json!({
+                            "model": "kimi-k2.6",
+                            "choices": [{"message": {"role": "assistant", "content": "ok"}}]
+                        }))
+                    }
+                }),
+            )
+        };
+        let (tinfoil_url, tinfoil_server) = start_mock_provider(tinfoil_app).await;
+        let (continuum_url, continuum_server) = start_mock_provider(continuum_app).await;
+        let provider_client =
+            ProviderClient::for_test(tinfoil_url.clone()).expect("test provider client");
+        let proxy_router = ProxyRouter::new(continuum_url, None, tinfoil_url);
+        let provider_router = ProviderRouter::default();
+        let intent = InferenceIntent::new(
+            Uuid::nil(),
+            crate::model_config::AUTO_POWERFUL_MODEL_ID,
+            crate::model_config::KIMI_K3_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+        let baseline = provider_router.shadow_completion_plan(&proxy_router, &intent, None);
+        let route = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &intent,
+            None,
+            baseline,
+        )
+        .expect("initial Auto Powerful K3 route");
+        assert_eq!(
+            route.model_selection_source,
+            crate::provider_routing::ModelSelectionSource::AutoPrimary
+        );
+        let pinned = PinnedCompletionRequest { intent, route };
+
+        let send_pinned_turn = |content: &'static str| {
+            let provider_client = &provider_client;
+            let pinned = &pinned;
+            async move {
+                let trace = try_provider(
+                    provider_client,
+                    &pinned.route.proxy,
+                    json!({
+                        "model": pinned.route.provider_model_id,
+                        "messages": [{"role": "user", "content": content}]
+                    })
+                    .to_string(),
+                    &HeaderMap::new(),
+                )
+                .await;
+                assert!(trace.prior_failures.is_empty());
+                let response = trace.result.expect("pinned K3 turn succeeds");
+                let attempt = pinned
+                    .begin_execution()
+                    .begin_attempt(pinned.route.identity());
+                let response = read_non_streaming_completion_response(
+                    response,
+                    &pinned.route.response_model_id,
+                    &attempt,
+                    None,
+                )
+                .await
+                .expect("canonical pinned K3 response");
+                assert_eq!(response["model"], crate::model_config::KIMI_K3_MODEL_ID);
+                attempt
+            }
+        };
+
+        let first_attempt = send_pinned_turn("first tool turn").await;
+        let external_error = ProviderRequestError::Upstream(UpstreamProviderError {
+            status: 429,
+            retry_after: Some(Duration::from_secs(60)),
+            upstream_request_id: None,
+        });
+        let external_failure = attempt_failure_from_provider_error(&external_error);
+        let external_intent = InferenceIntent::new(
+            Uuid::from_u128(7),
+            crate::model_config::KIMI_K3_MODEL_ID,
+            crate::model_config::KIMI_K3_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+        let _ = failed_completion_execution(
+            &provider_router,
+            external_intent
+                .begin_execution()
+                .begin_attempt(pinned.route.identity()),
+            external_failure.clone(),
+            public_completion_error(&external_error, &external_failure),
+        );
+
+        let second_attempt = send_pinned_turn("second tool turn").await;
+        assert_eq!(first_attempt.request_id, second_attempt.request_id);
+        assert_ne!(first_attempt.execution_id, second_attempt.execution_id);
+        assert_eq!(first_attempt.route, second_attempt.route);
+        assert_eq!(
+            second_attempt.route.public_model_id,
+            crate::model_config::KIMI_K3_MODEL_ID
+        );
+        assert_eq!(tinfoil_count.load(Ordering::SeqCst), 2);
+        assert_eq!(continuum_count.load(Ordering::SeqCst), 0);
+        assert!(tinfoil_bodies
+            .lock()
+            .expect("Tinfoil bodies")
+            .iter()
+            .all(|body| body["model"] == crate::model_config::KIMI_K3_MODEL_ID));
+
+        let next_intent = InferenceIntent::new(
+            Uuid::nil(),
+            crate::model_config::AUTO_POWERFUL_MODEL_ID,
+            crate::model_config::KIMI_K3_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+        let next_baseline =
+            provider_router.shadow_completion_plan(&proxy_router, &next_intent, None);
+        let next_route = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &next_intent,
+            None,
+            next_baseline,
+        )
+        .expect("new Auto request switches to K2.6");
+        assert_eq!(next_route.provider, ProviderId::Continuum);
+        assert_eq!(next_route.provider_model_id, "kimi-k2.6");
+        assert_eq!(
+            next_route.public_model_id,
+            crate::model_config::POWERFUL_MODEL_ID
+        );
+        assert_eq!(
+            next_route.model_selection_source,
+            crate::provider_routing::ModelSelectionSource::AutoFallback
+        );
 
         tinfoil_server.abort();
         continuum_server.abort();
@@ -4544,6 +4993,136 @@ mod tests {
             third_baseline,
         )
         .expect_err("both GLM routes are open");
+        let response = error.into_response();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response.headers()[crate::CLIENT_REPLAY_HEADER], "safe");
+        assert_eq!(response.headers()[crate::ERROR_CONTRACT_HEADER], "1");
+        assert_eq!(
+            response.headers()[crate::ERROR_CODE_HEADER],
+            crate::INFERENCE_CAPACITY_ERROR_CODE
+        );
+        assert_eq!(response.headers()[header::RETRY_AFTER], "30");
+        assert_eq!(tinfoil_count.load(Ordering::SeqCst), 0);
+        assert_eq!(continuum_count.load(Ordering::SeqCst), 0);
+
+        tinfoil_server.abort();
+        continuum_server.abort();
+    }
+
+    #[tokio::test]
+    async fn prepared_all_open_auto_powerful_models_send_zero_requests_and_return_capacity() {
+        let tinfoil_count = Arc::new(AtomicUsize::new(0));
+        let tinfoil_app = {
+            let count = Arc::clone(&tinfoil_count);
+            Router::new().route(
+                "/v1/chat/completions",
+                post(move || {
+                    let count = Arc::clone(&count);
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        StatusCode::OK
+                    }
+                }),
+            )
+        };
+        let continuum_count = Arc::new(AtomicUsize::new(0));
+        let continuum_app = {
+            let count = Arc::clone(&continuum_count);
+            Router::new().route(
+                "/v1/chat/completions",
+                post(move || {
+                    let count = Arc::clone(&count);
+                    async move {
+                        count.fetch_add(1, Ordering::SeqCst);
+                        StatusCode::OK
+                    }
+                }),
+            )
+        };
+        let (tinfoil_url, tinfoil_server) = start_mock_provider(tinfoil_app).await;
+        let (continuum_url, continuum_server) = start_mock_provider(continuum_app).await;
+        let proxy_router = ProxyRouter::new(continuum_url, None, tinfoil_url);
+        let provider_router = ProviderRouter::default();
+
+        let new_intent = || {
+            InferenceIntent::new(
+                Uuid::nil(),
+                crate::model_config::AUTO_POWERFUL_MODEL_ID,
+                crate::model_config::KIMI_K3_MODEL_ID,
+                ModelPlan::Paid,
+                InferenceSurface::Responses,
+                WorkloadClass::Interactive,
+            )
+        };
+        let first_intent = new_intent();
+        let first_baseline =
+            provider_router.shadow_completion_plan(&proxy_router, &first_intent, None);
+        let first_route = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &first_intent,
+            None,
+            first_baseline,
+        )
+        .expect("initial K3 route");
+        let first_error = ProviderRequestError::Upstream(UpstreamProviderError {
+            status: 429,
+            retry_after: Some(Duration::from_secs(40)),
+            upstream_request_id: None,
+        });
+        let first_failure = attempt_failure_from_provider_error(&first_error);
+        let _ = failed_completion_execution(
+            &provider_router,
+            first_intent
+                .begin_execution()
+                .begin_attempt(first_route.identity()),
+            first_failure.clone(),
+            public_completion_error(&first_error, &first_failure),
+        );
+
+        let second_intent = new_intent();
+        let second_baseline =
+            provider_router.shadow_completion_plan(&proxy_router, &second_intent, None);
+        let second_route = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &second_intent,
+            None,
+            second_baseline,
+        )
+        .expect("K2.6 route while K3 is open");
+        assert_eq!(second_route.provider, ProviderId::Continuum);
+        assert_eq!(
+            second_route.public_model_id,
+            crate::model_config::POWERFUL_MODEL_ID
+        );
+        let second_error = ProviderRequestError::Upstream(UpstreamProviderError {
+            status: 503,
+            retry_after: Some(Duration::from_secs(10)),
+            upstream_request_id: None,
+        });
+        let second_failure = attempt_failure_from_provider_error(&second_error);
+        let _ = failed_completion_execution(
+            &provider_router,
+            second_intent
+                .begin_execution()
+                .begin_attempt(second_route.identity()),
+            second_failure.clone(),
+            public_completion_error(&second_error, &second_failure),
+        );
+
+        let third_intent = new_intent();
+        let third_baseline =
+            provider_router.shadow_completion_plan(&proxy_router, &third_intent, None);
+        let error = select_prepared_completion_route(
+            &provider_router,
+            &proxy_router,
+            &third_intent,
+            None,
+            third_baseline,
+        )
+        .expect_err("K3 and K2.6 circuits are open");
         let response = error.into_response();
 
         assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -24,7 +24,7 @@ use crate::web::audio_utils::{merge_transcriptions, AudioSplitter, TINFOIL_MAX_S
 use crate::web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse};
 use crate::web::openai_auth::AuthMethod;
 use crate::{ApiError, AppState};
-use axum::http::{header, HeaderMap, HeaderName};
+use axum::http::{header, HeaderMap, HeaderName, StatusCode};
 use axum::{
     extract::State,
     response::sse::{Event, Sse},
@@ -542,6 +542,9 @@ impl BillingContext {
 pub struct CompletionUsage {
     pub prompt_tokens: i32,
     pub completion_tokens: i32,
+    /// Whether the provider explicitly reported a completion-token total.
+    /// A synthesized zero is not sufficient for enforcing aggregate output budgets.
+    pub completion_tokens_observed: bool,
     pub cached_prompt_tokens: Option<i32>,
 }
 
@@ -604,7 +607,7 @@ impl StreamUsageAccumulator {
                     .is_some_and(|tokens| tokens < previous.completion_tokens)
             {
                 warn!(
-                    "Streaming usage totals regressed: previous_prompt_tokens={}, previous_completion_tokens={}, observed_prompt_tokens={:?}, observed_completion_tokens={:?}; using the latest explicit provider values",
+                    "Streaming usage totals regressed: previous_prompt_tokens={}, previous_completion_tokens={}, observed_prompt_tokens={:?}, observed_completion_tokens={:?}; preserving the highest cumulative totals",
                     previous.prompt_tokens,
                     previous.completion_tokens,
                     observed.prompt_tokens,
@@ -613,19 +616,36 @@ impl StreamUsageAccumulator {
             }
         }
 
+        let prompt_tokens = observed
+            .prompt_tokens
+            .map(|tokens| {
+                self.latest_usage
+                    .as_ref()
+                    .map_or(tokens, |usage| tokens.max(usage.prompt_tokens))
+            })
+            .or_else(|| self.latest_usage.as_ref().map(|usage| usage.prompt_tokens))
+            .unwrap_or(0);
+        let completion_tokens = observed
+            .completion_tokens
+            .map(|tokens| {
+                self.latest_usage
+                    .as_ref()
+                    .map_or(tokens, |usage| tokens.max(usage.completion_tokens))
+            })
+            .or_else(|| {
+                self.latest_usage
+                    .as_ref()
+                    .map(|usage| usage.completion_tokens)
+            })
+            .unwrap_or(0);
         self.latest_usage = Some(CompletionUsage {
-            prompt_tokens: observed
-                .prompt_tokens
-                .or_else(|| self.latest_usage.as_ref().map(|usage| usage.prompt_tokens))
-                .unwrap_or(0),
-            completion_tokens: observed
-                .completion_tokens
-                .or_else(|| {
-                    self.latest_usage
-                        .as_ref()
-                        .map(|usage| usage.completion_tokens)
-                })
-                .unwrap_or(0),
+            prompt_tokens,
+            completion_tokens,
+            completion_tokens_observed: observed.completion_tokens.is_some()
+                || self
+                    .latest_usage
+                    .as_ref()
+                    .is_some_and(|usage| usage.completion_tokens_observed),
             cached_prompt_tokens: observed.cached_prompt_tokens.or_else(|| {
                 self.latest_usage
                     .as_ref()
@@ -727,6 +747,10 @@ impl CompletionExecutionError {
                 public_error
             }
         }
+    }
+
+    pub(crate) fn into_pre_persistence_api_error(self) -> ApiError {
+        self.into_api_error().with_client_replay_safe()
     }
 }
 
@@ -838,17 +862,52 @@ fn attempt_failure_from_provider_error(error: &ProviderRequestError) -> AttemptF
             AttemptStage::AwaitingResponse,
             ReplaySafety::NotProvenPreAcceptance,
         ),
-        ProviderRequestError::Upstream(upstream) => AttemptFailure::new(
-            AttemptFailureKind::HttpStatus,
-            AttemptStage::AwaitingResponse,
-            ReplaySafety::NotProvenPreAcceptance,
-        )
-        .with_upstream_response(
-            upstream.status,
-            upstream.retry_after,
-            upstream.upstream_request_id.clone(),
-        ),
+        ProviderRequestError::Upstream(upstream) => {
+            let is_capacity_rejection = public_capacity_status(upstream.status).is_some();
+            AttemptFailure::new(
+                if is_capacity_rejection {
+                    AttemptFailureKind::CapacityRejected
+                } else {
+                    AttemptFailureKind::HttpStatus
+                },
+                AttemptStage::AwaitingResponse,
+                if is_capacity_rejection {
+                    ReplaySafety::ProvenPreAcceptance
+                } else {
+                    ReplaySafety::NotProvenPreAcceptance
+                },
+            )
+            .with_upstream_response(
+                upstream.status,
+                upstream.retry_after,
+                upstream.upstream_request_id.clone(),
+            )
+        }
     }
+}
+
+fn public_capacity_status(upstream_status: u16) -> Option<StatusCode> {
+    match upstream_status {
+        429 => Some(StatusCode::TOO_MANY_REQUESTS),
+        503 | 529 => Some(StatusCode::SERVICE_UNAVAILABLE),
+        _ => None,
+    }
+}
+
+fn public_completion_error(error: &ProviderRequestError, failure: &AttemptFailure) -> ApiError {
+    if failure.kind == AttemptFailureKind::CapacityRejected {
+        let status = failure
+            .status
+            .and_then(public_capacity_status)
+            .expect("capacity failure must carry a supported upstream status");
+        return ApiError::InferenceCapacity {
+            status,
+            retry_after: failure.retry_after,
+            client_replay_safe: false,
+        };
+    }
+
+    ApiError::from(error.clone())
 }
 
 fn terminalize_recovered_provider_failures(
@@ -1091,7 +1150,25 @@ async fn process_completion_stream(
     let mut usage_accumulator = StreamUsageAccumulator::default();
 
     loop {
-        match timeout(chunk_timeout, body_stream.next()).await {
+        let next_chunk = tokio::select! {
+            biased;
+            _ = tx_consumer.closed() => {
+                return finish_stream_processing(
+                    &mut usage_accumulator,
+                    StreamUsageFinalization::ConsumerDropped,
+                    AttemptTerminal::Failed {
+                        attempt,
+                        failure: AttemptFailure::new(
+                            AttemptFailureKind::ConsumerDropped,
+                            AttemptStage::Stream,
+                            ReplaySafety::NotProvenPreAcceptance,
+                        ),
+                    },
+                );
+            }
+            result = timeout(chunk_timeout, body_stream.next()) => result,
+        };
+        match next_chunk {
             Ok(Some(Ok(bytes))) => {
                 buffer.extend_from_slice(bytes.as_ref());
 
@@ -1564,16 +1641,31 @@ pub(crate) async fn prepare_completion_request(
     Ok(PinnedCompletionRequest { intent, route })
 }
 
-/// Executes one model turn against a route pinned for the logical inference request.
-/// Billing remains internal until the usage-settlement stack separates the recorder.
-pub(crate) async fn get_chat_completion_response(
+/// A provider response whose HTTP success status has been observed, but whose
+/// body has not yet been consumed. Responses holds this value only across its
+/// persistence boundary so a capacity rejection can still be returned as an
+/// ordinary HTTP error without committing conversation state.
+pub(crate) struct StartedCompletion {
+    response: Option<ProviderResponse>,
+    successful_provider: String,
+    attempt: InferenceAttempt,
+    response_model_id: String,
+    is_streaming: bool,
+    billing_context: BillingContext,
+    non_streaming_body_limit: Option<usize>,
+    terminal_guard: Option<AttemptTerminalGuard>,
+}
+
+/// Starts one model turn against a route pinned for the logical inference
+/// request and returns immediately after a successful provider response start.
+pub(crate) async fn start_chat_completion_response(
     state: &Arc<AppState>,
     user: &User,
     body: Value,
     headers: &HeaderMap,
     billing_context: BillingContext,
     pinned: &PinnedCompletionRequest,
-) -> Result<CompletionStream, CompletionExecutionError> {
+) -> Result<StartedCompletion, CompletionExecutionError> {
     get_chat_completion_response_with_options(
         state,
         user,
@@ -1624,7 +1716,7 @@ pub(crate) async fn get_chat_completion_response_for_expected_route(
 
     let continuum_cache_salt = (route.provider_name == ProviderId::Continuum.as_str())
         .then(|| format!("server-selected-{}", Uuid::new_v4().simple()));
-    get_chat_completion_response_with_options(
+    let started = get_chat_completion_response_with_options(
         state,
         user,
         body,
@@ -1640,7 +1732,8 @@ pub(crate) async fn get_chat_completion_response_for_expected_route(
             non_streaming_body_limit: Some(MAX_BOUNDED_PROVIDER_RESPONSE_BYTES),
         },
     )
-    .await
+    .await?;
+    finish_started_completion(state, user, started).await
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1679,7 +1772,7 @@ async fn get_chat_completion_response_with_options(
     mut billing_context: BillingContext,
     pinned: &PinnedCompletionRequest,
     options: CompletionExecutionOptions,
-) -> Result<CompletionStream, CompletionExecutionError> {
+) -> Result<StartedCompletion, CompletionExecutionError> {
     if body.is_null() || body.as_object().is_none_or(|obj| obj.is_empty()) {
         error!("Request body is empty or invalid");
         return Err(ApiError::BadRequest.into());
@@ -1767,7 +1860,7 @@ async fn get_chat_completion_response_with_options(
         selected_route.provider.as_str()
     );
 
-    let (res, successful_provider, attempt, mut terminal_guard) = {
+    let (response, successful_provider, attempt, terminal_guard) = {
         let mut request_body = modified_body.clone();
         let proxy_config = selected_route.proxy.clone();
         let provider_model_name = selected_route.provider_model_id.clone();
@@ -1853,8 +1946,11 @@ async fn get_chat_completion_response_with_options(
                     failure.stage,
                     request_log_metadata
                 );
-                let execution_error =
-                    failed_completion_execution(attempt, failure, ApiError::from(err));
+                let execution_error = failed_completion_execution(
+                    attempt,
+                    failure.clone(),
+                    public_completion_error(&err, &failure),
+                );
                 terminal_guard.disarm();
                 return Err(execution_error);
             }
@@ -1866,6 +1962,40 @@ async fn get_chat_completion_response_with_options(
         successful_provider
     );
 
+    Ok(StartedCompletion {
+        response: Some(response),
+        successful_provider,
+        attempt,
+        response_model_id: selected_route.response_model_id,
+        is_streaming,
+        billing_context,
+        non_streaming_body_limit: options.non_streaming_body_limit,
+        terminal_guard: Some(terminal_guard),
+    })
+}
+
+/// Consumes a successfully started provider response. Billing remains internal
+/// until the usage-settlement stack separates the recorder.
+pub(crate) async fn finish_started_completion(
+    state: &Arc<AppState>,
+    user: &User,
+    mut started: StartedCompletion,
+) -> Result<CompletionStream, CompletionExecutionError> {
+    let response = started
+        .response
+        .take()
+        .expect("started completion response can only be consumed once");
+    let successful_provider = started.successful_provider.clone();
+    let attempt = started.attempt.clone();
+    let response_model_id = started.response_model_id.clone();
+    let is_streaming = started.is_streaming;
+    let billing_context = started.billing_context.clone();
+    let non_streaming_body_limit = started.non_streaming_body_limit;
+    let mut terminal_guard = started
+        .terminal_guard
+        .take()
+        .expect("started completion terminal guard can only be consumed once");
+
     // NOW: Process the response internally and handle billing
     if !is_streaming {
         // NON-STREAMING: Simple case
@@ -1873,10 +2003,10 @@ async fn get_chat_completion_response_with_options(
         // The request's streaming fields are forwarded unchanged, but this
         // encrypted endpoint currently buffers one byte-exact response carrier.
         let response_json = match read_non_streaming_completion_response(
-            res,
-            &selected_route.response_model_id,
+            response,
+            &response_model_id,
             &attempt,
-            options.non_streaming_body_limit,
+            non_streaming_body_limit,
         )
         .await
         {
@@ -1934,13 +2064,12 @@ async fn get_chat_completion_response_with_options(
     let user_clone = user.clone();
     let billing_ctx = billing_context.clone();
     let provider = successful_provider.clone();
-    let response_model_id = selected_route.response_model_id.clone();
     let stream_attempt = attempt.clone();
     terminal_guard.set_stage(AttemptStage::Stream);
 
     tokio::spawn(async move {
         let result = process_completion_stream(
-            res,
+            response,
             &response_model_id,
             stream_attempt,
             &tx_consumer,
@@ -1974,6 +2103,21 @@ async fn get_chat_completion_response_with_options(
     })
 }
 
+/// Executes one complete model turn. Responses uses the split start/finish
+/// functions so only the first response headers cross its persistence seam.
+pub(crate) async fn get_chat_completion_response(
+    state: &Arc<AppState>,
+    user: &User,
+    body: Value,
+    headers: &HeaderMap,
+    billing_context: BillingContext,
+    pinned: &PinnedCompletionRequest,
+) -> Result<CompletionStream, CompletionExecutionError> {
+    let started =
+        start_chat_completion_response(state, user, body, headers, billing_context, pinned).await?;
+    finish_started_completion(state, user, started).await
+}
+
 pub(crate) fn ensure_completion_model_access(
     model_name: &str,
     model_plan: ModelPlan,
@@ -2001,6 +2145,7 @@ fn extract_usage(json: &Value) -> Option<CompletionUsage> {
     Some(CompletionUsage {
         prompt_tokens,
         completion_tokens: observed.completion_tokens.unwrap_or(0),
+        completion_tokens_observed: observed.completion_tokens.is_some(),
         cached_prompt_tokens: observed
             .cached_prompt_tokens
             .map(|tokens| tokens.min(prompt_tokens)),
@@ -2012,20 +2157,23 @@ fn extract_usage_observation(json: &Value) -> Option<CompletionUsageObservation>
     let prompt_tokens = usage_json
         .get("prompt_tokens")
         .and_then(|v| v.as_i64())
-        .map(|tokens| tokens.clamp(0, i32::MAX as i64) as i32);
+        .filter(|tokens| *tokens >= 0)
+        .map(|tokens| tokens.min(i32::MAX as i64) as i32);
 
     let cached_prompt_tokens = usage_json
         .get("prompt_tokens_details")
         .and_then(|details| details.get("cached_tokens"))
         .and_then(|v| v.as_i64())
-        .map(|tokens| tokens.clamp(0, i32::MAX as i64) as i32);
+        .filter(|tokens| *tokens >= 0)
+        .map(|tokens| tokens.min(i32::MAX as i64) as i32);
 
     Some(CompletionUsageObservation {
         prompt_tokens,
         completion_tokens: usage_json
             .get("completion_tokens")
             .and_then(|v| v.as_i64())
-            .map(|tokens| tokens.clamp(0, i32::MAX as i64) as i32),
+            .filter(|tokens| *tokens >= 0)
+            .map(|tokens| tokens.min(i32::MAX as i64) as i32),
         cached_prompt_tokens,
     })
 }
@@ -3113,6 +3261,7 @@ async fn proxy_embeddings(
             let embedding_usage = CompletionUsage {
                 prompt_tokens,
                 completion_tokens: 0, // Embeddings don't have completion tokens
+                completion_tokens_observed: false,
                 cached_prompt_tokens: None,
             };
             publish_usage_event_internal(
@@ -3519,9 +3668,9 @@ mod tests {
             .contains("private upstream capacity detail"));
 
         let failure = attempt_failure_from_provider_error(&error);
-        assert_eq!(failure.kind, AttemptFailureKind::HttpStatus);
+        assert_eq!(failure.kind, AttemptFailureKind::CapacityRejected);
         assert_eq!(failure.stage, AttemptStage::AwaitingResponse);
-        assert_eq!(failure.replay_safety, ReplaySafety::NotProvenPreAcceptance);
+        assert_eq!(failure.replay_safety, ReplaySafety::ProvenPreAcceptance);
         assert_eq!(failure.status, Some(429));
         assert_eq!(failure.retry_after, Some(Duration::from_secs(17)));
         assert_eq!(
@@ -3567,9 +3716,47 @@ mod tests {
             Ok(_) => panic!("mock 429 unexpectedly succeeded"),
         };
         let failure = attempt_failure_from_provider_error(&error);
-        assert_eq!(failure.kind, AttemptFailureKind::HttpStatus);
+        assert_eq!(failure.kind, AttemptFailureKind::CapacityRejected);
         assert_eq!(failure.status, Some(429));
         assert_eq!(failure.retry_after, Some(Duration::from_secs(23)));
+    }
+
+    #[tokio::test]
+    async fn mock_provider_capacity_matrix_normalizes_503_and_synthetic_529() {
+        for status in [503u16, 529u16] {
+            let app = Router::new().route(
+                "/v1/chat/completions",
+                post(move || async move {
+                    axum::http::Response::builder()
+                        .status(status)
+                        .header(header::RETRY_AFTER, "11")
+                        .body(axum::body::Body::from(
+                            r#"{"error":{"message":"private capacity detail"}}"#,
+                        ))
+                        .expect("mock capacity response")
+                }),
+            );
+            let (trace, server) = call_mock_provider(app).await;
+            server.abort();
+            let error = match trace.result {
+                Err(error) => error,
+                Ok(_) => panic!("capacity response unexpectedly succeeded"),
+            };
+            assert!(!error.to_string().contains("private capacity detail"));
+            let failure = attempt_failure_from_provider_error(&error);
+            assert_eq!(failure.kind, AttemptFailureKind::CapacityRejected);
+            assert_eq!(failure.replay_safety, ReplaySafety::ProvenPreAcceptance);
+            assert_eq!(failure.status, Some(status));
+            assert_eq!(failure.retry_after, Some(Duration::from_secs(11)));
+            assert!(matches!(
+                public_completion_error(&error, &failure),
+                ApiError::InferenceCapacity {
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    client_replay_safe: false,
+                    ..
+                }
+            ));
+        }
     }
 
     #[tokio::test]
@@ -3716,6 +3903,49 @@ mod tests {
             AttemptTerminal::Failed {
                 failure: AttemptFailure {
                     kind: AttemptFailureKind::StreamTimeout,
+                    ..
+                },
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn dropping_completion_consumer_cancels_a_pending_provider_body() {
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(|| async {
+                let pending = futures::stream::pending::<Result<bytes::Bytes, std::io::Error>>();
+                axum::http::Response::builder()
+                    .status(axum::http::StatusCode::OK)
+                    .header(header::CONTENT_TYPE, "text/event-stream")
+                    .body(axum::body::Body::from_stream(pending))
+                    .expect("mock pending response")
+            }),
+        );
+        let (trace, server) = call_mock_provider(app).await;
+        let response = trace.result.expect("mock provider response start");
+        let pinned = pinned_test_completion();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let (tx, rx) = mpsc::channel(1);
+        drop(rx);
+
+        let result = timeout(
+            Duration::from_millis(100),
+            process_completion_stream(response, "kimi-k3", attempt, &tx, Duration::from_secs(30)),
+        )
+        .await
+        .expect("consumer drop should cancel without waiting for chunk timeout");
+        server.abort();
+
+        assert!(matches!(
+            result.terminal,
+            AttemptTerminal::Failed {
+                failure: AttemptFailure {
+                    kind: AttemptFailureKind::ConsumerDropped,
+                    stage: AttemptStage::Stream,
                     ..
                 },
                 ..
@@ -3928,8 +4158,8 @@ mod tests {
             upstream_request_id: Some("request-123".to_string()),
         });
         let failure = attempt_failure_from_provider_error(&upstream);
-        assert_eq!(failure.kind, AttemptFailureKind::HttpStatus);
-        assert_eq!(failure.replay_safety, ReplaySafety::NotProvenPreAcceptance);
+        assert_eq!(failure.kind, AttemptFailureKind::CapacityRejected);
+        assert_eq!(failure.replay_safety, ReplaySafety::ProvenPreAcceptance);
         assert_eq!(failure.status, Some(429));
         assert_eq!(failure.retry_after, Some(Duration::from_secs(60)));
         assert_eq!(failure.upstream_request_id.as_deref(), Some("request-123"));
@@ -4024,6 +4254,46 @@ mod tests {
         );
         assert_eq!(parse_retry_after_hint(Some("not-seconds")), None);
         assert_eq!(parse_retry_after_hint(None), None);
+    }
+
+    #[test]
+    fn capacity_statuses_are_explicit_rejections_and_529_is_normalized() {
+        for (upstream_status, public_status) in [
+            (429, StatusCode::TOO_MANY_REQUESTS),
+            (503, StatusCode::SERVICE_UNAVAILABLE),
+            (529, StatusCode::SERVICE_UNAVAILABLE),
+        ] {
+            let provider_error = ProviderRequestError::Upstream(UpstreamProviderError {
+                status: upstream_status,
+                retry_after: Some(Duration::from_secs(7)),
+                upstream_request_id: None,
+            });
+            let failure = attempt_failure_from_provider_error(&provider_error);
+            assert_eq!(failure.kind, AttemptFailureKind::CapacityRejected);
+            assert_eq!(failure.replay_safety, ReplaySafety::ProvenPreAcceptance);
+            assert_eq!(failure.status, Some(upstream_status));
+            assert!(matches!(
+                public_completion_error(&provider_error, &failure),
+                ApiError::InferenceCapacity {
+                    status,
+                    retry_after: Some(delay),
+                    client_replay_safe: false,
+                } if status == public_status && delay == Duration::from_secs(7)
+            ));
+        }
+
+        let generic = ProviderRequestError::Upstream(UpstreamProviderError {
+            status: 500,
+            retry_after: None,
+            upstream_request_id: None,
+        });
+        let failure = attempt_failure_from_provider_error(&generic);
+        assert_eq!(failure.kind, AttemptFailureKind::HttpStatus);
+        assert_eq!(failure.replay_safety, ReplaySafety::NotProvenPreAcceptance);
+        assert!(matches!(
+            public_completion_error(&generic, &failure),
+            ApiError::InternalServerError
+        ));
     }
 
     #[test]
@@ -4445,7 +4715,38 @@ mod tests {
 
         assert_eq!(usage.prompt_tokens, 100);
         assert_eq!(usage.completion_tokens, 20);
+        assert!(usage.completion_tokens_observed);
         assert_eq!(usage.cached_prompt_tokens, Some(42));
+    }
+
+    #[test]
+    fn prompt_only_usage_preserves_missing_completion_token_signal() {
+        let response = json!({
+            "usage": {
+                "prompt_tokens": 100
+            }
+        });
+
+        let usage = extract_usage(&response).expect("usage should parse");
+
+        assert_eq!(usage.prompt_tokens, 100);
+        assert_eq!(usage.completion_tokens, 0);
+        assert!(!usage.completion_tokens_observed);
+    }
+
+    #[test]
+    fn negative_completion_usage_is_not_treated_as_observed() {
+        let response = json!({
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": -1
+            }
+        });
+
+        let usage = extract_usage(&response).expect("prompt usage should parse");
+
+        assert_eq!(usage.completion_tokens, 0);
+        assert!(!usage.completion_tokens_observed);
     }
 
     #[test]
@@ -4502,6 +4803,7 @@ mod tests {
         let usage = CompletionUsage {
             prompt_tokens: 100,
             completion_tokens: 20,
+            completion_tokens_observed: true,
             cached_prompt_tokens: Some(42),
         };
 
@@ -4527,6 +4829,7 @@ mod tests {
         let usage = CompletionUsage {
             prompt_tokens: 100,
             completion_tokens: 20,
+            completion_tokens_observed: true,
             cached_prompt_tokens: Some(42),
         };
 
@@ -4622,6 +4925,7 @@ mod tests {
     ) {
         assert_eq!(usage.prompt_tokens, prompt_tokens);
         assert_eq!(usage.completion_tokens, completion_tokens);
+        assert!(usage.completion_tokens_observed);
         assert_eq!(usage.cached_prompt_tokens, cached_prompt_tokens);
     }
 
@@ -4682,6 +4986,18 @@ mod tests {
         assert!(accumulator
             .take_final_usage(StreamUsageFinalization::ConsumerDropped)
             .is_none());
+    }
+
+    #[test]
+    fn regressing_cumulative_usage_preserves_highest_totals() {
+        let mut accumulator = StreamUsageAccumulator::default();
+        accumulator.observe(&stream_usage_chunk(500, 100, None, None, false));
+        accumulator.observe(&stream_usage_chunk(400, 0, None, Some("stop"), true));
+
+        let usage = accumulator
+            .take_final_usage(StreamUsageFinalization::ProviderDone)
+            .expect("provider [DONE] should finalize usage");
+        assert_usage(usage, 500, 100, None);
     }
 
     #[test]
@@ -4800,6 +5116,22 @@ mod tests {
             .take_final_usage(StreamUsageFinalization::ProviderDone)
             .expect("non-zero prompt usage should be retained");
         assert_usage(usage, 33, 0, None);
+    }
+
+    #[test]
+    fn stream_prompt_only_usage_keeps_completion_tokens_unobserved() {
+        let mut accumulator = StreamUsageAccumulator::default();
+        accumulator.observe(&json!({
+            "choices": [{ "finish_reason": "tool_calls" }],
+            "usage": { "prompt_tokens": 33 }
+        }));
+
+        let usage = accumulator
+            .take_final_usage(StreamUsageFinalization::ProviderDone)
+            .expect("non-zero prompt usage should be retained");
+        assert_eq!(usage.prompt_tokens, 33);
+        assert_eq!(usage.completion_tokens, 0);
+        assert!(!usage.completion_tokens_observed);
     }
 
     #[test]

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -1,3 +1,8 @@
+use crate::inference::{
+    AttemptFailure, AttemptFailureKind, AttemptOutcome, AttemptStage, AttemptTerminal,
+    CompletionEvidence, InferenceAttempt, InferenceExecution, InferenceIntent, InferenceSurface,
+    ReplaySafety, WorkloadClass,
+};
 use crate::model_config::{
     model_alias_requires_flag_lookup, model_catalog_response, openai_models_response,
     ModelAliasTargets, ModelPlan,
@@ -5,16 +10,17 @@ use crate::model_config::{
 use crate::models::token_usage::NewTokenUsage;
 use crate::models::users::User;
 use crate::provider_client::{
-    ProviderClient, ProviderRequest, ProviderRequestError, ProviderResponse,
+    ProviderClient, ProviderRequest, ProviderRequestError, ProviderResponse, ProviderSendTrace,
+    UpstreamProviderError,
 };
-use crate::provider_routing::{ProviderName, ProviderRoutingError};
+use crate::provider_routing::{ProviderName, ProviderRoutingError, SelectedProviderRoute};
 use crate::proxy_config::ProxyConfig;
 use crate::sqs::UsageEvent;
 use crate::web::audio_utils::{merge_transcriptions, AudioSplitter, TINFOIL_MAX_SIZE};
 use crate::web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse};
 use crate::web::openai_auth::AuthMethod;
 use crate::{ApiError, AppState};
-use axum::http::HeaderMap;
+use axum::http::{header, HeaderMap, HeaderName};
 use axum::{
     extract::State,
     response::sse::{Event, Sse},
@@ -554,6 +560,7 @@ impl CompletionUsageObservation {
 enum StreamUsageFinalization {
     ProviderDone,
     EndOfStream,
+    ProviderError,
     TransportError,
     Timeout,
     ConsumerDropped,
@@ -650,10 +657,8 @@ pub enum CompletionChunk {
     FullResponse(Value),
     /// Usage information (for streaming with include_usage)
     Usage(CompletionUsage),
-    /// Stream finished
-    Done,
-    /// Stream error occurred
-    Error(String),
+    /// Exactly one typed terminal outcome for the upstream attempt.
+    Terminal(AttemptTerminal),
 }
 
 /// Metadata about the completion
@@ -662,6 +667,7 @@ pub struct CompletionMetadata {
     pub provider_name: String,
     pub model_name: String,
     pub is_streaming: bool,
+    pub(crate) attempt: InferenceAttempt,
 }
 
 /// Processed completion stream - billing happens automatically
@@ -672,8 +678,552 @@ pub struct CompletionStream {
     pub metadata: CompletionMetadata,
 }
 
-async fn finalize_stream_usage(
+#[derive(Debug, Clone)]
+pub(crate) struct PinnedCompletionRequest {
+    intent: InferenceIntent,
+    route: SelectedProviderRoute,
+}
+
+impl PinnedCompletionRequest {
+    pub(crate) fn intent(&self) -> &InferenceIntent {
+        &self.intent
+    }
+
+    fn begin_execution(&self) -> InferenceExecution {
+        self.intent.begin_execution()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum CompletionExecutionError {
+    Request(ApiError),
+    Attempt {
+        terminal: AttemptTerminal,
+        public_error: ApiError,
+    },
+}
+
+impl CompletionExecutionError {
+    pub(crate) fn terminal(&self) -> Option<&AttemptTerminal> {
+        match self {
+            Self::Request(_) => None,
+            Self::Attempt { terminal, .. } => Some(terminal),
+        }
+    }
+
+    pub(crate) fn into_api_error(self) -> ApiError {
+        let has_terminal = self.terminal().is_some();
+        match self {
+            Self::Request(error) => {
+                debug_assert!(!has_terminal);
+                error
+            }
+            Self::Attempt { public_error, .. } => {
+                debug_assert!(has_terminal);
+                public_error
+            }
+        }
+    }
+}
+
+impl From<ApiError> for CompletionExecutionError {
+    fn from(error: ApiError) -> Self {
+        Self::Request(error)
+    }
+}
+
+fn failed_completion_execution(
+    attempt: InferenceAttempt,
+    failure: AttemptFailure,
+    public_error: ApiError,
+) -> CompletionExecutionError {
+    let terminal = AttemptTerminal::Failed { attempt, failure };
+    record_attempt_outcome(&AttemptOutcome::Terminal(terminal.clone()));
+    CompletionExecutionError::Attempt {
+        terminal,
+        public_error,
+    }
+}
+
+/// Ensures cancellation or panic cannot make an in-flight attempt disappear
+/// from the typed terminal stream. Later routing layers may attach health
+/// observation to the same lifecycle without changing its exactly-once shape.
+struct AttemptTerminalGuard {
+    attempt: InferenceAttempt,
+    stage: AttemptStage,
+    armed: bool,
+}
+
+impl AttemptTerminalGuard {
+    fn new(attempt: InferenceAttempt, stage: AttemptStage) -> Self {
+        Self {
+            attempt,
+            stage,
+            armed: true,
+        }
+    }
+
+    fn set_stage(&mut self, stage: AttemptStage) {
+        self.stage = stage;
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+
+    fn record_terminal(&mut self, terminal: &AttemptTerminal) {
+        debug_assert_eq!(terminal.attempt(), &self.attempt);
+        record_attempt_outcome(&AttemptOutcome::Terminal(terminal.clone()));
+        self.disarm();
+    }
+
+    fn cancellation_terminal(&self) -> AttemptTerminal {
+        AttemptTerminal::Failed {
+            attempt: self.attempt.clone(),
+            failure: AttemptFailure::new(
+                AttemptFailureKind::ConsumerDropped,
+                self.stage,
+                ReplaySafety::NotProvenPreAcceptance,
+            ),
+        }
+    }
+}
+
+impl Drop for AttemptTerminalGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        let terminal = self.cancellation_terminal();
+        record_attempt_outcome(&AttemptOutcome::Terminal(terminal));
+        warn!(
+            "Inference attempt abandoned before terminal processing: request_id={}, execution_id={}, attempt_id={}, stage={:?}",
+            self.attempt.request_id,
+            self.attempt.execution_id,
+            self.attempt.attempt_id,
+            self.stage
+        );
+    }
+}
+
+fn attempt_failure_from_provider_error(error: &ProviderRequestError) -> AttemptFailure {
+    match error {
+        ProviderRequestError::TinfoilUnavailable => AttemptFailure::new(
+            AttemptFailureKind::ProviderUnavailable,
+            AttemptStage::BeforeSend,
+            ReplaySafety::ProvenPreAcceptance,
+        ),
+        ProviderRequestError::Build(_) => AttemptFailure::new(
+            AttemptFailureKind::RequestBuild,
+            AttemptStage::BeforeSend,
+            ReplaySafety::ProvenPreAcceptance,
+        ),
+        ProviderRequestError::Connect(_) => AttemptFailure::new(
+            AttemptFailureKind::Connect,
+            AttemptStage::BeforeSend,
+            ReplaySafety::ProvenPreAcceptance,
+        ),
+        ProviderRequestError::Timeout(_) => AttemptFailure::new(
+            AttemptFailureKind::ResponseStartTimeout,
+            AttemptStage::AwaitingResponse,
+            ReplaySafety::NotProvenPreAcceptance,
+        ),
+        ProviderRequestError::Send(_) => AttemptFailure::new(
+            AttemptFailureKind::Transport,
+            AttemptStage::AwaitingResponse,
+            ReplaySafety::NotProvenPreAcceptance,
+        ),
+        ProviderRequestError::Upstream(upstream) => AttemptFailure::new(
+            AttemptFailureKind::HttpStatus,
+            AttemptStage::AwaitingResponse,
+            ReplaySafety::NotProvenPreAcceptance,
+        )
+        .with_upstream_response(
+            upstream.status,
+            upstream.retry_after,
+            upstream.upstream_request_id.clone(),
+        ),
+    }
+}
+
+fn terminalize_recovered_provider_failures(
+    execution: InferenceExecution,
+    route: &crate::inference::RouteIdentity,
+    prior_failures: Vec<ProviderRequestError>,
+) -> Vec<AttemptTerminal> {
+    prior_failures
+        .into_iter()
+        .map(|prior_error| {
+            let attempt = execution.begin_attempt(route.clone());
+            let failure = attempt_failure_from_provider_error(&prior_error);
+            let terminal = AttemptTerminal::Failed {
+                attempt: attempt.clone(),
+                failure: failure.clone(),
+            };
+            record_attempt_outcome(&AttemptOutcome::Terminal(terminal.clone()));
+            warn!(
+                "Inference transport recovered a failed attempt: request_id={}, execution_id={}, attempt_id={}, kind={:?}, replay_safety={:?}",
+                attempt.request_id,
+                attempt.execution_id,
+                attempt.attempt_id,
+                failure.kind,
+                failure.replay_safety
+            );
+            terminal
+        })
+        .collect()
+}
+
+fn record_attempt_outcome(outcome: &AttemptOutcome) {
+    match outcome {
+        AttemptOutcome::ResponseStarted { attempt, status } => {
+            let route_key = attempt.route.route_key();
+            debug!(
+                "Inference attempt response started: request_id={}, execution_id={}, attempt_id={}, provider={}, public_model={}, provider_model={}, response_model={}, route_provider={}, route_model={}, source={:?}, bucket={:?}, status={}",
+                attempt.request_id,
+                attempt.execution_id,
+                attempt.attempt_id,
+                attempt.route.provider.as_str(),
+                attempt.route.public_model_id,
+                attempt.route.provider_model_id,
+                attempt.route.response_model_id,
+                route_key.provider.as_str(),
+                route_key.provider_model_id,
+                attempt.route.selection_source,
+                attempt.route.bucket,
+                status
+            );
+        }
+        AttemptOutcome::Terminal(terminal) => {
+            let attempt = terminal.attempt();
+            match terminal {
+                AttemptTerminal::Completed { evidence, .. } => debug!(
+                    "Inference attempt completed: request_id={}, execution_id={}, attempt_id={}, provider={}, public_model={}, provider_model={}, evidence={:?}",
+                    attempt.request_id,
+                    attempt.execution_id,
+                    attempt.attempt_id,
+                    attempt.route.provider.as_str(),
+                    attempt.route.public_model_id,
+                    attempt.route.provider_model_id,
+                    evidence
+                ),
+                AttemptTerminal::Failed { failure, .. } => warn!(
+                    "Inference attempt failed: request_id={}, execution_id={}, attempt_id={}, provider={}, public_model={}, provider_model={}, kind={:?}, stage={:?}, replay_safety={:?}, status={:?}, retry_after_ms={:?}, upstream_request_id={:?}, upstream_code={:?}",
+                    attempt.request_id,
+                    attempt.execution_id,
+                    attempt.attempt_id,
+                    attempt.route.provider.as_str(),
+                    attempt.route.public_model_id,
+                    attempt.route.provider_model_id,
+                    failure.kind,
+                    failure.stage,
+                    failure.replay_safety,
+                    failure.status,
+                    failure.retry_after.map(|duration| duration.as_millis()),
+                    failure.upstream_request_id,
+                    failure.upstream_code
+                ),
+            }
+        }
+    }
+}
+
+fn stream_end_terminal(
+    attempt: InferenceAttempt,
+    saw_finish_signal: bool,
+    has_incomplete_frame: bool,
+) -> AttemptTerminal {
+    if saw_finish_signal && !has_incomplete_frame {
+        AttemptTerminal::Completed {
+            attempt,
+            evidence: CompletionEvidence::FinishSignalThenEof,
+        }
+    } else {
+        AttemptTerminal::Failed {
+            attempt,
+            failure: AttemptFailure::new(
+                AttemptFailureKind::UnexpectedEof,
+                AttemptStage::Stream,
+                ReplaySafety::NotProvenPreAcceptance,
+            ),
+        }
+    }
+}
+
+struct StreamProcessResult {
+    terminal: AttemptTerminal,
+    finalization: StreamUsageFinalization,
+    usage: Option<CompletionUsage>,
+}
+
+fn finish_stream_processing(
     accumulator: &mut StreamUsageAccumulator,
+    finalization: StreamUsageFinalization,
+    terminal: AttemptTerminal,
+) -> StreamProcessResult {
+    StreamProcessResult {
+        terminal,
+        finalization,
+        usage: accumulator.take_final_usage(finalization),
+    }
+}
+
+fn bounded_upstream_error_code(error: &Value) -> Option<String> {
+    let code = error.get("code")?;
+    let code = match code {
+        Value::String(code) => code.clone(),
+        Value::Number(code) => code.to_string(),
+        _ => return None,
+    };
+    let code = code.trim();
+    (!code.is_empty() && code.len() <= 64 && code.chars().all(is_safe_identifier_char))
+        .then(|| code.to_string())
+}
+
+fn upstream_payload_failure(
+    json: &Value,
+    kind: AttemptFailureKind,
+    stage: AttemptStage,
+) -> Option<AttemptFailure> {
+    let error = json.get("error").filter(|error| !error.is_null())?;
+    Some(
+        AttemptFailure::new(kind, stage, ReplaySafety::NotProvenPreAcceptance)
+            .with_upstream_code(bounded_upstream_error_code(error)),
+    )
+}
+
+fn upstream_stream_failure(json: &Value) -> Option<AttemptFailure> {
+    upstream_payload_failure(
+        json,
+        AttemptFailureKind::UpstreamStreamError,
+        AttemptStage::Stream,
+    )
+}
+
+async fn read_non_streaming_completion_response(
+    response: ProviderResponse,
+    response_model_id: &str,
+    attempt: &InferenceAttempt,
+    body_limit: Option<usize>,
+) -> Result<Value, AttemptFailure> {
+    let body_bytes = match body_limit {
+        Some(limit_bytes) => bytes::Bytes::from(
+            collect_bounded_provider_response_body(response.bytes_stream(), limit_bytes)
+                .await
+                .map_err(|error| {
+                    error!(
+                        "Failed to read bounded inference response body: request_id={}, execution_id={}, attempt_id={}, error={}",
+                        attempt.request_id, attempt.execution_id, attempt.attempt_id, error
+                    );
+                    let kind = match error {
+                        BoundedProviderResponseBodyError::Read => {
+                            AttemptFailureKind::ResponseBody
+                        }
+                        BoundedProviderResponseBodyError::TooLarge { .. } => {
+                            AttemptFailureKind::InvalidResponse
+                        }
+                    };
+                    AttemptFailure::new(
+                        kind,
+                        AttemptStage::ResponseBody,
+                        ReplaySafety::NotProvenPreAcceptance,
+                    )
+                })?,
+        ),
+        None => response.bytes().await.map_err(|error| {
+            error!(
+                "Failed to read inference response body: request_id={}, execution_id={}, attempt_id={}, error={}",
+                attempt.request_id, attempt.execution_id, attempt.attempt_id, error
+            );
+            AttemptFailure::new(
+                AttemptFailureKind::ResponseBody,
+                AttemptStage::ResponseBody,
+                ReplaySafety::NotProvenPreAcceptance,
+            )
+        })?,
+    };
+
+    let mut response_json: Value = serde_json::from_slice(&body_bytes).map_err(|error| {
+        error!(
+            "Failed to parse inference response JSON: request_id={}, execution_id={}, attempt_id={}, error={}",
+            attempt.request_id, attempt.execution_id, attempt.attempt_id, error
+        );
+        AttemptFailure::new(
+            AttemptFailureKind::InvalidResponse,
+            AttemptStage::ResponseBody,
+            ReplaySafety::NotProvenPreAcceptance,
+        )
+    })?;
+
+    if let Some(failure) = upstream_payload_failure(
+        &response_json,
+        AttemptFailureKind::UpstreamResponseError,
+        AttemptStage::ResponseBody,
+    ) {
+        warn!(
+            "Inference provider emitted a non-streaming error payload: request_id={}, execution_id={}, attempt_id={}, upstream_code={:?}",
+            attempt.request_id,
+            attempt.execution_id,
+            attempt.attempt_id,
+            failure.upstream_code
+        );
+        return Err(failure);
+    }
+
+    canonicalize_response_model(&mut response_json, response_model_id);
+    Ok(response_json)
+}
+
+async fn process_completion_stream(
+    response: ProviderResponse,
+    response_model_id: &str,
+    attempt: InferenceAttempt,
+    tx_consumer: &mpsc::Sender<CompletionChunk>,
+    chunk_timeout: Duration,
+) -> StreamProcessResult {
+    let mut body_stream = response.bytes_stream();
+    let mut buffer = Vec::new();
+    let mut usage_accumulator = StreamUsageAccumulator::default();
+
+    loop {
+        match timeout(chunk_timeout, body_stream.next()).await {
+            Ok(Some(Ok(bytes))) => {
+                buffer.extend_from_slice(bytes.as_ref());
+
+                while let Some(frame) = extract_sse_frame(&mut buffer) {
+                    if frame == b"[DONE]" {
+                        return finish_stream_processing(
+                            &mut usage_accumulator,
+                            StreamUsageFinalization::ProviderDone,
+                            AttemptTerminal::Completed {
+                                attempt,
+                                evidence: CompletionEvidence::ProviderDone,
+                            },
+                        );
+                    }
+
+                    let mut json = match serde_json::from_slice::<Value>(&frame) {
+                        Ok(json) => json,
+                        Err(error) => {
+                            error!(
+                                "Received invalid inference stream data: request_id={}, execution_id={}, attempt_id={}, error={}",
+                                attempt.request_id,
+                                attempt.execution_id,
+                                attempt.attempt_id,
+                                error
+                            );
+                            return finish_stream_processing(
+                                &mut usage_accumulator,
+                                StreamUsageFinalization::InvalidData,
+                                AttemptTerminal::Failed {
+                                    attempt,
+                                    failure: AttemptFailure::new(
+                                        AttemptFailureKind::InvalidResponse,
+                                        AttemptStage::Stream,
+                                        ReplaySafety::NotProvenPreAcceptance,
+                                    ),
+                                },
+                            );
+                        }
+                    };
+
+                    if let Some(failure) = upstream_stream_failure(&json) {
+                        warn!(
+                            "Inference provider emitted an error stream frame: request_id={}, execution_id={}, attempt_id={}, upstream_code={:?}",
+                            attempt.request_id,
+                            attempt.execution_id,
+                            attempt.attempt_id,
+                            failure.upstream_code
+                        );
+                        return finish_stream_processing(
+                            &mut usage_accumulator,
+                            StreamUsageFinalization::ProviderError,
+                            AttemptTerminal::Failed { attempt, failure },
+                        );
+                    }
+
+                    usage_accumulator.observe(&json);
+                    canonicalize_response_model(&mut json, response_model_id);
+
+                    if tx_consumer
+                        .send(CompletionChunk::StreamChunk(json))
+                        .await
+                        .is_err()
+                    {
+                        return finish_stream_processing(
+                            &mut usage_accumulator,
+                            StreamUsageFinalization::ConsumerDropped,
+                            AttemptTerminal::Failed {
+                                attempt,
+                                failure: AttemptFailure::new(
+                                    AttemptFailureKind::ConsumerDropped,
+                                    AttemptStage::Stream,
+                                    ReplaySafety::NotProvenPreAcceptance,
+                                ),
+                            },
+                        );
+                    }
+                }
+            }
+            Ok(Some(Err(error))) => {
+                error!(
+                    "Inference stream transport error: request_id={}, execution_id={}, attempt_id={}, error={}",
+                    attempt.request_id, attempt.execution_id, attempt.attempt_id, error
+                );
+                return finish_stream_processing(
+                    &mut usage_accumulator,
+                    StreamUsageFinalization::TransportError,
+                    AttemptTerminal::Failed {
+                        attempt,
+                        failure: AttemptFailure::new(
+                            AttemptFailureKind::Transport,
+                            AttemptStage::Stream,
+                            ReplaySafety::NotProvenPreAcceptance,
+                        ),
+                    },
+                );
+            }
+            Ok(None) => {
+                let has_incomplete_frame = buffer.iter().any(|byte| !byte.is_ascii_whitespace());
+                let terminal = stream_end_terminal(
+                    attempt,
+                    usage_accumulator.saw_terminal_signal,
+                    has_incomplete_frame,
+                );
+                return finish_stream_processing(
+                    &mut usage_accumulator,
+                    StreamUsageFinalization::EndOfStream,
+                    terminal,
+                );
+            }
+            Err(_) => {
+                error!(
+                    "Inference stream chunk timeout: request_id={}, execution_id={}, attempt_id={}, timeout_ms={}",
+                    attempt.request_id,
+                    attempt.execution_id,
+                    attempt.attempt_id,
+                    chunk_timeout.as_millis()
+                );
+                return finish_stream_processing(
+                    &mut usage_accumulator,
+                    StreamUsageFinalization::Timeout,
+                    AttemptTerminal::Failed {
+                        attempt,
+                        failure: AttemptFailure::new(
+                            AttemptFailureKind::StreamTimeout,
+                            AttemptStage::Stream,
+                            ReplaySafety::NotProvenPreAcceptance,
+                        ),
+                    },
+                );
+            }
+        }
+    }
+}
+
+async fn publish_stream_usage(
+    usage: Option<CompletionUsage>,
     finalization: StreamUsageFinalization,
     state: &Arc<AppState>,
     user: &User,
@@ -681,7 +1231,7 @@ async fn finalize_stream_usage(
     provider: &str,
     tx_consumer: &mpsc::Sender<CompletionChunk>,
 ) {
-    let Some(usage) = accumulator.take_final_usage(finalization) else {
+    let Some(usage) = usage else {
         return;
     };
 
@@ -796,6 +1346,15 @@ async fn proxy_openai(
         ModelAliasTargets::for_plan(model_plan)
     };
     let model_name = alias_targets.resolve(&requested_model_name).to_string();
+    let intent = InferenceIntent::new(
+        user.uuid,
+        requested_model_name.clone(),
+        model_name.clone(),
+        model_plan,
+        InferenceSurface::ChatCompletions,
+        WorkloadClass::Interactive,
+    );
+    let pinned_completion = prepare_completion_request(&state, &user, intent).await?;
     if requested_model_name != model_name {
         debug!(
             "Resolved chat model {} to {}",
@@ -810,13 +1369,24 @@ async fn proxy_openai(
     let billing_context = BillingContext::new(auth_method, requested_model_name);
 
     // Get the completion stream - billing happens automatically inside!
-    let completion =
-        get_chat_completion_response(&state, &user, body, &headers, billing_context, model_plan)
-            .await?;
+    let completion = get_chat_completion_response(
+        &state,
+        &user,
+        body,
+        &headers,
+        billing_context,
+        &pinned_completion,
+    )
+    .await
+    .map_err(CompletionExecutionError::into_api_error)?;
 
     debug!(
-        "Received completion from provider: {} (streaming: {})",
-        completion.metadata.provider_name, completion.metadata.is_streaming
+        "Received completion stream: request_id={}, execution_id={}, attempt_id={}, provider={}, streaming={}",
+        completion.metadata.attempt.request_id,
+        completion.metadata.attempt.execution_id,
+        completion.metadata.attempt.attempt_id,
+        completion.metadata.provider_name,
+        completion.metadata.is_streaming
     );
 
     // Handle non-streaming vs streaming responses differently
@@ -850,7 +1420,6 @@ async fn proxy_openai(
                         Ok(event) => yield Ok::<Event, std::convert::Infallible>(event),
                         Err(e) => {
                             error!("Failed to encrypt event data: {:?}", e);
-                            yield Ok(Event::default().data("Error: Encryption failed"));
                             break;
                         }
                     }
@@ -859,19 +1428,37 @@ async fn proxy_openai(
                     // Billing already handled internally, no need to send to client
                     trace!("Received usage chunk (billing already processed)");
                 }
-                CompletionChunk::Done => {
-                    yield Ok(Event::default().data("[DONE]"));
-                    break;
-                }
-                CompletionChunk::Error(error_msg) => {
-                    error!("Stream error from completion API: {}", error_msg);
-                    yield Ok(Event::default().data(format!("Error: {}", error_msg)));
+                CompletionChunk::Terminal(terminal) => {
+                    match terminal {
+                        AttemptTerminal::Completed { .. } => {
+                            yield Ok(Event::default().data("[DONE]"));
+                        }
+                        AttemptTerminal::Failed { failure, .. } => {
+                            error!(
+                                "Completion attempt failed: kind={:?}, stage={:?}",
+                                failure.kind, failure.stage
+                            );
+                            let error_payload = completion_error_payload(failure.client_message());
+                            match encrypt_sse_event(&state, &session_id, &error_payload).await {
+                                Ok(event) => yield Ok(event),
+                                Err(error) => {
+                                    error!("Failed to encrypt terminal error event: {error:?}");
+                                }
+                            }
+                        }
+                    }
                     break;
                 }
                 CompletionChunk::FullResponse(_) => {
                     // Shouldn't happen in streaming mode
                     error!("Received FullResponse in streaming mode");
-                    yield Ok(Event::default().data("Error: Invalid event format"));
+                    let error_payload = completion_error_payload("Invalid inference response");
+                    match encrypt_sse_event(&state, &session_id, &error_payload).await {
+                        Ok(event) => yield Ok(event),
+                        Err(error) => {
+                            error!("Failed to encrypt invalid-format error event: {error:?}");
+                        }
+                    }
                     break;
                 }
             }
@@ -880,26 +1467,75 @@ async fn proxy_openai(
     Ok(Sse::new(stream).into_response())
 }
 
-/// Internal function to get chat completion response with automatic billing
-/// This can be used by both the proxy_openai endpoint and the responses API
-///
-/// Billing happens INTERNALLY within this function - consumers just receive processed chunks
-pub async fn get_chat_completion_response(
+pub(crate) async fn prepare_completion_request(
+    state: &Arc<AppState>,
+    user: &User,
+    intent: InferenceIntent,
+) -> Result<PinnedCompletionRequest, ApiError> {
+    if intent.account_uuid != user.uuid {
+        error!("Inference intent account did not match the authenticated user");
+        return Err(ApiError::InternalServerError);
+    }
+
+    ensure_completion_model_access(&intent.public_model_id, intent.model_plan)?;
+    let provider_preference = state
+        .provider_routing_preference(user.uuid, &intent.public_model_id)
+        .await;
+    let route = state
+        .provider_router
+        .select_completion_route_with_preference(
+            &state.proxy_router,
+            user.uuid,
+            &intent.public_model_id,
+            provider_preference,
+        )
+        .map_err(|err| match err {
+            ProviderRoutingError::UnsupportedModel(model) => {
+                error!("Unsupported completion model requested: {}", model);
+                ApiError::BadRequest
+            }
+            ProviderRoutingError::NoEligibleRoute(model) => {
+                error!("No eligible provider route for completion model: {}", model);
+                ApiError::InternalServerError
+            }
+        })?;
+
+    debug!(
+        "Pinned inference route: request_id={}, selection_mode={:?}, auto={}, surface={:?}, workload={:?}, requested_model={}, public_model={}, provider={}, provider_model={}, bucket={:?}, source={:?}",
+        intent.request_id,
+        intent.selection_mode,
+        intent.selection_mode.is_auto(),
+        intent.surface,
+        intent.workload_class,
+        intent.requested_model_id,
+        route.public_model_id,
+        route.provider.as_str(),
+        route.provider_model_id,
+        route.bucket,
+        route.selection_source
+    );
+
+    Ok(PinnedCompletionRequest { intent, route })
+}
+
+/// Executes one model turn against a route pinned for the logical inference request.
+/// Billing remains internal until the usage-settlement stack separates the recorder.
+pub(crate) async fn get_chat_completion_response(
     state: &Arc<AppState>,
     user: &User,
     body: Value,
     headers: &HeaderMap,
     billing_context: BillingContext,
-    model_plan: ModelPlan,
-) -> Result<CompletionStream, ApiError> {
-    get_chat_completion_response_with_expected_route(
+    pinned: &PinnedCompletionRequest,
+) -> Result<CompletionStream, CompletionExecutionError> {
+    get_chat_completion_response_with_options(
         state,
         user,
         body,
         headers,
         billing_context,
-        model_plan,
-        None,
+        pinned,
+        CompletionExecutionOptions::default(),
     )
     .await
 }
@@ -916,21 +1552,47 @@ pub(crate) async fn get_chat_completion_response_for_expected_route(
     billing_context: BillingContext,
     model_plan: ModelPlan,
     route: ServerSelectedCompletionRoute<'_>,
-) -> Result<CompletionStream, ApiError> {
+) -> Result<CompletionStream, CompletionExecutionError> {
+    let public_model_id = body
+        .get("model")
+        .and_then(Value::as_str)
+        .ok_or(CompletionExecutionError::Request(ApiError::BadRequest))?
+        .to_string();
+    let intent = InferenceIntent::new(
+        user.uuid,
+        public_model_id.clone(),
+        public_model_id,
+        model_plan,
+        InferenceSurface::Internal,
+        WorkloadClass::Interactive,
+    );
+    let pinned = prepare_completion_request(state, user, intent)
+        .await
+        .map_err(|error| {
+            error!(
+                "Failed to prepare server-selected completion route: expected_provider={}, expected_provider_model={}, error={error:?}",
+                route.provider_name, route.provider_model_id
+            );
+            CompletionExecutionError::Request(ApiError::ServiceUnavailable)
+        })?;
+
     let continuum_cache_salt = (route.provider_name == ProviderName::Continuum.as_str())
         .then(|| format!("server-selected-{}", Uuid::new_v4().simple()));
-    get_chat_completion_response_with_expected_route(
+    get_chat_completion_response_with_options(
         state,
         user,
         body,
         headers,
         billing_context,
-        model_plan,
-        Some(ExpectedCompletionRoute {
-            provider_name: route.provider_name,
-            provider_model_id: route.provider_model_id,
+        &pinned,
+        CompletionExecutionOptions {
+            exact_route: Some(ExactCompletionRoute {
+                provider_name: route.provider_name.to_string(),
+                provider_model_id: route.provider_model_id.to_string(),
+            }),
             continuum_cache_salt,
-        }),
+            non_streaming_body_limit: Some(MAX_BOUNDED_PROVIDER_RESPONSE_BYTES),
+        },
     )
     .await
 }
@@ -941,25 +1603,40 @@ pub(crate) struct ServerSelectedCompletionRoute<'a> {
     pub provider_model_id: &'a str,
 }
 
-struct ExpectedCompletionRoute<'a> {
-    provider_name: &'a str,
-    provider_model_id: &'a str,
+struct ExactCompletionRoute {
+    provider_name: String,
+    provider_model_id: String,
+}
+
+fn completion_route_matches_exact_constraint(
+    route: &SelectedProviderRoute,
+    expected: &ExactCompletionRoute,
+) -> bool {
+    route.provider.as_str() == expected.provider_name
+        && route.proxy.provider_name == expected.provider_name
+        && route.provider_model_id == expected.provider_model_id
+}
+
+#[derive(Default)]
+struct CompletionExecutionOptions {
+    exact_route: Option<ExactCompletionRoute>,
     continuum_cache_salt: Option<String>,
+    non_streaming_body_limit: Option<usize>,
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn get_chat_completion_response_with_expected_route(
+async fn get_chat_completion_response_with_options(
     state: &Arc<AppState>,
     user: &User,
     body: Value,
     headers: &HeaderMap,
     mut billing_context: BillingContext,
-    model_plan: ModelPlan,
-    expected_route: Option<ExpectedCompletionRoute<'_>>,
-) -> Result<CompletionStream, ApiError> {
+    pinned: &PinnedCompletionRequest,
+    options: CompletionExecutionOptions,
+) -> Result<CompletionStream, CompletionExecutionError> {
     if body.is_null() || body.as_object().is_none_or(|obj| obj.is_empty()) {
         error!("Request body is empty or invalid");
-        return Err(ApiError::BadRequest);
+        return Err(ApiError::BadRequest.into());
     }
 
     let mut modified_body = body
@@ -976,7 +1653,7 @@ async fn get_chat_completion_response_with_expected_route(
         .and_then(|s| s.as_bool())
         .unwrap_or(false);
 
-    let requested_model_name = modified_body
+    let body_model_name = modified_body
         .get("model")
         .and_then(|m| m.as_str())
         .ok_or_else(|| {
@@ -985,77 +1662,35 @@ async fn get_chat_completion_response_with_expected_route(
         })?
         .to_string();
 
-    let is_server_selected_route = expected_route.is_some();
-    if let Err(error) = ensure_completion_model_access(&requested_model_name, model_plan) {
-        if is_server_selected_route {
-            error!(
-                "Server-selected completion model is not available to the internal paid route: {}",
-                requested_model_name
-            );
-            return Err(ApiError::ServiceUnavailable);
-        }
-        return Err(error);
+    if body_model_name != pinned.intent.public_model_id {
+        error!(
+            "Prepared inference model did not match execution body: request_id={}, prepared_model={}, body_model={}",
+            pinned.intent.request_id, pinned.intent.public_model_id, body_model_name
+        );
+        return Err(ApiError::InternalServerError.into());
     }
 
-    let provider_preference = state
-        .provider_routing_preference(user.uuid, &requested_model_name)
-        .await;
-    let selected_route = state
-        .provider_router
-        .select_completion_route_with_preference(
-            &state.proxy_router,
-            user.uuid,
-            &requested_model_name,
-            provider_preference,
-        )
-        .map_err(|err| match err {
-            ProviderRoutingError::UnsupportedModel(model) => {
-                error!("Unsupported completion model requested: {}", model);
-                if is_server_selected_route {
-                    ApiError::ServiceUnavailable
-                } else {
-                    ApiError::BadRequest
-                }
-            }
-            ProviderRoutingError::NoEligibleRoute(model) => {
-                error!("No eligible provider route for completion model: {}", model);
-                if is_server_selected_route {
-                    ApiError::ServiceUnavailable
-                } else {
-                    ApiError::InternalServerError
-                }
-            }
-        })?;
-
-    if let Some(expected_route) = &expected_route {
-        if selected_route.proxy.provider_name != expected_route.provider_name
-            || selected_route.provider_model_id != expected_route.provider_model_id
-        {
+    ensure_completion_model_access(&pinned.intent.public_model_id, pinned.intent.model_plan)?;
+    let selected_route = pinned.route.clone();
+    if let Some(expected_route) = &options.exact_route {
+        if !completion_route_matches_exact_constraint(&selected_route, expected_route) {
             error!(
-                "Completion route did not match the server-selected constraint: public_model={}, expected_provider={}, expected_provider_model={}, selected_provider={}, selected_provider_model={}",
+                "Completion route did not match the server-selected constraint: request_id={}, public_model={}, expected_provider={}, expected_provider_model={}, selected_provider={}, selected_proxy_provider={}, selected_provider_model={}",
+                pinned.intent.request_id,
                 selected_route.public_model_id,
                 expected_route.provider_name,
                 expected_route.provider_model_id,
+                selected_route.provider.as_str(),
                 selected_route.proxy.provider_name,
                 selected_route.provider_model_id
             );
-            return Err(ApiError::ServiceUnavailable);
+            return Err(CompletionExecutionError::Request(
+                ApiError::ServiceUnavailable,
+            ));
         }
     }
-
-    if requested_model_name != selected_route.public_model_id
-        || selected_route.public_model_id != selected_route.provider_model_id
-    {
-        debug!(
-            "Selected completion route: requested_model={}, public_model={}, provider={}, provider_model={}, bucket={:?}, source={:?}",
-            requested_model_name,
-            selected_route.public_model_id,
-            selected_route.proxy.provider_name,
-            selected_route.provider_model_id,
-            selected_route.bucket,
-            selected_route.selection_source
-        );
-    }
+    let route_identity = selected_route.identity();
+    let execution = pinned.begin_execution();
     modified_body.insert(
         "model".to_string(),
         json!(selected_route.provider_model_id.clone()),
@@ -1065,24 +1700,28 @@ async fn get_chat_completion_response_with_expected_route(
         &selected_route.proxy.provider_name,
         user.uuid,
     );
-    if let Some(expected_route) = &expected_route {
+    if options.exact_route.is_some() {
         apply_server_selected_cache_isolation(
             &mut modified_body,
             &selected_route.proxy.provider_name,
-            expected_route.continuum_cache_salt.as_deref(),
+            options.continuum_cache_salt.as_deref(),
         )?;
     }
     billing_context.model_name = selected_route.public_model_id.clone();
 
-    // Prepare the request to proxies
+    // Prepare one logical model-turn execution. The provider transport may
+    // report more than one attempt when Tinfoil safely refreshes a stale
+    // attested route after a proven pre-connect failure.
     debug!(
-        "Sending request for public model {} as provider model {} via {}",
+        "Sending inference execution: request_id={}, execution_id={}, public_model={}, provider_model={}, provider={}",
+        execution.request_id,
+        execution.execution_id,
         selected_route.public_model_id,
         selected_route.provider_model_id,
-        selected_route.proxy.provider_name
+        selected_route.provider.as_str()
     );
 
-    let (res, successful_provider) = {
+    let (res, successful_provider, attempt, mut terminal_guard) = {
         let mut request_body = modified_body.clone();
         let proxy_config = selected_route.proxy.clone();
         let provider_model_name = selected_route.provider_model_id.clone();
@@ -1090,47 +1729,88 @@ async fn get_chat_completion_response_with_expected_route(
         ensure_stream_usage(&mut request_body);
 
         let request_body_value = Value::Object(request_body);
-        let request_body_json = serde_json::to_string(&request_body_value).map_err(|e| {
-            error!("Failed to serialize request body: {:?}", e);
-            ApiError::InternalServerError
-        })?;
+        let request_body_json = match serde_json::to_string(&request_body_value) {
+            Ok(json) => json,
+            Err(error) => {
+                let attempt = execution.begin_attempt(route_identity.clone());
+                let failure = AttemptFailure::new(
+                    AttemptFailureKind::RequestBuild,
+                    AttemptStage::BeforeSend,
+                    ReplaySafety::ProvenPreAcceptance,
+                );
+                error!(
+                    "Failed to serialize inference request: request_id={}, execution_id={}, attempt_id={}, error={:?}",
+                    attempt.request_id, attempt.execution_id, attempt.attempt_id, error
+                );
+                return Err(failed_completion_execution(
+                    attempt,
+                    failure,
+                    ApiError::InternalServerError,
+                ));
+            }
+        };
         let request_log_metadata =
             CompletionRequestLogMetadata::from_body(&request_body_value, request_body_json.len());
 
         debug!(
-            "Completion request metadata before provider call: user_uuid={}, provider={}, model={}, metadata={:?}",
-            user.uuid, proxy_config.provider_name, provider_model_name, request_log_metadata
+            "Completion request metadata before provider call: request_id={}, execution_id={}, provider={}, model={}, metadata={:?}",
+            execution.request_id,
+            execution.execution_id,
+            proxy_config.provider_name,
+            provider_model_name,
+            request_log_metadata
         );
 
-        match try_provider(
+        let attempt = execution.begin_attempt(route_identity.clone());
+        let mut terminal_guard =
+            AttemptTerminalGuard::new(attempt.clone(), AttemptStage::AwaitingResponse);
+        let ProviderSendTrace {
+            prior_failures,
+            result,
+        } = try_provider(
             &state.provider_client,
             &proxy_config,
             request_body_json,
             headers,
         )
-        .await
-        {
+        .await;
+
+        let _recovered_terminals =
+            terminalize_recovered_provider_failures(execution, &route_identity, prior_failures);
+
+        match result {
             Ok(response) => {
+                record_attempt_outcome(&AttemptOutcome::ResponseStarted {
+                    attempt: attempt.clone(),
+                    status: response.status_code(),
+                });
                 info!(
-                    "Successfully got response from provider {} for model {}",
-                    proxy_config.provider_name, provider_model_name
+                    "Inference response started: request_id={}, execution_id={}, attempt_id={}",
+                    attempt.request_id, attempt.execution_id, attempt.attempt_id
                 );
-                (response, proxy_config.provider_name.clone())
+                terminal_guard.set_stage(AttemptStage::ResponseBody);
+                (
+                    response,
+                    selected_route.provider.as_str().to_string(),
+                    attempt,
+                    terminal_guard,
+                )
             }
             Err(err) => {
+                let failure = attempt_failure_from_provider_error(&err);
                 error!(
-                    "Completion request metadata at provider failure: user_uuid={}, provider={}, model={}, error={}, metadata={:?}",
-                    user.uuid,
-                    proxy_config.provider_name,
-                    provider_model_name,
-                    err,
+                    "Completion provider attempt failed: request_id={}, execution_id={}, attempt_id={}, kind={:?}, stage={:?}, metadata={:?}",
+                    attempt.request_id,
+                    attempt.execution_id,
+                    attempt.attempt_id,
+                    failure.kind,
+                    failure.stage,
                     request_log_metadata
                 );
-                error!(
-                    "Chat completion request failed for provider {} and model {}: {}",
-                    proxy_config.provider_name, provider_model_name, err
-                );
-                return Err(ApiError::from(err));
+                let execution_error =
+                    failed_completion_execution(attempt, failure, ApiError::from(err));
+                terminal_guard.disarm();
+                return Err(execution_error);
             }
         }
     };
@@ -1146,35 +1826,25 @@ async fn get_chat_completion_response_with_expected_route(
         debug!("Processing non-streaming response with internal billing");
         // The request's streaming fields are forwarded unchanged, but this
         // encrypted endpoint currently buffers one byte-exact response carrier.
-        let body_bytes = if expected_route.is_some() {
-            bytes::Bytes::from(
-                collect_bounded_provider_response_body(
-                    res.bytes_stream(),
-                    MAX_BOUNDED_PROVIDER_RESPONSE_BYTES,
-                )
-                .await
-                .map_err(|error| {
-                    error!("Failed to read bounded server-selected response body: {error}");
-                    ApiError::InternalServerError
-                })?,
-            )
-        } else {
-            // Preserve the ordinary Chat Completions path's existing unbounded
-            // response-body behavior. Only server-selected image descriptor
-            // calls opt into the defensive cap above.
-            res.bytes().await.map_err(|e| {
-                error!("Failed to read response body: {:?}", e);
-                ApiError::InternalServerError
-            })?
+        let response_json = match read_non_streaming_completion_response(
+            res,
+            &selected_route.response_model_id,
+            &attempt,
+            options.non_streaming_body_limit,
+        )
+        .await
+        {
+            Ok(response_json) => response_json,
+            Err(failure) => {
+                let execution_error = failed_completion_execution(
+                    attempt.clone(),
+                    failure,
+                    ApiError::InternalServerError,
+                );
+                terminal_guard.disarm();
+                return Err(execution_error);
+            }
         };
-
-        let mut response_json: Value = serde_json::from_str(&String::from_utf8_lossy(&body_bytes))
-            .map_err(|e| {
-                error!("Failed to parse response JSON: {:?}", e);
-                ApiError::InternalServerError
-            })?;
-
-        canonicalize_response_model(&mut response_json, &selected_route.response_model_id);
 
         // ✅ Handle billing HERE, inside completions API
         if let Some(usage) = extract_usage(&response_json) {
@@ -1189,9 +1859,14 @@ async fn get_chat_completion_response_with_expected_route(
         }
 
         // Return the full response as a single chunk
-        let (tx, rx) = mpsc::channel(2); // Need space for FullResponse + Done
+        let terminal = AttemptTerminal::Completed {
+            attempt: attempt.clone(),
+            evidence: CompletionEvidence::NonStreamingResponse,
+        };
+        terminal_guard.record_terminal(&terminal);
+        let (tx, rx) = mpsc::channel(2); // Need space for FullResponse + terminal
         let _ = tx.send(CompletionChunk::FullResponse(response_json)).await;
-        let _ = tx.send(CompletionChunk::Done).await;
+        let _ = tx.send(CompletionChunk::Terminal(terminal)).await;
 
         return Ok(CompletionStream {
             stream: rx,
@@ -1199,6 +1874,7 @@ async fn get_chat_completion_response_with_expected_route(
                 provider_name: successful_provider,
                 model_name: billing_context.model_name.clone(),
                 is_streaming: false,
+                attempt,
             },
         });
     }
@@ -1213,146 +1889,32 @@ async fn get_chat_completion_response_with_expected_route(
     let billing_ctx = billing_context.clone();
     let provider = successful_provider.clone();
     let response_model_id = selected_route.response_model_id.clone();
+    let stream_attempt = attempt.clone();
+    terminal_guard.set_stage(AttemptStage::Stream);
 
     tokio::spawn(async move {
-        let mut body_stream = res.bytes_stream();
-        let mut buffer = Vec::new();
-        let mut usage_accumulator = StreamUsageAccumulator::default();
-
-        loop {
-            match timeout(
-                Duration::from_secs(STREAM_CHUNK_TIMEOUT_SECS),
-                body_stream.next(),
-            )
-            .await
-            {
-                Ok(Some(chunk_result)) => {
-                    match chunk_result {
-                        Ok(bytes) => {
-                            buffer.extend_from_slice(bytes.as_ref());
-
-                            // Parse SSE frames
-                            while let Some(frame) = extract_sse_frame(&mut buffer) {
-                                if frame == b"[DONE]" {
-                                    finalize_stream_usage(
-                                        &mut usage_accumulator,
-                                        StreamUsageFinalization::ProviderDone,
-                                        &state_clone,
-                                        &user_clone,
-                                        &billing_ctx,
-                                        &provider,
-                                        &tx_consumer,
-                                    )
-                                    .await;
-                                    let _ = tx_consumer.send(CompletionChunk::Done).await;
-                                    return;
-                                }
-
-                                match serde_json::from_slice::<Value>(&frame) {
-                                    Ok(mut json) => {
-                                        // vLLM can report cumulative usage on every delta, while
-                                        // providers may add cache details after finish_reason.
-                                        // Accumulate observations and publish only when the stream
-                                        // lifecycle confirms completion.
-                                        usage_accumulator.observe(&json);
-
-                                        canonicalize_response_model(&mut json, &response_model_id);
-
-                                        // Send full JSON chunk to consumer (preserves all metadata)
-                                        if tx_consumer
-                                            .send(CompletionChunk::StreamChunk(json))
-                                            .await
-                                            .is_err()
-                                        {
-                                            finalize_stream_usage(
-                                                &mut usage_accumulator,
-                                                StreamUsageFinalization::ConsumerDropped,
-                                                &state_clone,
-                                                &user_clone,
-                                                &billing_ctx,
-                                                &provider,
-                                                &tx_consumer,
-                                            )
-                                            .await;
-                                            return;
-                                        }
-                                    }
-                                    Err(e) => {
-                                        error!("Received non-JSON data event. Error: {:?}", e);
-                                        finalize_stream_usage(
-                                            &mut usage_accumulator,
-                                            StreamUsageFinalization::InvalidData,
-                                            &state_clone,
-                                            &user_clone,
-                                            &billing_ctx,
-                                            &provider,
-                                            &tx_consumer,
-                                        )
-                                        .await;
-                                        let _ = tx_consumer
-                                            .send(CompletionChunk::Error(
-                                                "Invalid JSON".to_string(),
-                                            ))
-                                            .await;
-                                        return;
-                                    }
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            error!("Stream error: {:?}", e);
-                            finalize_stream_usage(
-                                &mut usage_accumulator,
-                                StreamUsageFinalization::TransportError,
-                                &state_clone,
-                                &user_clone,
-                                &billing_ctx,
-                                &provider,
-                                &tx_consumer,
-                            )
-                            .await;
-                            let _ = tx_consumer
-                                .send(CompletionChunk::Error(e.to_string()))
-                                .await;
-                            return;
-                        }
-                    }
-                }
-                Ok(None) => {
-                    // Stream ended without explicit [DONE]
-                    finalize_stream_usage(
-                        &mut usage_accumulator,
-                        StreamUsageFinalization::EndOfStream,
-                        &state_clone,
-                        &user_clone,
-                        &billing_ctx,
-                        &provider,
-                        &tx_consumer,
-                    )
-                    .await;
-                    let _ = tx_consumer.send(CompletionChunk::Done).await;
-                    return;
-                }
-                Err(_) => {
-                    // Timeout waiting for next chunk
-                    error!("Stream chunk timeout after {}s", STREAM_CHUNK_TIMEOUT_SECS);
-                    finalize_stream_usage(
-                        &mut usage_accumulator,
-                        StreamUsageFinalization::Timeout,
-                        &state_clone,
-                        &user_clone,
-                        &billing_ctx,
-                        &provider,
-                        &tx_consumer,
-                    )
-                    .await;
-                    let _ = tx_consumer
-                        .send(CompletionChunk::Error("Stream timeout".to_string()))
-                        .await;
-                    return;
-                }
-            }
-        }
+        let result = process_completion_stream(
+            res,
+            &response_model_id,
+            stream_attempt,
+            &tx_consumer,
+            Duration::from_secs(STREAM_CHUNK_TIMEOUT_SECS),
+        )
+        .await;
+        publish_stream_usage(
+            result.usage,
+            result.finalization,
+            &state_clone,
+            &user_clone,
+            &billing_ctx,
+            &provider,
+            &tx_consumer,
+        )
+        .await;
+        terminal_guard.record_terminal(&result.terminal);
+        let _ = tx_consumer
+            .send(CompletionChunk::Terminal(result.terminal))
+            .await;
     });
 
     Ok(CompletionStream {
@@ -1361,6 +1923,7 @@ async fn get_chat_completion_response_with_expected_route(
             provider_name: successful_provider,
             model_name: billing_context.model_name.clone(),
             is_streaming: true,
+            attempt,
         },
     })
 }
@@ -1705,8 +2268,19 @@ async fn encrypt_sse_event(
             ApiError::InternalServerError
         })?;
 
-    let base64_encrypted = general_purpose::STANDARD.encode(&encrypted_data);
-    Ok(Event::default().data(base64_encrypted))
+    Ok(sse_event_from_encrypted_data(&encrypted_data))
+}
+
+fn completion_error_payload(message: &'static str) -> Value {
+    json!({
+        "error": {
+            "message": message
+        }
+    })
+}
+
+fn sse_event_from_encrypted_data(encrypted_data: &[u8]) -> Event {
+    Event::default().data(general_purpose::STANDARD.encode(encrypted_data))
 }
 
 async fn proxy_models(
@@ -2544,11 +3118,14 @@ async fn try_provider(
     proxy_config: &ProxyConfig,
     body_json: String,
     headers: &HeaderMap,
-) -> Result<ProviderResponse, ProviderRequestError> {
+) -> ProviderSendTrace {
     debug!("Making request to {}", proxy_config.provider_name);
 
-    match client
-        .send(
+    let ProviderSendTrace {
+        prior_failures,
+        result,
+    } = client
+        .send_traced(
             proxy_config,
             ProviderRequest::new(
                 Method::POST,
@@ -2561,28 +3138,28 @@ async fn try_provider(
             // retry templates then clone that buffer by reference.
             .body(body_json),
         )
-        .await
-    {
+        .await;
+
+    let result = match result {
         Ok(response) => {
             if response.is_success() {
                 Ok(response)
             } else {
                 let status = response.status_code();
+                let retry_after = parse_retry_after_hint(response.header_str(&header::RETRY_AFTER));
+                let upstream_request_id = upstream_request_id(&response);
                 error!(
                     "Provider {} returned non-success status: {}",
                     proxy_config.provider_name, status
                 );
-                // Drain only a bounded amount and never log provider response
-                // bodies because they may echo user content.
-                let _ = collect_bounded_provider_response_body(
-                    response.bytes_stream(),
-                    MAX_BOUNDED_PROVIDER_RESPONSE_BYTES,
-                )
-                .await;
-                Err(ProviderRequestError::Send(format!(
-                    "Provider {} returned status {}",
-                    proxy_config.provider_name, status
-                )))
+                // The status and bounded safe headers are the complete routing
+                // contract. Never wait for or buffer an untrusted error body.
+                drop(response);
+                Err(ProviderRequestError::Upstream(UpstreamProviderError {
+                    status,
+                    retry_after,
+                    upstream_request_id,
+                }))
             }
         }
         Err(e) => {
@@ -2592,7 +3169,35 @@ async fn try_provider(
             );
             Err(e)
         }
+    };
+
+    ProviderSendTrace {
+        prior_failures,
+        result,
     }
+}
+
+fn parse_retry_after_hint(value: Option<&str>) -> Option<Duration> {
+    const MAX_RETRY_AFTER_HINT_SECS: u64 = 60 * 60;
+
+    let seconds = value?.trim().parse::<u64>().ok()?;
+    Some(Duration::from_secs(seconds.min(MAX_RETRY_AFTER_HINT_SECS)))
+}
+
+fn upstream_request_id(response: &ProviderResponse) -> Option<String> {
+    const REQUEST_ID_HEADERS: &[&str] =
+        &["x-request-id", "request-id", "x-amzn-requestid", "cf-ray"];
+
+    REQUEST_ID_HEADERS.iter().find_map(|name| {
+        let name = HeaderName::from_static(name);
+        let value = response.header_str(&name)?.trim();
+        (!value.is_empty() && value.len() <= 128 && value.chars().all(is_safe_identifier_char))
+            .then(|| value.to_string())
+    })
+}
+
+fn is_safe_identifier_char(character: char) -> bool {
+    character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.' | ':')
 }
 
 #[cfg(test)]
@@ -2626,6 +3231,259 @@ mod tests {
         );
     }
 
+    async fn call_mock_provider(app: Router) -> (ProviderSendTrace, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock provider");
+        let address = listener.local_addr().expect("mock provider address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve mock provider");
+        });
+        let base_url = format!("http://{address}");
+        let client = ProviderClient::for_test(base_url.clone()).expect("mock provider client");
+        let proxy = ProxyConfig {
+            base_url,
+            api_key: None,
+            provider_name: ProviderName::Tinfoil.as_str().to_string(),
+        };
+        let trace = try_provider(
+            &client,
+            &proxy,
+            r#"{"model":"kimi-k3","messages":[]}"#.to_string(),
+            &HeaderMap::new(),
+        )
+        .await;
+        (trace, server)
+    }
+
+    fn static_sse_app(body: &'static str) -> Router {
+        Router::new().route(
+            "/v1/chat/completions",
+            post(move || async move {
+                axum::http::Response::builder()
+                    .status(axum::http::StatusCode::OK)
+                    .header(header::CONTENT_TYPE, "text/event-stream")
+                    .body(axum::body::Body::from(body))
+                    .expect("mock SSE response")
+            }),
+        )
+    }
+
+    async fn process_mock_sse(body: &'static str) -> (StreamProcessResult, Vec<Value>) {
+        let (trace, server) = call_mock_provider(static_sse_app(body)).await;
+        assert!(trace.prior_failures.is_empty());
+        let response = match trace.result {
+            Ok(response) => response,
+            Err(error) => panic!("mock provider failed before stream processing: {error}"),
+        };
+        let pinned = pinned_test_completion();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let (tx, mut rx) = mpsc::channel(16);
+        let result =
+            process_completion_stream(response, "kimi-k3", attempt, &tx, Duration::from_secs(1))
+                .await;
+        drop(tx);
+        server.abort();
+
+        let mut chunks = Vec::new();
+        while let Some(chunk) = rx.recv().await {
+            match chunk {
+                CompletionChunk::StreamChunk(json) => chunks.push(json),
+                unexpected => panic!("parser emitted unexpected chunk: {unexpected:?}"),
+            }
+        }
+        (result, chunks)
+    }
+
+    fn pinned_test_completion() -> PinnedCompletionRequest {
+        PinnedCompletionRequest {
+            intent: InferenceIntent::new(
+                Uuid::nil(),
+                crate::model_config::AUTO_POWERFUL_MODEL_ID,
+                "kimi-k3",
+                ModelPlan::Paid,
+                InferenceSurface::Responses,
+                WorkloadClass::Interactive,
+            ),
+            route: SelectedProviderRoute {
+                provider: ProviderName::Tinfoil,
+                proxy: ProxyConfig {
+                    base_url: "http://tinfoil.example.com".to_string(),
+                    api_key: None,
+                    provider_name: "tinfoil".to_string(),
+                },
+                public_model_id: "kimi-k3".to_string(),
+                provider_model_id: "kimi-k3".to_string(),
+                response_model_id: "kimi-k3".to_string(),
+                bucket: None,
+                selection_source: crate::provider_routing::ProviderSelectionSource::StaticSplit,
+            },
+        }
+    }
+
+    #[test]
+    fn exact_completion_constraint_checks_typed_and_transport_route() {
+        let pinned = pinned_test_completion();
+        let matching = ExactCompletionRoute {
+            provider_name: "tinfoil".to_string(),
+            provider_model_id: "kimi-k3".to_string(),
+        };
+        assert!(completion_route_matches_exact_constraint(
+            &pinned.route,
+            &matching
+        ));
+
+        let wrong_provider = ExactCompletionRoute {
+            provider_name: "continuum".to_string(),
+            provider_model_id: "kimi-k3".to_string(),
+        };
+        assert!(!completion_route_matches_exact_constraint(
+            &pinned.route,
+            &wrong_provider
+        ));
+
+        let wrong_model = ExactCompletionRoute {
+            provider_name: "tinfoil".to_string(),
+            provider_model_id: "gemma4-31b".to_string(),
+        };
+        assert!(!completion_route_matches_exact_constraint(
+            &pinned.route,
+            &wrong_model
+        ));
+    }
+
+    #[tokio::test]
+    async fn mock_provider_streams_produce_one_sanitized_terminal_result() {
+        enum ExpectedTerminal {
+            Completed(CompletionEvidence),
+            Failed(AttemptFailureKind),
+        }
+
+        let cases = [
+            (
+                "provider done",
+                concat!(
+                    "data: {\"model\":\"upstream-k3\",\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n",
+                    "data: [DONE]\n\n"
+                ),
+                ExpectedTerminal::Completed(CompletionEvidence::ProviderDone),
+                1,
+            ),
+            (
+                "finish then eof",
+                "data: {\"model\":\"upstream-k3\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+                ExpectedTerminal::Completed(CompletionEvidence::FinishSignalThenEof),
+                1,
+            ),
+            (
+                "bare eof",
+                "data: {\"model\":\"upstream-k3\",\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n",
+                ExpectedTerminal::Failed(AttemptFailureKind::UnexpectedEof),
+                1,
+            ),
+            (
+                "truncated trailing frame",
+                concat!(
+                    "data: {\"model\":\"upstream-k3\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+                    "data: {\"choices\":["
+                ),
+                ExpectedTerminal::Failed(AttemptFailureKind::UnexpectedEof),
+                1,
+            ),
+            (
+                "invalid json",
+                "data: not-json\n\n",
+                ExpectedTerminal::Failed(AttemptFailureKind::InvalidResponse),
+                0,
+            ),
+            (
+                "provider error then done",
+                concat!(
+                    "data: {\"model\":\"upstream-k3\",\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n",
+                    "data: {\"error\":{\"message\":\"private upstream detail\",\"code\":\"capacity_error-17\"}}\n\n",
+                    "data: [DONE]\n\n"
+                ),
+                ExpectedTerminal::Failed(AttemptFailureKind::UpstreamStreamError),
+                1,
+            ),
+        ];
+
+        for (name, body, expected, expected_chunks) in cases {
+            let (result, chunks) = process_mock_sse(body).await;
+            assert_eq!(chunks.len(), expected_chunks, "{name}");
+            assert!(
+                chunks.iter().all(|chunk| chunk.get("error").is_none()),
+                "{name}"
+            );
+            assert!(
+                chunks.iter().all(|chunk| chunk["model"] == "kimi-k3"),
+                "{name}"
+            );
+
+            match (expected, result.terminal) {
+                (
+                    ExpectedTerminal::Completed(expected_evidence),
+                    AttemptTerminal::Completed { evidence, .. },
+                ) => assert_eq!(evidence, expected_evidence, "{name}"),
+                (
+                    ExpectedTerminal::Failed(expected_kind),
+                    AttemptTerminal::Failed { failure, .. },
+                ) => {
+                    assert_eq!(failure.kind, expected_kind, "{name}");
+                    assert_eq!(
+                        failure.replay_safety,
+                        ReplaySafety::NotProvenPreAcceptance,
+                        "{name}"
+                    );
+                    if expected_kind == AttemptFailureKind::UpstreamStreamError {
+                        assert_eq!(failure.upstream_code.as_deref(), Some("capacity_error-17"));
+                    }
+                }
+                (_, terminal) => panic!("{name}: unexpected terminal {terminal:?}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_provider_429_preserves_bounded_metadata_without_body_leak() {
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(|| async {
+                axum::http::Response::builder()
+                    .status(axum::http::StatusCode::TOO_MANY_REQUESTS)
+                    .header(header::RETRY_AFTER, "17")
+                    .header("x-request-id", "req-429_a.b:c")
+                    .body(axum::body::Body::from("private upstream capacity detail"))
+                    .expect("mock rate-limit response")
+            }),
+        );
+        let (trace, server) = call_mock_provider(app).await;
+        server.abort();
+        assert!(trace.prior_failures.is_empty());
+        let error = match trace.result {
+            Err(error) => error,
+            Ok(_) => panic!("mock 429 unexpectedly succeeded"),
+        };
+        assert!(!error
+            .to_string()
+            .contains("private upstream capacity detail"));
+
+        let failure = attempt_failure_from_provider_error(&error);
+        assert_eq!(failure.kind, AttemptFailureKind::HttpStatus);
+        assert_eq!(failure.stage, AttemptStage::AwaitingResponse);
+        assert_eq!(failure.replay_safety, ReplaySafety::NotProvenPreAcceptance);
+        assert_eq!(failure.status, Some(429));
+        assert_eq!(failure.retry_after, Some(Duration::from_secs(17)));
+        assert_eq!(
+            failure.upstream_request_id.as_deref(),
+            Some("req-429_a.b:c")
+        );
+    }
+
     #[tokio::test]
     async fn bounded_provider_response_body_maps_stream_errors_without_content() {
         let body_stream = futures::stream::iter([
@@ -2637,6 +3495,431 @@ mod tests {
             collect_bounded_provider_response_body(body_stream, 6).await,
             Err(BoundedProviderResponseBodyError::Read)
         );
+    }
+
+    #[tokio::test]
+    async fn mock_provider_429_does_not_wait_for_pending_error_body() {
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(|| async {
+                let pending = futures::stream::pending::<Result<bytes::Bytes, std::io::Error>>();
+                axum::http::Response::builder()
+                    .status(axum::http::StatusCode::TOO_MANY_REQUESTS)
+                    .header(header::RETRY_AFTER, "23")
+                    .body(axum::body::Body::from_stream(pending))
+                    .expect("mock pending rate-limit response")
+            }),
+        );
+
+        let (trace, server) = timeout(Duration::from_secs(1), call_mock_provider(app))
+            .await
+            .expect("429 classification must finish after headers without reading the body");
+        server.abort();
+
+        let error = match trace.result {
+            Err(error) => error,
+            Ok(_) => panic!("mock 429 unexpectedly succeeded"),
+        };
+        let failure = attempt_failure_from_provider_error(&error);
+        assert_eq!(failure.kind, AttemptFailureKind::HttpStatus);
+        assert_eq!(failure.status, Some(429));
+        assert_eq!(failure.retry_after, Some(Duration::from_secs(23)));
+    }
+
+    #[tokio::test]
+    async fn mock_provider_non_streaming_error_payload_is_a_sanitized_failure() {
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(|| async {
+                axum::http::Response::builder()
+                    .status(axum::http::StatusCode::OK)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(axum::body::Body::from(
+                        r#"{"error":{"message":"private upstream detail","code":"capacity_error-17"}}"#,
+                    ))
+                    .expect("mock non-streaming error response")
+            }),
+        );
+        let (trace, server) = call_mock_provider(app).await;
+        let response = match trace.result {
+            Ok(response) => response,
+            Err(error) => panic!("mock provider failed before response parsing: {error}"),
+        };
+        let pinned = pinned_test_completion();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let failure = read_non_streaming_completion_response(response, "kimi-k3", &attempt, None)
+            .await
+            .expect_err("top-level provider error payload must fail the attempt");
+        server.abort();
+
+        assert_eq!(failure.kind, AttemptFailureKind::UpstreamResponseError);
+        assert_eq!(failure.stage, AttemptStage::ResponseBody);
+        assert_eq!(failure.replay_safety, ReplaySafety::NotProvenPreAcceptance);
+        assert_eq!(failure.upstream_code.as_deref(), Some("capacity_error-17"));
+        assert!(!format!("{failure:?}").contains("private upstream detail"));
+    }
+
+    #[tokio::test]
+    async fn bounded_non_streaming_response_is_a_typed_invalid_response() {
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(|| async {
+                axum::http::Response::builder()
+                    .status(axum::http::StatusCode::OK)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(axum::body::Body::from(
+                        r#"{"model":"upstream-k3","choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1}}"#,
+                    ))
+                    .expect("mock bounded response")
+            }),
+        );
+        let (trace, server) = call_mock_provider(app).await;
+        let response = match trace.result {
+            Ok(response) => response,
+            Err(error) => panic!("mock provider failed before bounded read: {error}"),
+        };
+        let pinned = pinned_test_completion();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let failure =
+            read_non_streaming_completion_response(response, "kimi-k3", &attempt, Some(8))
+                .await
+                .expect_err("response over the descriptor cap must fail");
+        server.abort();
+
+        assert_eq!(failure.kind, AttemptFailureKind::InvalidResponse);
+        assert_eq!(failure.stage, AttemptStage::ResponseBody);
+        assert_eq!(failure.replay_safety, ReplaySafety::NotProvenPreAcceptance);
+    }
+
+    #[tokio::test]
+    async fn terminal_error_event_round_trips_through_maple_encrypted_sse_contract() {
+        use axum::body::to_bytes;
+        use chacha20poly1305::{aead::Aead, ChaCha20Poly1305, Key, KeyInit, Nonce};
+        use std::convert::Infallible;
+
+        let payload = completion_error_payload("Inference provider request failed");
+        let plaintext = payload.to_string();
+        let key_bytes = [0x42; 32];
+        let nonce_bytes = [0x24; 12];
+        let cipher = ChaCha20Poly1305::new(Key::from_slice(&key_bytes));
+        let ciphertext = cipher
+            .encrypt(Nonce::from_slice(&nonce_bytes), plaintext.as_bytes())
+            .expect("encrypt mock SSE error payload");
+        let encrypted = [nonce_bytes.as_slice(), ciphertext.as_slice()].concat();
+
+        let event = sse_event_from_encrypted_data(&encrypted);
+        let response =
+            Sse::new(futures::stream::iter([Ok::<Event, Infallible>(event)])).into_response();
+        let body = to_bytes(response.into_body(), 4096)
+            .await
+            .expect("serialize SSE event");
+        let body = std::str::from_utf8(&body).expect("SSE body is UTF-8");
+        let encoded = body
+            .strip_prefix("data: ")
+            .and_then(|value| value.strip_suffix("\n\n"))
+            .expect("one SSE data event");
+
+        assert_ne!(encoded, plaintext);
+        let decoded = general_purpose::STANDARD
+            .decode(encoded)
+            .expect("Maple SDK base64 contract");
+        let (nonce, ciphertext) = decoded.split_at(12);
+        let nonce: [u8; 12] = nonce.try_into().expect("12-byte nonce");
+        let decrypted = crate::web::attestation_routes::SessionState::new(key_bytes)
+            .decrypt(ciphertext, &nonce)
+            .expect("Maple SDK AEAD contract");
+        assert_eq!(decrypted, plaintext.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn mock_provider_pending_stream_has_one_timeout_terminal_result() {
+        let app = Router::new().route(
+            "/v1/chat/completions",
+            post(|| async {
+                let pending = futures::stream::pending::<Result<bytes::Bytes, std::io::Error>>();
+                axum::http::Response::builder()
+                    .status(axum::http::StatusCode::OK)
+                    .header(header::CONTENT_TYPE, "text/event-stream")
+                    .body(axum::body::Body::from_stream(pending))
+                    .expect("mock pending response")
+            }),
+        );
+        let (trace, server) = call_mock_provider(app).await;
+        let response = match trace.result {
+            Ok(response) => response,
+            Err(error) => panic!("mock provider failed before timeout test: {error}"),
+        };
+        let pinned = pinned_test_completion();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let (tx, mut rx) = mpsc::channel(1);
+        let result =
+            process_completion_stream(response, "kimi-k3", attempt, &tx, Duration::from_millis(20))
+                .await;
+        drop(tx);
+        server.abort();
+
+        assert!(rx.recv().await.is_none());
+        assert!(matches!(
+            result.terminal,
+            AttemptTerminal::Failed {
+                failure: AttemptFailure {
+                    kind: AttemptFailureKind::StreamTimeout,
+                    ..
+                },
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn mock_provider_truncated_http_body_has_one_transport_terminal_result() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind truncated-body provider");
+        let address = listener
+            .local_addr()
+            .expect("truncated-body provider address");
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept provider request");
+            let mut request = vec![0u8; 4096];
+            let _ = socket
+                .read(&mut request)
+                .await
+                .expect("read provider request");
+
+            let body = concat!(
+                "data: {\"model\":\"upstream-k3\",",
+                "\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n"
+            );
+            let declared_length = body.len() + 128;
+            let headers = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {declared_length}\r\nConnection: close\r\n\r\n"
+            );
+            socket
+                .write_all(headers.as_bytes())
+                .await
+                .expect("write response headers");
+            socket
+                .write_all(body.as_bytes())
+                .await
+                .expect("write partial response body");
+            socket.shutdown().await.expect("close partial response");
+        });
+
+        let base_url = format!("http://{address}");
+        let client = ProviderClient::for_test(base_url.clone()).expect("mock provider client");
+        let proxy = ProxyConfig {
+            base_url,
+            api_key: None,
+            provider_name: ProviderName::Tinfoil.as_str().to_string(),
+        };
+        let trace = try_provider(
+            &client,
+            &proxy,
+            r#"{"model":"kimi-k3","messages":[]}"#.to_string(),
+            &HeaderMap::new(),
+        )
+        .await;
+        let response = match trace.result {
+            Ok(response) => response,
+            Err(error) => panic!("mock provider failed before body truncation: {error}"),
+        };
+        let pinned = pinned_test_completion();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let (tx, mut rx) = mpsc::channel(4);
+        let result =
+            process_completion_stream(response, "kimi-k3", attempt, &tx, Duration::from_secs(1))
+                .await;
+        drop(tx);
+        server.await.expect("truncated-body provider task");
+
+        let chunk = rx.recv().await.expect("partial stream chunk");
+        assert!(matches!(chunk, CompletionChunk::StreamChunk(_)));
+        assert!(rx.recv().await.is_none());
+        assert!(matches!(
+            result.terminal,
+            AttemptTerminal::Failed {
+                failure: AttemptFailure {
+                    kind: AttemptFailureKind::Transport,
+                    ..
+                },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn pinned_completion_keeps_route_and_request_identity_across_model_turns() {
+        let pinned = pinned_test_completion();
+        let first = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let second = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+
+        assert_eq!(first.request_id, second.request_id);
+        assert_ne!(first.execution_id, second.execution_id);
+        assert_ne!(first.attempt_id, second.attempt_id);
+        assert_eq!(first.route, second.route);
+        assert_eq!(first.route.public_model_id, "kimi-k3");
+        assert_eq!(first.route.provider_model_id, "kimi-k3");
+        assert_eq!(
+            pinned.intent().requested_model_id,
+            crate::model_config::AUTO_POWERFUL_MODEL_ID
+        );
+        assert!(pinned.intent().selection_mode.is_auto());
+    }
+
+    #[test]
+    fn provider_request_replay_safety_is_conservative() {
+        let cases = [
+            (
+                ProviderRequestError::TinfoilUnavailable,
+                AttemptFailureKind::ProviderUnavailable,
+                ReplaySafety::ProvenPreAcceptance,
+            ),
+            (
+                ProviderRequestError::Build("invalid request".to_string()),
+                AttemptFailureKind::RequestBuild,
+                ReplaySafety::ProvenPreAcceptance,
+            ),
+            (
+                ProviderRequestError::Connect("connection refused".to_string()),
+                AttemptFailureKind::Connect,
+                ReplaySafety::ProvenPreAcceptance,
+            ),
+            (
+                ProviderRequestError::Timeout(Duration::from_secs(30)),
+                AttemptFailureKind::ResponseStartTimeout,
+                ReplaySafety::NotProvenPreAcceptance,
+            ),
+            (
+                ProviderRequestError::Send("connection reset".to_string()),
+                AttemptFailureKind::Transport,
+                ReplaySafety::NotProvenPreAcceptance,
+            ),
+        ];
+
+        for (error, expected_kind, expected_replay_safety) in cases {
+            let failure = attempt_failure_from_provider_error(&error);
+            assert_eq!(failure.kind, expected_kind);
+            assert_eq!(failure.replay_safety, expected_replay_safety);
+            assert_eq!(failure.status, None);
+        }
+
+        let upstream = ProviderRequestError::Upstream(UpstreamProviderError {
+            status: 429,
+            retry_after: Some(Duration::from_secs(60)),
+            upstream_request_id: Some("request-123".to_string()),
+        });
+        let failure = attempt_failure_from_provider_error(&upstream);
+        assert_eq!(failure.kind, AttemptFailureKind::HttpStatus);
+        assert_eq!(failure.replay_safety, ReplaySafety::NotProvenPreAcceptance);
+        assert_eq!(failure.status, Some(429));
+        assert_eq!(failure.retry_after, Some(Duration::from_secs(60)));
+        assert_eq!(failure.upstream_request_id.as_deref(), Some("request-123"));
+    }
+
+    #[test]
+    fn cancelled_in_flight_attempt_has_one_conservative_terminal_shape() {
+        let pinned = pinned_test_completion();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let mut guard = AttemptTerminalGuard::new(attempt.clone(), AttemptStage::AwaitingResponse);
+
+        assert!(matches!(
+            guard.cancellation_terminal(),
+            AttemptTerminal::Failed {
+                attempt: terminal_attempt,
+                failure: AttemptFailure {
+                    kind: AttemptFailureKind::ConsumerDropped,
+                    stage: AttemptStage::AwaitingResponse,
+                    replay_safety: ReplaySafety::NotProvenPreAcceptance,
+                    ..
+                },
+            } if terminal_attempt == attempt
+        ));
+        guard.disarm();
+    }
+
+    #[test]
+    fn recovered_transport_retry_gets_a_distinct_attempt_in_the_same_execution() {
+        let pinned = pinned_test_completion();
+        let execution = pinned.begin_execution();
+        let route = pinned.route.identity();
+        let recovered = terminalize_recovered_provider_failures(
+            execution,
+            &route,
+            vec![ProviderRequestError::Connect(
+                "attested route changed before connect".to_string(),
+            )],
+        );
+        let final_attempt = execution.begin_attempt(route);
+
+        let recovered_attempt = match recovered.as_slice() {
+            [AttemptTerminal::Failed { attempt, failure }] => {
+                assert_eq!(failure.kind, AttemptFailureKind::Connect);
+                assert_eq!(failure.replay_safety, ReplaySafety::ProvenPreAcceptance);
+                attempt
+            }
+            terminals => panic!("unexpected recovered terminal sequence: {terminals:?}"),
+        };
+        assert_eq!(recovered_attempt.request_id, final_attempt.request_id);
+        assert_eq!(recovered_attempt.execution_id, final_attempt.execution_id);
+        assert_ne!(recovered_attempt.attempt_id, final_attempt.attempt_id);
+    }
+
+    #[test]
+    fn stream_eof_requires_prior_finish_evidence() {
+        let pinned = pinned_test_completion();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+
+        assert!(matches!(
+            stream_end_terminal(attempt.clone(), true, false),
+            AttemptTerminal::Completed {
+                evidence: CompletionEvidence::FinishSignalThenEof,
+                ..
+            }
+        ));
+        assert!(matches!(
+            stream_end_terminal(attempt, false, false),
+            AttemptTerminal::Failed {
+                failure: AttemptFailure {
+                    kind: AttemptFailureKind::UnexpectedEof,
+                    replay_safety: ReplaySafety::NotProvenPreAcceptance,
+                    ..
+                },
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn retry_after_seconds_are_bounded_and_invalid_values_are_ignored() {
+        assert_eq!(
+            parse_retry_after_hint(Some("60")),
+            Some(Duration::from_secs(60))
+        );
+        assert_eq!(
+            parse_retry_after_hint(Some("7200")),
+            Some(Duration::from_secs(3600))
+        );
+        assert_eq!(parse_retry_after_hint(Some("not-seconds")), None);
+        assert_eq!(parse_retry_after_hint(None), None);
     }
 
     #[test]

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -1,3 +1,4 @@
+use crate::inference::health::ShadowObservationMode;
 use crate::inference::{
     AttemptFailure, AttemptFailureKind, AttemptOutcome, AttemptStage, AttemptTerminal,
     CompletionEvidence, InferenceAttempt, InferenceExecution, InferenceIntent, InferenceSurface,
@@ -16,7 +17,8 @@ use crate::provider_client::{
 };
 use crate::provider_registry::{ProviderId, SHADOW_ROUTING_POLICY_VERSION};
 use crate::provider_routing::{
-    compare_shadow_route, ProviderRoutingError, SelectedProviderRoute, ShadowRouteComparison,
+    compare_shadow_route, ProviderRouter, ProviderRoutingError, SelectedProviderRoute,
+    ShadowRouteComparison,
 };
 use crate::proxy_config::ProxyConfig;
 use crate::sqs::UsageEvent;
@@ -761,77 +763,20 @@ impl From<ApiError> for CompletionExecutionError {
 }
 
 fn failed_completion_execution(
+    provider_router: &ProviderRouter,
     attempt: InferenceAttempt,
     failure: AttemptFailure,
     public_error: ApiError,
 ) -> CompletionExecutionError {
     let terminal = AttemptTerminal::Failed { attempt, failure };
-    record_attempt_outcome(&AttemptOutcome::Terminal(terminal.clone()));
+    record_attempt_outcome(
+        provider_router,
+        &AttemptOutcome::Terminal(terminal.clone()),
+        ShadowObservationMode::Update,
+    );
     CompletionExecutionError::Attempt {
         terminal,
         public_error,
-    }
-}
-
-/// Ensures cancellation or panic cannot make an in-flight attempt disappear
-/// from the typed terminal stream. Later routing layers may attach health
-/// observation to the same lifecycle without changing its exactly-once shape.
-struct AttemptTerminalGuard {
-    attempt: InferenceAttempt,
-    stage: AttemptStage,
-    armed: bool,
-}
-
-impl AttemptTerminalGuard {
-    fn new(attempt: InferenceAttempt, stage: AttemptStage) -> Self {
-        Self {
-            attempt,
-            stage,
-            armed: true,
-        }
-    }
-
-    fn set_stage(&mut self, stage: AttemptStage) {
-        self.stage = stage;
-    }
-
-    fn disarm(&mut self) {
-        self.armed = false;
-    }
-
-    fn record_terminal(&mut self, terminal: &AttemptTerminal) {
-        debug_assert_eq!(terminal.attempt(), &self.attempt);
-        record_attempt_outcome(&AttemptOutcome::Terminal(terminal.clone()));
-        self.disarm();
-    }
-
-    fn cancellation_terminal(&self) -> AttemptTerminal {
-        AttemptTerminal::Failed {
-            attempt: self.attempt.clone(),
-            failure: AttemptFailure::new(
-                AttemptFailureKind::ConsumerDropped,
-                self.stage,
-                ReplaySafety::NotProvenPreAcceptance,
-            ),
-        }
-    }
-}
-
-impl Drop for AttemptTerminalGuard {
-    fn drop(&mut self) {
-        if !self.armed {
-            return;
-        }
-
-        let terminal = self.cancellation_terminal();
-        record_attempt_outcome(&AttemptOutcome::Terminal(terminal));
-        warn!(
-            "Inference attempt abandoned before terminal processing: request_id={}, execution_id={}, attempt_id={}, stage={:?}",
-            self.attempt.request_id,
-            self.attempt.execution_id,
-            self.attempt.attempt_id,
-            self.stage
-        );
     }
 }
 
@@ -911,6 +856,7 @@ fn public_completion_error(error: &ProviderRequestError, failure: &AttemptFailur
 }
 
 fn terminalize_recovered_provider_failures(
+    provider_router: &ProviderRouter,
     execution: InferenceExecution,
     route: &crate::inference::RouteIdentity,
     prior_failures: Vec<ProviderRequestError>,
@@ -924,7 +870,11 @@ fn terminalize_recovered_provider_failures(
                 attempt: attempt.clone(),
                 failure: failure.clone(),
             };
-            record_attempt_outcome(&AttemptOutcome::Terminal(terminal.clone()));
+            record_attempt_outcome(
+                provider_router,
+                &AttemptOutcome::Terminal(terminal.clone()),
+                ShadowObservationMode::TelemetryOnly,
+            );
             warn!(
                 "Inference transport recovered a failed attempt: request_id={}, execution_id={}, attempt_id={}, kind={:?}, replay_safety={:?}",
                 attempt.request_id,
@@ -938,7 +888,11 @@ fn terminalize_recovered_provider_failures(
         .collect()
 }
 
-fn record_attempt_outcome(outcome: &AttemptOutcome) {
+fn record_attempt_outcome(
+    provider_router: &ProviderRouter,
+    outcome: &AttemptOutcome,
+    shadow_mode: ShadowObservationMode,
+) {
     match outcome {
         AttemptOutcome::ResponseStarted { attempt, status } => {
             let route_key = attempt.route.route_key();
@@ -960,6 +914,21 @@ fn record_attempt_outcome(outcome: &AttemptOutcome) {
         }
         AttemptOutcome::Terminal(terminal) => {
             let attempt = terminal.attempt();
+            let shadow_report = provider_router.observe_attempt_terminal(terminal, shadow_mode);
+            debug!(
+                "Inference shadow health observation: request_id={}, execution_id={}, attempt_id={}, policy_version={}, mode={:?}, route_provider={}, route_model={}, signal={:?}, capacity_pool={:?}, snapshot={:?}, mutated={}",
+                attempt.request_id,
+                attempt.execution_id,
+                attempt.attempt_id,
+                shadow_report.policy_version,
+                shadow_report.mode,
+                shadow_report.route.provider.as_str(),
+                shadow_report.route.provider_model_id,
+                shadow_report.signal,
+                shadow_report.capacity_pool,
+                shadow_report.snapshot,
+                shadow_report.mutated
+            );
             match terminal {
                 AttemptTerminal::Completed { evidence, .. } => debug!(
                     "Inference attempt completed: request_id={}, execution_id={}, attempt_id={}, provider={}, public_model={}, provider_model={}, evidence={:?}",
@@ -990,6 +959,20 @@ fn record_attempt_outcome(outcome: &AttemptOutcome) {
             }
         }
     }
+}
+
+#[cfg(test)]
+async fn send_attempt_terminal(
+    provider_router: &ProviderRouter,
+    sender: &mpsc::Sender<CompletionChunk>,
+    terminal: AttemptTerminal,
+) {
+    record_attempt_outcome(
+        provider_router,
+        &AttemptOutcome::Terminal(terminal.clone()),
+        ShadowObservationMode::Update,
+    );
+    let _ = sender.send(CompletionChunk::Terminal(terminal)).await;
 }
 
 fn stream_end_terminal(
@@ -1601,6 +1584,30 @@ pub(crate) async fn prepare_completion_request(
         &intent,
         provider_preference,
     );
+    if let Ok(plan) = &shadow {
+        let candidate_health = plan
+            .eligible_routes
+            .iter()
+            .map(|candidate| {
+                let route_key = crate::inference::RouteKey {
+                    provider: candidate.provider,
+                    provider_model_id: candidate.provider_model_id.clone(),
+                };
+                (
+                    candidate.provider.as_str(),
+                    candidate.provider_model_id.as_str(),
+                    state.provider_router.shadow_health_snapshot(&route_key),
+                )
+            })
+            .collect::<Vec<_>>();
+        debug!(
+            "Shadow route health remained observational: request_id={}, public_model={}, routing_policy_version={}, candidate_health={:?}",
+            intent.request_id,
+            intent.public_model_id,
+            plan.policy_version,
+            candidate_health
+        );
+    }
     let active = state
         .provider_router
         .select_completion_route_with_preference(
@@ -1641,6 +1648,94 @@ pub(crate) async fn prepare_completion_request(
     Ok(PinnedCompletionRequest { intent, route })
 }
 
+/// Ensures cancellation or panic cannot make an in-flight attempt disappear
+/// from the terminal observation stream. Consumer cancellation is deliberately
+/// neutral for route health, but it must still be represented exactly once.
+struct AttemptObservationGuard {
+    attempt: InferenceAttempt,
+    provider_router: Arc<ProviderRouter>,
+    stage: AttemptStage,
+    armed: bool,
+}
+
+impl AttemptObservationGuard {
+    fn new(
+        attempt: InferenceAttempt,
+        provider_router: Arc<ProviderRouter>,
+        stage: AttemptStage,
+    ) -> Self {
+        Self {
+            attempt,
+            provider_router,
+            stage,
+            armed: true,
+        }
+    }
+
+    fn attempt(&self) -> &InferenceAttempt {
+        &self.attempt
+    }
+
+    fn set_stage(&mut self, stage: AttemptStage) {
+        self.stage = stage;
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+
+    fn record_terminal(&mut self, terminal: &AttemptTerminal) {
+        debug_assert_eq!(terminal.attempt(), &self.attempt);
+        record_attempt_outcome(
+            &self.provider_router,
+            &AttemptOutcome::Terminal(terminal.clone()),
+            ShadowObservationMode::Update,
+        );
+        self.disarm();
+    }
+
+    fn cancellation_terminal(&self) -> AttemptTerminal {
+        AttemptTerminal::Failed {
+            attempt: self.attempt.clone(),
+            failure: AttemptFailure::new(
+                AttemptFailureKind::ConsumerDropped,
+                self.stage,
+                ReplaySafety::NotProvenPreAcceptance,
+            ),
+        }
+    }
+}
+
+impl Drop for AttemptObservationGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        let terminal = self.cancellation_terminal();
+        record_attempt_outcome(
+            &self.provider_router,
+            &AttemptOutcome::Terminal(terminal),
+            ShadowObservationMode::Update,
+        );
+        warn!(
+            "Inference attempt abandoned before terminal processing: request_id={}, execution_id={}, attempt_id={}, stage={:?}",
+            self.attempt.request_id,
+            self.attempt.execution_id,
+            self.attempt.attempt_id,
+            self.stage
+        );
+    }
+}
+
+async fn await_attempt_result<T>(
+    terminal_guard: AttemptObservationGuard,
+    future: impl std::future::Future<Output = T>,
+) -> (T, AttemptObservationGuard) {
+    let result = future.await;
+    (result, terminal_guard)
+}
+
 /// A provider response whose HTTP success status has been observed, but whose
 /// body has not yet been consumed. Responses holds this value only across its
 /// persistence boundary so a capacity rejection can still be returned as an
@@ -1649,11 +1744,11 @@ pub(crate) struct StartedCompletion {
     response: Option<ProviderResponse>,
     successful_provider: String,
     attempt: InferenceAttempt,
+    terminal_guard: Option<AttemptObservationGuard>,
     response_model_id: String,
     is_streaming: bool,
     billing_context: BillingContext,
     non_streaming_body_limit: Option<usize>,
-    terminal_guard: Option<AttemptTerminalGuard>,
 }
 
 /// Starts one model turn against a route pinned for the logical inference
@@ -1882,6 +1977,7 @@ async fn get_chat_completion_response_with_options(
                     attempt.request_id, attempt.execution_id, attempt.attempt_id, error
                 );
                 return Err(failed_completion_execution(
+                    &state.provider_router,
                     attempt,
                     failure,
                     ApiError::InternalServerError,
@@ -1900,29 +1996,46 @@ async fn get_chat_completion_response_with_options(
             request_log_metadata
         );
 
-        let attempt = execution.begin_attempt(route_identity.clone());
-        let mut terminal_guard =
-            AttemptTerminalGuard::new(attempt.clone(), AttemptStage::AwaitingResponse);
-        let ProviderSendTrace {
-            prior_failures,
-            result,
-        } = try_provider(
-            &state.provider_client,
-            &proxy_config,
-            request_body_json,
-            headers,
+        let terminal_guard = AttemptObservationGuard::new(
+            execution.begin_attempt(route_identity.clone()),
+            Arc::clone(&state.provider_router),
+            AttemptStage::AwaitingResponse,
+        );
+        let (
+            ProviderSendTrace {
+                prior_failures,
+                result,
+            },
+            mut terminal_guard,
+        ) = await_attempt_result(
+            terminal_guard,
+            try_provider(
+                &state.provider_client,
+                &proxy_config,
+                request_body_json,
+                headers,
+            ),
         )
         .await;
 
-        let _recovered_terminals =
-            terminalize_recovered_provider_failures(execution, &route_identity, prior_failures);
+        let _recovered_terminals = terminalize_recovered_provider_failures(
+            &state.provider_router,
+            execution,
+            &route_identity,
+            prior_failures,
+        );
 
+        let attempt = terminal_guard.attempt().clone();
         match result {
             Ok(response) => {
-                record_attempt_outcome(&AttemptOutcome::ResponseStarted {
-                    attempt: attempt.clone(),
-                    status: response.status_code(),
-                });
+                record_attempt_outcome(
+                    &state.provider_router,
+                    &AttemptOutcome::ResponseStarted {
+                        attempt: attempt.clone(),
+                        status: response.status_code(),
+                    },
+                    ShadowObservationMode::Update,
+                );
                 info!(
                     "Inference response started: request_id={}, execution_id={}, attempt_id={}",
                     attempt.request_id, attempt.execution_id, attempt.attempt_id
@@ -1947,6 +2060,7 @@ async fn get_chat_completion_response_with_options(
                     request_log_metadata
                 );
                 let execution_error = failed_completion_execution(
+                    &state.provider_router,
                     attempt,
                     failure.clone(),
                     public_completion_error(&err, &failure),
@@ -1966,11 +2080,11 @@ async fn get_chat_completion_response_with_options(
         response: Some(response),
         successful_provider,
         attempt,
+        terminal_guard: Some(terminal_guard),
         response_model_id: selected_route.response_model_id,
         is_streaming,
         billing_context,
         non_streaming_body_limit: options.non_streaming_body_limit,
-        terminal_guard: Some(terminal_guard),
     })
 }
 
@@ -1985,16 +2099,16 @@ pub(crate) async fn finish_started_completion(
         .response
         .take()
         .expect("started completion response can only be consumed once");
+    let mut terminal_guard = started
+        .terminal_guard
+        .take()
+        .expect("started completion terminal guard can only be consumed once");
     let successful_provider = started.successful_provider.clone();
     let attempt = started.attempt.clone();
     let response_model_id = started.response_model_id.clone();
     let is_streaming = started.is_streaming;
     let billing_context = started.billing_context.clone();
     let non_streaming_body_limit = started.non_streaming_body_limit;
-    let mut terminal_guard = started
-        .terminal_guard
-        .take()
-        .expect("started completion terminal guard can only be consumed once");
 
     // NOW: Process the response internally and handle billing
     if !is_streaming {
@@ -2013,6 +2127,7 @@ pub(crate) async fn finish_started_completion(
             Ok(response_json) => response_json,
             Err(failure) => {
                 let execution_error = failed_completion_execution(
+                    &state.provider_router,
                     attempt.clone(),
                     failure,
                     ApiError::InternalServerError,
@@ -2021,6 +2136,12 @@ pub(crate) async fn finish_started_completion(
                 return Err(execution_error);
             }
         };
+
+        let terminal = AttemptTerminal::Completed {
+            attempt: attempt.clone(),
+            evidence: CompletionEvidence::NonStreamingResponse,
+        };
+        terminal_guard.record_terminal(&terminal);
 
         // ✅ Handle billing HERE, inside completions API
         if let Some(usage) = extract_usage(&response_json) {
@@ -2035,11 +2156,6 @@ pub(crate) async fn finish_started_completion(
         }
 
         // Return the full response as a single chunk
-        let terminal = AttemptTerminal::Completed {
-            attempt: attempt.clone(),
-            evidence: CompletionEvidence::NonStreamingResponse,
-        };
-        terminal_guard.record_terminal(&terminal);
         let (tx, rx) = mpsc::channel(2); // Need space for FullResponse + terminal
         let _ = tx.send(CompletionChunk::FullResponse(response_json)).await;
         let _ = tx.send(CompletionChunk::Terminal(terminal)).await;
@@ -2076,6 +2192,8 @@ pub(crate) async fn finish_started_completion(
             Duration::from_secs(STREAM_CHUNK_TIMEOUT_SECS),
         )
         .await;
+        let terminal = result.terminal.clone();
+        terminal_guard.record_terminal(&terminal);
         publish_stream_usage(
             result.usage,
             result.finalization,
@@ -2086,10 +2204,7 @@ pub(crate) async fn finish_started_completion(
             &tx_consumer,
         )
         .await;
-        terminal_guard.record_terminal(&result.terminal);
-        let _ = tx_consumer
-            .send(CompletionChunk::Terminal(result.terminal))
-            .await;
+        let _ = tx_consumer.send(CompletionChunk::Terminal(terminal)).await;
     });
 
     Ok(CompletionStream {
@@ -3551,6 +3666,95 @@ mod tests {
         ));
     }
 
+    async fn record_terminal_once(
+        provider_router: &ProviderRouter,
+        terminal: &AttemptTerminal,
+    ) -> crate::inference::health::ShadowRouteSnapshot {
+        let route_key = terminal.attempt().route.route_key();
+        let (terminal_tx, mut terminal_rx) = mpsc::channel(1);
+        send_attempt_terminal(provider_router, &terminal_tx, terminal.clone()).await;
+        drop(terminal_tx);
+        assert!(matches!(
+            terminal_rx.recv().await,
+            Some(CompletionChunk::Terminal(_))
+        ));
+        assert!(terminal_rx.recv().await.is_none());
+        provider_router
+            .shadow_health_snapshot(&route_key)
+            .expect("registered terminal route")
+    }
+
+    #[tokio::test]
+    async fn cancelling_while_awaiting_provider_result_records_one_neutral_terminal() {
+        let provider_router = Arc::new(ProviderRouter::default());
+        let pinned = pinned_test_completion();
+        let route_key = pinned.route.identity().route_key();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let terminal_guard = AttemptObservationGuard::new(
+            attempt,
+            Arc::clone(&provider_router),
+            AttemptStage::AwaitingResponse,
+        );
+
+        let result = timeout(
+            Duration::from_millis(5),
+            await_attempt_result(terminal_guard, futures::future::pending::<()>()),
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(provider_router.shadow_observation_count(), 1);
+        assert_eq!(
+            provider_router
+                .shadow_health_snapshot(&route_key)
+                .expect("registered K3 route")
+                .effective,
+            crate::inference::health::ShadowDisposition::Healthy
+        );
+    }
+
+    #[tokio::test]
+    async fn taking_started_response_does_not_disarm_drop_observation() {
+        let (trace, server) = call_mock_provider(static_sse_app("data: [DONE]\n\n")).await;
+        let response = trace.result.expect("mock provider response start");
+        let provider_router = Arc::new(ProviderRouter::default());
+        let pinned = pinned_test_completion();
+        let route_key = pinned.route.identity().route_key();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let terminal_guard = AttemptObservationGuard::new(
+            attempt.clone(),
+            Arc::clone(&provider_router),
+            AttemptStage::ResponseBody,
+        );
+        let mut started = StartedCompletion {
+            response: Some(response),
+            successful_provider: ProviderId::Tinfoil.as_str().to_string(),
+            attempt,
+            terminal_guard: Some(terminal_guard),
+            response_model_id: "kimi-k3".to_string(),
+            is_streaming: false,
+            billing_context: BillingContext::new(AuthMethod::Jwt, "kimi-k3".to_string()),
+            non_streaming_body_limit: None,
+        };
+
+        drop(started.response.take());
+        drop(started);
+        server.abort();
+
+        assert_eq!(provider_router.shadow_observation_count(), 1);
+        assert_eq!(
+            provider_router
+                .shadow_health_snapshot(&route_key)
+                .expect("registered K3 route")
+                .effective,
+            crate::inference::health::ShadowDisposition::Healthy
+        );
+    }
+
     #[tokio::test]
     async fn mock_provider_streams_produce_one_sanitized_terminal_result() {
         enum ExpectedTerminal {
@@ -3619,6 +3823,23 @@ mod tests {
                 "{name}"
             );
 
+            let provider_router = ProviderRouter::default();
+            let health = record_terminal_once(&provider_router, &result.terminal).await;
+            match &result.terminal {
+                AttemptTerminal::Completed { .. } => assert_eq!(
+                    health.effective,
+                    crate::inference::health::ShadowDisposition::Healthy,
+                    "{name}"
+                ),
+                AttemptTerminal::Failed { .. } => assert_eq!(
+                    health.route_health,
+                    crate::inference::health::ShadowDisposition::Watch {
+                        consecutive_failures: 1
+                    },
+                    "{name}"
+                ),
+            }
+
             match (expected, result.terminal) {
                 (
                     ExpectedTerminal::Completed(expected_evidence),
@@ -3677,6 +3898,26 @@ mod tests {
             failure.upstream_request_id.as_deref(),
             Some("req-429_a.b:c")
         );
+
+        let provider_router = ProviderRouter::default();
+        let pinned = pinned_test_completion();
+        let route_key = pinned.route.identity().route_key();
+        let attempt = pinned
+            .begin_execution()
+            .begin_attempt(pinned.route.identity());
+        let _ = failed_completion_execution(
+            &provider_router,
+            attempt,
+            failure,
+            ApiError::InternalServerError,
+        );
+        assert!(matches!(
+            provider_router
+                .shadow_health_snapshot(&route_key)
+                .expect("registered K3 route")
+                .effective,
+            crate::inference::health::ShadowDisposition::WouldOpen { .. }
+        ));
     }
 
     #[tokio::test]
@@ -3756,6 +3997,26 @@ mod tests {
                     ..
                 }
             ));
+
+            let provider_router = ProviderRouter::default();
+            let pinned = pinned_test_completion();
+            let route_key = pinned.route.identity().route_key();
+            let attempt = pinned
+                .begin_execution()
+                .begin_attempt(pinned.route.identity());
+            let _ = failed_completion_execution(
+                &provider_router,
+                attempt,
+                failure,
+                ApiError::InternalServerError,
+            );
+            assert!(matches!(
+                provider_router
+                    .shadow_health_snapshot(&route_key)
+                    .expect("registered K3 route")
+                    .deployment_capacity,
+                crate::inference::health::ShadowDisposition::WouldOpen { .. }
+            ));
         }
     }
 
@@ -3771,7 +4032,9 @@ mod tests {
         let attempt = pinned
             .begin_execution()
             .begin_attempt(pinned.route.identity());
+        let provider_router = ProviderRouter::default();
         let response = failed_completion_execution(
+            &provider_router,
             attempt,
             failure.clone(),
             public_completion_error(&provider_error, &failure),
@@ -3822,6 +4085,16 @@ mod tests {
         assert_eq!(failure.replay_safety, ReplaySafety::NotProvenPreAcceptance);
         assert_eq!(failure.upstream_code.as_deref(), Some("capacity_error-17"));
         assert!(!format!("{failure:?}").contains("private upstream detail"));
+
+        let provider_router = ProviderRouter::default();
+        let terminal = AttemptTerminal::Failed { attempt, failure };
+        let health = record_terminal_once(&provider_router, &terminal).await;
+        assert_eq!(
+            health.route_health,
+            crate::inference::health::ShadowDisposition::Watch {
+                consecutive_failures: 1
+            }
+        );
     }
 
     #[tokio::test]
@@ -3938,6 +4211,14 @@ mod tests {
                 ..
             }
         ));
+        let provider_router = ProviderRouter::default();
+        let health = record_terminal_once(&provider_router, &result.terminal).await;
+        assert_eq!(
+            health.route_health,
+            crate::inference::health::ShadowDisposition::Watch {
+                consecutive_failures: 1
+            }
+        );
     }
 
     #[tokio::test]
@@ -3981,6 +4262,12 @@ mod tests {
                 ..
             }
         ));
+        let provider_router = ProviderRouter::default();
+        let health = record_terminal_once(&provider_router, &result.terminal).await;
+        assert_eq!(
+            health.effective,
+            crate::inference::health::ShadowDisposition::Healthy
+        );
     }
 
     #[tokio::test]
@@ -4061,6 +4348,54 @@ mod tests {
                 },
                 ..
             }
+        ));
+        let provider_router = ProviderRouter::default();
+        let health = record_terminal_once(&provider_router, &result.terminal).await;
+        assert_eq!(
+            health.route_health,
+            crate::inference::health::ShadowDisposition::Watch {
+                consecutive_failures: 1
+            }
+        );
+    }
+
+    #[test]
+    fn response_started_is_not_a_health_success_and_cannot_clear_capacity() {
+        let provider_router = ProviderRouter::default();
+        let pinned = pinned_test_completion();
+        let route = pinned.route.identity();
+        let route_key = route.route_key();
+        let execution = pinned.begin_execution();
+        let mut capacity_failure = AttemptFailure::new(
+            AttemptFailureKind::CapacityRejected,
+            AttemptStage::AwaitingResponse,
+            ReplaySafety::ProvenPreAcceptance,
+        );
+        capacity_failure.status = Some(429);
+        capacity_failure.retry_after = Some(Duration::from_secs(60));
+        record_attempt_outcome(
+            &provider_router,
+            &AttemptOutcome::Terminal(AttemptTerminal::Failed {
+                attempt: execution.begin_attempt(route.clone()),
+                failure: capacity_failure,
+            }),
+            ShadowObservationMode::Update,
+        );
+        record_attempt_outcome(
+            &provider_router,
+            &AttemptOutcome::ResponseStarted {
+                attempt: execution.begin_attempt(route),
+                status: 200,
+            },
+            ShadowObservationMode::Update,
+        );
+
+        assert!(matches!(
+            provider_router
+                .shadow_health_snapshot(&route_key)
+                .expect("registered K3 route")
+                .effective,
+            crate::inference::health::ShadowDisposition::WouldOpen { .. }
         ));
     }
 
@@ -4197,11 +4532,16 @@ mod tests {
 
     #[test]
     fn cancelled_in_flight_attempt_has_one_conservative_terminal_shape() {
+        let provider_router = Arc::new(ProviderRouter::default());
         let pinned = pinned_test_completion();
         let attempt = pinned
             .begin_execution()
             .begin_attempt(pinned.route.identity());
-        let mut guard = AttemptTerminalGuard::new(attempt.clone(), AttemptStage::AwaitingResponse);
+        let mut guard = AttemptObservationGuard::new(
+            attempt.clone(),
+            provider_router,
+            AttemptStage::AwaitingResponse,
+        );
 
         assert!(matches!(
             guard.cancellation_terminal(),
@@ -4221,9 +4561,11 @@ mod tests {
     #[test]
     fn recovered_transport_retry_gets_a_distinct_attempt_in_the_same_execution() {
         let pinned = pinned_test_completion();
+        let provider_router = ProviderRouter::default();
         let execution = pinned.begin_execution();
         let route = pinned.route.identity();
         let recovered = terminalize_recovered_provider_failures(
+            &provider_router,
             execution,
             &route,
             vec![ProviderRequestError::Connect(

--- a/src/web/responses/builders.rs
+++ b/src/web/responses/builders.rs
@@ -8,7 +8,7 @@ use crate::{
         conversations::ConversationResponse,
         handlers::{
             ContentPart, InputTokenDetails, OutputItem, OutputTokenDetails, ReasoningInfo,
-            ResponseUsage, ResponsesCreateResponse, TextFormat, TextFormatSpec,
+            ResponseError, ResponseUsage, ResponsesCreateResponse, TextFormat, TextFormatSpec,
         },
     },
 };
@@ -121,6 +121,11 @@ impl ResponseBuilder {
     /// * `metadata` - Optional JSON metadata
     pub fn metadata(mut self, metadata: Option<Value>) -> Self {
         self.response.metadata = metadata;
+        self
+    }
+
+    pub fn error(mut self, error: ResponseError) -> Self {
+        self.response.error = Some(error);
         self
     }
 

--- a/src/web/responses/constants.rs
+++ b/src/web/responses/constants.rs
@@ -29,7 +29,7 @@ pub const EVENT_RESPONSE_CONTENT_PART_DONE: &str = "response.content_part.done";
 pub const EVENT_RESPONSE_OUTPUT_ITEM_DONE: &str = "response.output_item.done";
 pub const EVENT_RESPONSE_COMPLETED: &str = "response.completed";
 pub const EVENT_RESPONSE_CANCELLED: &str = "response.cancelled";
-pub const EVENT_RESPONSE_ERROR: &str = "response.error";
+pub const EVENT_RESPONSE_FAILED: &str = "response.failed";
 
 /// Error event data
 pub const ERROR_DATA_ENCRYPTION_FAILED: &str = "encryption_failed";
@@ -38,6 +38,7 @@ pub const ERROR_DATA_SERIALIZATION_FAILED: &str = "serialization_failed";
 /// Message statuses
 pub const STATUS_IN_PROGRESS: &str = "in_progress";
 pub const STATUS_COMPLETED: &str = "completed";
+pub const STATUS_FAILED: &str = "failed";
 pub const STATUS_INCOMPLETE: &str = "incomplete";
 pub const STATUS_CANCELLED: &str = "cancelled";
 

--- a/src/web/responses/events.rs
+++ b/src/web/responses/events.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 use super::constants::{
     ERROR_DATA_ENCRYPTION_FAILED, ERROR_DATA_SERIALIZATION_FAILED, EVENT_RESPONSE_CANCELLED,
     EVENT_RESPONSE_COMPLETED, EVENT_RESPONSE_CONTENT_PART_ADDED, EVENT_RESPONSE_CONTENT_PART_DONE,
-    EVENT_RESPONSE_CREATED, EVENT_RESPONSE_ERROR, EVENT_RESPONSE_IN_PROGRESS,
+    EVENT_RESPONSE_CREATED, EVENT_RESPONSE_FAILED, EVENT_RESPONSE_IN_PROGRESS,
     EVENT_RESPONSE_OUTPUT_ITEM_ADDED, EVENT_RESPONSE_OUTPUT_ITEM_DONE,
     EVENT_RESPONSE_OUTPUT_TEXT_DELTA, EVENT_RESPONSE_OUTPUT_TEXT_DONE,
     EVENT_RESPONSE_REASONING_TEXT_DELTA, EVENT_RESPONSE_REASONING_TEXT_DONE,
@@ -17,7 +17,7 @@ use super::constants::{
 };
 use super::handlers::{
     encrypt_event, ResponseCancelledEvent, ResponseCompletedEvent, ResponseContentPartAddedEvent,
-    ResponseContentPartDoneEvent, ResponseCreatedEvent, ResponseErrorEvent,
+    ResponseContentPartDoneEvent, ResponseCreatedEvent, ResponseFailedEvent,
     ResponseInProgressEvent, ResponseOutputItemAddedEvent, ResponseOutputItemDoneEvent,
     ResponseOutputTextDeltaEvent, ResponseOutputTextDoneEvent, ResponseReasoningTextDeltaEvent,
     ResponseReasoningTextDoneEvent, ToolCallCreatedEvent, ToolOutputCreatedEvent,
@@ -141,7 +141,7 @@ pub enum ResponseEvent {
     OutputItemDone(ResponseOutputItemDoneEvent),
     Completed(ResponseCompletedEvent),
     Cancelled(ResponseCancelledEvent),
-    Error(ResponseErrorEvent),
+    Failed(ResponseFailedEvent),
     ToolCallCreated(ToolCallCreatedEvent),
     ToolOutputCreated(ToolOutputCreatedEvent),
 }
@@ -162,7 +162,7 @@ impl ResponseEvent {
             ResponseEvent::OutputItemDone(_) => EVENT_RESPONSE_OUTPUT_ITEM_DONE,
             ResponseEvent::Completed(_) => EVENT_RESPONSE_COMPLETED,
             ResponseEvent::Cancelled(_) => EVENT_RESPONSE_CANCELLED,
-            ResponseEvent::Error(_) => EVENT_RESPONSE_ERROR,
+            ResponseEvent::Failed(_) => EVENT_RESPONSE_FAILED,
             ResponseEvent::ToolCallCreated(_) => EVENT_TOOL_CALL_CREATED,
             ResponseEvent::ToolOutputCreated(_) => EVENT_TOOL_OUTPUT_CREATED,
         }
@@ -187,7 +187,7 @@ impl ResponseEvent {
             ResponseEvent::Cancelled(e) => {
                 emitter.emit_without_sequence(self.event_type(), e).await
             }
-            ResponseEvent::Error(e) => emitter.emit_without_sequence(self.event_type(), e).await,
+            ResponseEvent::Failed(e) => emitter.emit(self.event_type(), e).await,
             ResponseEvent::ToolCallCreated(e) => emitter.emit(self.event_type(), e).await,
             ResponseEvent::ToolOutputCreated(e) => emitter.emit(self.event_type(), e).await,
         }
@@ -198,8 +198,8 @@ impl ResponseEvent {
 mod tests {
     use super::*;
     use crate::web::responses::constants::{
-        OBJECT_TYPE_RESPONSE, STATUS_IN_PROGRESS, TEXT_FORMAT_TYPE, TOOL_CHOICE_AUTO,
-        TRUNCATION_DISABLED,
+        OBJECT_TYPE_RESPONSE, STATUS_FAILED, STATUS_IN_PROGRESS, TEXT_FORMAT_TYPE,
+        TOOL_CHOICE_AUTO, TRUNCATION_DISABLED,
     };
 
     #[derive(Serialize)]
@@ -236,48 +236,79 @@ mod tests {
         use uuid::Uuid;
 
         // Test that event types map correctly
+        let response = ResponsesCreateResponse {
+            id: Uuid::new_v4(),
+            object: OBJECT_TYPE_RESPONSE,
+            created_at: 0,
+            status: STATUS_IN_PROGRESS.to_string(),
+            background: false,
+            error: None,
+            incomplete_details: None,
+            instructions: None,
+            max_output_tokens: None,
+            max_tool_calls: None,
+            model: "test".to_string(),
+            output: vec![],
+            parallel_tool_calls: false,
+            previous_response_id: None,
+            prompt_cache_key: None,
+            reasoning: ReasoningInfo {
+                effort: None,
+                summary: None,
+            },
+            safety_identifier: None,
+            store: true,
+            temperature: 1.0,
+            text: TextFormat {
+                format: TextFormatSpec {
+                    format_type: TEXT_FORMAT_TYPE.to_string(),
+                },
+            },
+            tool_choice: TOOL_CHOICE_AUTO.to_string(),
+            tools: vec![],
+            top_logprobs: 0,
+            top_p: 1.0,
+            truncation: TRUNCATION_DISABLED,
+            usage: None,
+            user: None,
+            metadata: None,
+        };
         let created = ResponseEvent::Created(ResponseCreatedEvent {
             event_type: EVENT_RESPONSE_CREATED,
-            response: ResponsesCreateResponse {
-                id: Uuid::new_v4(),
-                object: OBJECT_TYPE_RESPONSE,
-                created_at: 0,
-                status: STATUS_IN_PROGRESS.to_string(),
-                background: false,
-                error: None,
-                incomplete_details: None,
-                instructions: None,
-                max_output_tokens: None,
-                max_tool_calls: None,
-                model: "test".to_string(),
-                output: vec![],
-                parallel_tool_calls: false,
-                previous_response_id: None,
-                prompt_cache_key: None,
-                reasoning: ReasoningInfo {
-                    effort: None,
-                    summary: None,
-                },
-                safety_identifier: None,
-                store: true,
-                temperature: 1.0,
-                text: TextFormat {
-                    format: TextFormatSpec {
-                        format_type: TEXT_FORMAT_TYPE.to_string(),
-                    },
-                },
-                tool_choice: TOOL_CHOICE_AUTO.to_string(),
-                tools: vec![],
-                top_logprobs: 0,
-                top_p: 1.0,
-                truncation: TRUNCATION_DISABLED,
-                usage: None,
-                user: None,
-                metadata: None,
-            },
+            response: response.clone(),
             sequence_number: 0,
         });
 
         assert_eq!(created.event_type(), EVENT_RESPONSE_CREATED);
+
+        let failed_payload = ResponseFailedEvent {
+            event_type: EVENT_RESPONSE_FAILED,
+            response: ResponsesCreateResponse {
+                status: STATUS_FAILED.to_string(),
+                error: Some(ResponseError {
+                    code: "rate_limit_exceeded".to_string(),
+                    message: "Inference capacity is temporarily unavailable.".to_string(),
+                }),
+                ..response
+            },
+            sequence_number: 1,
+            opensecret: Some(OpenSecretResponseError {
+                error_contract: "1",
+                error_code: "inference_capacity",
+            }),
+        };
+        let serialized = serde_json::to_value(&failed_payload).unwrap();
+        assert_eq!(serialized["type"], EVENT_RESPONSE_FAILED);
+        assert_eq!(serialized["response"]["status"], STATUS_FAILED);
+        assert_eq!(
+            serialized["response"]["error"]["code"],
+            "rate_limit_exceeded"
+        );
+        assert!(serialized.get("error").is_none());
+        assert_eq!(serialized["opensecret"]["error_code"], "inference_capacity");
+        assert_eq!(
+            ResponseEvent::Failed(failed_payload).event_type(),
+            EVENT_RESPONSE_FAILED
+        );
     }
 }

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -5,6 +5,10 @@ use crate::{
     billing::{BillingError, ChatBillingAccess},
     db::DBError,
     encrypt::{decrypt_content, decrypt_string, encrypt_with_key},
+    inference::{
+        AttemptFailure, AttemptFailureKind, AttemptTerminal, InferenceIntent, InferenceSurface,
+        ReplaySafety, WorkloadClass,
+    },
     jwt::AuthContext,
     model_config::{
         model_alias_requires_flag_lookup, model_config, model_reasoning_history_strategy,
@@ -20,7 +24,8 @@ use crate::{
         encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
         openai::{
             ensure_completion_model_access, get_chat_completion_response,
-            get_chat_completion_response_for_expected_route, BillingContext, CompletionChunk,
+            get_chat_completion_response_for_expected_route, prepare_completion_request,
+            BillingContext, CompletionChunk, CompletionExecutionError, PinnedCompletionRequest,
             ServerSelectedCompletionRoute,
         },
         openai_auth::AuthMethod,
@@ -398,7 +403,8 @@ mod tests {
         assistant_turn_finished_with_tool_call, build_internal_system_prompt_for_now,
         build_model_turn_request, build_provider_tools, final_assistant_finish_reason,
         finalize_first_model_tool_call, has_streamed_tool_call_entries, image_attachments,
-        image_description_access, image_description_api_error, maple_kagi_web_search_prompt,
+        image_description_access, image_description_api_error,
+        image_description_attempt_failure_class, maple_kagi_web_search_prompt,
         model_turn_request_without_user_payload, resolve_responses_model,
         resolve_responses_sampling, wait_for_response_cancellation, web_search_is_selected,
         web_search_tool_turn_limit, web_search_tool_turn_limit_error,
@@ -411,6 +417,7 @@ mod tests {
     use crate::web::responses::tools;
     use crate::{
         billing::{BillingClient, ChatBillingAccess},
+        inference::{AttemptFailure, AttemptFailureKind, AttemptStage, ReplaySafety},
         model_config::{ModelAliasTargets, ModelPlan},
         ApiError,
     };
@@ -686,6 +693,63 @@ mod tests {
         );
         assert_eq!(
             image_description_api_error(ApiError::InternalServerError).class,
+            ImageDescriptionFailureClass::AmbiguousAfterSend
+        );
+    }
+
+    #[test]
+    fn test_image_description_typed_failures_preserve_fallback_safety() {
+        let pre_acceptance = AttemptFailure::new(
+            AttemptFailureKind::Connect,
+            AttemptStage::BeforeSend,
+            ReplaySafety::ProvenPreAcceptance,
+        );
+        assert_eq!(
+            image_description_attempt_failure_class(&pre_acceptance),
+            ImageDescriptionFailureClass::PreAcceptance
+        );
+
+        for status in [408, 425, 429, 500, 503, 529] {
+            let retryable = AttemptFailure::new(
+                AttemptFailureKind::HttpStatus,
+                AttemptStage::AwaitingResponse,
+                ReplaySafety::NotProvenPreAcceptance,
+            )
+            .with_upstream_response(status, None, None);
+            assert_eq!(
+                image_description_attempt_failure_class(&retryable),
+                ImageDescriptionFailureClass::RetryableResponse
+            );
+        }
+
+        let deterministic_rejection = AttemptFailure::new(
+            AttemptFailureKind::HttpStatus,
+            AttemptStage::AwaitingResponse,
+            ReplaySafety::NotProvenPreAcceptance,
+        )
+        .with_upstream_response(400, None, None);
+        assert_eq!(
+            image_description_attempt_failure_class(&deterministic_rejection),
+            ImageDescriptionFailureClass::Terminal
+        );
+
+        let invalid_response = AttemptFailure::new(
+            AttemptFailureKind::InvalidResponse,
+            AttemptStage::ResponseBody,
+            ReplaySafety::NotProvenPreAcceptance,
+        );
+        assert_eq!(
+            image_description_attempt_failure_class(&invalid_response),
+            ImageDescriptionFailureClass::InvalidResponse
+        );
+
+        let ambiguous = AttemptFailure::new(
+            AttemptFailureKind::ResponseBody,
+            AttemptStage::ResponseBody,
+            ReplaySafety::NotProvenPreAcceptance,
+        );
+        assert_eq!(
+            image_description_attempt_failure_class(&ambiguous),
             ImageDescriptionFailureClass::AmbiguousAfterSend
         );
     }
@@ -2460,6 +2524,58 @@ fn image_description_api_error(error: ApiError) -> ImageDescriptionAttemptError 
     ImageDescriptionAttemptError::new(class, format!("descriptor request failed: {error}"))
 }
 
+fn image_description_attempt_failure_class(
+    failure: &AttemptFailure,
+) -> ImageDescriptionFailureClass {
+    if failure.replay_safety == ReplaySafety::ProvenPreAcceptance {
+        return ImageDescriptionFailureClass::PreAcceptance;
+    }
+
+    match failure.kind {
+        AttemptFailureKind::HttpStatus
+            if failure.status.is_some_and(|status| {
+                matches!(status, 408 | 425 | 429) || (500..=599).contains(&status)
+            }) =>
+        {
+            ImageDescriptionFailureClass::RetryableResponse
+        }
+        AttemptFailureKind::HttpStatus
+            if failure
+                .status
+                .is_some_and(|status| (400..=499).contains(&status)) =>
+        {
+            ImageDescriptionFailureClass::Terminal
+        }
+        AttemptFailureKind::InvalidResponse | AttemptFailureKind::UpstreamResponseError => {
+            ImageDescriptionFailureClass::InvalidResponse
+        }
+        _ => ImageDescriptionFailureClass::AmbiguousAfterSend,
+    }
+}
+
+fn image_description_execution_error(
+    error: CompletionExecutionError,
+) -> ImageDescriptionAttemptError {
+    match error {
+        CompletionExecutionError::Request(error) => image_description_api_error(error),
+        CompletionExecutionError::Attempt {
+            terminal,
+            public_error,
+        } => {
+            let class = match &terminal {
+                AttemptTerminal::Failed { failure, .. } => {
+                    image_description_attempt_failure_class(failure)
+                }
+                AttemptTerminal::Completed { .. } => ImageDescriptionFailureClass::InvalidResponse,
+            };
+            ImageDescriptionAttemptError::new(
+                class,
+                format!("descriptor request failed: {public_error}"),
+            )
+        }
+    }
+}
+
 #[async_trait::async_trait]
 impl ImageDescriptionAttemptExecutor for ResponsesImageDescriptionExecutor<'_> {
     async fn execute(
@@ -2490,7 +2606,7 @@ impl ImageDescriptionAttemptExecutor for ResponsesImageDescriptionExecutor<'_> {
             },
         )
         .await
-        .map_err(image_description_api_error)?;
+        .map_err(image_description_execution_error)?;
 
         if completion.metadata.provider_name != candidate.provider.as_str()
             || completion.metadata.model_name != candidate.public_model_id
@@ -2510,11 +2626,15 @@ impl ImageDescriptionAttemptExecutor for ResponsesImageDescriptionExecutor<'_> {
                     )
                 })
             }
-            Some(CompletionChunk::Error(_)) => Err(ImageDescriptionAttemptError::new(
-                ImageDescriptionFailureClass::AmbiguousAfterSend,
-                "descriptor response stream returned an error",
-            )),
-            Some(_) => Err(ImageDescriptionAttemptError::new(
+            Some(CompletionChunk::Terminal(AttemptTerminal::Failed { failure, .. })) => {
+                Err(ImageDescriptionAttemptError::new(
+                    image_description_attempt_failure_class(&failure),
+                    "descriptor response ended with a failed terminal",
+                ))
+            }
+            Some(CompletionChunk::Terminal(AttemptTerminal::Completed { .. }))
+            | Some(CompletionChunk::StreamChunk(_))
+            | Some(CompletionChunk::Usage(_)) => Err(ImageDescriptionAttemptError::new(
                 ImageDescriptionFailureClass::InvalidResponse,
                 "descriptor response had an unexpected chunk type",
             )),
@@ -2685,6 +2805,25 @@ async fn spawn_title_generation_task(
             crate::web::openai_auth::AuthMethod::Jwt,
             "llama3-3-70b".to_string(),
         );
+        let title_intent = InferenceIntent::new(
+            user.uuid,
+            "llama3-3-70b",
+            "llama3-3-70b",
+            ModelPlan::Free,
+            InferenceSurface::Internal,
+            WorkloadClass::Background,
+        );
+        let pinned_completion = match prepare_completion_request(&state, &user, title_intent).await
+        {
+            Ok(pinned) => pinned,
+            Err(error) => {
+                error!(
+                    "Title generation: failed to prepare inference route: {:?}",
+                    error
+                );
+                return;
+            }
+        };
 
         debug!("Title generation: about to call get_chat_completion_response");
         match get_chat_completion_response(
@@ -2693,7 +2832,7 @@ async fn spawn_title_generation_task(
             title_request,
             &headers,
             billing_context,
-            ModelPlan::Free,
+            &pinned_completion,
         )
         .await
         {
@@ -2713,7 +2852,6 @@ async fn spawn_title_generation_task(
                         {
                             let title = title.trim();
                             trace!("Generated title for conversation {}", conversation_uuid);
-
                             // Get current conversation metadata
                             match state
                                 .db
@@ -2776,7 +2914,7 @@ async fn spawn_title_generation_task(
                             );
                         }
                     }
-                    Some(_other_chunk) => {
+                    Some(_) => {
                         error!("Expected FullResponse chunk for title generation but got unexpected chunk type");
                     }
                     None => {
@@ -3427,7 +3565,7 @@ async fn stream_one_assistant_turn(
     state: &Arc<AppState>,
     user: &User,
     body: &ResponsesCreateRequest,
-    model_plan: ModelPlan,
+    pinned_completion: &PinnedCompletionRequest,
     headers: &HeaderMap,
     prompt_messages: &[Value],
     tools_enabled: bool,
@@ -3446,8 +3584,8 @@ async fn stream_one_assistant_turn(
         .unwrap_or_default();
 
     debug!(
-        "Responses assistant turn request metadata: user_uuid={}, conversation_uuid={}, response_uuid={}, model={}, tool_turn_count={}, prompt_token_estimate={}, prompt_message_count={}, tools_enabled={}, chat_request_bytes={}",
-        user.uuid,
+        "Responses assistant turn request metadata: request_id={}, conversation_uuid={}, response_uuid={}, model={}, tool_turn_count={}, prompt_token_estimate={}, prompt_message_count={}, tools_enabled={}, chat_request_bytes={}",
+        pinned_completion.intent().request_id,
         conversation_uuid,
         response_uuid,
         body.model,
@@ -3460,7 +3598,7 @@ async fn stream_one_assistant_turn(
 
     let billing_context = crate::web::openai::BillingContext::new(
         crate::web::openai_auth::AuthMethod::Jwt,
-        body.model.clone(),
+        pinned_completion.intent().requested_model_id.clone(),
     );
 
     let mut completion = get_chat_completion_response(
@@ -3469,13 +3607,18 @@ async fn stream_one_assistant_turn(
         chat_request.take(),
         headers,
         billing_context,
-        model_plan,
+        pinned_completion,
     )
-    .await?;
+    .await
+    .map_err(CompletionExecutionError::into_api_error)?;
 
     debug!(
-        "Received completion from provider: {} (model: {})",
-        completion.metadata.provider_name, completion.metadata.model_name
+        "Received Responses completion stream: request_id={}, execution_id={}, attempt_id={}, provider={}, model={}",
+        completion.metadata.attempt.request_id,
+        completion.metadata.attempt.execution_id,
+        completion.metadata.attempt.attempt_id,
+        completion.metadata.provider_name,
+        completion.metadata.model_name
     );
 
     let mut streamed_tool_calls = Vec::new();
@@ -3635,7 +3778,9 @@ async fn stream_one_assistant_turn(
                 )
                 .await?;
             }
-            crate::web::openai::CompletionChunk::Done => {
+            crate::web::openai::CompletionChunk::Terminal(AttemptTerminal::Completed {
+                ..
+            }) => {
                 close_reasoning_if_active(&mut reasoning, tx_storage, tx_client).await?;
 
                 if assistant_turn_finished_with_tool_call(
@@ -3697,8 +3842,14 @@ async fn stream_one_assistant_turn(
                 .await?;
                 return Ok(AssistantTurnOutcome::Final);
             }
-            crate::web::openai::CompletionChunk::Error(error_msg) => {
-                error!("Received error from completion stream: {}", error_msg);
+            crate::web::openai::CompletionChunk::Terminal(AttemptTerminal::Failed {
+                failure,
+                ..
+            }) => {
+                error!(
+                    "Received failed inference terminal: kind={:?}, stage={:?}",
+                    failure.kind, failure.stage
+                );
                 return Err(ApiError::InternalServerError);
             }
             crate::web::openai::CompletionChunk::FullResponse(_) => {
@@ -3722,6 +3873,7 @@ async fn setup_completion_processor(
     state: &Arc<AppState>,
     user: &User,
     body: &ResponsesCreateRequest,
+    pinned_completion: &PinnedCompletionRequest,
     model_plan: ModelPlan,
     context: &BuiltContext,
     user_key: &SecretKey,
@@ -3745,7 +3897,7 @@ async fn setup_completion_processor(
                 state,
                 user,
                 body,
-                model_plan,
+                pinned_completion,
                 headers,
                 &prompt_messages,
                 tools_enabled,
@@ -3862,7 +4014,6 @@ async fn create_response_stream(
     Extension(mut body): Extension<ResponsesCreateRequest>,
 ) -> Result<Response, ApiError> {
     trace!("=== ENTERING create_response_stream ===");
-    trace!("User: {}", user.uuid);
     let requested_model = body.model.clone();
     let billing_access = state.chat_billing_access(user.uuid, false).await;
     let model_plan =
@@ -3963,6 +4114,19 @@ async fn create_response_stream(
         .await?
     };
 
+    // Descriptor attempts are independent internal requests. Pin the user's
+    // main Responses route only after preprocessing so it observes the latest
+    // local routing state, then fail before persistence if no route is usable.
+    let inference_intent = InferenceIntent::new(
+        user.uuid,
+        requested_model,
+        body.model.clone(),
+        model_plan,
+        InferenceSurface::Responses,
+        WorkloadClass::Interactive,
+    );
+    let pinned_completion = prepare_completion_request(&state, &user, inference_intent).await?;
+
     // Phase 3: Persist request data
     let persisted = persist_request_data(
         &state,
@@ -4024,6 +4188,7 @@ async fn create_response_stream(
     let web_search_enabled = context.web_search_enabled;
     let image_descriptions_for_stream = Arc::new(image_descriptions);
     let model_turn_body = model_turn_request_without_user_payload(&body);
+    let pinned_completion_for_stream = pinned_completion.clone();
 
     // Phases 4-6 now happen INSIDE the stream to start sending events ASAP
     trace!("Creating SSE event stream for client");
@@ -4105,6 +4270,7 @@ async fn create_response_stream(
         let orchestrator_last_item_created_at = persisted.last_item_created_at;
         let orchestrator_conversation = conversation_for_stream.clone();
         let orchestrator_prompt_messages = prompt_messages.clone();
+        let orchestrator_pinned_completion = pinned_completion_for_stream.clone();
 
         tokio::spawn(async move {
             trace!("Orchestrator: Starting phases 5-6 in background");
@@ -4142,6 +4308,7 @@ async fn create_response_stream(
                         &orchestrator_state,
                         &orchestrator_user,
                         &orchestrator_body,
+                        &orchestrator_pinned_completion,
                         model_plan,
                         &context_for_completion,
                         &user_key,
@@ -4203,6 +4370,7 @@ async fn create_response_stream(
                     yield Ok(ResponseEvent::ContentPartAdded(content_part_added_event).to_sse_event(&mut emitter).await);
                 }
                 StorageMessage::ContentDelta { item_id, delta } => {
+                    trace!("Client stream received content delta bytes={}", delta.len());
                     let Some(output_index) = client_state.append_message_delta(item_id, &delta) else {
                         warn!("Received content delta for unknown message item {}", item_id);
                         continue;
@@ -4280,6 +4448,7 @@ async fn create_response_stream(
                     yield Ok(ResponseEvent::OutputItemAdded(reasoning_item_added).to_sse_event(&mut emitter).await);
                 }
                 StorageMessage::ReasoningDelta { item_id, delta } => {
+                    trace!("Client stream received reasoning delta bytes={}", delta.len());
                     let Some(output_index) = client_state.append_reasoning_delta(item_id, &delta) else {
                         warn!("Received reasoning delta for unknown item {}", item_id);
                         continue;

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -538,11 +538,12 @@ mod tests {
         finalize_first_model_tool_call, has_streamed_tool_call_entries, image_attachments,
         image_description_access, image_description_api_error,
         image_description_attempt_failure_class, maple_kagi_web_search_prompt,
-        model_turn_request_without_user_payload, resolve_responses_model,
-        resolve_responses_sampling, responses_pre_persistence_api_error, send_storage_message,
-        wait_for_response_cancellation, web_search_is_selected, web_search_tool_turn_limit,
-        web_search_tool_turn_limit_error, web_search_tool_turn_limit_reached, ClientResponseState,
-        ConversationParam, ImageAttachment, ImageDescriptionFailureClass, ImageDescriptionInput,
+        model_turn_request_without_user_payload, pin_responses_request_model,
+        resolve_responses_model, resolve_responses_sampling, responses_context_requires_rebuild,
+        responses_pre_persistence_api_error, send_storage_message, wait_for_response_cancellation,
+        web_search_is_selected, web_search_tool_turn_limit, web_search_tool_turn_limit_error,
+        web_search_tool_turn_limit_reached, ClientResponseState, ConversationParam,
+        ImageAttachment, ImageDescriptionFailureClass, ImageDescriptionInput,
         ImageDescriptionToolPair, InputMessage, MessageContent, MessageContentPart, MessageInput,
         PublicResponseFailure, ResponseExecutionPolicy, ResponsesCreateRequest, StorageMessage,
         StreamedToolCall, DEFAULT_RESPONSE_OUTPUT_TOKEN_BUDGET, MAX_RESPONSE_OUTPUT_TOKEN_BUDGET,
@@ -1051,6 +1052,40 @@ mod tests {
         );
         assert!(!serialized.contains("sensitive-image-bytes"));
         assert!(!serialized.contains("request metadata"));
+    }
+
+    #[test]
+    fn pinned_responses_model_drives_the_provider_body_and_model_defaults() {
+        let mut body = responses_request_for_model(crate::model_config::AUTO_POWERFUL_MODEL_ID);
+
+        pin_responses_request_model(&mut body, crate::model_config::POWERFUL_MODEL_ID);
+        let provider_body =
+            build_model_turn_request(&body, &[json!({"role": "user", "content": "hello"})], false);
+
+        assert_eq!(body.model, crate::model_config::POWERFUL_MODEL_ID);
+        assert_eq!(
+            provider_body["model"],
+            crate::model_config::POWERFUL_MODEL_ID
+        );
+        assert_eq!(
+            provider_body["chat_template_kwargs"]["preserve_thinking"],
+            true
+        );
+    }
+
+    #[test]
+    fn responses_context_rebuilds_for_images_or_auto_model_substitution() {
+        assert!(!responses_context_requires_rebuild(
+            "kimi-k3", "kimi-k3", false
+        ));
+        assert!(responses_context_requires_rebuild(
+            "kimi-k3", "kimi-k3", true
+        ));
+        assert!(responses_context_requires_rebuild(
+            "kimi-k3",
+            "kimi-k2-6",
+            false
+        ));
     }
 
     #[tokio::test]
@@ -1869,6 +1904,18 @@ fn model_turn_request_without_user_payload(
         metadata: None,
         stream: body.stream,
     }
+}
+
+fn pin_responses_request_model(body: &mut ResponsesCreateRequest, public_model_id: &str) {
+    body.model = public_model_id.to_string();
+}
+
+fn responses_context_requires_rebuild(
+    initially_resolved_model: &str,
+    pinned_model: &str,
+    completed_image_descriptions: bool,
+) -> bool {
+    completed_image_descriptions || pinned_model != initially_resolved_model
 }
 
 /// Immediate response returned when creating a new response
@@ -4525,7 +4572,8 @@ async fn create_response_stream(
             requested_model, resolved_model
         );
     }
-    body.model = resolved_model;
+    let initially_resolved_model = resolved_model;
+    body.model = initially_resolved_model.clone();
 
     trace!("Stream requested: {}", body.stream);
     let (input_kind, input_message_count) = match &body.input {
@@ -4579,9 +4627,33 @@ async fn create_response_stream(
         None => Vec::new(),
     };
 
-    // Rebuild with enough reserved room for the persisted descriptions so
-    // historical context can be truncated instead of rejecting a valid turn.
-    let context = if image_descriptions.is_empty() {
+    // Descriptor attempts are independent internal requests. Pin the user's
+    // main Responses route only after preprocessing so it observes the latest
+    // local routing state. Auto may select a different public model here; an
+    // explicit selection may only move between providers for the same model.
+    let inference_intent = InferenceIntent::new(
+        user.uuid,
+        requested_model,
+        initially_resolved_model.clone(),
+        model_plan,
+        InferenceSurface::Responses,
+        WorkloadClass::Interactive,
+    );
+    let pinned_completion = prepare_completion_request(&state, &user, inference_intent)
+        .await
+        .map_err(|error| {
+            responses_pre_persistence_api_error(error.into(), !image_descriptions.is_empty())
+        })?;
+    pin_responses_request_model(&mut body, pinned_completion.public_model_id());
+
+    // Rebuild for persisted descriptions and for Auto substitution so context
+    // truncation, tool-call normalization, billing, and model defaults all use
+    // the exact public model pinned for this logical request.
+    let context = if !responses_context_requires_rebuild(
+        &initially_resolved_model,
+        &body.model,
+        !image_descriptions.is_empty(),
+    ) {
         base_context
     } else {
         build_context_and_check_billing(
@@ -4595,23 +4667,6 @@ async fn create_response_stream(
         )
         .await?
     };
-
-    // Descriptor attempts are independent internal requests. Pin the user's
-    // main Responses route only after preprocessing so it observes the latest
-    // local routing state, then fail before persistence if no route is usable.
-    let inference_intent = InferenceIntent::new(
-        user.uuid,
-        requested_model,
-        body.model.clone(),
-        model_plan,
-        InferenceSurface::Responses,
-        WorkloadClass::Interactive,
-    );
-    let pinned_completion = prepare_completion_request(&state, &user, inference_intent)
-        .await
-        .map_err(|error| {
-            responses_pre_persistence_api_error(error.into(), !image_descriptions.is_empty())
-        })?;
 
     // Start only the first provider request before persistence. A recognized
     // capacity rejection at this seam proves that no response or user-message

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -23,10 +23,11 @@ use crate::{
     web::{
         encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
         openai::{
-            ensure_completion_model_access, get_chat_completion_response,
-            get_chat_completion_response_for_expected_route, prepare_completion_request,
-            BillingContext, CompletionChunk, CompletionExecutionError, PinnedCompletionRequest,
-            ServerSelectedCompletionRoute,
+            ensure_completion_model_access, finish_started_completion,
+            get_chat_completion_response, get_chat_completion_response_for_expected_route,
+            prepare_completion_request, start_chat_completion_response, BillingContext,
+            CompletionChunk, CompletionExecutionError, PinnedCompletionRequest,
+            ServerSelectedCompletionRoute, StartedCompletion,
         },
         openai_auth::AuthMethod,
         responses::{
@@ -45,7 +46,7 @@ use crate::{
             ResponseBuilder, ResponseEvent, SseEventEmitter,
         },
     },
-    ApiError, AppState,
+    ApiError, AppState, ERROR_CONTRACT_VERSION, INFERENCE_CAPACITY_ERROR_CODE,
 };
 use axum::{
     extract::{Path, State},
@@ -60,7 +61,7 @@ use axum::{
 };
 use base64::Engine;
 use chrono::Utc;
-use futures::Stream;
+use futures::{FutureExt, Stream};
 use secp256k1::SecretKey;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -70,13 +71,17 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::time::Instant as TokioInstant;
 use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
 
 const RESPONSES_SSE_KEEPALIVE_INTERVAL_SECS: u64 = 1;
 const MAX_WEB_SEARCH_TOOL_TURNS_FREE: usize = 5;
 const MAX_WEB_SEARCH_TOOL_TURNS_PAID: usize = 30;
+const DEFAULT_RESPONSE_OUTPUT_TOKEN_BUDGET: i32 = 4096;
+const MAX_RESPONSE_OUTPUT_TOKEN_BUDGET: i32 = 4096;
+const RESPONSE_EXECUTION_DEADLINE: Duration = Duration::from_secs(10 * 60);
 
 // Default functions for serde
 fn default_store() -> bool {
@@ -202,7 +207,128 @@ struct StreamedToolCall {
 #[derive(Debug, Clone)]
 enum AssistantTurnOutcome {
     ToolCall(ModelToolCall),
-    Final,
+    Final { finish_reason: String },
+}
+
+struct AssistantTurnResult {
+    outcome: AssistantTurnOutcome,
+    completion_tokens: i32,
+    completion_tokens_seen: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ResponseExecutionPolicy {
+    deadline: TokioInstant,
+    max_model_turns: usize,
+    max_tool_executions: usize,
+    output_token_budget: i32,
+}
+
+impl ResponseExecutionPolicy {
+    fn new(body: &ResponsesCreateRequest, model_plan: ModelPlan, tools_enabled: bool) -> Self {
+        let output_token_budget = body
+            .max_output_tokens
+            .unwrap_or(DEFAULT_RESPONSE_OUTPUT_TOKEN_BUDGET)
+            .clamp(1, MAX_RESPONSE_OUTPUT_TOKEN_BUDGET);
+        let max_tool_executions = if tools_enabled {
+            web_search_tool_turn_limit(model_plan)
+        } else {
+            0
+        };
+        let max_model_turns = if tools_enabled {
+            max_tool_executions + 2
+        } else {
+            1
+        };
+        Self {
+            deadline: TokioInstant::now() + RESPONSE_EXECUTION_DEADLINE,
+            max_model_turns,
+            max_tool_executions,
+            output_token_budget,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublicResponseFailure {
+    CapacityRateLimited,
+    CapacityOverloaded,
+    DeadlineExceeded,
+    Internal,
+}
+
+impl PublicResponseFailure {
+    fn from_completion_error(error: &CompletionExecutionError) -> Self {
+        match error.terminal() {
+            Some(AttemptTerminal::Failed { failure, .. })
+                if failure.kind == crate::inference::AttemptFailureKind::CapacityRejected =>
+            {
+                if failure.status == Some(429) {
+                    Self::CapacityRateLimited
+                } else {
+                    Self::CapacityOverloaded
+                }
+            }
+            _ => Self::Internal,
+        }
+    }
+
+    fn openai_code(self) -> &'static str {
+        match self {
+            Self::CapacityRateLimited => "rate_limit_exceeded",
+            Self::CapacityOverloaded | Self::DeadlineExceeded | Self::Internal => "server_error",
+        }
+    }
+
+    fn message(self) -> &'static str {
+        match self {
+            Self::CapacityRateLimited | Self::CapacityOverloaded => {
+                "Inference capacity is temporarily unavailable."
+            }
+            Self::DeadlineExceeded => "The response exceeded its execution deadline.",
+            Self::Internal => "The response could not be completed.",
+        }
+    }
+
+    fn contract_metadata(self) -> Option<OpenSecretResponseError> {
+        matches!(self, Self::CapacityRateLimited | Self::CapacityOverloaded).then_some(
+            OpenSecretResponseError {
+                error_contract: ERROR_CONTRACT_VERSION,
+                error_code: INFERENCE_CAPACITY_ERROR_CODE,
+            },
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResponseTerminal {
+    Completed { finish_reason: String },
+    Failed(PublicResponseFailure),
+    Cancelled,
+}
+
+impl ResponseTerminal {
+    pub(crate) fn status(&self) -> ResponseStatus {
+        match self {
+            Self::Completed { .. } => ResponseStatus::Completed,
+            Self::Failed(_) => ResponseStatus::Failed,
+            Self::Cancelled => ResponseStatus::Cancelled,
+        }
+    }
+}
+
+fn responses_pre_persistence_api_error(
+    error: CompletionExecutionError,
+    completed_image_descriptions: bool,
+) -> ApiError {
+    if completed_image_descriptions {
+        // Descriptor completions have already consumed provider capacity and
+        // published usage. The conversation is still cleanly replayable, but
+        // the whole HTTP request is not side-effect-free.
+        error.into_api_error()
+    } else {
+        error.into_pre_persistence_api_error()
+    }
 }
 
 fn web_search_is_selected(
@@ -406,19 +532,21 @@ mod tests {
         image_description_access, image_description_api_error,
         image_description_attempt_failure_class, maple_kagi_web_search_prompt,
         model_turn_request_without_user_payload, resolve_responses_model,
-        resolve_responses_sampling, wait_for_response_cancellation, web_search_is_selected,
-        web_search_tool_turn_limit, web_search_tool_turn_limit_error,
-        web_search_tool_turn_limit_reached, ClientResponseState, ConversationParam,
-        ImageAttachment, ImageDescriptionFailureClass, ImageDescriptionInput,
+        resolve_responses_sampling, responses_pre_persistence_api_error, send_storage_message,
+        wait_for_response_cancellation, web_search_is_selected, web_search_tool_turn_limit,
+        web_search_tool_turn_limit_error, web_search_tool_turn_limit_reached, ClientResponseState,
+        ConversationParam, ImageAttachment, ImageDescriptionFailureClass, ImageDescriptionInput,
         ImageDescriptionToolPair, InputMessage, MessageContent, MessageContentPart, MessageInput,
-        ResponsesCreateRequest, StorageMessage, StreamedToolCall, MAX_WEB_SEARCH_TOOL_TURNS_FREE,
-        MAX_WEB_SEARCH_TOOL_TURNS_PAID, READ_IMAGE_TOOL_NAME,
+        PublicResponseFailure, ResponseExecutionPolicy, ResponsesCreateRequest, StorageMessage,
+        StreamedToolCall, DEFAULT_RESPONSE_OUTPUT_TOKEN_BUDGET, MAX_RESPONSE_OUTPUT_TOKEN_BUDGET,
+        MAX_WEB_SEARCH_TOOL_TURNS_FREE, MAX_WEB_SEARCH_TOOL_TURNS_PAID, READ_IMAGE_TOOL_NAME,
     };
-    use crate::web::responses::tools;
+    use crate::web::responses::{constants::*, tools};
     use crate::{
         billing::{BillingClient, ChatBillingAccess},
         inference::{AttemptFailure, AttemptFailureKind, AttemptStage, ReplaySafety},
         model_config::{ModelAliasTargets, ModelPlan},
+        web::openai::CompletionExecutionError,
         ApiError,
     };
     use axum::{routing::get, Json, Router};
@@ -427,7 +555,7 @@ mod tests {
     use std::collections::HashMap;
     use tokio::{
         net::TcpListener,
-        sync::{broadcast, mpsc},
+        sync::broadcast,
         time::{timeout, Duration},
     };
     use uuid::Uuid;
@@ -454,6 +582,25 @@ mod tests {
             .expect("load billing access");
         server.abort();
         access
+    }
+
+    #[test]
+    fn completed_image_descriptions_suppress_request_replay_safety() {
+        for (completed_image_descriptions, expected_replay_safe) in [(false, true), (true, false)] {
+            let error = CompletionExecutionError::from(ApiError::InferenceCapacity {
+                status: axum::http::StatusCode::TOO_MANY_REQUESTS,
+                retry_after: Some(Duration::from_secs(7)),
+                client_replay_safe: false,
+            });
+
+            assert!(matches!(
+                responses_pre_persistence_api_error(error, completed_image_descriptions),
+                ApiError::InferenceCapacity {
+                    client_replay_safe,
+                    ..
+                } if client_replay_safe == expected_replay_safe
+            ));
+        }
     }
 
     fn test_image_attachment() -> ImageAttachment {
@@ -576,10 +723,12 @@ mod tests {
         match &client_messages[0] {
             StorageMessage::ToolCall {
                 tool_call_id: actual_id,
+                tool_output_id: actual_output_id,
                 name,
                 arguments: actual_arguments,
             } => {
                 assert_eq!(*actual_id, tool_call_id);
+                assert_eq!(*actual_output_id, tool_output_id);
                 assert_eq!(name, READ_IMAGE_TOOL_NAME);
                 assert_eq!(actual_arguments, &arguments);
             }
@@ -885,44 +1034,107 @@ mod tests {
         let response_uuid = Uuid::new_v4();
         let unrelated_uuid = Uuid::new_v4();
         let (cancel_tx, cancel_rx) = broadcast::channel(8);
-        let (storage_tx, mut storage_rx) = mpsc::channel(2);
-        let (client_tx, mut client_rx) = mpsc::channel(2);
-
-        let listener = tokio::spawn(wait_for_response_cancellation(
-            response_uuid,
-            cancel_rx,
-            storage_tx,
-            client_tx,
-        ));
+        let mut listener = tokio::spawn(wait_for_response_cancellation(response_uuid, cancel_rx));
 
         cancel_tx.send(unrelated_uuid).unwrap();
         assert!(
-            timeout(Duration::from_millis(25), storage_rx.recv())
+            timeout(Duration::from_millis(25), &mut listener)
                 .await
                 .is_err(),
-            "unrelated cancellation should not emit a storage cancellation"
-        );
-        assert!(
-            timeout(Duration::from_millis(25), client_rx.recv())
-                .await
-                .is_err(),
-            "unrelated cancellation should not emit a client cancellation"
-        );
-        assert!(
-            !listener.is_finished(),
             "listener should continue after unrelated cancellation"
         );
 
         cancel_tx.send(response_uuid).unwrap();
+        timeout(Duration::from_secs(1), &mut listener)
+            .await
+            .expect("matching cancellation should finish listener")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancelled_fanout_does_not_commit_to_only_one_channel() {
+        let (tx_storage, mut rx_storage) = tokio::sync::mpsc::channel(1);
+        let (tx_client, mut rx_client) = tokio::sync::mpsc::channel(1);
+        tx_client
+            .send(StorageMessage::Usage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+            })
+            .await
+            .unwrap();
+
+        let mut fanout = tokio::spawn(async move {
+            send_storage_message(
+                &tx_storage,
+                &tx_client,
+                StorageMessage::Usage {
+                    prompt_tokens: 2,
+                    completion_tokens: 2,
+                },
+            )
+            .await
+        });
+        tokio::task::yield_now().await;
+        assert!(timeout(Duration::from_millis(25), &mut fanout)
+            .await
+            .is_err());
+        fanout.abort();
+        let _ = fanout.await;
+
+        assert!(rx_storage.try_recv().is_err());
         assert!(matches!(
-            storage_rx.recv().await,
-            Some(StorageMessage::Cancelled)
+            rx_client.recv().await,
+            Some(StorageMessage::Usage {
+                prompt_tokens: 1,
+                completion_tokens: 1
+            })
         ));
-        assert!(matches!(
-            client_rx.recv().await,
-            Some(StorageMessage::Cancelled)
-        ));
-        listener.await.unwrap();
+        assert!(rx_client.try_recv().is_err());
+    }
+
+    #[test]
+    fn response_execution_policy_hard_bounds_turns_tools_and_output() {
+        let mut body = responses_request_for_model("llama3-3-70b");
+        body.max_output_tokens = None;
+        let free = ResponseExecutionPolicy::new(&body, ModelPlan::Free, true);
+        assert_eq!(free.max_tool_executions, MAX_WEB_SEARCH_TOOL_TURNS_FREE);
+        assert_eq!(free.max_model_turns, MAX_WEB_SEARCH_TOOL_TURNS_FREE + 2);
+        assert_eq!(
+            free.output_token_budget,
+            DEFAULT_RESPONSE_OUTPUT_TOKEN_BUDGET
+        );
+
+        body.max_output_tokens = Some(i32::MAX);
+        let paid = ResponseExecutionPolicy::new(&body, ModelPlan::Paid, true);
+        assert_eq!(paid.max_tool_executions, MAX_WEB_SEARCH_TOOL_TURNS_PAID);
+        assert_eq!(paid.max_model_turns, MAX_WEB_SEARCH_TOOL_TURNS_PAID + 2);
+        assert_eq!(paid.output_token_budget, MAX_RESPONSE_OUTPUT_TOKEN_BUDGET);
+
+        body.max_output_tokens = Some(-5);
+        let no_tools = ResponseExecutionPolicy::new(&body, ModelPlan::Paid, false);
+        assert_eq!(no_tools.max_tool_executions, 0);
+        assert_eq!(no_tools.max_model_turns, 1);
+        assert_eq!(no_tools.output_token_budget, 1);
+    }
+
+    #[test]
+    fn only_capacity_failures_expose_opensecret_terminal_metadata() {
+        let rate_limit = PublicResponseFailure::CapacityRateLimited;
+        assert_eq!(rate_limit.openai_code(), "rate_limit_exceeded");
+        let metadata = rate_limit.contract_metadata().unwrap();
+        assert_eq!(metadata.error_contract, "1");
+        assert_eq!(metadata.error_code, "inference_capacity");
+
+        assert_eq!(
+            PublicResponseFailure::CapacityOverloaded.openai_code(),
+            "server_error"
+        );
+        assert!(PublicResponseFailure::Internal
+            .contract_metadata()
+            .is_none());
+        assert!(PublicResponseFailure::DeadlineExceeded
+            .contract_metadata()
+            .is_none());
     }
 
     #[test]
@@ -1483,6 +1695,27 @@ mod tests {
             Some(tool_call_id_str.as_str())
         );
     }
+
+    #[test]
+    fn client_response_state_marks_only_done_items_completed() {
+        let mut state = ClientResponseState::default();
+        let message_id = Uuid::new_v4();
+        let reasoning_id = Uuid::new_v4();
+
+        state.push_message(message_id);
+        state.push_reasoning(reasoning_id);
+
+        let output_items = state.build_output_items();
+        assert_eq!(output_items[0].status, STATUS_INCOMPLETE);
+        assert_eq!(output_items[1].status, STATUS_INCOMPLETE);
+
+        assert!(state.mark_message_completed(message_id));
+        assert!(state.mark_reasoning_completed(reasoning_id));
+
+        let output_items = state.build_output_items();
+        assert_eq!(output_items[0].status, STATUS_COMPLETED);
+        assert_eq!(output_items[1].status, STATUS_COMPLETED);
+    }
 }
 
 /// Conversation parameter - can be a string UUID or an object with id field
@@ -1768,9 +2001,8 @@ pub struct OutputItem {
 /// Response error structure
 #[derive(Debug, Clone, Serialize)]
 pub struct ResponseError {
-    /// Error type
-    #[serde(rename = "type")]
-    pub error_type: String,
+    /// OpenAI-compatible stable error code
+    pub code: String,
 
     /// Error message
     pub message: String,
@@ -1830,15 +2062,21 @@ pub struct ResponseCompletedEvent {
     pub sequence_number: i32,
 }
 
-/// SSE Event wrapper for response.error
+/// SSE Event wrapper for the standard response.failed terminal.
 #[derive(Debug, Clone, Serialize)]
-pub struct ResponseErrorEvent {
-    /// Event type (always "response.error")
+pub struct ResponseFailedEvent {
     #[serde(rename = "type")]
     pub event_type: &'static str,
+    pub response: ResponsesCreateResponse,
+    pub sequence_number: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub opensecret: Option<OpenSecretResponseError>,
+}
 
-    /// The error information
-    pub error: ResponseError,
+#[derive(Debug, Clone, Serialize)]
+pub struct OpenSecretResponseError {
+    pub error_contract: &'static str,
+    pub error_code: &'static str,
 }
 
 /// SSE Event wrapper for response.cancelled
@@ -2190,14 +2428,11 @@ pub enum StorageMessage {
         prompt_tokens: i32,
         completion_tokens: i32,
     },
-    ResponseDone {
-        finish_reason: String,
-    },
-    Error(String),
-    Cancelled,
+    Terminal(ResponseTerminal),
     /// Tool-related messages
     ToolCall {
         tool_call_id: Uuid,
+        tool_output_id: Uuid,
         name: String,
         arguments: Value,
     },
@@ -2213,10 +2448,12 @@ enum StreamOutputItemRecord {
     Message {
         id: Uuid,
         text: String,
+        completed: bool,
     },
     Reasoning {
         id: Uuid,
         text: String,
+        completed: bool,
     },
     ToolCall {
         id: Uuid,
@@ -2243,6 +2480,7 @@ impl ClientResponseState {
         self.items.push(StreamOutputItemRecord::Message {
             id: item_id,
             text: String::new(),
+            completed: false,
         });
         self.indices.insert(item_id, output_index);
         output_index as i32
@@ -2253,6 +2491,7 @@ impl ClientResponseState {
         self.items.push(StreamOutputItemRecord::Reasoning {
             id: item_id,
             text: String::new(),
+            completed: false,
         });
         self.indices.insert(item_id, output_index);
         output_index as i32
@@ -2326,14 +2565,49 @@ impl ClientResponseState {
         }
     }
 
+    fn mark_message_completed(&mut self, item_id: Uuid) -> bool {
+        let Some(index) = self.indices.get(&item_id).copied() else {
+            return false;
+        };
+        match self.items.get_mut(index) {
+            Some(StreamOutputItemRecord::Message { completed, .. }) => {
+                *completed = true;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn mark_reasoning_completed(&mut self, item_id: Uuid) -> bool {
+        let Some(index) = self.indices.get(&item_id).copied() else {
+            return false;
+        };
+        match self.items.get_mut(index) {
+            Some(StreamOutputItemRecord::Reasoning { completed, .. }) => {
+                *completed = true;
+                true
+            }
+            _ => false,
+        }
+    }
+
     fn build_output_items(&self) -> Vec<OutputItem> {
         self.items
             .iter()
             .map(|item| match item {
-                StreamOutputItemRecord::Message { id, text } => OutputItem {
+                StreamOutputItemRecord::Message {
+                    id,
+                    text,
+                    completed,
+                } => OutputItem {
                     id: id.to_string(),
                     output_type: OUTPUT_TYPE_MESSAGE.to_string(),
-                    status: STATUS_COMPLETED.to_string(),
+                    status: if *completed {
+                        STATUS_COMPLETED
+                    } else {
+                        STATUS_INCOMPLETE
+                    }
+                    .to_string(),
                     role: Some(ROLE_ASSISTANT.to_string()),
                     content: Some(vec![
                         ContentPartBuilder::new_output_text(text.clone()).build()
@@ -2343,10 +2617,15 @@ impl ClientResponseState {
                     arguments: None,
                     output: None,
                 },
-                StreamOutputItemRecord::Reasoning { id, .. } => OutputItem {
+                StreamOutputItemRecord::Reasoning { id, completed, .. } => OutputItem {
                     id: id.to_string(),
                     output_type: "reasoning".to_string(),
-                    status: STATUS_COMPLETED.to_string(),
+                    status: if *completed {
+                        STATUS_COMPLETED
+                    } else {
+                        STATUS_INCOMPLETE
+                    }
+                    .to_string(),
                     role: None,
                     content: Some(vec![]),
                     call_id: None,
@@ -2448,6 +2727,7 @@ impl ImageDescriptionToolPair {
         [
             StorageMessage::ToolCall {
                 tool_call_id: self.tool_call_id,
+                tool_output_id: self.tool_output_id,
                 name: READ_IMAGE_TOOL_NAME.to_string(),
                 arguments: self.arguments.clone(),
             },
@@ -3167,6 +3447,7 @@ async fn persist_request_data(
     body: &ResponsesCreateRequest,
     prepared: &PreparedRequest,
     conversation: &crate::models::responses::Conversation,
+    response_uuid: Uuid,
     image_descriptions: &[ImageDescriptionToolPair],
 ) -> Result<PersistedData, ApiError> {
     use crate::models::responses::{NewResponse, ResponseStatus};
@@ -3204,7 +3485,7 @@ async fn persist_request_data(
 
     // Create the Response (job tracker)
     let new_response = NewResponse {
-        uuid: Uuid::new_v4(),
+        uuid: response_uuid,
         user_id: user.uuid,
         conversation_id: conversation.id,
         status: ResponseStatus::InProgress,
@@ -3217,7 +3498,8 @@ async fn persist_request_data(
         store: body.store,
         metadata_enc: metadata_enc.clone(),
     };
-    // Create the simplified user message with extracted UUID.
+    // Create the simplified user message with extracted UUID. The database
+    // fills its response_id from the response inserted in the same transaction.
     let new_msg = NewUserMessage {
         uuid: message_uuid,
         conversation_id: conversation.id,
@@ -3226,7 +3508,6 @@ async fn persist_request_data(
         content_enc: prepared.content_enc.clone(),
         prompt_tokens: prepared.user_message_tokens,
     };
-
     let mut new_tool_items = Vec::with_capacity(image_descriptions.len());
     for pair in image_descriptions {
         let arguments_json = serde_json::to_string(&pair.arguments).map_err(|e| {
@@ -3338,28 +3619,19 @@ async fn execute_tool_call_and_wait(
 
     let tool_call_msg = StorageMessage::ToolCall {
         tool_call_id,
+        tool_output_id,
         name: tool_call.name.clone(),
         arguments: tool_call.arguments.clone(),
     };
 
-    if let Err(e) = tx_storage.send(tool_call_msg.clone()).await {
-        error!(
-            "Critical: Storage channel closed during tool_call for response {} - {:?}",
-            persisted.response.uuid, e
-        );
-        let _ = tx_client
-            .send(StorageMessage::Error(
-                "Internal storage failure - request aborted".to_string(),
-            ))
-            .await;
-        return Err(ApiError::InternalServerError);
-    }
-    if tx_client.try_send(tool_call_msg).is_err() {
-        warn!(
-            "Client channel full or closed, skipping tool_call {} for response {}",
-            tool_call_id, persisted.response.uuid
-        );
-    }
+    send_storage_message(tx_storage, tx_client, tool_call_msg)
+        .await
+        .inspect_err(|_| {
+            error!(
+                "Failed to fan out tool_call for response {}",
+                persisted.response.uuid
+            );
+        })?;
     debug!(
         "Tool loop: enqueued tool_call {} ({}) for response {} in {} ms",
         tool_call_id,
@@ -3418,24 +3690,14 @@ async fn execute_tool_call_and_wait(
         output: tool_output,
     };
 
-    if let Err(e) = tx_storage.send(tool_output_msg.clone()).await {
-        error!(
-            "Critical: Storage channel closed during tool_output for response {} - {:?}",
-            persisted.response.uuid, e
-        );
-        let _ = tx_client
-            .send(StorageMessage::Error(
-                "Internal storage failure - request aborted".to_string(),
-            ))
-            .await;
-        return Err(ApiError::InternalServerError);
-    }
-    if tx_client.try_send(tool_output_msg).is_err() {
-        warn!(
-            "Client channel full or closed, skipping tool_output {} for tool_call {} on response {}",
-            tool_output_id, tool_call_id, persisted.response.uuid
-        );
-    }
+    send_storage_message(tx_storage, tx_client, tool_output_msg)
+        .await
+        .inspect_err(|_| {
+            error!(
+                "Failed to fan out tool_output for response {}",
+                persisted.response.uuid
+            );
+        })?;
     debug!(
         "Tool loop: enqueued tool_output {} for tool_call {} on response {} in {} ms",
         tool_output_id,
@@ -3481,13 +3743,19 @@ async fn send_storage_message(
     tx_client: &mpsc::Sender<StorageMessage>,
     msg: StorageMessage,
 ) -> Result<(), ApiError> {
-    if tx_storage.send(msg.clone()).await.is_err() {
+    // Reserve both bounded queues before committing either copy. If this
+    // future is cancelled while backpressured, the acquired permit is dropped
+    // and neither observer crosses a partial event boundary.
+    let storage_permit = tx_storage.reserve().await.map_err(|_| {
         error!("Storage channel closed unexpectedly");
-        return Err(ApiError::InternalServerError);
-    }
-    if tx_client.try_send(msg).is_err() {
-        warn!("Client channel full or closed");
-    }
+        ApiError::InternalServerError
+    })?;
+    let client_permit = tx_client.reserve().await.map_err(|_| {
+        debug!("Client channel closed while streaming response data");
+        ApiError::InternalServerError
+    })?;
+    storage_permit.send(msg.clone());
+    client_permit.send(msg);
     Ok(())
 }
 
@@ -3561,7 +3829,7 @@ async fn ensure_message_started(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn stream_one_assistant_turn(
+async fn start_responses_assistant_turn(
     state: &Arc<AppState>,
     user: &User,
     body: &ResponsesCreateRequest,
@@ -3569,15 +3837,15 @@ async fn stream_one_assistant_turn(
     headers: &HeaderMap,
     prompt_messages: &[Value],
     tools_enabled: bool,
-    tx_client: &mpsc::Sender<StorageMessage>,
-    tx_storage: &mpsc::Sender<StorageMessage>,
-    next_message_id: &mut Option<Uuid>,
     response_uuid: Uuid,
     conversation_uuid: Uuid,
     tool_turn_count: usize,
     prompt_token_estimate: usize,
-) -> Result<AssistantTurnOutcome, ApiError> {
-    let mut chat_request = build_model_turn_request(body, prompt_messages, tools_enabled);
+    max_output_tokens: i32,
+) -> Result<StartedCompletion, CompletionExecutionError> {
+    let mut turn_body = body.clone();
+    turn_body.max_output_tokens = Some(max_output_tokens);
+    let mut chat_request = build_model_turn_request(&turn_body, prompt_messages, tools_enabled);
 
     let chat_request_bytes = serde_json::to_vec(&chat_request)
         .map(|bytes| bytes.len())
@@ -3601,7 +3869,7 @@ async fn stream_one_assistant_turn(
         pinned_completion.intent().requested_model_id.clone(),
     );
 
-    let mut completion = get_chat_completion_response(
+    start_chat_completion_response(
         state,
         user,
         chat_request.take(),
@@ -3610,7 +3878,22 @@ async fn stream_one_assistant_turn(
         pinned_completion,
     )
     .await
-    .map_err(CompletionExecutionError::into_api_error)?;
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn stream_one_assistant_turn(
+    state: &Arc<AppState>,
+    user: &User,
+    started: StartedCompletion,
+    tools_enabled: bool,
+    tx_client: &mpsc::Sender<StorageMessage>,
+    tx_storage: &mpsc::Sender<StorageMessage>,
+    next_message_id: &mut Option<Uuid>,
+    response_uuid: Uuid,
+) -> Result<AssistantTurnResult, ApiError> {
+    let mut completion = finish_started_completion(state, user, started)
+        .await
+        .map_err(CompletionExecutionError::into_api_error)?;
 
     debug!(
         "Received Responses completion stream: request_id={}, execution_id={}, attempt_id={}, provider={}, model={}",
@@ -3627,6 +3910,8 @@ async fn stream_one_assistant_turn(
     let mut reasoning = ReasoningState::NotStarted;
     let mut saw_tool_calls = false;
     let mut ignored_disabled_tool_calls = false;
+    let mut completion_tokens = 0i32;
+    let mut completion_tokens_seen = false;
 
     while let Some(chunk) = completion.stream.recv().await {
         match chunk {
@@ -3768,6 +4053,8 @@ async fn stream_one_assistant_turn(
                 }
             }
             crate::web::openai::CompletionChunk::Usage(usage) => {
+                completion_tokens_seen |= usage.completion_tokens_observed;
+                completion_tokens = completion_tokens.saturating_add(usage.completion_tokens);
                 send_storage_message(
                     tx_storage,
                     tx_client,
@@ -3794,7 +4081,11 @@ async fn stream_one_assistant_turn(
                     );
                     let tool_call = finalize_first_model_tool_call(&streamed_tool_calls)
                         .ok_or(ApiError::InternalServerError)?;
-                    return Ok(AssistantTurnOutcome::ToolCall(tool_call));
+                    return Ok(AssistantTurnResult {
+                        outcome: AssistantTurnOutcome::ToolCall(tool_call),
+                        completion_tokens,
+                        completion_tokens_seen,
+                    });
                 }
 
                 // Ensure a final message item exists even if the model emitted no content.
@@ -3832,15 +4123,13 @@ async fn stream_one_assistant_turn(
                 )
                 .await?;
 
-                send_storage_message(
-                    tx_storage,
-                    tx_client,
-                    StorageMessage::ResponseDone {
+                return Ok(AssistantTurnResult {
+                    outcome: AssistantTurnOutcome::Final {
                         finish_reason: final_finish_reason,
                     },
-                )
-                .await?;
-                return Ok(AssistantTurnOutcome::Final);
+                    completion_tokens,
+                    completion_tokens_seen,
+                });
             }
             crate::web::openai::CompletionChunk::Terminal(AttemptTerminal::Failed {
                 failure,
@@ -3883,17 +4172,37 @@ async fn setup_completion_processor(
     tx_client: mpsc::Sender<StorageMessage>,
     tx_storage: mpsc::Sender<StorageMessage>,
     mut rx_tool_ack: mpsc::Receiver<Result<(), String>>,
-) -> Result<crate::models::responses::Response, ApiError> {
-    let tools_enabled = context.web_search_enabled;
+    first_started: StartedCompletion,
+    execution_policy: ResponseExecutionPolicy,
+) -> ResponseTerminal {
+    let tools_requested = context.web_search_enabled;
     let mut prompt_messages = Arc::as_ref(&context.prompt_messages).clone();
     let mut prompt_token_estimate = context.total_prompt_tokens;
     let mut kagi_allowed_urls = tools::collect_kagi_allowed_urls_from_prompt(&prompt_messages);
+    let mut next_message_id = Some(assistant_message_id);
+    let mut tool_turn_count = 0usize;
+    let mut model_turn_count = 0usize;
+    let mut remaining_output_tokens = execution_policy.output_token_budget;
+    let mut force_final_without_tools = false;
+    let mut first_started = Some(first_started);
 
-    let loop_result: Result<(), ApiError> = async {
-        let mut next_message_id = Some(assistant_message_id);
-        let mut tool_turn_count = 0usize;
-        loop {
-            match stream_one_assistant_turn(
+    loop {
+        if model_turn_count >= execution_policy.max_model_turns || remaining_output_tokens <= 0 {
+            warn!(
+                "Responses execution budget exhausted: response_uuid={}, model_turns={}, max_model_turns={}, remaining_output_tokens={}",
+                persisted.response.uuid,
+                model_turn_count,
+                execution_policy.max_model_turns,
+                remaining_output_tokens
+            );
+            return ResponseTerminal::Failed(PublicResponseFailure::Internal);
+        }
+        model_turn_count += 1;
+        let tools_enabled = tools_requested && !force_final_without_tools;
+
+        let started = match first_started.take() {
+            Some(started) => started,
+            None => match start_responses_assistant_turn(
                 state,
                 user,
                 body,
@@ -3901,71 +4210,114 @@ async fn setup_completion_processor(
                 headers,
                 &prompt_messages,
                 tools_enabled,
-                &tx_client,
-                &tx_storage,
-                &mut next_message_id,
                 persisted.response.uuid,
                 context.conversation.uuid,
                 tool_turn_count,
                 prompt_token_estimate,
+                remaining_output_tokens,
             )
-            .await?
+            .await
             {
-                AssistantTurnOutcome::ToolCall(tool_call) => {
-                    debug!(
-                        "Tool loop: assistant turn requested tool {} for response {}",
-                        tool_call.name, persisted.response.uuid
+                Ok(started) => started,
+                Err(error) => {
+                    let failure = PublicResponseFailure::from_completion_error(&error);
+                    error!(
+                        "Responses provider start failed after persistence: response_uuid={}, failure={:?}",
+                        persisted.response.uuid, failure
                     );
-
-                    tool_turn_count += 1;
-                    execute_tool_call_and_wait(
-                        state,
-                        persisted,
-                        tool_call,
-                        &tx_client,
-                        &tx_storage,
-                        &mut rx_tool_ack,
-                        &mut kagi_allowed_urls,
-                        tool_turn_count,
-                        model_plan,
-                    )
-                    .await?;
-
-                    let internal_system_prompt =
-                        build_internal_system_prompt(tools_enabled, model_plan);
-                    let (rebuilt_messages, rebuilt_tokens) = build_prompt(
-                        state.db.as_ref(),
-                        context.conversation.id,
-                        user.uuid,
-                        user_key,
-                        &body.model,
-                        body.instructions.as_deref(),
-                        Some(&internal_system_prompt),
-                    )?;
-                    prompt_messages = rebuilt_messages;
-                    prompt_token_estimate = rebuilt_tokens;
+                    return ResponseTerminal::Failed(failure);
                 }
-                AssistantTurnOutcome::Final => return Ok(()),
+            },
+        };
+
+        let turn = match stream_one_assistant_turn(
+            state,
+            user,
+            started,
+            tools_enabled,
+            &tx_client,
+            &tx_storage,
+            &mut next_message_id,
+            persisted.response.uuid,
+        )
+        .await
+        {
+            Ok(turn) => turn,
+            Err(_) => return ResponseTerminal::Failed(PublicResponseFailure::Internal),
+        };
+
+        let turn_completion_tokens = turn.completion_tokens.max(0);
+        if turn_completion_tokens > remaining_output_tokens {
+            warn!(
+                "Provider exceeded Responses output budget: response_uuid={}, observed={}, remaining={}",
+                persisted.response.uuid, turn_completion_tokens, remaining_output_tokens
+            );
+            return ResponseTerminal::Failed(PublicResponseFailure::Internal);
+        }
+        remaining_output_tokens -= turn_completion_tokens;
+
+        match turn.outcome {
+            AssistantTurnOutcome::ToolCall(tool_call) => {
+                if !turn.completion_tokens_seen {
+                    warn!(
+                        "Responses tool turn omitted completion-token usage; failing closed: response_uuid={}",
+                        persisted.response.uuid
+                    );
+                    return ResponseTerminal::Failed(PublicResponseFailure::Internal);
+                }
+
+                debug!(
+                    "Tool loop: assistant turn requested tool {} for response {}",
+                    tool_call.name, persisted.response.uuid
+                );
+                tool_turn_count += 1;
+                if execute_tool_call_and_wait(
+                    state,
+                    persisted,
+                    tool_call,
+                    &tx_client,
+                    &tx_storage,
+                    &mut rx_tool_ack,
+                    &mut kagi_allowed_urls,
+                    tool_turn_count,
+                    model_plan,
+                )
+                .await
+                .is_err()
+                {
+                    return ResponseTerminal::Failed(PublicResponseFailure::Internal);
+                }
+                if tool_turn_count > execution_policy.max_tool_executions {
+                    force_final_without_tools = true;
+                }
+
+                let internal_system_prompt =
+                    build_internal_system_prompt(tools_requested, model_plan);
+                let (rebuilt_messages, rebuilt_tokens) = match build_prompt(
+                    state.db.as_ref(),
+                    context.conversation.id,
+                    user.uuid,
+                    user_key,
+                    &body.model,
+                    body.instructions.as_deref(),
+                    Some(&internal_system_prompt),
+                ) {
+                    Ok(prompt) => prompt,
+                    Err(_) => return ResponseTerminal::Failed(PublicResponseFailure::Internal),
+                };
+                prompt_messages = rebuilt_messages;
+                prompt_token_estimate = rebuilt_tokens;
+            }
+            AssistantTurnOutcome::Final { finish_reason } => {
+                return ResponseTerminal::Completed { finish_reason };
             }
         }
     }
-    .await;
-
-    if let Err(e) = loop_result {
-        let msg = StorageMessage::Error(format!("Streaming failed: {:?}", e));
-        let _ = tx_storage.send(msg.clone()).await;
-        let _ = tx_client.try_send(msg);
-        return Err(e);
-    }
-
-    Ok(persisted.response.clone())
 }
 
 async fn wait_for_response_cancellation(
     response_uuid: Uuid,
     mut cancel_rx: broadcast::Receiver<Uuid>,
-    tx_storage: mpsc::Sender<StorageMessage>,
-    tx_client: mpsc::Sender<StorageMessage>,
 ) {
     loop {
         match cancel_rx.recv().await {
@@ -3975,10 +4327,7 @@ async fn wait_for_response_cancellation(
                     response_uuid
                 );
 
-                let _ = tx_storage.send(StorageMessage::Cancelled).await;
-                let _ = tx_client.send(StorageMessage::Cancelled).await;
-
-                trace!("Orchestrator: Cancellation handled, exiting");
+                trace!("Orchestrator: Cancellation selected by supervisor");
                 return;
             }
             Ok(cancelled_id) => {
@@ -4003,6 +4352,115 @@ async fn wait_for_response_cancellation(
             }
         }
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn supervise_response_execution(
+    state: Arc<AppState>,
+    user: User,
+    body: ResponsesCreateRequest,
+    pinned_completion: PinnedCompletionRequest,
+    model_plan: ModelPlan,
+    context: BuiltContext,
+    user_key: SecretKey,
+    assistant_message_id: Uuid,
+    persisted: PersistedData,
+    headers: HeaderMap,
+    tx_client: mpsc::Sender<StorageMessage>,
+    tx_storage: mpsc::Sender<StorageMessage>,
+    rx_tool_ack: mpsc::Receiver<Result<(), String>>,
+    terminal_ack: oneshot::Receiver<Result<Option<ResponseTerminal>, String>>,
+    cancel_rx: broadcast::Receiver<Uuid>,
+    first_started: StartedCompletion,
+    execution_policy: ResponseExecutionPolicy,
+) {
+    let response_uuid = persisted.response.uuid;
+    let requested_terminal = {
+        let worker = std::panic::AssertUnwindSafe(setup_completion_processor(
+            &state,
+            &user,
+            &body,
+            &pinned_completion,
+            model_plan,
+            &context,
+            &user_key,
+            assistant_message_id,
+            &persisted,
+            &headers,
+            tx_client.clone(),
+            tx_storage.clone(),
+            rx_tool_ack,
+            first_started,
+            execution_policy,
+        ))
+        .catch_unwind();
+        tokio::pin!(worker);
+
+        tokio::select! {
+            biased;
+            _ = wait_for_response_cancellation(response_uuid, cancel_rx) => {
+                ResponseTerminal::Cancelled
+            }
+            _ = tx_client.closed() => {
+                warn!("Responses client disconnected: response_uuid={}", response_uuid);
+                ResponseTerminal::Failed(PublicResponseFailure::Internal)
+            }
+            _ = tokio::time::sleep_until(execution_policy.deadline) => {
+                warn!("Responses execution deadline reached: response_uuid={}", response_uuid);
+                ResponseTerminal::Failed(PublicResponseFailure::DeadlineExceeded)
+            }
+            result = &mut worker => match result {
+                Ok(terminal) => terminal,
+                Err(_) => {
+                    error!("Responses execution worker panicked: response_uuid={}", response_uuid);
+                    ResponseTerminal::Failed(PublicResponseFailure::Internal)
+                }
+            },
+        }
+    };
+
+    if tx_storage
+        .send(StorageMessage::Terminal(requested_terminal))
+        .await
+        .is_err()
+    {
+        error!(
+            "Storage task closed before terminal persistence: response_uuid={}",
+            response_uuid
+        );
+        return;
+    }
+
+    let authoritative = match terminal_ack.await {
+        Ok(Ok(Some(terminal))) => terminal,
+        Ok(Ok(None)) => {
+            debug!(
+                "Response was deleted before terminal persistence completed: response_uuid={}",
+                response_uuid
+            );
+            return;
+        }
+        Ok(Err(e)) => {
+            error!(
+                "Storage task could not verify terminal persistence: response_uuid={}, error={}",
+                response_uuid, e
+            );
+            return;
+        }
+        Err(_) => {
+            error!(
+                "Storage task dropped terminal acknowledgement: response_uuid={}",
+                response_uuid
+            );
+            return;
+        }
+    };
+
+    // This is the sole client-terminal writer. Awaiting the send preserves all
+    // preceding data under backpressure while the stream remains connected.
+    let _ = tx_client
+        .send(StorageMessage::Terminal(authoritative))
+        .await;
 }
 
 async fn create_response_stream(
@@ -4127,6 +4585,32 @@ async fn create_response_stream(
     );
     let pinned_completion = prepare_completion_request(&state, &user, inference_intent).await?;
 
+    // Start only the first provider request before persistence. A recognized
+    // capacity rejection at this seam proves that no response or user-message
+    // row exists yet, so the caller may safely replay the identical request.
+    // A successful response body remains untouched until Phase 3 commits.
+    let execution_policy =
+        ResponseExecutionPolicy::new(&body, model_plan, context.web_search_enabled);
+    body.max_output_tokens = Some(execution_policy.output_token_budget);
+    let response_uuid = Uuid::new_v4();
+    let model_turn_body = model_turn_request_without_user_payload(&body);
+    let first_started = start_responses_assistant_turn(
+        &state,
+        &user,
+        &model_turn_body,
+        &pinned_completion,
+        &headers,
+        context.prompt_messages.as_ref(),
+        context.web_search_enabled,
+        response_uuid,
+        context.conversation.uuid,
+        0,
+        context.total_prompt_tokens,
+        execution_policy.output_token_budget,
+    )
+    .await
+    .map_err(|error| responses_pre_persistence_api_error(error, !image_descriptions.is_empty()))?;
+
     // Phase 3: Persist request data
     let persisted = persist_request_data(
         &state,
@@ -4134,11 +4618,13 @@ async fn create_response_stream(
         &body,
         &prepared,
         &context.conversation,
+        response_uuid,
         &image_descriptions,
     )
     .await?;
 
-    // Check if first message and spawn title generation task
+    // Capture stream and title data before moving execution state into the
+    // supervisor task.
     let (user_count, assistant_count) =
         context
             .prompt_messages
@@ -4153,29 +4639,23 @@ async fn create_response_stream(
                 }
             });
 
-    if user_count == 1 && assistant_count == 0 {
-        let user_content =
-            MessageContentConverter::extract_text_for_token_counting(&prepared.message_content);
-        spawn_title_generation_task(
-            state.clone(),
+    let title_request = (user_count == 1 && assistant_count == 0).then(|| {
+        (
             context.conversation.id,
             context.conversation.uuid,
-            user.clone(),
             prepared.user_key,
-            user_content,
+            MessageContentConverter::extract_text_for_token_counting(&prepared.message_content),
         )
-        .await;
-    }
-
-    // Capture variables needed inside the stream
+    });
+    let assistant_message_id = prepared.assistant_message_id;
     let response_for_stream = persisted.response.clone();
     let decrypted_metadata = persisted.decrypted_metadata.clone();
-    let assistant_message_id = prepared.assistant_message_id;
     let total_prompt_tokens = context.total_prompt_tokens;
     let response_id = persisted.response.id;
     let response_uuid = persisted.response.uuid;
     // Persist all generated response items on a single monotonic timestamp sequence that
-    // begins immediately after the user message so retrieval order matches stream order.
+    // begins immediately after the last durable request item so retrieval order matches stream
+    // order even when read_image call/output pairs were persisted with the user message.
     let first_response_item_created_at = persisted
         .last_item_created_at
         .checked_add_signed(chrono::Duration::microseconds(1))
@@ -4183,160 +4663,97 @@ async fn create_response_stream(
     let conversation_id = context.conversation.id;
     let user_id = user.uuid;
     let user_key = prepared.user_key;
-    let conversation_for_stream = context.conversation.clone();
-    let prompt_messages = context.prompt_messages.clone();
-    let web_search_enabled = context.web_search_enabled;
-    let image_descriptions_for_stream = Arc::new(image_descriptions);
-    let model_turn_body = model_turn_request_without_user_payload(&body);
-    let pinned_completion_for_stream = pinned_completion.clone();
+    drop(prepared);
+    let (tx_storage, rx_storage) = mpsc::channel::<StorageMessage>(STORAGE_CHANNEL_BUFFER);
+    let (tx_client, mut rx_client) = mpsc::channel::<StorageMessage>(CLIENT_CHANNEL_BUFFER);
+    let (tx_tool_ack, rx_tool_ack) = mpsc::channel::<Result<(), String>>(8);
+    let (tx_terminal_ack, rx_terminal_ack) =
+        oneshot::channel::<Result<Option<ResponseTerminal>, String>>();
+    let cancel_rx = state.cancellation_broadcast.subscribe();
 
-    // Phases 4-6 now happen INSIDE the stream to start sending events ASAP
+    // The image pairs are already durable. Emit them before the supervisor can
+    // enqueue any assistant output, and never send them back through storage.
+    for pair in &image_descriptions {
+        for message in pair.client_messages() {
+            tx_client
+                .send(message)
+                .await
+                .map_err(|_| ApiError::InternalServerError)?;
+        }
+    }
+
+    let storage_db = state.db.clone();
+    tokio::spawn(async move {
+        storage_task(
+            rx_storage,
+            Some(tx_tool_ack),
+            Some(tx_terminal_ack),
+            storage_db,
+            response_id,
+            response_uuid,
+            first_response_item_created_at,
+            conversation_id,
+            user_id,
+            user_key,
+        )
+        .await;
+    });
+
+    tokio::spawn(supervise_response_execution(
+        state.clone(),
+        user.clone(),
+        model_turn_body,
+        pinned_completion,
+        model_plan,
+        context,
+        user_key,
+        assistant_message_id,
+        persisted,
+        headers,
+        tx_client,
+        tx_storage,
+        rx_tool_ack,
+        rx_terminal_ack,
+        cancel_rx,
+        first_started,
+        execution_policy,
+    ));
+
+    if let Some((conversation_id, conversation_uuid, user_key, user_content)) = title_request {
+        spawn_title_generation_task(
+            state.clone(),
+            conversation_id,
+            conversation_uuid,
+            user.clone(),
+            user_key,
+            user_content,
+        )
+        .await;
+    }
+
+    // Storage and execution are already running; the body only translates the
+    // ordered client channel into encrypted SSE events.
     trace!("Creating SSE event stream for client");
     let event_stream = async_stream::stream! {
         trace!("=== STARTING SSE STREAM ===");
-
-        // Initialize the SSE event emitter
         let mut emitter = SseEventEmitter::new(&state, session_id, 0);
-
-        // Send initial response.created event IMMEDIATELY (before any processing)
-        trace!("Building response.created event");
         let created_response = ResponseBuilder::from_response(&response_for_stream)
             .status(STATUS_IN_PROGRESS)
             .metadata(decrypted_metadata.clone())
             .build();
-
         let created_event = ResponseCreatedEvent {
             event_type: EVENT_RESPONSE_CREATED,
             response: created_response.clone(),
             sequence_number: emitter.sequence_number(),
         };
-
         yield Ok(ResponseEvent::Created(created_event).to_sse_event(&mut emitter).await);
-
-        // Event 2: response.in_progress
         let in_progress_event = ResponseInProgressEvent {
             event_type: EVENT_RESPONSE_IN_PROGRESS,
             response: created_response,
             sequence_number: emitter.sequence_number(),
         };
-
         yield Ok(ResponseEvent::InProgress(in_progress_event).to_sse_event(&mut emitter).await);
 
-        // Phase 4: Create dual streams and spawn storage task
-        trace!("Phase 4: Creating dual streams and spawning storage task");
-        let (tx_storage, rx_storage) = mpsc::channel::<StorageMessage>(STORAGE_CHANNEL_BUFFER);
-        let (tx_client, mut rx_client) = mpsc::channel::<StorageMessage>(CLIENT_CHANNEL_BUFFER);
-
-        // These pairs are already durable. Queue them only for client emission,
-        // before the orchestrator can enqueue any assistant output.
-        for pair in image_descriptions_for_stream.iter() {
-            for message in pair.client_messages() {
-                let _ = tx_client.send(message).await;
-            }
-        }
-
-        // Create channel for tool persistence acknowledgments (supports multiple tool loops)
-        let (tx_tool_ack, rx_tool_ack) = mpsc::channel::<Result<(), String>>(8);
-
-        let _storage_handle = {
-            let db = state.db.clone();
-
-            tokio::spawn(async move {
-                storage_task(
-                    rx_storage,
-                    Some(tx_tool_ack),
-                    db,
-                    response_id,
-                    response_uuid,
-                    first_response_item_created_at,
-                    conversation_id,
-                    user_id,
-                    user_key,
-                )
-                .await;
-            })
-        };
-
-        // Spawn orchestrator task for phases 5-6 (runs in background, sends events to tx_client)
-        trace!("Spawning background orchestrator for phases 5-6");
-        let orchestrator_tx_client = tx_client.clone();
-        let orchestrator_tx_storage = tx_storage.clone();
-        let orchestrator_state = state.clone();
-        let orchestrator_user = user.clone();
-        let orchestrator_body = model_turn_body.clone();
-        let orchestrator_headers = headers.clone();
-        let orchestrator_response = response_for_stream.clone();
-        let orchestrator_metadata = decrypted_metadata.clone();
-        let orchestrator_last_item_created_at = persisted.last_item_created_at;
-        let orchestrator_conversation = conversation_for_stream.clone();
-        let orchestrator_prompt_messages = prompt_messages.clone();
-        let orchestrator_pinned_completion = pinned_completion_for_stream.clone();
-
-        tokio::spawn(async move {
-            trace!("Orchestrator: Starting phases 5-6 in background");
-
-            // Subscribe to cancellation broadcast. The endpoint lives on a separate
-            // request task, so each stream listens for its own response UUID.
-            let cancel_rx = orchestrator_state.cancellation_broadcast.subscribe();
-            let cancellation_listener = wait_for_response_cancellation(
-                response_uuid,
-                cancel_rx,
-                orchestrator_tx_storage.clone(),
-                orchestrator_tx_client.clone(),
-            );
-
-            // Run phases 5-6 with cancellation support
-            tokio::select! {
-                _ = async {
-                    // Phase 5-6: Run the normal assistant/tool loop
-                    trace!("Orchestrator: Setting up assistant/tool loop");
-
-                    let context_for_completion = BuiltContext {
-                        conversation: orchestrator_conversation,
-                        prompt_messages: orchestrator_prompt_messages,
-                        total_prompt_tokens,
-                        web_search_enabled,
-                    };
-
-                    let persisted_for_completion = PersistedData {
-                        response: orchestrator_response.clone(),
-                        decrypted_metadata: orchestrator_metadata.clone(),
-                        last_item_created_at: orchestrator_last_item_created_at,
-                    };
-
-                    match setup_completion_processor(
-                        &orchestrator_state,
-                        &orchestrator_user,
-                        &orchestrator_body,
-                        &orchestrator_pinned_completion,
-                        model_plan,
-                        &context_for_completion,
-                        &user_key,
-                        assistant_message_id,
-                        &persisted_for_completion,
-                        &orchestrator_headers,
-                        orchestrator_tx_client.clone(),
-                        orchestrator_tx_storage.clone(),
-                        rx_tool_ack,
-                    )
-                    .await
-                    {
-                        Ok(_) => {
-                            trace!("Orchestrator: Assistant/tool loop completed");
-                        }
-                        Err(e) => {
-                            error!("Orchestrator: Assistant/tool loop failed: {:?}", e);
-                        }
-                    }
-                } => {
-                    trace!("Orchestrator: Phases 5-6 completed normally");
-                }
-
-                _ = cancellation_listener => {}
-            }
-        });
-
-        // NOW immediately start the event loop - it will receive events from orchestrator as they happen
         trace!("Starting event loop to receive messages from background tasks");
         let mut client_state = ClientResponseState::default();
         let mut total_prompt_tokens_used = 0i32;
@@ -4426,6 +4843,7 @@ async fn create_response_stream(
                             .build(),
                     };
                     yield Ok(ResponseEvent::OutputItemDone(output_item_done_event).to_sse_event(&mut emitter).await);
+                    client_state.mark_message_completed(item_id);
                 }
                 StorageMessage::ReasoningStarted { item_id } => {
                     let output_index = client_state.push_reasoning(item_id);
@@ -4503,8 +4921,14 @@ async fn create_response_stream(
                         },
                     };
                     yield Ok(ResponseEvent::OutputItemDone(reasoning_item_done).to_sse_event(&mut emitter).await);
+                    client_state.mark_reasoning_completed(item_id);
                 }
-                StorageMessage::ResponseDone { finish_reason: _finish_reason } => {
+                StorageMessage::Usage { prompt_tokens, completion_tokens } => {
+                    trace!("Client stream received usage data");
+                    total_prompt_tokens_used += prompt_tokens;
+                    total_completion_tokens += completion_tokens;
+                }
+                StorageMessage::Terminal(terminal) => {
                     let usage = build_usage(
                         if total_prompt_tokens_used > 0 {
                             total_prompt_tokens_used
@@ -4513,58 +4937,58 @@ async fn create_response_stream(
                         },
                         total_completion_tokens,
                     );
-
-                    let done_response = ResponseBuilder::from_response(&response_for_stream)
-                        .status(STATUS_COMPLETED)
-                        .output(client_state.build_output_items())
-                        .usage(usage)
-                        .metadata(decrypted_metadata.clone())
-                        .build();
-
-                    let completed_event = ResponseCompletedEvent {
-                        event_type: EVENT_RESPONSE_COMPLETED,
-                        response: done_response,
-                        sequence_number: emitter.sequence_number(),
-                    };
-
-                    yield Ok(ResponseEvent::Completed(completed_event).to_sse_event(&mut emitter).await);
+                    match terminal {
+                        ResponseTerminal::Completed { .. } => {
+                            let done_response = ResponseBuilder::from_response(&response_for_stream)
+                                .status(STATUS_COMPLETED)
+                                .output(client_state.build_output_items())
+                                .usage(usage)
+                                .metadata(decrypted_metadata.clone())
+                                .build();
+                            let completed_event = ResponseCompletedEvent {
+                                event_type: EVENT_RESPONSE_COMPLETED,
+                                response: done_response,
+                                sequence_number: emitter.sequence_number(),
+                            };
+                            yield Ok(ResponseEvent::Completed(completed_event).to_sse_event(&mut emitter).await);
+                        }
+                        ResponseTerminal::Cancelled => {
+                            let cancelled_event = ResponseCancelledEvent {
+                                id: Uuid::new_v4().to_string(),
+                                event_type: EVENT_RESPONSE_CANCELLED,
+                                created_at: Utc::now().timestamp(),
+                                data: ResponseCancelledData { id: response_uuid },
+                            };
+                            yield Ok(ResponseEvent::Cancelled(cancelled_event).to_sse_event(&mut emitter).await);
+                        }
+                        ResponseTerminal::Failed(failure) => {
+                            let failed_response = ResponseBuilder::from_response(&response_for_stream)
+                                .status(STATUS_FAILED)
+                                .output(client_state.build_output_items())
+                                .usage(usage)
+                                .metadata(decrypted_metadata.clone())
+                                .error(ResponseError {
+                                    code: failure.openai_code().to_string(),
+                                    message: failure.message().to_string(),
+                                })
+                                .build();
+                            let failed_event = ResponseFailedEvent {
+                                event_type: EVENT_RESPONSE_FAILED,
+                                response: failed_response,
+                                sequence_number: emitter.sequence_number(),
+                                opensecret: failure.contract_metadata(),
+                            };
+                            yield Ok(ResponseEvent::Failed(failed_event).to_sse_event(&mut emitter).await);
+                        }
+                    }
                     break;
                 }
-                StorageMessage::Usage { prompt_tokens, completion_tokens } => {
-                    trace!("Client stream received usage data");
-                    total_prompt_tokens_used += prompt_tokens;
-                    total_completion_tokens += completion_tokens;
-                }
-                StorageMessage::Cancelled => {
-                    debug!("Client stream received cancellation signal");
-                    // Send response.cancelled event
-                    let cancelled_event = ResponseCancelledEvent {
-                        id: Uuid::new_v4().to_string(),
-                        event_type: EVENT_RESPONSE_CANCELLED,
-                        created_at: Utc::now().timestamp(),
-                        data: ResponseCancelledData {
-                            id: response_uuid,
-                        },
-                    };
-
-                    yield Ok(ResponseEvent::Cancelled(cancelled_event).to_sse_event(&mut emitter).await);
-                    break;
-                }
-                StorageMessage::Error(error_msg) => {
-                    error!("Client stream received error: {}", error_msg);
-                    // Send error event to client
-                    let error_event = ResponseErrorEvent {
-                        event_type: EVENT_RESPONSE_ERROR,
-                        error: ResponseError {
-                            error_type: "stream_error".to_string(),
-                            message: error_msg,
-                        },
-                    };
-
-                    yield Ok(ResponseEvent::Error(error_event).to_sse_event(&mut emitter).await);
-                    break;
-                }
-                StorageMessage::ToolCall { tool_call_id, name, arguments } => {
+                StorageMessage::ToolCall {
+                    tool_call_id,
+                    tool_output_id: _,
+                    name,
+                    arguments,
+                } => {
                     debug!(
                         "Client stream received tool_call {} ({}) for response {}",
                         tool_call_id, name, response_uuid
@@ -4992,6 +5416,10 @@ async fn delete_response(
             _ => ApiError::InternalServerError,
         }
     })?;
+
+    // Stop any in-flight provider/tool work for the deleted response. Storage
+    // treats the now-absent row as an authoritative nonterminal transport stop.
+    let _ = state.cancellation_broadcast.send(id);
 
     let response = DeletedObjectResponse::response(id);
 

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -5,6 +5,7 @@ use crate::{
     billing::{BillingError, ChatBillingAccess},
     db::DBError,
     encrypt::{decrypt_content, decrypt_string, encrypt_with_key},
+    inference::admission::{AdmissionRejection, LogicalAdmissionTicket},
     inference::{
         AttemptFailure, AttemptFailureKind, AttemptTerminal, InferenceIntent, InferenceSurface,
         ReplaySafety, WorkloadClass,
@@ -50,7 +51,7 @@ use crate::{
 };
 use axum::{
     extract::{Path, State},
-    http::{header, HeaderMap, HeaderName, HeaderValue},
+    http::{header, HeaderMap, HeaderName, HeaderValue, StatusCode},
     middleware::from_fn_with_state,
     response::{
         sse::{Event, KeepAlive, Sse},
@@ -61,7 +62,7 @@ use axum::{
 };
 use base64::Engine;
 use chrono::Utc;
-use futures::{FutureExt, Stream};
+use futures::{FutureExt, Stream, StreamExt};
 use secp256k1::SecretKey;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -259,6 +260,15 @@ pub enum PublicResponseFailure {
 
 impl PublicResponseFailure {
     fn from_completion_error(error: &CompletionExecutionError) -> Self {
+        if let CompletionExecutionError::Request(ApiError::InferenceCapacity { status, .. }) = error
+        {
+            return if *status == StatusCode::TOO_MANY_REQUESTS {
+                Self::CapacityRateLimited
+            } else {
+                Self::CapacityOverloaded
+            };
+        }
+
         match error.terminal() {
             Some(AttemptTerminal::Failed { failure, .. })
                 if failure.kind == crate::inference::AttemptFailureKind::CapacityRejected =>
@@ -297,6 +307,19 @@ impl PublicResponseFailure {
                 error_code: INFERENCE_CAPACITY_ERROR_CODE,
             },
         )
+    }
+}
+
+fn logical_admission_api_error(rejection: AdmissionRejection) -> ApiError {
+    let status = if rejection.status_hint() == StatusCode::TOO_MANY_REQUESTS.as_u16() {
+        StatusCode::TOO_MANY_REQUESTS
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    ApiError::InferenceCapacity {
+        status,
+        retry_after: Some(rejection.retry_after),
+        client_replay_safe: false,
     }
 }
 
@@ -557,7 +580,7 @@ mod tests {
         web::openai::CompletionExecutionError,
         ApiError,
     };
-    use axum::{routing::get, Json, Router};
+    use axum::{http::StatusCode, routing::get, Json, Router};
     use chrono::{TimeZone, Utc};
     use serde_json::json;
     use std::collections::HashMap;
@@ -859,6 +882,15 @@ mod tests {
         }
         assert_eq!(
             image_description_api_error(ApiError::ServiceUnavailable).class,
+            ImageDescriptionFailureClass::PreAcceptance
+        );
+        assert_eq!(
+            image_description_api_error(ApiError::InferenceCapacity {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                retry_after: Some(Duration::from_secs(1)),
+                client_replay_safe: false,
+            })
+            .class,
             ImageDescriptionFailureClass::PreAcceptance
         );
         assert_eq!(
@@ -1194,6 +1226,29 @@ mod tests {
         assert!(PublicResponseFailure::DeadlineExceeded
             .contract_metadata()
             .is_none());
+    }
+
+    #[test]
+    fn local_admission_failures_preserve_capacity_class_after_persistence() {
+        let rate_limited = CompletionExecutionError::Request(ApiError::InferenceCapacity {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            retry_after: Some(Duration::from_secs(1)),
+            client_replay_safe: false,
+        });
+        assert_eq!(
+            PublicResponseFailure::from_completion_error(&rate_limited),
+            PublicResponseFailure::CapacityRateLimited
+        );
+
+        let overloaded = CompletionExecutionError::Request(ApiError::InferenceCapacity {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            retry_after: Some(Duration::from_secs(1)),
+            client_replay_safe: false,
+        });
+        assert_eq!(
+            PublicResponseFailure::from_completion_error(&overloaded),
+            PublicResponseFailure::CapacityOverloaded
+        );
     }
 
     #[test]
@@ -2868,7 +2923,9 @@ fn image_description_api_error(error: ApiError) -> ImageDescriptionAttemptError 
         ApiError::BadRequest | ApiError::Unauthorized | ApiError::ModelNotAvailableOnPlan => {
             ImageDescriptionFailureClass::Terminal
         }
-        ApiError::ServiceUnavailable => ImageDescriptionFailureClass::PreAcceptance,
+        ApiError::ServiceUnavailable | ApiError::InferenceCapacity { .. } => {
+            ImageDescriptionFailureClass::PreAcceptance
+        }
         ApiError::TooManyRequests => ImageDescriptionFailureClass::RetryableResponse,
         _ => ImageDescriptionFailureClass::AmbiguousAfterSend,
     };
@@ -2941,6 +2998,17 @@ impl ImageDescriptionAttemptExecutor for ResponsesImageDescriptionExecutor<'_> {
             ));
         }
 
+        // Each descriptor candidate is its own logical inference request. The
+        // outer image scheduler limits concurrent candidates so a multi-image
+        // Responses request cannot bypass or self-overflow the account bound.
+        let _logical_ticket = self
+            .state
+            .inference_admission
+            .acquire_logical(self.user.uuid, WorkloadClass::Interactive)
+            .await
+            .map_err(logical_admission_api_error)
+            .map_err(image_description_api_error)?;
+
         let headers = HeaderMap::new();
         let billing_context =
             BillingContext::new(AuthMethod::Jwt, candidate.public_model_id.to_string());
@@ -3010,8 +3078,11 @@ async fn describe_images(
     };
     let fallback_policy = RetryNonTerminalImageDescriptionFallbackPolicy;
 
-    let outcomes =
-        futures::future::join_all(images.iter().enumerate().map(|(image_index, image)| {
+    let descriptor_concurrency = state.inference_admission.policy().per_account_in_flight();
+    let pending = images
+        .iter()
+        .enumerate()
+        .map(|(image_index, image)| {
             let executor = &executor;
             let fallback_policy = &fallback_policy;
             async move {
@@ -3026,7 +3097,11 @@ async fn describe_images(
                 .await;
                 (image_index, image.content_index, result)
             }
-        }))
+        })
+        .collect::<Vec<_>>();
+    let outcomes = futures::stream::iter(pending)
+        .buffered(descriptor_concurrency)
+        .collect::<Vec<_>>()
         .await;
 
     let mut pairs = Vec::with_capacity(outcomes.len());
@@ -3124,6 +3199,24 @@ async fn spawn_title_generation_task(
     user_content: String,
 ) {
     tokio::spawn(async move {
+        let _logical_ticket = match state
+            .inference_admission
+            .acquire_logical(user.uuid, WorkloadClass::Background)
+            .await
+        {
+            Ok(ticket) => ticket,
+            Err(rejection) => {
+                debug!(
+                    user_uuid = %user.uuid,
+                    conversation_uuid = %conversation_uuid,
+                    kind = ?rejection.kind,
+                    retry_after_seconds = rejection.retry_after.as_secs(),
+                    "Title generation shed by local admission control"
+                );
+                return;
+            }
+        };
+
         debug!(
             "Starting background title generation for conversation {}",
             conversation_uuid
@@ -4442,6 +4535,7 @@ async fn supervise_response_execution(
     rx_tool_ack: mpsc::Receiver<Result<(), String>>,
     terminal_ack: oneshot::Receiver<Result<Option<ResponseTerminal>, String>>,
     cancel_rx: broadcast::Receiver<Uuid>,
+    logical_ticket: LogicalAdmissionTicket,
     first_started: StartedCompletion,
     execution_policy: ResponseExecutionPolicy,
 ) {
@@ -4526,6 +4620,11 @@ async fn supervise_response_execution(
             return;
         }
     };
+
+    // The logical admission ticket covers the complete Responses job, including
+    // every model/tool turn and the authoritative terminal write. Client
+    // backpressure after persistence must not consume scarce logical capacity.
+    drop(logical_ticket);
 
     // This is the sole client-terminal writer. Awaiting the send preserves all
     // preceding data under backpressure while the stream remains connected.
@@ -4677,6 +4776,21 @@ async fn create_response_stream(
     body.max_output_tokens = Some(execution_policy.output_token_budget);
     let response_uuid = Uuid::new_v4();
     let model_turn_body = model_turn_request_without_user_payload(&body);
+
+    // Descriptor requests have settled. The main Responses request now owns
+    // one logical ticket through its full model/tool loop and authoritative
+    // terminal persistence. If descriptors already completed, a rejection at
+    // this seam must not advertise the whole HTTP request as side-effect-free.
+    let logical_ticket = state
+        .inference_admission
+        .acquire_logical(user.uuid, WorkloadClass::Interactive)
+        .await
+        .map_err(logical_admission_api_error)
+        .map_err(CompletionExecutionError::Request)
+        .map_err(|error| {
+            responses_pre_persistence_api_error(error, !image_descriptions.is_empty())
+        })?;
+
     let first_started = start_responses_assistant_turn(
         &state,
         &user,
@@ -4798,6 +4912,7 @@ async fn create_response_stream(
         rx_tool_ack,
         rx_terminal_ack,
         cancel_rx,
+        logical_ticket,
         first_started,
         execution_policy,
     ));

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -325,7 +325,14 @@ fn responses_pre_persistence_api_error(
         // Descriptor completions have already consumed provider capacity and
         // published usage. The conversation is still cleanly replayable, but
         // the whole HTTP request is not side-effect-free.
-        error.into_api_error()
+        let mut error = error.into_api_error();
+        if let ApiError::InferenceCapacity {
+            client_replay_safe, ..
+        } = &mut error
+        {
+            *client_replay_safe = false;
+        }
+        error
     } else {
         error.into_pre_persistence_api_error()
     }
@@ -601,6 +608,23 @@ mod tests {
                 } if client_replay_safe == expected_replay_safe
             ));
         }
+    }
+
+    #[test]
+    fn route_preparation_capacity_after_image_descriptions_is_not_replay_safe() {
+        let route_error = ApiError::InferenceCapacity {
+            status: axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            retry_after: Some(Duration::from_secs(30)),
+            client_replay_safe: true,
+        };
+
+        assert!(matches!(
+            responses_pre_persistence_api_error(route_error.into(), true),
+            ApiError::InferenceCapacity {
+                client_replay_safe: false,
+                ..
+            }
+        ));
     }
 
     fn test_image_attachment() -> ImageAttachment {
@@ -4583,7 +4607,11 @@ async fn create_response_stream(
         InferenceSurface::Responses,
         WorkloadClass::Interactive,
     );
-    let pinned_completion = prepare_completion_request(&state, &user, inference_intent).await?;
+    let pinned_completion = prepare_completion_request(&state, &user, inference_intent)
+        .await
+        .map_err(|error| {
+            responses_pre_persistence_api_error(error.into(), !image_descriptions.is_empty())
+        })?;
 
     // Start only the first provider request before persistence. A recognized
     // capacity rejection at this seam proves that no response or user-message

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -934,6 +934,80 @@ mod tests {
     }
 
     #[test]
+    fn test_golden_responses_alias_resolution_matrix() {
+        struct Case {
+            name: &'static str,
+            plan: ModelPlan,
+            powerful_kimi_k3: bool,
+            selector: &'static str,
+            expected_model: &'static str,
+            expected_access: bool,
+        }
+
+        let cases = [
+            Case {
+                name: "free auto quick",
+                plan: ModelPlan::Free,
+                powerful_kimi_k3: false,
+                selector: crate::model_config::AUTO_QUICK_MODEL_ID,
+                expected_model: crate::model_config::QUICK_MODEL_ID,
+                expected_access: true,
+            },
+            Case {
+                name: "free auto powerful, flag on",
+                plan: ModelPlan::Free,
+                powerful_kimi_k3: true,
+                selector: crate::model_config::AUTO_POWERFUL_MODEL_ID,
+                expected_model: crate::model_config::POWERFUL_MODEL_ID,
+                expected_access: false,
+            },
+            Case {
+                name: "paid auto quick",
+                plan: ModelPlan::Paid,
+                powerful_kimi_k3: false,
+                selector: crate::model_config::AUTO_QUICK_MODEL_ID,
+                expected_model: crate::model_config::DEEPSEEK_V4_FLASH_MODEL_ID,
+                expected_access: true,
+            },
+            Case {
+                name: "paid auto powerful, flag off",
+                plan: ModelPlan::Paid,
+                powerful_kimi_k3: false,
+                selector: crate::model_config::AUTO_POWERFUL_MODEL_ID,
+                expected_model: crate::model_config::POWERFUL_MODEL_ID,
+                expected_access: true,
+            },
+            Case {
+                name: "paid auto powerful, flag on",
+                plan: ModelPlan::Paid,
+                powerful_kimi_k3: true,
+                selector: crate::model_config::AUTO_POWERFUL_MODEL_ID,
+                expected_model: crate::model_config::KIMI_K3_MODEL_ID,
+                expected_access: true,
+            },
+        ];
+
+        for case in cases {
+            let flags = HashMap::from([(
+                crate::os_flags::PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY.to_string(),
+                case.powerful_kimi_k3,
+            )]);
+            let targets = ModelAliasTargets::for_plan_with_overrides(
+                case.plan,
+                crate::model_config::PaidModelAliasOverrides::from_flag_values(&flags),
+            );
+            let selected_model = targets.resolve(case.selector);
+
+            assert_eq!(selected_model, case.expected_model, "{}", case.name);
+            let result = resolve_responses_model(selected_model, "tinfoil", case.plan);
+            assert_eq!(result.is_ok(), case.expected_access, "{}", case.name);
+            if case.expected_access {
+                assert_eq!(result.unwrap(), case.expected_model, "{}", case.name);
+            }
+        }
+    }
+
+    #[test]
     fn test_build_model_turn_request_applies_reasoning_history_template_kwargs() {
         let kimi = responses_request_for_model("kimi-k2-6");
         let kimi_request =

--- a/src/web/responses/storage.rs
+++ b/src/web/responses/storage.rs
@@ -1,9 +1,11 @@
 //! Storage task components for persisting streaming response items.
 
 use crate::{
+    db::DBError,
     encrypt::encrypt_with_key,
     models::responses::{
         NewAssistantMessage, NewReasoningItem, NewToolCall, NewToolOutput, ResponseStatus,
+        ResponsesError,
     },
     tokens::count_tokens,
     web::responses::constants::{
@@ -13,22 +15,71 @@ use crate::{
 };
 use chrono::Utc;
 use secp256k1::SecretKey;
-use std::{collections::HashMap, sync::Arc, time::Instant};
-use tokio::sync::mpsc;
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, trace, warn};
 use uuid::Uuid;
 
-use super::handlers::StorageMessage;
+use super::handlers::{PublicResponseFailure, ResponseTerminal, StorageMessage};
 
-#[derive(Default)]
+const TERMINAL_RETRY_INITIAL_DELAY: Duration = Duration::from_millis(100);
+const TERMINAL_RETRY_MAX_DELAY: Duration = Duration::from_secs(5);
+const INTERRUPTED_TOOL_OUTPUT: &str = "Tool execution was interrupted before completion.";
+
+#[derive(Clone, Default)]
 struct PendingAssistantMessage {
     content: String,
     created_at: Option<chrono::DateTime<chrono::Utc>>,
+    completed_finish_reason: Option<String>,
 }
 
-#[derive(Default)]
+impl PendingAssistantMessage {
+    fn terminal_status_and_finish_reason(
+        &self,
+        incomplete_finish_reason: Option<String>,
+    ) -> (&'static str, Option<String>) {
+        match &self.completed_finish_reason {
+            Some(finish_reason) => (STATUS_COMPLETED, Some(finish_reason.clone())),
+            None => (STATUS_INCOMPLETE, incomplete_finish_reason),
+        }
+    }
+}
+
+#[derive(Clone, Default)]
 struct PendingReasoningItem {
     content: String,
+    created_at: Option<chrono::DateTime<chrono::Utc>>,
+    completed: bool,
+}
+
+impl PendingReasoningItem {
+    fn terminal_status(&self) -> &'static str {
+        if self.completed {
+            STATUS_COMPLETED
+        } else {
+            STATUS_INCOMPLETE
+        }
+    }
+}
+
+#[derive(Clone)]
+struct PendingToolCall {
+    name: String,
+    arguments: serde_json::Value,
+    created_at: chrono::DateTime<chrono::Utc>,
+    output_id: Uuid,
+    output: Option<String>,
+    output_created_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+impl PendingToolCall {
+    fn terminal_output(&self) -> &str {
+        self.output.as_deref().unwrap_or(INTERRUPTED_TOOL_OUTPUT)
+    }
 }
 
 fn clamp_token_count(text: &str, label: &str) -> i32 {
@@ -84,27 +135,62 @@ fn update_terminal_response_status(
     db: &Arc<dyn DBConnection + Send + Sync>,
     response_id: i64,
     response_uuid: Uuid,
-    status: ResponseStatus,
+    user_id: Uuid,
+    requested: ResponseTerminal,
     reason: &str,
-) {
+) -> Result<Option<ResponseTerminal>, String> {
+    let status = requested.status();
     match db.update_response_status_if_current(
         response_id,
         ResponseStatus::InProgress,
         status,
         Some(Utc::now()),
     ) {
-        Ok(true) => {}
+        Ok(true) => Ok(Some(requested)),
         Ok(false) => {
             debug!(
                 "Storage: skipped setting response {} ({}) to {:?} after {}; response was no longer in_progress",
                 response_id, response_uuid, status, reason
             );
+            match db.get_response_by_uuid_and_user(response_uuid, user_id) {
+                Ok(response) => match response.status {
+                    ResponseStatus::Completed => Ok(Some(match requested {
+                        ResponseTerminal::Completed { .. } => requested,
+                        _ => ResponseTerminal::Completed {
+                            finish_reason: "stop".to_string(),
+                        },
+                    })),
+                    ResponseStatus::Cancelled => Ok(Some(ResponseTerminal::Cancelled)),
+                    ResponseStatus::Failed => Ok(Some(ResponseTerminal::Failed(
+                        PublicResponseFailure::Internal,
+                    ))),
+                    ResponseStatus::Queued | ResponseStatus::InProgress => Err(format!(
+                        "Response remained {:?} after terminal compare-and-set",
+                        response.status
+                    )),
+                },
+                Err(DBError::ResponsesError(ResponsesError::ResponseNotFound)) => {
+                    debug!(
+                        "Response {} ({}) was deleted before terminal persistence completed",
+                        response_id, response_uuid
+                    );
+                    Ok(None)
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to read authoritative response {} ({}) status after {}: {:?}",
+                        response_id, response_uuid, reason, e
+                    );
+                    Err("Failed to read authoritative terminal response status".to_string())
+                }
+            }
         }
         Err(e) => {
             error!(
                 "Failed to update response {} ({}) status to {:?} after {}: {:?}",
                 response_id, response_uuid, status, reason, e
             );
+            Err("Failed to persist terminal response status".to_string())
         }
     }
 }
@@ -134,7 +220,7 @@ async fn finalize_assistant_message(
     .map_err(|e| format!("Failed to update assistant message: {:?}", e))
 }
 
-fn create_reasoning_item(
+fn create_reasoning_item_if_missing(
     db: &Arc<dyn DBConnection + Send + Sync>,
     conversation_id: i64,
     response_id: i64,
@@ -142,20 +228,25 @@ fn create_reasoning_item(
     item_id: Uuid,
     created_at: chrono::DateTime<chrono::Utc>,
 ) -> Result<(), String> {
-    db.create_reasoning_item(NewReasoningItem {
-        uuid: item_id,
-        conversation_id,
-        response_id: Some(response_id),
-        assistant_message_id: None,
-        user_id,
-        content_enc: None,
-        summary_enc: None,
-        reasoning_tokens: 0,
-        status: STATUS_IN_PROGRESS.to_string(),
-        created_at,
-    })
-    .map(|_| ())
-    .map_err(|e| format!("Failed to create reasoning item: {:?}", e))
+    match db.get_reasoning_item_by_uuid(item_id) {
+        Ok(Some(_)) => Ok(()),
+        Ok(None) => db
+            .create_reasoning_item(NewReasoningItem {
+                uuid: item_id,
+                conversation_id,
+                response_id: Some(response_id),
+                assistant_message_id: None,
+                user_id,
+                content_enc: None,
+                summary_enc: None,
+                reasoning_tokens: 0,
+                status: STATUS_IN_PROGRESS.to_string(),
+                created_at,
+            })
+            .map(|_| ())
+            .map_err(|e| format!("Failed to create reasoning item: {:?}", e)),
+        Err(e) => Err(format!("Failed to look up reasoning item: {:?}", e)),
+    }
 }
 
 async fn finalize_reasoning_item(
@@ -213,6 +304,38 @@ async fn persist_tool_call(
 }
 
 #[allow(clippy::too_many_arguments)]
+async fn persist_tool_call_if_missing(
+    db: &Arc<dyn DBConnection + Send + Sync>,
+    user_key: &SecretKey,
+    conversation_id: i64,
+    response_id: i64,
+    user_id: Uuid,
+    tool_call_id: Uuid,
+    name: String,
+    arguments: serde_json::Value,
+    created_at: chrono::DateTime<chrono::Utc>,
+) -> Result<(), String> {
+    match db.get_tool_call_by_uuid(tool_call_id, user_id) {
+        Ok(_) => Ok(()),
+        Err(DBError::ResponsesError(ResponsesError::ToolCallNotFound)) => {
+            persist_tool_call(
+                db,
+                user_key,
+                conversation_id,
+                response_id,
+                user_id,
+                tool_call_id,
+                name,
+                arguments,
+                created_at,
+            )
+            .await
+        }
+        Err(e) => Err(format!("Failed to look up tool_call: {:?}", e)),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn persist_tool_output(
     db: &Arc<dyn DBConnection + Send + Sync>,
     user_key: &SecretKey,
@@ -246,39 +369,324 @@ async fn persist_tool_output(
     .map_err(|e| format!("Failed to persist tool_output: {:?}", e))
 }
 
-async fn mark_pending_items_incomplete(
+#[allow(clippy::too_many_arguments)]
+async fn persist_tool_output_if_missing(
     db: &Arc<dyn DBConnection + Send + Sync>,
     user_key: &SecretKey,
+    conversation_id: i64,
+    response_id: i64,
+    user_id: Uuid,
+    tool_output_id: Uuid,
+    tool_call_id: Uuid,
+    output: String,
+    created_at: chrono::DateTime<chrono::Utc>,
+) -> Result<(), String> {
+    match db.get_tool_output_by_uuid(tool_output_id, user_id) {
+        Ok(_) => Ok(()),
+        Err(DBError::ResponsesError(ResponsesError::ToolOutputNotFound)) => {
+            persist_tool_output(
+                db,
+                user_key,
+                conversation_id,
+                response_id,
+                user_id,
+                tool_output_id,
+                tool_call_id,
+                output,
+                created_at,
+            )
+            .await
+        }
+        Err(e) => Err(format!("Failed to look up tool_output: {:?}", e)),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn finalize_pending_items_for_terminal(
+    db: &Arc<dyn DBConnection + Send + Sync>,
+    user_key: &SecretKey,
+    conversation_id: i64,
+    response_id: i64,
+    user_id: Uuid,
+    next_created_at: &mut chrono::DateTime<chrono::Utc>,
     pending_messages: &mut HashMap<Uuid, PendingAssistantMessage>,
     pending_reasoning: &mut HashMap<Uuid, PendingReasoningItem>,
     message_finish_reason: Option<String>,
-) {
-    for (item_id, pending) in pending_messages.drain() {
-        if let Err(e) = finalize_assistant_message(
+) -> Result<(), String> {
+    let mut failures = Vec::new();
+    let message_ids: Vec<_> = pending_messages.keys().copied().collect();
+    for item_id in message_ids {
+        let pending = {
+            let Some(pending) = pending_messages.get_mut(&item_id) else {
+                continue;
+            };
+            pending
+                .created_at
+                .get_or_insert_with(|| allocate_created_at(next_created_at));
+            pending.clone()
+        };
+        let create_result = create_assistant_message_if_missing(
             db,
-            user_key,
+            conversation_id,
+            response_id,
+            user_id,
             item_id,
-            pending.content,
-            STATUS_INCOMPLETE,
-            message_finish_reason.clone(),
-        )
-        .await
-        {
-            error!(
-                "Failed to finalize pending assistant message {}: {}",
-                item_id, e
-            );
+            pending
+                .created_at
+                .expect("pending message timestamp is set"),
+        );
+        let (status, finish_reason) =
+            pending.terminal_status_and_finish_reason(message_finish_reason.clone());
+        let result = match create_result {
+            Ok(()) => {
+                finalize_assistant_message(
+                    db,
+                    user_key,
+                    item_id,
+                    pending.content,
+                    status,
+                    finish_reason,
+                )
+                .await
+            }
+            Err(e) => Err(e),
+        };
+        match result {
+            Ok(()) => {
+                pending_messages.remove(&item_id);
+            }
+            Err(e) => {
+                error!(
+                    "Failed to finalize pending assistant message {}: {}",
+                    item_id, e
+                );
+                failures.push(e);
+            }
         }
     }
 
-    for (item_id, pending) in pending_reasoning.drain() {
-        if let Err(e) =
-            finalize_reasoning_item(db, user_key, item_id, pending.content, STATUS_INCOMPLETE).await
-        {
-            error!(
-                "Failed to finalize pending reasoning item {}: {}",
-                item_id, e
-            );
+    let reasoning_ids: Vec<_> = pending_reasoning.keys().copied().collect();
+    for item_id in reasoning_ids {
+        let pending = {
+            let Some(pending) = pending_reasoning.get_mut(&item_id) else {
+                continue;
+            };
+            pending
+                .created_at
+                .get_or_insert_with(|| allocate_created_at(next_created_at));
+            pending.clone()
+        };
+        let result = create_reasoning_item_if_missing(
+            db,
+            conversation_id,
+            response_id,
+            user_id,
+            item_id,
+            pending
+                .created_at
+                .expect("pending reasoning timestamp is set"),
+        );
+        let status = pending.terminal_status();
+        let result = match result {
+            Ok(()) => finalize_reasoning_item(db, user_key, item_id, pending.content, status).await,
+            Err(e) => Err(e),
+        };
+        match result {
+            Ok(()) => {
+                pending_reasoning.remove(&item_id);
+            }
+            Err(e) => {
+                error!(
+                    "Failed to finalize pending reasoning item {}: {}",
+                    item_id, e
+                );
+                failures.push(e);
+            }
+        }
+    }
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "Failed to finalize {} pending response item(s)",
+            failures.len()
+        ))
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn finalize_pending_tool_calls_for_terminal(
+    db: &Arc<dyn DBConnection + Send + Sync>,
+    user_key: &SecretKey,
+    conversation_id: i64,
+    response_id: i64,
+    user_id: Uuid,
+    next_created_at: &mut chrono::DateTime<chrono::Utc>,
+    pending_tool_calls: &mut HashMap<Uuid, PendingToolCall>,
+) -> Result<(), String> {
+    let mut failures = Vec::new();
+    let tool_call_ids: Vec<_> = pending_tool_calls.keys().copied().collect();
+
+    for tool_call_id in tool_call_ids {
+        let pending = {
+            let Some(pending) = pending_tool_calls.get_mut(&tool_call_id) else {
+                continue;
+            };
+            pending
+                .output_created_at
+                .get_or_insert_with(|| allocate_created_at(next_created_at));
+            pending.clone()
+        };
+        let terminal_output = pending.terminal_output().to_string();
+
+        let call_result = persist_tool_call_if_missing(
+            db,
+            user_key,
+            conversation_id,
+            response_id,
+            user_id,
+            tool_call_id,
+            pending.name,
+            pending.arguments,
+            pending.created_at,
+        )
+        .await;
+        let output_result = match call_result {
+            Ok(()) => {
+                persist_tool_output_if_missing(
+                    db,
+                    user_key,
+                    conversation_id,
+                    response_id,
+                    user_id,
+                    pending.output_id,
+                    tool_call_id,
+                    terminal_output,
+                    pending
+                        .output_created_at
+                        .expect("pending tool output timestamp is set"),
+                )
+                .await
+            }
+            Err(e) => Err(e),
+        };
+
+        match output_result {
+            Ok(()) => {
+                pending_tool_calls.remove(&tool_call_id);
+            }
+            Err(e) => {
+                error!(
+                    "Failed to terminalize pending tool_call {}: {}",
+                    tool_call_id, e
+                );
+                failures.push(e);
+            }
+        }
+    }
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "Failed to terminalize {} pending tool call(s)",
+            failures.len()
+        ))
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn persist_terminal_until_authoritative(
+    db: &Arc<dyn DBConnection + Send + Sync>,
+    user_key: &SecretKey,
+    conversation_id: i64,
+    response_id: i64,
+    response_uuid: Uuid,
+    user_id: Uuid,
+    next_created_at: &mut chrono::DateTime<chrono::Utc>,
+    pending_messages: &mut HashMap<Uuid, PendingAssistantMessage>,
+    pending_reasoning: &mut HashMap<Uuid, PendingReasoningItem>,
+    pending_tool_calls: &mut HashMap<Uuid, PendingToolCall>,
+    requested: ResponseTerminal,
+    message_finish_reason: Option<String>,
+    reason: &str,
+) -> Option<ResponseTerminal> {
+    let mut retry_delay = TERMINAL_RETRY_INITIAL_DELAY;
+
+    loop {
+        let item_cleanup_result = finalize_pending_items_for_terminal(
+            db,
+            user_key,
+            conversation_id,
+            response_id,
+            user_id,
+            next_created_at,
+            pending_messages,
+            pending_reasoning,
+            message_finish_reason.clone(),
+        )
+        .await;
+        let tool_cleanup_result = finalize_pending_tool_calls_for_terminal(
+            db,
+            user_key,
+            conversation_id,
+            response_id,
+            user_id,
+            next_created_at,
+            pending_tool_calls,
+        )
+        .await;
+        let cleanup_result = match (item_cleanup_result, tool_cleanup_result) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(e), Ok(())) | (Ok(()), Err(e)) => Err(e),
+            (Err(item_error), Err(tool_error)) => Err(format!(
+                "Pending item cleanup failed: {}; pending tool cleanup failed: {}",
+                item_error, tool_error
+            )),
+        };
+
+        let terminal_result = match cleanup_result {
+            Ok(()) => update_terminal_response_status(
+                db,
+                response_id,
+                response_uuid,
+                user_id,
+                requested.clone(),
+                reason,
+            ),
+            Err(cleanup_error) => match db.get_response_by_uuid_and_user(response_uuid, user_id) {
+                Err(DBError::ResponsesError(ResponsesError::ResponseNotFound)) => {
+                    debug!(
+                        "Response {} ({}) was deleted while pending item cleanup was retrying",
+                        response_id, response_uuid
+                    );
+                    Ok(None)
+                }
+                Ok(_) => Err(cleanup_error),
+                Err(e) => {
+                    warn!(
+                        "Failed to verify response existence after cleanup error: response_uuid={}, error={:?}",
+                        response_uuid, e
+                    );
+                    Err(cleanup_error)
+                }
+            },
+        };
+
+        match terminal_result {
+            Ok(authoritative) => return authoritative,
+            Err(e) => {
+                warn!(
+                    "Storage terminal persistence will retry: response_uuid={}, reason={}, retry_delay_ms={}, error={}",
+                    response_uuid,
+                    reason,
+                    retry_delay.as_millis(),
+                    e
+                );
+                tokio::time::sleep(retry_delay).await;
+                retry_delay = retry_delay.saturating_mul(2).min(TERMINAL_RETRY_MAX_DELAY);
+            }
         }
     }
 }
@@ -288,6 +696,7 @@ async fn mark_pending_items_incomplete(
 pub async fn storage_task(
     mut rx: mpsc::Receiver<StorageMessage>,
     tool_persist_ack: Option<mpsc::Sender<Result<(), String>>>,
+    terminal_persist_ack: Option<oneshot::Sender<Result<Option<ResponseTerminal>, String>>>,
     db: Arc<dyn DBConnection + Send + Sync>,
     response_id: i64,
     response_uuid: Uuid,
@@ -297,9 +706,12 @@ pub async fn storage_task(
     user_key: SecretKey,
 ) {
     let tool_ack = tool_persist_ack;
+    let mut terminal_ack = terminal_persist_ack;
     let mut pending_messages: HashMap<Uuid, PendingAssistantMessage> = HashMap::new();
     let mut pending_reasoning: HashMap<Uuid, PendingReasoningItem> = HashMap::new();
+    let mut pending_tool_calls: HashMap<Uuid, PendingToolCall> = HashMap::new();
     let mut next_item_created_at = first_item_created_at;
+    let mut storage_failed = false;
 
     while let Some(msg) = rx.recv().await {
         match msg {
@@ -319,6 +731,7 @@ pub async fn storage_task(
                     created_at,
                 ) {
                     error!("{}", e);
+                    storage_failed = true;
                 }
             }
             StorageMessage::ContentDelta { item_id, delta } => {
@@ -341,38 +754,56 @@ pub async fn storage_task(
                     "Storage: message done {} with finish_reason={}",
                     item_id, finish_reason
                 );
-                let pending = pending_messages.remove(&item_id).unwrap_or_default();
-                let created_at = pending
-                    .created_at
-                    .unwrap_or_else(|| allocate_created_at(&mut next_item_created_at));
-                if let Err(e) = create_assistant_message_if_missing(
+                let (created_at, content) = {
+                    let pending = pending_messages.entry(item_id).or_default();
+                    pending.completed_finish_reason = Some(finish_reason.clone());
+                    let created_at = pending
+                        .created_at
+                        .get_or_insert_with(|| allocate_created_at(&mut next_item_created_at))
+                        .to_owned();
+                    (created_at, pending.content.clone())
+                };
+                let create_result = create_assistant_message_if_missing(
                     &db,
                     conversation_id,
                     response_id,
                     user_id,
                     item_id,
                     created_at,
-                ) {
+                );
+                if let Err(e) = &create_result {
                     error!("{}", e);
+                    storage_failed = true;
                 }
-                if let Err(e) = finalize_assistant_message(
-                    &db,
-                    &user_key,
-                    item_id,
-                    pending.content,
-                    STATUS_COMPLETED,
-                    Some(finish_reason),
-                )
-                .await
-                {
-                    error!("{}", e);
+                if create_result.is_ok() {
+                    match finalize_assistant_message(
+                        &db,
+                        &user_key,
+                        item_id,
+                        content,
+                        STATUS_COMPLETED,
+                        Some(finish_reason),
+                    )
+                    .await
+                    {
+                        Ok(()) => {
+                            pending_messages.remove(&item_id);
+                        }
+                        Err(e) => {
+                            error!("{}", e);
+                            storage_failed = true;
+                        }
+                    }
                 }
             }
             StorageMessage::ReasoningStarted { item_id } => {
                 trace!("Storage: reasoning started {}", item_id);
-                pending_reasoning.entry(item_id).or_default();
-                let created_at = allocate_created_at(&mut next_item_created_at);
-                if let Err(e) = create_reasoning_item(
+                let pending = pending_reasoning.entry(item_id).or_default();
+                let created_at = pending
+                    .created_at
+                    .get_or_insert_with(|| allocate_created_at(&mut next_item_created_at))
+                    .to_owned();
+                if let Err(e) = create_reasoning_item_if_missing(
                     &db,
                     conversation_id,
                     response_id,
@@ -381,6 +812,7 @@ pub async fn storage_task(
                     created_at,
                 ) {
                     error!("{}", e);
+                    storage_failed = true;
                 }
             }
             StorageMessage::ReasoningDelta { item_id, delta } => {
@@ -401,15 +833,14 @@ pub async fn storage_task(
                     "Storage: finalizing reasoning item {} for response {}",
                     item_id, response_id
                 );
-                let pending = pending_reasoning.remove(&item_id).unwrap_or_default();
-                if let Err(e) = finalize_reasoning_item(
-                    &db,
-                    &user_key,
-                    item_id,
-                    pending.content,
-                    STATUS_COMPLETED,
-                )
-                .await
+                let content = {
+                    let pending = pending_reasoning.entry(item_id).or_default();
+                    pending.completed = true;
+                    pending.content.clone()
+                };
+                if let Err(e) =
+                    finalize_reasoning_item(&db, &user_key, item_id, content, STATUS_COMPLETED)
+                        .await
                 {
                     error!(
                         "Failed to finalize reasoning item {} for response {} after {} ms: {}",
@@ -418,7 +849,9 @@ pub async fn storage_task(
                         reasoning_finalize_started.elapsed().as_millis(),
                         e
                     );
+                    storage_failed = true;
                 } else {
+                    pending_reasoning.remove(&item_id);
                     debug!(
                         "Storage: finalized reasoning item {} for response {} in {} ms",
                         item_id,
@@ -430,85 +863,51 @@ pub async fn storage_task(
             StorageMessage::Usage { .. } => {
                 trace!("Storage: usage message ignored for item persistence");
             }
-            StorageMessage::ResponseDone { finish_reason } => {
-                debug!(
-                    "Storage: response done {} ({}) with finish_reason={}",
-                    response_id, response_uuid, finish_reason
-                );
-                // Sender invariant: stream_one_assistant_turn always emits MessageDone /
-                // ReasoningDone before ResponseDone. If that invariant ever breaks we'd
-                // leave items as "in_progress" forever, so defensively finalize any
-                // stragglers as incomplete and log loudly so the bug is visible.
-                if !pending_messages.is_empty() || !pending_reasoning.is_empty() {
-                    error!(
-                        "ResponseDone received with {} pending message(s) and {} pending reasoning item(s); sender invariant violated -- finalizing as incomplete",
-                        pending_messages.len(),
-                        pending_reasoning.len()
-                    );
-                    mark_pending_items_incomplete(
-                        &db,
-                        &user_key,
-                        &mut pending_messages,
-                        &mut pending_reasoning,
-                        None,
-                    )
-                    .await;
+            StorageMessage::Terminal(mut requested) => {
+                if storage_failed && matches!(requested, ResponseTerminal::Completed { .. }) {
+                    requested = ResponseTerminal::Failed(PublicResponseFailure::Internal);
                 }
-                update_terminal_response_status(
-                    &db,
-                    response_id,
-                    response_uuid,
-                    ResponseStatus::Completed,
-                    "ResponseDone",
-                );
-                return;
-            }
-            StorageMessage::Cancelled => {
-                debug!(
-                    "Storage: cancellation received for response {} ({})",
-                    response_id, response_uuid
-                );
-                update_terminal_response_status(
-                    &db,
-                    response_id,
-                    response_uuid,
-                    ResponseStatus::Cancelled,
-                    "cancellation",
-                );
-                mark_pending_items_incomplete(
+
+                if (!pending_messages.is_empty()
+                    || !pending_reasoning.is_empty()
+                    || !pending_tool_calls.is_empty())
+                    && matches!(requested, ResponseTerminal::Completed { .. })
+                {
+                    error!(
+                        "Completed terminal received with {} pending message(s), {} pending reasoning item(s), and {} pending tool call(s); failing response",
+                        pending_messages.len(),
+                        pending_reasoning.len(),
+                        pending_tool_calls.len()
+                    );
+                    requested = ResponseTerminal::Failed(PublicResponseFailure::Internal);
+                }
+
+                let finish_reason = matches!(requested, ResponseTerminal::Cancelled)
+                    .then(|| FINISH_REASON_CANCELLED.to_string());
+                let effective = persist_terminal_until_authoritative(
                     &db,
                     &user_key,
-                    &mut pending_messages,
-                    &mut pending_reasoning,
-                    Some(FINISH_REASON_CANCELLED.to_string()),
-                )
-                .await;
-                return;
-            }
-            StorageMessage::Error(error_msg) => {
-                error!(
-                    "Storage: received error for response {} ({}): {}",
-                    response_id, response_uuid, error_msg
-                );
-                update_terminal_response_status(
-                    &db,
+                    conversation_id,
                     response_id,
                     response_uuid,
-                    ResponseStatus::Failed,
-                    "streaming error",
-                );
-                mark_pending_items_incomplete(
-                    &db,
-                    &user_key,
+                    user_id,
+                    &mut next_item_created_at,
                     &mut pending_messages,
                     &mut pending_reasoning,
-                    None,
+                    &mut pending_tool_calls,
+                    requested,
+                    finish_reason,
+                    "supervised terminal",
                 )
                 .await;
+                if let Some(ack) = terminal_ack.take() {
+                    let _ = ack.send(Ok(effective));
+                }
                 return;
             }
             StorageMessage::ToolCall {
                 tool_call_id,
+                tool_output_id,
                 name,
                 arguments,
             } => {
@@ -519,7 +918,18 @@ pub async fn storage_task(
                     tool_call_id, tool_name, response_id
                 );
                 let created_at = allocate_created_at(&mut next_item_created_at);
-                match persist_tool_call(
+                pending_tool_calls.insert(
+                    tool_call_id,
+                    PendingToolCall {
+                        name: name.clone(),
+                        arguments: arguments.clone(),
+                        created_at,
+                        output_id: tool_output_id,
+                        output: None,
+                        output_created_at: None,
+                    },
+                );
+                match persist_tool_call_if_missing(
                     &db,
                     &user_key,
                     conversation_id,
@@ -548,6 +958,7 @@ pub async fn storage_task(
                             tool_call_persist_started.elapsed().as_millis(),
                             e
                         );
+                        storage_failed = true;
                         if let Some(ack) = &tool_ack {
                             let _ = ack.send(Err(e)).await;
                         }
@@ -565,7 +976,12 @@ pub async fn storage_task(
                     tool_output_id, tool_call_id, response_id
                 );
                 let created_at = allocate_created_at(&mut next_item_created_at);
-                match persist_tool_output(
+                if let Some(pending) = pending_tool_calls.get_mut(&tool_call_id) {
+                    pending.output_id = tool_output_id;
+                    pending.output = Some(output.clone());
+                    pending.output_created_at = Some(created_at);
+                }
+                match persist_tool_output_if_missing(
                     &db,
                     &user_key,
                     conversation_id,
@@ -579,6 +995,7 @@ pub async fn storage_task(
                 .await
                 {
                     Ok(()) => {
+                        pending_tool_calls.remove(&tool_call_id);
                         debug!(
                             "Storage: persisted tool_output {} for tool_call {} on response {} in {} ms",
                             tool_output_id,
@@ -599,6 +1016,7 @@ pub async fn storage_task(
                             tool_output_persist_started.elapsed().as_millis(),
                             e
                         );
+                        storage_failed = true;
                         if let Some(ack) = &tool_ack {
                             let _ = ack.send(Err(e)).await;
                         }
@@ -609,22 +1027,78 @@ pub async fn storage_task(
     }
 
     warn!(
-        "Storage channel closed before receiving ResponseDone signal for response {} ({})",
+        "Storage channel closed before receiving a supervised terminal for response {} ({})",
         response_id, response_uuid
     );
-    update_terminal_response_status(
-        &db,
-        response_id,
-        response_uuid,
-        ResponseStatus::Failed,
-        "premature storage channel close",
-    );
-    mark_pending_items_incomplete(
+    let effective = persist_terminal_until_authoritative(
         &db,
         &user_key,
+        conversation_id,
+        response_id,
+        response_uuid,
+        user_id,
+        &mut next_item_created_at,
         &mut pending_messages,
         &mut pending_reasoning,
+        &mut pending_tool_calls,
+        ResponseTerminal::Failed(PublicResponseFailure::Internal),
         None,
+        "premature storage channel close",
     )
     .await;
+    if let Some(ack) = terminal_ack.take() {
+        let _ = ack.send(Ok(effective));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_item_status_preserves_done_boundaries() {
+        let active_message = PendingAssistantMessage::default();
+        let (status, finish_reason) = active_message
+            .terminal_status_and_finish_reason(Some(FINISH_REASON_CANCELLED.to_string()));
+        assert_eq!(status, STATUS_INCOMPLETE);
+        assert_eq!(finish_reason.as_deref(), Some(FINISH_REASON_CANCELLED));
+
+        let done_message = PendingAssistantMessage {
+            completed_finish_reason: Some("stop".to_string()),
+            ..PendingAssistantMessage::default()
+        };
+        let (status, finish_reason) = done_message
+            .terminal_status_and_finish_reason(Some(FINISH_REASON_CANCELLED.to_string()));
+        assert_eq!(status, STATUS_COMPLETED);
+        assert_eq!(finish_reason.as_deref(), Some("stop"));
+
+        assert_eq!(
+            PendingReasoningItem::default().terminal_status(),
+            STATUS_INCOMPLETE
+        );
+        assert_eq!(
+            PendingReasoningItem {
+                completed: true,
+                ..PendingReasoningItem::default()
+            }
+            .terminal_status(),
+            STATUS_COMPLETED
+        );
+    }
+
+    #[test]
+    fn pending_tool_call_uses_real_output_or_interrupted_fallback() {
+        let mut pending = PendingToolCall {
+            name: "web_search".to_string(),
+            arguments: serde_json::json!({"query": "maple"}),
+            created_at: Utc::now(),
+            output_id: Uuid::new_v4(),
+            output: None,
+            output_created_at: None,
+        };
+
+        assert_eq!(pending.terminal_output(), INTERRUPTED_TOOL_OUTPUT);
+        pending.output = Some("real tool output".to_string());
+        assert_eq!(pending.terminal_output(), "real tool output");
+    }
 }


### PR DESCRIPTION
## Summary

- add a fixed-topology, enclave-local admission scheduler with bounded fair queues, atomic reservations, per-deployment concurrency, and a typed policy boundary
- use a reviewed policy compiled into the binary; remove environment, database/KMS, and JSON policy inputs from this first release
- retain provider quota and deployment-override structures for a future authenticated admin control plane, while leaving the baseline maps empty rather than guessing provider entitlements
- add atomic half-open probe leases across route, deployment, and shared provider-account gates so recovery probes are single-flight within an enclave
- pin the selected provider route and public model across Responses tool turns; explicit models never switch identity, while Auto Powerful remains limited to the agreed Kimi K3/K2.6 compatibility pair
- conservatively reserve prompt, cached, image, and completion capacity; reconcile independent authoritative usage dimensions; bound completion fanout and strip provider controls that could bypass accounting
- preserve pre-send-only replanning and the no same-request failover/replay contract, with typed 429/503 admission failures and retry guidance

## Compiled baseline

- deployment concurrency: 4 turns per provider-model deployment
- logical account concurrency: 2 active and 2 queued
- provider-pool queue: 16 turns, with fair account scheduling
- interactive/background wait: 5 seconds / immediate shed
- local retry hint and rolling window: 1 second / 60 seconds
- default completion reservation: 4096 tokens per choice
- maximum completion choices: 8
- provider RPM/TPM budgets and deployment overrides: intentionally empty

Changing this policy requires code review, a new build, and a process or enclave restart. The typed `AdmissionPolicy` to `AppStateBuilder` to `AdmissionController` boundary is retained for a future versioned admin API.

## Scope boundaries

- state is intentionally process-local; there is no distributed coordination or shared runtime state
- a process restart resets local health and admission state
- each enclave may independently admit one recovery probe
- no environment variable or `enclave_secrets` row can change admission policy
- Stack 9 and automated distributed adaptation are intentionally excluded

## Validation

- `nix develop --no-update-lock-file -c cargo fmt --all -- --check`
- `nix develop --no-update-lock-file -c cargo check --locked --all-targets --all-features`
- `nix develop --no-update-lock-file -c cargo clippy --locked --all-targets --all-features -- -D warnings`
- `nix develop --no-update-lock-file -c cargo test --locked --all-targets --all-features` (528 passed, 17 environment-gated ignored, 0 failed)
- isolated `ows smoke routing-v2` after rebuilding OpenSecret with the compiled startup path
- mock-provider coverage for 429, 503, synthetic 529, stalled bodies/streams, queue saturation, half-open races, route pinning, and usage settlement
- bounded live Kimi K3 and GLM-5.2 completion smoke tests; no provider rate-limit stress

## Review

P0/P1 spot checks were clean for routing concurrency, settlement, pinned K3/K2.6 prompt accounting, and the final hardcoded-policy diff. The Nitro EIF build remains Linux/custom-runner-only and is expected to be exercised by CI.