### PR TITLE
Specify transport v2 and prepare the v1 transport seam

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ OpenAI-compatible wire endpoint. Use an OpenSecret SDK or Maple for
 protected-route integration tests; plain `curl` is suitable only for public
 health probes.
 
+The additive, fail-closed next-generation network contract is specified in
+[`docs/transport-v2-protocol.md`](docs/transport-v2-protocol.md). Existing
+clients and routes retain their current transport behavior during the staged
+rollout.
+
 Contributor and coding-agent standards live in [`AGENTS.md`](AGENTS.md).
 Task-specific development, API, provider, security, and validation workflows
 live under [`.agents/skills/`](.agents/skills/).

--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -1,0 +1,576 @@
+# OpenSecret Transport Protocol v2
+
+Status: pre-implementation protocol contract
+
+Transport v2 carries a complete logical OpenSecret request inside one
+attested, encrypted request record. It binds authentication to that encrypted
+session, protects bodyless and bodyful operations equally, and rejects replay
+before application side effects.
+
+This is an additive network protocol. Existing routes, session behavior,
+authentication middleware, response formats, and streaming behavior remain the
+transport-v1 contract. A transport-v2 client never falls back to transport v1.
+
+## 1. Goals and non-goals
+
+Transport v2 provides these properties:
+
+- The untrusted parent and network can see only a coarse v2 endpoint, an opaque
+  session identifier, ciphertext sizes, timing, and connection metadata.
+- A credential accepted for an OpenSecret operation is established through the
+  same attested encrypted session that carries that operation.
+- A credential cannot be paired with an attacker-controlled encryption session.
+- Method, logical path, query, admitted headers, and body are authenticated as
+  one request.
+- Each accepted request identifier is single-use for the lifetime of its
+  session key epoch.
+- Every response record is encrypted by the exact session context that admitted
+  its request and is bound to that request identifier.
+- Streaming records are ordered and end with an authenticated terminal record.
+- Existing application APIs and SDK public methods can retain their current
+  shapes even though their outer network transport changes.
+
+The first implementation deliberately does not add:
+
+- bHTTP, EHBP, DPoP, HPKE, TLS termination inside the enclave, or WebSockets;
+- general application-level idempotency or transparent retry of uncertain
+  mutations;
+- raw API-key rotation;
+- database rollback protection;
+- refresh-token revocation; or
+- a transport-v1 compatibility mode inside new transport-v2 SDK releases.
+
+Those are independent features. They must not be implied by a transport-v2
+success response.
+
+## 2. Version boundary and rollout
+
+The server keeps transport v1 and v2 as separate stacks:
+
+- Transport-v1 routes keep their current handlers, middleware order, session
+  cache, keys, ciphertexts, errors, and SSE framing.
+- Transport v2 has separate pending-attestation and session caches. Transport-v2
+  traffic cannot evict or acquire a transport-v1 session.
+- A session identifier is valid in exactly one transport version.
+- The next major JavaScript and Rust SDK releases speak transport v2 only while
+  preserving their public application APIs.
+- Already-published SDKs continue to use transport v1.
+- A new client treats an old server as unsupported. A `404`, redirect, plaintext
+  error, decryption failure, or malformed v2 response never triggers fallback.
+
+The rollout unit is the SDK release, not a runtime feature flag. Deploy all
+additive server support before publishing clients that require v2. Rolling a
+client back means installing the previous SDK/application release; it does not
+mean negotiating down on a live connection.
+
+The term **transport v2** is intentionally distinct from the existing
+`USER_TOKEN_FORMAT_V2`, which describes first-party JWT claims rather than the
+network protocol.
+
+## 3. Outer HTTP surface
+
+Transport v2 initially exposes three coarse endpoints:
+
+```text
+GET  /v2/attestation/:nonce
+POST /v2/key_exchange
+POST /v2/request
+```
+
+The v2 attestation endpoint has the same Nitro attestation purpose as the
+existing endpoint but stores its one-shot ephemeral key in the separate v2
+pending-attestation cache.
+
+`POST /v2/request` carries unary and streaming operations. Its meaningful outer
+inputs are:
+
+```text
+x-session-id: <opaque UUID>
+content-type: application/json
+
+{"encrypted":"<canonical padded standard-base64 record>"}
+```
+
+It does not accept outer authorization, cookies, logical query parameters, or
+application/provider headers. Intermediaries may add ordinary transport
+headers, but those headers cannot affect application authorization or dispatch.
+
+The outer response may use HTTP status and content type for transport framing.
+The SDK treats logical status, headers, errors, and stream termination as valid
+only after authenticating the encrypted response record.
+
+## 4. Attested key exchange
+
+The client generates:
+
+- a fresh attestation nonce; and
+- a fresh X25519 ephemeral key pair.
+
+The client verifies the Nitro attestation document, including its requested
+nonce, attested enclave ephemeral X25519 public key, signature chain, freshness
+policy, and approved PCR policy, before continuing.
+
+The client sends its X25519 public key and the attestation nonce to
+`POST /v2/key_exchange`. The enclave consumes the corresponding one-shot
+pending key and rejects a non-contributory X25519 result.
+
+The enclave generates a random 32-byte session master and a random session
+UUID. X25519 is used only to protect this fresh session master; it is not used
+directly as the request or response key.
+
+The key-exchange wrapping key is:
+
+```text
+handshake_key = HKDF-SHA256(
+  input_key_material = x25519_shared_secret,
+  salt = empty,
+  info = UTF8("opensecret/transport-v2/handshake-key"),
+  length = 32
+)
+```
+
+The encrypted key payload contains the protocol version, session UUID, session
+master, and absolute expiry. The outer and encrypted session UUIDs must match.
+The record uses ChaCha20-Poly1305 and this AAD:
+
+```text
+UTF8("opensecret/transport-v2/key-exchange")
+```
+
+This domain-separates v2 from the legacy direct-shared-secret wrapping format.
+The exact payload encoding and golden bytes are frozen by the cross-language
+test vectors before the endpoint is registered.
+
+## 5. Session key schedule
+
+Request and response keys are derived from the random session master:
+
+```text
+request_key = HKDF-SHA256(
+  input_key_material = session_master,
+  salt = empty,
+  info = UTF8("opensecret/transport-v2/client-request"),
+  length = 32
+)
+
+response_key = HKDF-SHA256(
+  input_key_material = session_master,
+  salt = empty,
+  info = UTF8("opensecret/transport-v2/enclave-response"),
+  length = 32
+)
+```
+
+The enclave retains the directional keys, not the session master. Secret key
+material is zeroized when the session is removed.
+
+Each encrypted record is:
+
+```text
+random_nonce[12] || chacha20_poly1305_ciphertext_and_tag
+```
+
+The 96-bit nonce is generated independently for every record. A record shorter
+than 28 bytes is invalid. Standard base64 is canonical and padded; decoders
+reject alternate textual encodings.
+
+Request-record AAD is:
+
+```text
+UTF8("opensecret/transport-v2/request-record")
+|| 0x00
+|| session_uuid_bytes[16]
+```
+
+Unary-response AAD is:
+
+```text
+UTF8("opensecret/transport-v2/unary-response-record")
+|| 0x00
+|| session_uuid_bytes[16]
+|| request_id[16]
+```
+
+Streaming-response AAD is:
+
+```text
+UTF8("opensecret/transport-v2/stream-response-record")
+|| 0x00
+|| session_uuid_bytes[16]
+|| request_id[16]
+|| sequence_u64_be
+```
+
+The session UUID is serialized as its 16 RFC 9562 network-order bytes, never as
+text. The request identifier and sequence are known to the client before it
+opens the corresponding response record.
+
+## 6. Complete encrypted request
+
+The decrypted request is a strict JSON envelope:
+
+```json
+{
+  "version": 2,
+  "request_id": "00112233445566778899aabbccddeeff",
+  "response_mode": "auto",
+  "credential": null,
+  "request": {
+    "method": "POST",
+    "path": "/v1/responses",
+    "query": null,
+    "headers": [
+      {
+        "name": "content-type",
+        "value_base64": "YXBwbGljYXRpb24vanNvbg=="
+      }
+    ],
+    "body_base64": "eyJtb2RlbCI6Ii4uLiJ9"
+  }
+}
+```
+
+Fields have these meanings:
+
+- `version` is exactly the integer `2`.
+- `request_id` is lowercase hexadecimal for exactly 16 bytes generated by the
+  operating-system CSPRNG. It is not a UUIDv4 because UUIDv4 exposes only 122
+  random bits.
+- `response_mode` is `unary`, `stream`, or `auto`. `auto` lets raw SDK/proxy
+  APIs preserve a server-selected unary or streaming response. Explicit modes
+  must agree with the selected route and application request.
+- `credential` is normally `null`. It is used only for a permitted anonymous
+  authentication transition such as initial API-key binding.
+- `method` is a supported uppercase HTTP method.
+- `path` is one origin-relative application path with no query or fragment.
+- `query` is either `null` or the exact query string without a leading `?`.
+- `headers` preserves supported duplicate fields in order. Header names are
+  lowercase ASCII and values are exact bytes encoded as canonical base64.
+- `body_base64: null` means no request body. An empty string means an explicitly
+  present empty body. Other values preserve exact request bytes without
+  transport-layer JSON parsing or reserialization.
+
+Unknown and duplicate JSON fields are rejected. The implementation parses the
+path and query once, rejects schemes, authorities, fragments, backslashes,
+dot-segments, encoded separator ambiguity, and invalid percent encoding, then
+maps `(method, path)` through an exact application allowlist.
+
+The gateway never hands an arbitrary URI to the full transport-v1 router.
+Application operations are projected deliberately onto shared application
+services/handlers.
+
+The encrypted-header policy is route scoped. Typed application operations use
+explicit per-operation allowlists. Raw inference operations preserve the
+current SDK contract for arbitrary valid end-to-end extension headers and
+duplicates, but apply a strict denylist. Every policy rejects at least:
+
+- `authorization`, `cookie`, `set-cookie`, `host`, and `x-session-id`;
+- connection, proxy, transfer, upgrade, and other hop-by-hop/framing headers;
+- client-supplied provider credentials; and
+- unsafe fields selected by a `connection` header and any field the existing
+  raw-inference contract already strips.
+
+The implementation PR owns the exact typed allowlists and raw-inference
+denylist. It tests them against the current Rust and JavaScript raw-request
+contracts, including safe extension headers such as `x-provider-beta`. Outer
+headers are never forwarded into application or provider logic.
+
+## 7. Request admission and replay
+
+The enclave processes every v2 request in this order:
+
+1. Read the bounded outer body.
+2. Parse the outer session UUID and acquire one lease from the v2 cache.
+3. Reject a session past absolute expiry, bound-authentication expiry, or record
+   budget. Authentication expiry closes the bound session fail closed.
+4. Decode and decrypt with that lease's request key and request AAD.
+5. Strictly parse and structurally validate the envelope.
+6. Validate method, path, query, headers, body presence, credential use, and
+   response mode for the selected application operation.
+7. Atomically claim the decoded 16-byte request identifier.
+8. Only then authenticate, dispatch, mutate state, bill, send email, or call a
+   provider.
+
+Replay rules are:
+
+- Identifiers are scoped to one v2 session/key epoch.
+- Distinct requests may arrive and complete in any order.
+- The enclave stores exact identifiers, not a highest sequence counter or a
+  packet-order assumption.
+- An identifier is never evicted while its session keys can admit requests.
+- Two concurrent requests with one identifier have exactly one winner at the
+  replay gate.
+- A duplicate returns an encrypted `replay_detected` error. It does not return a
+  cached result and does not reveal whether the first execution completed.
+- If the per-session or global replay budget is exhausted, the session becomes
+  exhausted and admits no more application requests. The client establishes a
+  new attested session for later requests.
+- Malformed, undecryptable, structurally invalid, and replayed records do not
+  refresh idle state and never dispatch.
+
+The first release uses a 65-minute absolute key lifetime. A lease may allow an
+already-admitted response stream to finish, but it does not allow new requests
+after absolute expiry. Exact session and replay capacities are chosen and
+memory-accounted in the v2-core implementation PR; they are not borrowed from
+the transport-v1 cache budget.
+
+Replay detection is not application idempotency. Once request bytes may have
+reached the enclave, a transport failure is an uncertain outcome. The v2 SDK
+does not transparently resend that application request under either the same or
+a new session. A caller may retry only according to an operation's explicit
+idempotency contract.
+
+## 8. Authentication and immutable session binding
+
+A v2 session has one of these authority states:
+
+```text
+Anonymous
+  -> Authenticating(request_id)
+  -> Bound(User | Platform | ApiKey)
+  -> Closing
+```
+
+The transition to `Authenticating` is atomic and happens before asynchronous
+credential verification or authentication side effects. Failure and
+cancellation return the session to `Anonymous`. Exactly one successful
+transition can bind a session.
+
+Once bound:
+
+- the principal kind and identity are immutable;
+- account switching requires a new attested session;
+- login, registration, resumption, and API-key rebinding are rejected;
+- protected authorization comes from the bound session, never an outer bearer;
+  and
+- logout encrypts its response with the admitting lease before closing and
+  zeroizing the session.
+
+The SDK owns each v2 session within exactly one authentication/client context;
+it never reuses the current origin-and-PCR-only global cache across users,
+platform users, API keys, or anonymous clients. User/account changes and
+`set_api_key` or `clear_api_key` abandon the affected bound session and establish
+a fresh one. Distinct API keys can have concurrent sessions against one origin
+without sharing authority.
+
+A password change may replace the same user's credential-bound `AuthContext`.
+That is credential-context evolution for one principal, not principal rebinding.
+
+### 8.1 User sessions
+
+A user binding retains immutable user/project identity, the current
+credential-bound `AuthContext`, and authentication expiry. Authorization keeps
+the existing active seed-wrap and live user/project checks so password changes,
+destructive resets, and account deletion invalidate old authority.
+
+Fresh password, registration, and OAuth success bind the anonymous session that
+carried the operation. Resumption binds a new anonymous v2 session only after
+validating a transport-v2 resumption credential inside ciphertext.
+
+### 8.2 Platform sessions
+
+A platform binding retains platform-user identity and authentication expiry.
+Organization membership and Owner/Admin authority remain live database checks;
+they are not cached in the transport session.
+
+### 8.3 API-key sessions
+
+The existing raw API key is sent once inside the encrypted initial credential
+transition. It is not rotated. A successful transition binds a distinct
+inference-only API-key principal and the triggering request may proceed.
+
+The binding retains a non-secret key identity/hash and rechecks current key
+existence before every operation so deletion remains immediately effective.
+API-key sessions can reach only the same inference operation set that accepts
+API keys today; they never become general user sessions.
+
+## 9. First-party and third-party tokens
+
+Transport v2 removes first-party JWTs from steady-state OpenSecret request
+authorization. It can temporarily preserve the SDK's current token-shaped
+login result for Maple compatibility:
+
+- `access_token` is a signed, v2-only compatibility/session descriptor with a
+  distinct audience that transport-v1 middleware rejects. The v2 SDK never
+  sends it as OpenSecret authorization.
+- `refresh_token` is a v2-only resumption credential accepted only inside an
+  encrypted v2 transition. Transport-v1 refresh rejects it.
+- Existing v1 access and refresh JWTs cannot bootstrap a v2 session. Initial
+  adoption therefore requires the agreed one-time fresh login.
+- The returned fields remain encrypted and retain current public SDK response
+  shapes while Maple's auth-state bridge is migrated separately later.
+
+All transport-v2 access and resumption audiences are reserved internal
+audiences. Third-party token issuance rejects them, just as it rejects existing
+first-party audiences. Resumption validates the expected v2 audience, token
+kind, principal kind and identity, project/authentication context where
+applicable, issue/expiry times, and active credential state; an audience match
+alone is never sufficient.
+
+These credentials remain bearer secrets if stolen from the client. Transport
+v2 protects them from the parent/network threat; it does not claim to protect a
+fully compromised same-origin application or device.
+
+Third-party JWT issuance remains an ordinary bound-user application operation.
+Its existing audience, project signing configuration, claims, expiry, and
+portability for billing and other microservices remain unchanged. Third-party
+JWTs never authenticate OpenSecret v2 and cannot bind a v2 session. Platform and
+API-key principals cannot issue them.
+
+## 10. Unary responses and errors
+
+Once a valid session decrypts a request identifier, responses use a strict
+encrypted unary envelope. This includes structural/pre-dispatch errors and
+`replay_detected`; success and side-effecting application errors additionally
+require the identifier to have passed the replay gate.
+
+```json
+{
+  "version": 2,
+  "request_id": "00112233445566778899aabbccddeeff",
+  "status": 200,
+  "headers": [
+    {
+      "name": "content-type",
+      "value_base64": "YXBwbGljYXRpb24vanNvbg=="
+    }
+  ],
+  "body_base64": "eyJvayI6dHJ1ZX0="
+}
+```
+
+The response uses the exact leased crypto context that admitted the request. It
+does not look up a session again from an outer UUID. The SDK verifies response
+AAD and exact `request_id` before accepting status, headers, or body.
+
+Response headers use a strict allowlist and exclude transport framing, cookies,
+server internals, and credentials.
+
+Failures before a valid session can be leased and the request identifier can be
+recovered are generic bounded plaintext transport errors. They are untrusted
+and terminal for that attempt. They cannot authorize automatic replay or
+fallback.
+
+## 11. Streaming responses
+
+Transport v2 preserves the SDK's caller-visible streaming response, including
+SSE used by chat and Responses APIs. The outer response is an SSE carrier whose
+`data` field contains one canonical-base64 encrypted record.
+
+Decrypted records are one of:
+
+```json
+{"version":2,"request_id":"...","sequence":0,"kind":"start","status":200,"headers":[]}
+{"version":2,"request_id":"...","sequence":1,"kind":"chunk","body_base64":"..."}
+{"version":2,"request_id":"...","sequence":2,"kind":"end"}
+{"version":2,"request_id":"...","sequence":2,"kind":"error","status":500,"body_base64":"..."}
+```
+
+Rules are:
+
+- Sequence starts at zero and increments by one for every encrypted record.
+- Sequence is included in both AAD and plaintext and must equal the client's
+  next expected value.
+- `start` is first and authenticates logical status and response headers.
+- `chunk` carries exact raw response bytes. The SDK reconstructs the current
+  SSE or other streaming body without parsing application events in the
+  transport layer.
+- Exactly one authenticated `end` or `error` terminal record is required.
+- EOF before a terminal record, a duplicate/out-of-order sequence, plaintext
+  application data, or an undecryptable record fails the stream.
+- The exact request lease remains held until terminal delivery or body drop.
+
+This record layer is not specific to SSE application semantics. It can later
+carry other ordered server-to-client byte streams. Bidirectional transports
+such as WebSocket, WebTransport, or WebRTC require a separate framing profile
+and are not added by this protocol version.
+
+## 12. Parsing and resource limits
+
+All limits are checked before allocation or work at the corresponding boundary.
+At minimum v2 bounds:
+
+- outer encrypted request bytes;
+- decrypted envelope bytes;
+- path and query bytes;
+- header count, individual name/value bytes, and aggregate header bytes;
+- logical body bytes;
+- individual encrypted/decrypted streaming record bytes;
+- concurrent sessions and pending attestations;
+- absolute session age;
+- request records per session;
+- response records per request and session; and
+- per-session and global replay identifiers.
+
+The initial outer ceiling may retain the current 50 MiB limit. Base64 expansion
+and simultaneous outer/decoded/decrypted buffers must be included in memory
+accounting rather than described as only wire overhead.
+
+No outer content encoding or decompression is accepted. Application-layer
+payload validation remains owned by the existing application operation.
+
+## 13. Required compatibility and security tests
+
+Before registering public v2 routes, backend, TypeScript, and Rust tests share
+golden vectors for:
+
+- handshake HKDF and encrypted key payload;
+- request and response directional keys;
+- UUID and request-ID byte encodings;
+- request, unary-response, and streaming AAD;
+- fixed nonces and expected ChaCha20-Poly1305 records;
+- no body versus an explicitly empty body;
+- exact query/header/body bytes; and
+- wrong key/direction/session/request ID/sequence, malformed encodings, and tag
+  tampering.
+
+The backend additionally proves:
+
+- concurrent identical request IDs have exactly one replay-gate winner;
+- distinct request IDs are admitted out of order;
+- replay is claimed before a mocked mutation/provider/billing/email side effect;
+- malformed, undecryptable, and replayed requests never dispatch;
+- replay/session exhaustion fails closed;
+- authentication transitions are atomic and cancellation safe;
+- bound principals cannot switch kind or identity;
+- API-key deletion remains effective for an already-bound session;
+- every stream outcome has encrypted ordered terminal framing; and
+- v2 load, leases, and cache exhaustion cannot alter a v1 session.
+
+Every server PR runs current released-style JavaScript and Rust v1 clients
+against the new server and characterizes existing route, status, error,
+encryption, bodyless, and SSE behavior. Client cutover proves:
+
+- old client against new server still uses unchanged v1;
+- new client against old server fails as unsupported with no fallback;
+- new client sends no outer authorization or application metadata;
+- an ambiguous post-send failure is surfaced without automatic resend; and
+- third-party JWT issuance remains usable downstream but cannot authenticate
+  OpenSecret.
+- two client instances or API keys at one origin never share a bound session.
+
+## 14. Planned pull-request stack
+
+1. **Protocol contract**: this document and byte-level review decisions.
+2. **V1 transport seam**: behavior-neutral response/session context and
+   characterization tests; no v2 routes.
+3. **Dormant v2 core**: codecs, key schedule, directional AEAD, separate session
+   state/cache, absolute expiry, replay registry, budgets, and vectors; no
+   public routes.
+4. **V2 gateway and binding**: attestation/key exchange/request endpoints,
+   anonymous authentication transitions, v2-only resumption, and API-key
+   binding.
+5. **Application projection and streaming**: existing operation families over
+   v2, live authorization checks, unary responses, and ordered streaming.
+6. **Additive SDK v2 internals**: TypeScript and Rust codecs/session managers
+   behind private seams, still not selected by public calls.
+7. **Atomic SDK cutover**: v2-only network behavior, no downgrade, one-time
+   fresh login, and Maple/proxy integration.
+8. **SDK major/version packaging**: package metadata, locks, integration pin,
+   compatibility matrix, and release rehearsal. Publication/deployment remain
+   separate authorized actions.
+
+Each implementation PR receives one focused security review and one focused
+compatibility review. Reviews should report credible vulnerabilities,
+behavioral regressions, or small correctness fixes; unrelated redesign and
+speculative edge cases stay out of this stack.

--- a/src/security_invariants.rs
+++ b/src/security_invariants.rs
@@ -176,6 +176,36 @@ fn openai_compatible_routes_do_not_request_user_storage_keys() {
 }
 
 #[test]
+fn response_encryption_routes_through_transport_session() {
+    let web_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/web");
+
+    let mut direct_session_encryption = Vec::new();
+    collect_pattern_matches(
+        &web_root,
+        ".encrypt_session_data(",
+        &mut direct_session_encryption,
+    );
+    assert_eq!(
+        direct_session_encryption.len(),
+        1,
+        "response encryption must stay centralized in TransportSession:\n{}",
+        direct_session_encryption.join("\n")
+    );
+    assert!(
+        direct_session_encryption[0].contains("encryption_middleware.rs"),
+        "the sole legacy session-encryption delegate must live in encryption_middleware.rs"
+    );
+
+    let mut bare_session_extensions = Vec::new();
+    collect_pattern_matches(&web_root, "Extension<Uuid>", &mut bare_session_extensions);
+    assert!(
+        bare_session_extensions.is_empty(),
+        "handlers must receive TransportSession rather than a bare session UUID:\n{}",
+        bare_session_extensions.join("\n")
+    );
+}
+
+#[test]
 fn models_route_allows_optional_identity_but_requires_session_e2ee() {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let main_source = fs::read_to_string(manifest_dir.join("src/main.rs"))
@@ -200,7 +230,7 @@ fn models_route_allows_optional_identity_but_requires_session_e2ee() {
     let handler_body = extract_function_body(&openai_source, "async fn proxy_models");
     assert!(
         openai_source.contains(
-            "async fn proxy_models(\n    State(state): State<Arc<AppState>>,\n    axum::Extension(session_id): axum::Extension<Uuid>,\n    user: Option<axum::Extension<User>>"
+            "async fn proxy_models(\n    State(state): State<Arc<AppState>>,\n    axum::Extension(session_id): axum::Extension<TransportSession>,\n    user: Option<axum::Extension<User>>"
         )
             && handler_body.contains("encrypt_response(&state, &session_id, &models_response)"),
         "the models handler must require session E2EE while allowing optional identity"

--- a/src/web/encryption_middleware.rs
+++ b/src/web/encryption_middleware.rs
@@ -20,6 +20,42 @@ use crate::{ApiError, AppState};
 
 const MAX_ENCRYPTED_BODY_BYTES: usize = 50 * 1024 * 1024; // 50MB
 
+/// Identifies the transport context that must encrypt a handler response.
+///
+/// Keeping this distinct from the application's authenticated principal makes
+/// the response transport explicit at the handler boundary. V1 contains only
+/// the legacy session identifier; future protocol versions can carry their
+/// exact response-encryption context without changing every handler again.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TransportSession {
+    kind: TransportSessionKind,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum TransportSessionKind {
+    V1 { session_id: Uuid },
+}
+
+impl TransportSession {
+    fn v1(session_id: Uuid) -> Self {
+        Self {
+            kind: TransportSessionKind::V1 { session_id },
+        }
+    }
+
+    pub(crate) async fn encrypt_response_bytes(
+        &self,
+        state: &AppState,
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, ApiError> {
+        match &self.kind {
+            TransportSessionKind::V1 { session_id } => {
+                state.encrypt_session_data(session_id, plaintext).await
+            }
+        }
+    }
+}
+
 #[derive(Deserialize)]
 pub struct EncryptedRequest {
     pub encrypted: String,
@@ -73,7 +109,9 @@ where
     if std::any::TypeId::of::<T>() == std::any::TypeId::of::<()>() {
         request.extensions_mut().insert(());
     }
-    request.extensions_mut().insert(session_id);
+    request
+        .extensions_mut()
+        .insert(TransportSession::v1(session_id));
     let response = run_next(request).await;
     Ok(hold_resource_through_response_body(response, resource))
 }
@@ -128,7 +166,9 @@ where
     })?;
 
     request.extensions_mut().insert(decrypted);
-    request.extensions_mut().insert(session_id);
+    request
+        .extensions_mut()
+        .insert(TransportSession::v1(session_id));
     let response = next.run(request).await;
     Ok(hold_resource_through_response_body(response, session_lease))
 }
@@ -175,12 +215,12 @@ where
 
 pub async fn encrypt_response<T: Serialize>(
     state: &AppState,
-    session_id: &Uuid,
+    transport_session: &TransportSession,
     response: &T,
 ) -> Result<Json<EncryptedResponse<T>>, ApiError> {
     let response_json = serde_json::to_vec(response).map_err(|_| ApiError::InternalServerError)?;
-    let encrypted_response = state
-        .encrypt_session_data(session_id, &response_json)
+    let encrypted_response = transport_session
+        .encrypt_response_bytes(state, &response_json)
         .await?;
     Ok(Json(EncryptedResponse::new(
         base64::engine::general_purpose::STANDARD.encode(encrypted_response),
@@ -274,7 +314,10 @@ mod tests {
                 .body(Body::empty())
                 .unwrap(),
             move |request| {
-                assert_eq!(request.extensions().get::<Uuid>(), Some(&session_id));
+                assert_eq!(
+                    request.extensions().get::<TransportSession>(),
+                    Some(&TransportSession::v1(session_id))
+                );
                 assert!(request.extensions().get::<()>().is_some());
                 observed_calls.fetch_add(1, Ordering::SeqCst);
                 async { Response::new(Body::empty()) }

--- a/src/web/login_routes.rs
+++ b/src/web/login_routes.rs
@@ -5,7 +5,10 @@ use crate::{
     jwt::{validate_token, AuthContext, NewToken, TokenType},
     models::email_verification::NewEmailVerification,
 };
-use crate::{jwt::USER_REFRESH, web::encryption_middleware::EncryptedResponse};
+use crate::{
+    jwt::USER_REFRESH,
+    web::encryption_middleware::{EncryptedResponse, TransportSession},
+};
 use crate::{
     web::encryption_middleware::{decrypt_request, encrypt_response},
     Error,
@@ -134,7 +137,7 @@ pub struct LogoutRequest {
 pub async fn login(
     State(data): State<Arc<AppState>>,
     Extension(creds): Extension<Credentials>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<AuthResponse>>, ApiError> {
     tracing::trace!("call login");
 
@@ -243,7 +246,7 @@ async fn login_internal(data: Arc<AppState>, creds: Credentials) -> Result<AuthR
 pub async fn logout(
     State(data): State<Arc<AppState>>,
     Extension(logout_request): Extension<LogoutRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     info!("Logout request received");
     // TODO actually delete the refresh token
@@ -256,7 +259,7 @@ pub async fn logout(
 pub async fn register(
     State(data): State<Arc<AppState>>,
     Extension(creds): Extension<RegisterCredentials>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<AuthResponse>>, ApiError> {
     tracing::trace!("call register");
 
@@ -342,7 +345,7 @@ pub async fn handle_new_user_registration(
 pub async fn refresh_token(
     State(data): State<Arc<AppState>>,
     Extension(refresh_request): Extension<RefreshRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<RefreshResponse>>, ApiError> {
     info!("Refresh token request received");
 
@@ -376,7 +379,7 @@ pub async fn refresh_token(
 pub async fn verify_email(
     State(data): State<Arc<AppState>>,
     Path(code): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     let verification = match data.db.get_email_verification_by_code(code) {
         Ok(v) => v,
@@ -410,7 +413,7 @@ pub async fn verify_email(
 pub async fn password_reset_request(
     State(data): State<Arc<AppState>>,
     Extension(payload): Extension<PasswordResetRequestPayload>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     // Get project by client_id
     let project = data
@@ -462,7 +465,7 @@ pub async fn password_reset_request(
 pub async fn password_reset_confirm(
     State(data): State<Arc<AppState>>,
     Extension(payload): Extension<PasswordResetConfirmPayload>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     // Get project by client_id
     let project = data

--- a/src/web/oauth_routes.rs
+++ b/src/web/oauth_routes.rs
@@ -3,7 +3,9 @@ use crate::apple_signin::{generate_apple_client_secret, validate_apple_native_to
 use crate::models::oauth::NewUserOAuthConnection;
 use crate::models::oauth::UserOAuthConnection;
 use crate::oauth::{BasicClient, OAuthState};
-use crate::web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse};
+use crate::web::encryption_middleware::{
+    decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+};
 use crate::web::login_routes::handle_new_user_registration;
 use crate::web::platform::common::{
     PROJECT_APPLE_OAUTH_SECRET, PROJECT_GITHUB_OAUTH_SECRET, PROJECT_GOOGLE_OAUTH_SECRET,
@@ -421,7 +423,7 @@ async fn get_project_oauth_client(
 pub async fn initiate_oauth(
     State(app_state): State<Arc<AppState>>,
     Extension(auth_request): Extension<OAuthAuthRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     provider_name: &str,
 ) -> Result<Json<EncryptedResponse<OAuthOAuthCallbackResponse>>, ApiError> {
     // Get project
@@ -473,7 +475,7 @@ pub async fn initiate_oauth(
 pub async fn oauth_callback(
     State(app_state): State<Arc<AppState>>,
     Extension(callback_request): Extension<OAuthCallbackRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     provider_name: &str,
 ) -> Result<Json<EncryptedResponse<OAuthCallbackResponse>>, ApiError> {
     debug!(
@@ -1279,7 +1281,7 @@ async fn find_or_create_user_from_oauth(
 pub async fn handle_apple_native_signin(
     State(app_state): State<Arc<AppState>>,
     Extension(request): Extension<AppleNativeSignInRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<OAuthCallbackResponse>>, ApiError> {
     debug!("Handling Apple native sign-in");
 

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -10,7 +10,9 @@ use crate::provider_routing::{ProviderName, ProviderRoutingError};
 use crate::proxy_config::ProxyConfig;
 use crate::sqs::UsageEvent;
 use crate::web::audio_utils::{merge_transcriptions, AudioSplitter, TINFOIL_MAX_SIZE};
-use crate::web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse};
+use crate::web::encryption_middleware::{
+    decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+};
 use crate::web::openai_auth::AuthMethod;
 use crate::{ApiError, AppState};
 use axum::http::HeaderMap;
@@ -753,7 +755,7 @@ pub fn models_router(app_state: Arc<AppState>) -> Router<()> {
 async fn proxy_openai(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
-    axum::Extension(session_id): axum::Extension<Uuid>,
+    axum::Extension(session_id): axum::Extension<TransportSession>,
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(auth_method): axum::Extension<AuthMethod>,
     axum::Extension(mut body): axum::Extension<Value>,
@@ -1688,12 +1690,12 @@ fn build_usage_event(
 /// Helper to encrypt an SSE event
 async fn encrypt_sse_event(
     state: &AppState,
-    session_id: &Uuid,
+    transport_session: &TransportSession,
     json: &Value,
 ) -> Result<Event, ApiError> {
     let json_str = json.to_string();
-    let encrypted_data = state
-        .encrypt_session_data(session_id, json_str.as_bytes())
+    let encrypted_data = transport_session
+        .encrypt_response_bytes(state, json_str.as_bytes())
         .await
         .map_err(|e| {
             error!("Failed to encrypt SSE event data: {:?}", e);
@@ -1706,7 +1708,7 @@ async fn encrypt_sse_event(
 
 async fn proxy_models(
     State(state): State<Arc<AppState>>,
-    axum::Extension(session_id): axum::Extension<Uuid>,
+    axum::Extension(session_id): axum::Extension<TransportSession>,
     user: Option<axum::Extension<User>>,
 ) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
     let _ = user;
@@ -1768,7 +1770,7 @@ async fn fetch_provider_models(
 async fn proxy_model_catalog(
     State(state): State<Arc<AppState>>,
     _headers: HeaderMap,
-    axum::Extension(session_id): axum::Extension<Uuid>,
+    axum::Extension(session_id): axum::Extension<TransportSession>,
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(_body): axum::Extension<()>,
@@ -1883,7 +1885,7 @@ async fn send_transcription_with_retries(
 async fn proxy_transcription(
     State(state): State<Arc<AppState>>,
     _headers: HeaderMap,
-    axum::Extension(session_id): axum::Extension<Uuid>,
+    axum::Extension(session_id): axum::Extension<TransportSession>,
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(transcription_request): axum::Extension<TranscriptionRequest>,
@@ -2288,7 +2290,7 @@ async fn ensure_paid_tts_access(state: &AppState, user: &User) -> Result<(), Api
 
 async fn proxy_tts(
     State(state): State<Arc<AppState>>,
-    axum::Extension(session_id): axum::Extension<Uuid>,
+    axum::Extension(session_id): axum::Extension<TransportSession>,
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(tts_request): axum::Extension<TTSRequest>,
@@ -2381,7 +2383,7 @@ async fn proxy_tts(
 async fn proxy_embeddings(
     State(state): State<Arc<AppState>>,
     _headers: HeaderMap,
-    axum::Extension(session_id): axum::Extension<Uuid>,
+    axum::Extension(session_id): axum::Extension<TransportSession>,
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(embedding_request): axum::Extension<EmbeddingRequest>,

--- a/src/web/platform/invite_routes.rs
+++ b/src/web/platform/invite_routes.rs
@@ -5,7 +5,9 @@ use crate::{
         org_memberships::{NewOrgMembership, OrgRole},
         platform_users::PlatformUser,
     },
-    web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+    web::encryption_middleware::{
+        decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+    },
     ApiError, AppState, DBError,
 };
 use axum::{
@@ -55,7 +57,7 @@ async fn create_invite(
     Extension(platform_user): Extension<PlatformUser>,
     Path(org_id): Path<Uuid>,
     Extension(create_request): Extension<CreateInviteRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<InviteResponse>>, ApiError> {
     debug!("Creating invite");
 
@@ -133,7 +135,7 @@ async fn list_invites(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path(org_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<Vec<InviteResponse>>>, ApiError> {
     debug!("Listing organization invites");
 
@@ -187,7 +189,7 @@ async fn get_invite(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, invite_code)): Path<(Uuid, Uuid)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<DetailedInviteResponse>>, ApiError> {
     debug!("Getting invite by code");
 
@@ -247,7 +249,7 @@ async fn delete_invite(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, invite_code)): Path<(Uuid, Uuid)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     debug!("Deleting invite");
 
@@ -299,7 +301,7 @@ async fn accept_invite(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path(code): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     debug!("Accepting invite");
 

--- a/src/web/platform/login_routes.rs
+++ b/src/web/platform/login_routes.rs
@@ -5,7 +5,9 @@ use crate::{
         org_memberships::OrgRole, platform_email_verification::NewPlatformEmailVerification,
         platform_users::NewPlatformUser,
     },
-    web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+    web::encryption_middleware::{
+        decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+    },
     ApiError, AppState, Error,
 };
 use axum::{
@@ -193,7 +195,7 @@ pub fn router(app_state: Arc<AppState>) -> Router<()> {
 pub async fn login_platform_user(
     State(data): State<Arc<AppState>>,
     Extension(login_request): Extension<PlatformLoginRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<PlatformAuthResponse>>, ApiError> {
     // Validate request
     if let Err(errors) = login_request.validate() {
@@ -245,7 +247,7 @@ async fn login_internal_platform(
 pub async fn register_platform_user(
     State(data): State<Arc<AppState>>,
     Extension(register_request): Extension<PlatformRegisterRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<PlatformAuthResponse>>, ApiError> {
     // Validate request
     if let Err(errors) = register_request.validate() {
@@ -350,7 +352,7 @@ pub async fn register_platform_user(
 pub async fn refresh_platform_token(
     State(data): State<Arc<AppState>>,
     Extension(refresh_request): Extension<PlatformRefreshRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<PlatformRefreshResponse>>, ApiError> {
     // Validate request
     if let Err(errors) = refresh_request.validate() {
@@ -383,7 +385,7 @@ pub async fn refresh_platform_token(
 pub async fn verify_platform_email(
     State(data): State<Arc<AppState>>,
     Path(code): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     // Retrieve the verification record using the code
     let verification = match data.db.get_platform_email_verification_by_code(code) {
@@ -433,7 +435,7 @@ pub async fn verify_platform_email(
 pub async fn logout_platform_user(
     State(data): State<Arc<AppState>>,
     Extension(logout_request): Extension<PlatformLogoutRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     info!("Platform logout request received");
 
@@ -447,7 +449,7 @@ pub async fn logout_platform_user(
 pub async fn platform_password_reset_request(
     State(data): State<Arc<AppState>>,
     Extension(payload): Extension<PlatformPasswordResetRequestPayload>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     // Validate request
     if let Err(errors) = payload.validate() {
@@ -499,7 +501,7 @@ pub async fn platform_password_reset_request(
 pub async fn platform_password_reset_confirm(
     State(data): State<Arc<AppState>>,
     Extension(payload): Extension<PlatformPasswordResetConfirmPayload>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     // Validate request
     if let Err(errors) = payload.validate() {

--- a/src/web/platform/me_routes.rs
+++ b/src/web/platform/me_routes.rs
@@ -2,7 +2,9 @@ use crate::{
     email::send_platform_verification_email,
     models::platform_email_verification::NewPlatformEmailVerification,
     models::platform_users::PlatformUser,
-    web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+    web::encryption_middleware::{
+        decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+    },
     ApiError, AppState,
 };
 use axum::{
@@ -16,7 +18,6 @@ use serde_json::json;
 use std::sync::Arc;
 use tokio::spawn;
 use tracing::error;
-use uuid::Uuid;
 use validator::Validate;
 
 use super::common::{MeResponse, OrgResponse, PlatformUserResponse};
@@ -63,7 +64,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
 async fn get_platform_user(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<MeResponse>>, ApiError> {
     // Check if email is verified
     let email_verified = match data
@@ -130,7 +131,7 @@ async fn get_platform_user(
 async fn request_platform_verification(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     // Check if the user is already verified
     match data
@@ -200,7 +201,7 @@ pub async fn platform_change_password(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Extension(change_request): Extension<PlatformChangePasswordRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     // Validate request
     if let Err(errors) = change_request.validate() {

--- a/src/web/platform/membership_routes.rs
+++ b/src/web/platform/membership_routes.rs
@@ -3,7 +3,9 @@ use crate::{
         org_memberships::{OrgMembershipError, OrgRole},
         platform_users::PlatformUser,
     },
-    web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+    web::encryption_middleware::{
+        decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+    },
     ApiError, AppState, DBError,
 };
 use axum::{
@@ -44,7 +46,7 @@ async fn list_memberships(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path(org_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<Vec<MembershipResponse>>>, ApiError> {
     debug!("Listing memberships");
 
@@ -87,7 +89,7 @@ async fn update_membership(
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, user_id)): Path<(Uuid, Uuid)>,
     Extension(update_request): Extension<UpdateMembershipRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<MembershipResponse>>, ApiError> {
     debug!(
         "Updating membership for user {} in org {} to role {:?}",
@@ -193,7 +195,7 @@ async fn delete_membership(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, user_id)): Path<(Uuid, Uuid)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     debug!("Deleting membership");
 

--- a/src/web/platform/org_routes.rs
+++ b/src/web/platform/org_routes.rs
@@ -1,6 +1,8 @@
 use crate::{
     models::{org_memberships::OrgRole, orgs::NewOrg, platform_users::PlatformUser},
-    web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+    web::encryption_middleware::{
+        decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+    },
     ApiError, AppState,
 };
 use axum::{
@@ -41,7 +43,7 @@ async fn create_org(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Extension(create_request): Extension<CreateOrgRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<OrgResponse>>, ApiError> {
     debug!("Creating new organization");
 
@@ -72,7 +74,7 @@ async fn create_org(
 async fn list_orgs(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<Vec<OrgResponse>>>, ApiError> {
     debug!("Listing organizations");
 
@@ -112,7 +114,7 @@ async fn delete_org(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path(org_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     debug!("Deleting organization");
 

--- a/src/web/platform/project_routes.rs
+++ b/src/web/platform/project_routes.rs
@@ -6,7 +6,9 @@ use crate::{
         platform_users::PlatformUser,
         project_settings::{EmailSettings, OAuthSettings},
     },
-    web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+    web::encryption_middleware::{
+        decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+    },
     ApiError, AppState,
 };
 use axum::routing::put;
@@ -108,7 +110,7 @@ async fn create_project(
     Extension(platform_user): Extension<PlatformUser>,
     Path(org_id): Path<Uuid>,
     Extension(create_request): Extension<CreateProjectRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<ProjectResponse>>, ApiError> {
     debug!("Creating new project");
 
@@ -181,7 +183,7 @@ async fn list_projects(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path(org_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<Vec<ProjectResponse>>>, ApiError> {
     debug!("Listing projects");
 
@@ -223,7 +225,7 @@ async fn update_project(
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
     Extension(update_request): Extension<UpdateProjectRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<ProjectResponse>>, ApiError> {
     debug!("Updating project");
 
@@ -305,7 +307,7 @@ async fn get_project(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<ProjectResponse>>, ApiError> {
     debug!("Getting project");
 
@@ -349,7 +351,7 @@ async fn delete_project(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     debug!("Deleting project");
 
@@ -398,7 +400,7 @@ async fn create_secret(
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
     Extension(create_request): Extension<CreateSecretRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<SecretResponse>>, ApiError> {
     debug!("Creating project secret");
 
@@ -476,7 +478,7 @@ async fn list_secrets(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<Vec<SecretResponse>>>, ApiError> {
     debug!("Listing project secrets");
 
@@ -528,7 +530,7 @@ async fn delete_secret(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id, key_name)): Path<(Uuid, Uuid, String)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     debug!("Deleting project secret");
 
@@ -590,7 +592,7 @@ async fn get_email_settings(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<EmailSettings>>, ApiError> {
     debug!("Getting project email settings");
 
@@ -634,7 +636,7 @@ async fn update_email_settings(
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
     Extension(update_request): Extension<UpdateEmailSettingsRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<EmailSettings>>, ApiError> {
     debug!("Updating project email settings");
 
@@ -697,7 +699,7 @@ async fn get_oauth_settings(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<OAuthSettings>>, ApiError> {
     debug!("Getting project OAuth settings");
 
@@ -738,7 +740,7 @@ async fn update_oauth_settings(
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
     Extension(update_request): Extension<UpdateOAuthSettingsRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<OAuthSettings>>, ApiError> {
     debug!("Updating project OAuth settings");
 

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -4,7 +4,9 @@ use crate::message_signing::SigningAlgorithm;
 use crate::private_key::{
     derive_bip85_mnemonic_from_root, plaintext_user_seed_to_mnemonic, VALID_BIP39_WORD_COUNTS,
 };
-use crate::web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse};
+use crate::web::encryption_middleware::{
+    decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+};
 use crate::Error;
 use crate::KVPair;
 use crate::{
@@ -554,7 +556,7 @@ pub fn router(app_state: Arc<AppState>) -> Router<()> {
 pub async fn user_protected(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<ProtectedUserData>>, ApiError> {
     let mut app_user: AppUser = AppUser::from(&user);
 
@@ -622,7 +624,7 @@ pub async fn get_kv(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Path(key): Path<String>,
 ) -> Result<Json<EncryptedResponse<Option<String>>>, ApiError> {
     let value = match data.get(&user, &auth_context, key).await {
@@ -639,7 +641,7 @@ pub async fn put_kv(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Path(key): Path<String>,
     Extension(value): Extension<String>,
 ) -> Result<Json<EncryptedResponse<String>>, ApiError> {
@@ -657,7 +659,7 @@ pub async fn delete_kv(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Path(key): Path<String>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     match data.delete(&user, &auth_context, key).await {
@@ -675,7 +677,7 @@ pub async fn delete_kv(
 pub async fn delete_all_kv(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     match data.delete_all(user.uuid).await {
         Ok(_) => {
@@ -695,7 +697,7 @@ pub async fn list_kv(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<Vec<KVPair>>>, ApiError> {
     let kvs = match data.list(&user, &auth_context).await {
         Ok(kvs) => kvs,
@@ -710,7 +712,7 @@ pub async fn list_kv(
 pub async fn request_new_verification_code(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     // First check if user has an email
     let email = match user.get_email() {
@@ -775,7 +777,7 @@ pub async fn change_password(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(change_request): Extension<ChangePasswordRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     // Check if user is an OAuth-only user
     if user.password_enc.is_none() {
@@ -845,7 +847,7 @@ pub async fn get_private_key(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Query(query): Query<DerivationPathQuery>,
 ) -> Result<Json<EncryptedResponse<PrivateKeyResponse>>, ApiError> {
     // Validate paths if present
@@ -890,7 +892,7 @@ pub async fn get_private_key_bytes(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Query(query): Query<DerivationPathQuery>,
 ) -> Result<Json<EncryptedResponse<PrivateKeyBytesResponse>>, ApiError> {
     // Validate derivation path if present
@@ -933,7 +935,7 @@ pub async fn sign_message(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(sign_request): Extension<SignMessageRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<SignMessageResponseJson>>, ApiError> {
     // Validate key_options
     let validation_query = DerivationPathQuery {
@@ -985,7 +987,7 @@ pub async fn get_public_key(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Query(query): Query<PublicKeyQuery>,
 ) -> Result<Json<EncryptedResponse<PublicKeyResponseJson>>, ApiError> {
     // Validate the key_options
@@ -1037,7 +1039,7 @@ pub async fn generate_third_party_token(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(request): Extension<ThirdPartyTokenRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<ThirdPartyTokenResponse>>, ApiError> {
     // Validate the audience
     if let Some(audience) = request.audience.as_ref() {
@@ -1073,7 +1075,7 @@ pub async fn encrypt_data(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(request): Extension<EncryptDataRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<EncryptDataResponse>>, ApiError> {
     // Validate key_options
     let validation_query = DerivationPathQuery {
@@ -1127,7 +1129,7 @@ pub async fn decrypt_data(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(request): Extension<DecryptDataRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<String>>, ApiError> {
     // Validate key_options
     let validation_query = DerivationPathQuery {
@@ -1196,7 +1198,7 @@ pub async fn initiate_account_deletion(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(delete_request): Extension<InitiateAccountDeletionRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     info!("User {} is initiating account deletion request", user.uuid);
 
@@ -1230,7 +1232,7 @@ pub async fn confirm_account_deletion(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(confirm_request): Extension<ConfirmAccountDeletionRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     info!("User {} is confirming account deletion", user.uuid);
 
@@ -1278,7 +1280,7 @@ pub async fn create_api_key(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(request): Extension<CreateApiKeyRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<CreateApiKeyResponse>>, ApiError> {
     debug!("Creating new API key for user: {}", user.uuid);
 
@@ -1334,7 +1336,7 @@ pub async fn create_api_key(
 pub async fn list_api_keys(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<ListApiKeysResponse>>, ApiError> {
     debug!("Listing API keys for user: {}", user.uuid);
 
@@ -1363,7 +1365,7 @@ pub async fn delete_api_key(
     State(data): State<Arc<AppState>>,
     Path(name): Path<String>,
     Extension(user): Extension<User>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     debug!("Deleting API key '{}' for user: {}", name, user.uuid);
 

--- a/src/web/responses/conversation_projects.rs
+++ b/src/web/responses/conversation_projects.rs
@@ -7,7 +7,9 @@ use crate::{
     models::users::User,
     tokens::count_tokens,
     web::{
-        encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+        encryption_middleware::{
+            decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+        },
         responses::{
             constants::{
                 DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_ORDER, MAX_PAGINATION_LIMIT,
@@ -157,7 +159,7 @@ fn build_project_response(
 
 async fn create_conversation_project(
     State(state): State<Arc<AppState>>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<CreateConversationProjectRequest>,
@@ -184,7 +186,7 @@ async fn create_conversation_project(
 async fn list_conversation_projects(
     State(state): State<Arc<AppState>>,
     Query(params): Query<ListConversationProjectsParams>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<ConversationProjectListResponse>>, ApiError> {
@@ -241,7 +243,7 @@ async fn list_conversation_projects(
 async fn get_conversation_project(
     State(state): State<Arc<AppState>>,
     Path(project_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<ConversationProjectResponse>>, ApiError> {
@@ -263,7 +265,7 @@ async fn get_conversation_project(
 async fn update_conversation_project(
     State(state): State<Arc<AppState>>,
     Path(project_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<UpdateConversationProjectRequest>,
@@ -321,7 +323,7 @@ async fn update_conversation_project(
 async fn delete_conversation_project(
     State(state): State<Arc<AppState>>,
     Path(project_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
 ) -> Result<Json<EncryptedResponse<DeletedObjectResponse>>, ApiError> {
     debug!(

--- a/src/web/responses/conversations.rs
+++ b/src/web/responses/conversations.rs
@@ -7,7 +7,9 @@ use crate::{
     models::responses::{ConversationProjectFilter, NewConversation},
     models::users::User,
     web::{
-        encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+        encryption_middleware::{
+            decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+        },
         responses::{
             constants::{
                 self, DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_ORDER, MAX_PAGINATION_LIMIT,
@@ -382,7 +384,7 @@ fn build_conversation_response(
 /// POST /v1/conversations - Create a new conversation
 async fn create_conversation(
     State(state): State<Arc<AppState>>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<CreateConversationRequest>,
@@ -467,7 +469,7 @@ async fn create_conversation(
 async fn get_conversation(
     State(state): State<Arc<AppState>>,
     Path(conversation_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<ConversationResponse>>, ApiError> {
@@ -489,7 +491,7 @@ async fn get_conversation(
 async fn update_conversation(
     State(state): State<Arc<AppState>>,
     Path(conversation_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<UpdateConversationRequest>,
@@ -552,7 +554,7 @@ async fn update_conversation(
 async fn delete_conversation(
     State(state): State<Arc<AppState>>,
     Path(conversation_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<DeletedObjectResponse>>, ApiError> {
@@ -574,7 +576,7 @@ async fn list_conversation_items(
     State(state): State<Arc<AppState>>,
     Path(conversation_id): Path<Uuid>,
     Query(params): Query<ListItemsParams>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<ConversationItemListResponse>>, ApiError> {
@@ -640,7 +642,7 @@ async fn list_conversation_items(
 async fn get_conversation_item(
     State(state): State<Arc<AppState>>,
     Path((conversation_id, item_id)): Path<(Uuid, Uuid)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<ConversationItem>>, ApiError> {
@@ -675,7 +677,7 @@ async fn get_conversation_item(
 async fn list_conversations(
     State(state): State<Arc<AppState>>,
     Query(params): Query<ListConversationsParams>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<ConversationListResponse>>, ApiError> {
@@ -750,7 +752,7 @@ async fn list_conversations(
 /// DELETE /v1/conversations - Delete all conversations
 async fn delete_all_conversations(
     State(state): State<Arc<AppState>>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     state
@@ -772,7 +774,7 @@ const MAX_CONVERSATION_BATCH_SIZE: usize = 20;
 /// POST /v1/conversations/batch-delete - Delete multiple specific conversations
 async fn batch_delete_conversations(
     State(state): State<Arc<AppState>>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(body): Extension<BatchDeleteConversationsRequest>,
 ) -> Result<Json<EncryptedResponse<BatchDeleteConversationsResponse>>, ApiError> {
@@ -833,7 +835,7 @@ async fn batch_delete_conversations(
 /// POST /v1/conversations/batch-update-project - Update project assignment for multiple conversations
 async fn batch_update_conversation_project(
     State(state): State<Arc<AppState>>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(body): Extension<BatchUpdateConversationProjectRequest>,
 ) -> Result<Json<EncryptedResponse<BatchUpdateConversationProjectResponse>>, ApiError> {

--- a/src/web/responses/events.rs
+++ b/src/web/responses/events.rs
@@ -1,10 +1,9 @@
 //! SSE event handling utilities
 
-use crate::AppState;
+use crate::{web::encryption_middleware::TransportSession, AppState};
 use axum::response::sse::Event;
 use serde::Serialize;
 use tracing::{error, trace};
-use uuid::Uuid;
 
 use super::constants::{
     ERROR_DATA_ENCRYPTION_FAILED, ERROR_DATA_SERIALIZATION_FAILED, EVENT_RESPONSE_CANCELLED,
@@ -32,16 +31,20 @@ use super::handlers::{
 /// - Sequence number management
 pub struct SseEventEmitter<'a> {
     state: &'a AppState,
-    session_id: Uuid,
+    transport_session: TransportSession,
     sequence_number: i32,
 }
 
 impl<'a> SseEventEmitter<'a> {
     /// Create a new SSE event emitter
-    pub fn new(state: &'a AppState, session_id: Uuid, initial_sequence: i32) -> Self {
+    pub fn new(
+        state: &'a AppState,
+        transport_session: TransportSession,
+        initial_sequence: i32,
+    ) -> Self {
         Self {
             state,
-            session_id,
+            transport_session,
             sequence_number: initial_sequence,
         }
     }
@@ -63,7 +66,7 @@ impl<'a> SseEventEmitter<'a> {
     pub async fn emit<T: Serialize>(&mut self, event_type: &str, data: &T) -> Event {
         match serde_json::to_value(data) {
             Ok(json) => {
-                match encrypt_event(self.state, &self.session_id, event_type, &json).await {
+                match encrypt_event(self.state, &self.transport_session, event_type, &json).await {
                     Ok(event) => {
                         self.sequence_number += 1;
                         trace!(
@@ -97,7 +100,7 @@ impl<'a> SseEventEmitter<'a> {
     pub async fn emit_without_sequence<T: Serialize>(&self, event_type: &str, data: &T) -> Event {
         match serde_json::to_value(data) {
             Ok(json) => {
-                match encrypt_event(self.state, &self.session_id, event_type, &json).await {
+                match encrypt_event(self.state, &self.transport_session, event_type, &json).await {
                     Ok(event) => event,
                     Err(e) => {
                         error!("Failed to encrypt {} event: {:?}", event_type, e);

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -16,7 +16,9 @@ use crate::{
     models::users::User,
     tokens::count_tokens,
     web::{
-        encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+        encryption_middleware::{
+            decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+        },
         openai::{
             ensure_completion_model_access, get_chat_completion_response,
             get_chat_completion_response_for_expected_route, BillingContext, CompletionChunk,
@@ -3758,7 +3760,7 @@ async fn wait_for_response_cancellation(
 async fn create_response_stream(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(mut body): Extension<ResponsesCreateRequest>,
@@ -4451,14 +4453,14 @@ where
 /// Helper to create encrypted SSE event
 pub async fn encrypt_event(
     state: &AppState,
-    session_id: &Uuid,
+    transport_session: &TransportSession,
     event_type: &str,
     payload: &Value,
 ) -> Result<Event, ApiError> {
     trace!("encrypt_event called for event type: {}", event_type);
     let payload_str = payload.to_string();
-    let encrypted = state
-        .encrypt_session_data(session_id, payload_str.as_bytes())
+    let encrypted = transport_session
+        .encrypt_response_bytes(state, payload_str.as_bytes())
         .await
         .map_err(|e| {
             error!("Failed to encrypt event data: {:?}", e);
@@ -4475,7 +4477,7 @@ async fn get_response(
     Path(id): Path<Uuid>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<ResponsesRetrieveResponse>>, ApiError> {
     debug!("Getting response {} for user {}", id, user.uuid);
 
@@ -4637,7 +4639,7 @@ async fn cancel_response(
     State(state): State<Arc<AppState>>,
     Path(id): Path<Uuid>,
     Extension(user): Extension<User>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<ResponsesRetrieveResponse>>, ApiError> {
     debug!("Cancelling response {} for user {}", id, user.uuid);
 
@@ -4705,7 +4707,7 @@ async fn delete_response(
     State(state): State<Arc<AppState>>,
     Path(id): Path<Uuid>,
     Extension(user): Extension<User>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<DeletedObjectResponse>>, ApiError> {
     debug!("Deleting response {} for user {}", id, user.uuid);
 

--- a/src/web/responses/instructions.rs
+++ b/src/web/responses/instructions.rs
@@ -8,7 +8,9 @@ use crate::{
     models::users::User,
     tokens::count_tokens,
     web::{
-        encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+        encryption_middleware::{
+            decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+        },
         responses::{
             constants::{
                 DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_ORDER, MAX_PAGINATION_LIMIT,
@@ -247,7 +249,7 @@ impl InstructionResponseBuilder {
 /// POST /v1/instructions - Create a new user instruction
 async fn create_instruction(
     State(state): State<Arc<AppState>>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<CreateInstructionRequest>,
@@ -318,7 +320,7 @@ async fn create_instruction(
 async fn get_instruction(
     State(state): State<Arc<AppState>>,
     Path(instruction_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<InstructionResponse>>, ApiError> {
@@ -342,7 +344,7 @@ async fn get_instruction(
 async fn update_instruction(
     State(state): State<Arc<AppState>>,
     Path(instruction_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<UpdateInstructionRequest>,
@@ -418,7 +420,7 @@ async fn update_instruction(
 async fn delete_instruction(
     State(state): State<Arc<AppState>>,
     Path(instruction_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<DeletedObjectResponse>>, ApiError> {
@@ -448,7 +450,7 @@ async fn delete_instruction(
 async fn list_instructions(
     State(state): State<Arc<AppState>>,
     Query(params): Query<ListInstructionsParams>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<InstructionListResponse>>, ApiError> {
@@ -522,7 +524,7 @@ async fn list_instructions(
 async fn set_default_instruction(
     State(state): State<Arc<AppState>>,
     Path(instruction_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<InstructionResponse>>, ApiError> {

--- a/src/web/web_routes.rs
+++ b/src/web/web_routes.rs
@@ -22,7 +22,6 @@ use std::{
     time::Duration,
 };
 use tracing::{debug, info, warn};
-use uuid::Uuid;
 
 use crate::{
     kagi::{
@@ -31,7 +30,9 @@ use crate::{
     },
     models::users::User,
     web::{
-        encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+        encryption_middleware::{
+            decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+        },
         web_safety::{compact_untrusted_markdown, normalize_public_https_url, strip_image_embeds},
     },
     ApiError, AppMode, AppState,
@@ -272,7 +273,7 @@ pub fn router(app_state: Arc<AppState>) -> Router<()> {
 
 async fn search_web(
     axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(body): Extension<Value>,
 ) -> Result<Json<EncryptedResponse<WebSearchResponse>>, WebRouteError> {
@@ -292,7 +293,7 @@ async fn search_web(
 
 async fn extract_web(
     axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(body): Extension<Value>,
 ) -> Result<Json<EncryptedResponse<WebExtractResponse>>, WebRouteError> {


### PR DESCRIPTION
## Summary

- specify the complete encrypted transport-v2 protocol, threat model, compatibility policy, replay rules, authority binding, response binding, streaming contract, and staged rollout
- introduce the behavior-neutral `TransportSession` response seam used by every existing unary and SSE response
- keep the only active response implementation as a direct delegate to the existing v1 session encryption
- add source invariants preventing handlers from recovering bare session UUIDs or bypassing the seam

This consolidated PR contains the original commits from #307 and #308. It introduces no v2 route or wire behavior.

## Compatibility

No v1 key exchange, ciphertext, base64, headers, routes, middleware order, authentication, status/error, retry, streaming, or session-cache behavior changes.

## Validation

- strict formatting, Clippy, and full Rust suite
- managed OpenSecret/Postgres/Continuum smoke
- released TypeScript and Rust v1 SDK compatibility proofs
- focused security and compatibility reviews

The original per-commit discussion and validation record remains available in #307.