### PR TITLE
Add dormant encrypted transport v2 core

### DIFF
--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -129,17 +129,28 @@ handshake_key = HKDF-SHA256(
 )
 ```
 
-The encrypted key payload contains the protocol version, session UUID, session
-master, and absolute expiry. The outer and encrypted session UUIDs must match.
-The record uses ChaCha20-Poly1305 and this AAD:
+The encrypted key payload is a fixed 57-byte binary value:
+
+```text
+version_u8
+|| session_uuid_bytes[16]
+|| session_master[32]
+|| expires_at_unix_seconds_u64_be
+```
+
+The version byte is exactly `2`. The UUID uses its RFC 9562 network-order
+bytes. The expiry is an unsigned Unix timestamp in whole seconds and is a
+client renewal hint; the enclave enforces the 65-minute lifetime with a
+monotonic clock. The outer and encrypted session UUIDs must match. The record
+uses ChaCha20-Poly1305 and this AAD:
 
 ```text
 UTF8("opensecret/transport-v2/key-exchange")
 ```
 
 This domain-separates v2 from the legacy direct-shared-secret wrapping format.
-The exact payload encoding and golden bytes are frozen by the cross-language
-test vectors before the endpoint is registered.
+The exact golden bytes are frozen by the cross-language test vectors before the
+endpoint is registered.
 
 ## 5. Session key schedule
 
@@ -240,7 +251,12 @@ Fields have these meanings:
   APIs preserve a server-selected unary or streaming response. Explicit modes
   must agree with the selected route and application request.
 - `credential` is normally `null`. It is used only for a permitted anonymous
-  authentication transition such as initial API-key binding.
+  authentication transition. The initial strict variants are
+  `{"kind":"api_key","value_base64":"..."}` and
+  `{"kind":"resumption","value_base64":"..."}`. The value is the exact
+  credential bytes in canonical padded standard base64. Password, registration,
+  OAuth, and recovery credentials remain part of their logical operation body;
+  they do not become generic transport credentials.
 - `method` is a supported uppercase HTTP method.
 - `path` is one origin-relative application path with no query or fragment.
 - `query` is either `null` or the exact query string without a leading `?`.
@@ -287,9 +303,16 @@ The enclave processes every v2 request in this order:
 5. Strictly parse and structurally validate the envelope.
 6. Validate method, path, query, headers, body presence, credential use, and
    response mode for the selected application operation.
-7. Atomically claim the decoded 16-byte request identifier.
-8. Only then authenticate, dispatch, mutate state, bill, send email, or call a
+7. Reserve response capacity before dispatch: one record for unary, or start
+   and terminal records atomically for streaming.
+8. Atomically claim the decoded 16-byte request identifier.
+9. Only then authenticate, dispatch, mutate state, bill, send email, or call a
    provider.
+
+Unused pre-dispatch response reservations are released. Once encryption of a
+reserved record is attempted, its slot remains charged even if encryption
+fails. Later stream chunks charge capacity individually while the terminal
+reservation remains unavailable to them.
 
 Replay rules are:
 
@@ -476,6 +499,8 @@ Rules are:
   SSE or other streaming body without parsing application events in the
   transport layer.
 - Exactly one authenticated `end` or `error` terminal record is required.
+- The enclave reserves both `start` and terminal record capacity before
+  dispatch; later chunks cannot consume either reservation.
 - EOF before a terminal record, a duplicate/out-of-order sequence, plaintext
   application data, or an undecryptable record fails the stream.
 - The exact request lease remains held until terminal delivery or body drop.
@@ -505,6 +530,33 @@ At minimum v2 bounds:
 The initial outer ceiling may retain the current 50 MiB limit. Base64 expansion
 and simultaneous outer/decoded/decrypted buffers must be included in memory
 accounting rather than described as only wire overhead.
+
+The initial v2-core limits are:
+
+| Resource | Limit |
+| --- | ---: |
+| Absolute session lifetime | 3,900 seconds |
+| Pending attestations | 65,536 |
+| Live sessions | 65,536 |
+| Request records per session | 65,536 |
+| Response records per session | 65,536 |
+| Replay identifiers per session | 65,536 |
+| Replay identifiers globally | 2,097,152 |
+| Decrypted envelope | 50 MiB |
+| Logical body | 28 MiB |
+
+The separate v2 cache budget is 256 MiB. Capacity accounting reserves 512
+bytes per live session, 64 bytes per replay identifier, and 192 bytes per
+pending attestation entry: approximately 172 MiB at the independent hard
+limits, leaving headroom for allocator and cache metadata. Replay sets allocate
+lazily. The dormant core defines and tests these limits but does not allocate a
+cache until the v2 gateway is wired.
+
+The 28 MiB logical-body limit is deliberate. A body is base64-encoded inside
+the JSON envelope, then the envelope is encrypted and base64-encoded again for
+the outer request. Keeping a 50 MiB outer ceiling therefore cannot preserve
+transport v1's larger effective plaintext ceiling. Raising the v2 outer limit
+requires separate enclave-memory measurement rather than an implicit change.
 
 No outer content encoding or decompression is accepted. Application-layer
 payload validation remains owned by the existing application operation.

--- a/flake.nix
+++ b/flake.nix
@@ -476,6 +476,7 @@
                 (baseName != ".env" && baseName != ".env.sample") &&
                 (
                   (builtins.elem "src" parts) ||
+                  (builtins.elem "testdata" parts) ||
                   (type == "regular" && (
                     baseName == "Cargo.toml" ||
                     baseName == "Cargo.lock" ||

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,7 @@ mod security_invariants;
 mod seed_wrapping;
 mod sqs;
 mod tokens;
+mod transport_v2;
 mod web;
 
 #[cfg(test)]

--- a/src/transport_v2/crypto.rs
+++ b/src/transport_v2/crypto.rs
@@ -1,0 +1,517 @@
+//! Cryptographic primitives and byte encodings for transport v2.
+//!
+//! This module deliberately exposes operation-specific record methods rather
+//! than raw keys. That keeps key direction and associated-data construction at
+//! the same boundary as ChaCha20-Poly1305 authentication.
+
+use std::fmt;
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use chacha20poly1305::{
+    aead::{Aead, Payload},
+    ChaCha20Poly1305, KeyInit, Nonce,
+};
+use hkdf::Hkdf;
+use sha2::Sha256;
+use subtle::ConstantTimeEq;
+use thiserror::Error;
+use uuid::Uuid;
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use super::envelope::RequestId;
+
+const KEY_LEN: usize = 32;
+const RECORD_NONCE_LEN: usize = 12;
+const RECORD_TAG_LEN: usize = 16;
+const MIN_RECORD_LEN: usize = RECORD_NONCE_LEN + RECORD_TAG_LEN;
+
+const HANDSHAKE_PAYLOAD_VERSION: u8 = 2;
+const HANDSHAKE_PAYLOAD_LEN: usize = 1 + 16 + KEY_LEN + 8;
+
+const HANDSHAKE_KEY_INFO: &[u8] = b"opensecret/transport-v2/handshake-key";
+const REQUEST_KEY_INFO: &[u8] = b"opensecret/transport-v2/client-request";
+const RESPONSE_KEY_INFO: &[u8] = b"opensecret/transport-v2/enclave-response";
+
+const KEY_EXCHANGE_AAD: &[u8] = b"opensecret/transport-v2/key-exchange";
+const REQUEST_RECORD_AAD: &[u8] = b"opensecret/transport-v2/request-record";
+const UNARY_RESPONSE_RECORD_AAD: &[u8] = b"opensecret/transport-v2/unary-response-record";
+const STREAM_RESPONSE_RECORD_AAD: &[u8] = b"opensecret/transport-v2/stream-response-record";
+
+/// Stable, non-sensitive failures from the transport-v2 cryptographic layer.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub(crate) enum CryptoError {
+    #[error("secure randomness is unavailable")]
+    RandomnessUnavailable,
+    #[error("key derivation failed")]
+    KeyDerivationFailed,
+    #[error("non-contributory key exchange")]
+    NonContributorySharedSecret,
+    #[error("record encryption failed")]
+    EncryptionFailed,
+    #[error("record authentication failed")]
+    DecryptionFailed,
+    #[error("encrypted record is too short")]
+    RecordTooShort,
+    #[error("invalid standard base64")]
+    InvalidBase64,
+    #[error("non-canonical standard base64")]
+    NonCanonicalBase64,
+}
+
+/// Fresh random secret from which one directional session-key pair is derived.
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub(crate) struct SessionMaster([u8; KEY_LEN]);
+
+impl SessionMaster {
+    pub(crate) fn random() -> Result<Self, CryptoError> {
+        let mut master = Self([0; KEY_LEN]);
+        fill_random(&mut master.0)?;
+        Ok(master)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_bytes(bytes: [u8; KEY_LEN]) -> Self {
+        Self(bytes)
+    }
+
+    fn as_bytes(&self) -> &[u8; KEY_LEN] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for SessionMaster {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SessionMaster([REDACTED])")
+    }
+}
+
+/// The fixed plaintext protected by the handshake wrapping key.
+///
+/// The payload contains the session master, so it is itself secret-bearing and
+/// is zeroized on drop.
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub(crate) struct HandshakePayload([u8; HANDSHAKE_PAYLOAD_LEN]);
+
+impl HandshakePayload {
+    pub(crate) fn new(
+        session_id: &Uuid,
+        session_master: &SessionMaster,
+        expires_at_unix_seconds: u64,
+    ) -> Self {
+        let mut bytes = [0; HANDSHAKE_PAYLOAD_LEN];
+        bytes[0] = HANDSHAKE_PAYLOAD_VERSION;
+        bytes[1..17].copy_from_slice(session_id.as_bytes());
+        bytes[17..49].copy_from_slice(session_master.as_bytes());
+        bytes[49..57].copy_from_slice(&expires_at_unix_seconds.to_be_bytes());
+        Self(bytes)
+    }
+
+    pub(crate) fn as_bytes(&self) -> &[u8; HANDSHAKE_PAYLOAD_LEN] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for HandshakePayload {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("HandshakePayload([REDACTED])")
+    }
+}
+
+#[derive(Zeroize, ZeroizeOnDrop)]
+struct RecordKey([u8; KEY_LEN]);
+
+impl RecordKey {
+    fn derive(input_key_material: &[u8], info: &[u8]) -> Result<Self, CryptoError> {
+        let hkdf = Hkdf::<Sha256>::new(None, input_key_material);
+        let mut key = Self([0; KEY_LEN]);
+        hkdf.expand(info, &mut key.0)
+            .map_err(|_| CryptoError::KeyDerivationFailed)?;
+        Ok(key)
+    }
+
+    fn encrypt(&self, plaintext: &[u8], aad: &[u8]) -> Result<Vec<u8>, CryptoError> {
+        let mut nonce = [0; RECORD_NONCE_LEN];
+        fill_random(&mut nonce)?;
+        self.encrypt_with_nonce(plaintext, aad, nonce)
+    }
+
+    fn encrypt_with_nonce(
+        &self,
+        plaintext: &[u8],
+        aad: &[u8],
+        nonce: [u8; RECORD_NONCE_LEN],
+    ) -> Result<Vec<u8>, CryptoError> {
+        let cipher =
+            ChaCha20Poly1305::new_from_slice(&self.0).map_err(|_| CryptoError::EncryptionFailed)?;
+        let ciphertext = cipher
+            .encrypt(
+                Nonce::from_slice(&nonce),
+                Payload {
+                    msg: plaintext,
+                    aad,
+                },
+            )
+            .map_err(|_| CryptoError::EncryptionFailed)?;
+
+        let mut record = Vec::with_capacity(RECORD_NONCE_LEN + ciphertext.len());
+        record.extend_from_slice(&nonce);
+        record.extend_from_slice(&ciphertext);
+        Ok(record)
+    }
+
+    fn decrypt(&self, record: &[u8], aad: &[u8]) -> Result<Vec<u8>, CryptoError> {
+        if record.len() < MIN_RECORD_LEN {
+            return Err(CryptoError::RecordTooShort);
+        }
+
+        let (nonce, ciphertext) = record.split_at(RECORD_NONCE_LEN);
+        let cipher =
+            ChaCha20Poly1305::new_from_slice(&self.0).map_err(|_| CryptoError::DecryptionFailed)?;
+        cipher
+            .decrypt(
+                Nonce::from_slice(nonce),
+                Payload {
+                    msg: ciphertext,
+                    aad,
+                },
+            )
+            .map_err(|_| CryptoError::DecryptionFailed)
+    }
+}
+
+/// Direction-separated request and response keys for one v2 session.
+#[derive(Zeroize, ZeroizeOnDrop)]
+pub(crate) struct DirectionalKeys {
+    request: RecordKey,
+    response: RecordKey,
+}
+
+impl DirectionalKeys {
+    pub(crate) fn derive(session_master: &SessionMaster) -> Result<Self, CryptoError> {
+        Ok(Self {
+            request: RecordKey::derive(session_master.as_bytes(), REQUEST_KEY_INFO)?,
+            response: RecordKey::derive(session_master.as_bytes(), RESPONSE_KEY_INFO)?,
+        })
+    }
+
+    pub(crate) fn decrypt_request_record(
+        &self,
+        session_id: &Uuid,
+        record: &[u8],
+    ) -> Result<Vec<u8>, CryptoError> {
+        self.request
+            .decrypt(record, &request_record_aad(session_id))
+    }
+
+    pub(crate) fn encrypt_unary_response_record(
+        &self,
+        session_id: &Uuid,
+        request_id: &RequestId,
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, CryptoError> {
+        self.response.encrypt(
+            plaintext,
+            &unary_response_record_aad(session_id, request_id),
+        )
+    }
+
+    pub(crate) fn encrypt_stream_response_record(
+        &self,
+        session_id: &Uuid,
+        request_id: &RequestId,
+        sequence: u64,
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, CryptoError> {
+        self.response.encrypt(
+            plaintext,
+            &stream_response_record_aad(session_id, request_id, sequence),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn encrypt_request_record_with_nonce(
+        &self,
+        session_id: &Uuid,
+        plaintext: &[u8],
+        nonce: [u8; RECORD_NONCE_LEN],
+    ) -> Result<Vec<u8>, CryptoError> {
+        self.request
+            .encrypt_with_nonce(plaintext, &request_record_aad(session_id), nonce)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn encrypt_unary_response_record_with_nonce(
+        &self,
+        session_id: &Uuid,
+        request_id: &RequestId,
+        plaintext: &[u8],
+        nonce: [u8; RECORD_NONCE_LEN],
+    ) -> Result<Vec<u8>, CryptoError> {
+        self.response.encrypt_with_nonce(
+            plaintext,
+            &unary_response_record_aad(session_id, request_id),
+            nonce,
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn encrypt_stream_response_record_with_nonce(
+        &self,
+        session_id: &Uuid,
+        request_id: &RequestId,
+        sequence: u64,
+        plaintext: &[u8],
+        nonce: [u8; RECORD_NONCE_LEN],
+    ) -> Result<Vec<u8>, CryptoError> {
+        self.response.encrypt_with_nonce(
+            plaintext,
+            &stream_response_record_aad(session_id, request_id, sequence),
+            nonce,
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn decrypt_unary_response_record(
+        &self,
+        session_id: &Uuid,
+        request_id: &RequestId,
+        record: &[u8],
+    ) -> Result<Vec<u8>, CryptoError> {
+        self.response
+            .decrypt(record, &unary_response_record_aad(session_id, request_id))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn decrypt_stream_response_record(
+        &self,
+        session_id: &Uuid,
+        request_id: &RequestId,
+        sequence: u64,
+        record: &[u8],
+    ) -> Result<Vec<u8>, CryptoError> {
+        self.response.decrypt(
+            record,
+            &stream_response_record_aad(session_id, request_id, sequence),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn request_key_bytes(&self) -> &[u8; KEY_LEN] {
+        &self.request.0
+    }
+
+    #[cfg(test)]
+    pub(crate) fn response_key_bytes(&self) -> &[u8; KEY_LEN] {
+        &self.response.0
+    }
+}
+
+impl fmt::Debug for DirectionalKeys {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("DirectionalKeys([REDACTED])")
+    }
+}
+
+/// Encrypts the fixed handshake payload under the HKDF-derived wrapping key.
+pub(crate) fn encrypt_key_exchange_record(
+    x25519_shared_secret: &[u8; KEY_LEN],
+    payload: &HandshakePayload,
+) -> Result<Vec<u8>, CryptoError> {
+    let key = derive_handshake_key(x25519_shared_secret)?;
+    key.encrypt(payload.as_bytes(), KEY_EXCHANGE_AAD)
+}
+
+#[cfg(test)]
+pub(crate) fn encrypt_key_exchange_record_with_nonce(
+    x25519_shared_secret: &[u8; KEY_LEN],
+    payload: &HandshakePayload,
+    nonce: [u8; RECORD_NONCE_LEN],
+) -> Result<Vec<u8>, CryptoError> {
+    let key = derive_handshake_key(x25519_shared_secret)?;
+    key.encrypt_with_nonce(payload.as_bytes(), KEY_EXCHANGE_AAD, nonce)
+}
+
+#[cfg(test)]
+pub(crate) fn decrypt_key_exchange_record(
+    x25519_shared_secret: &[u8; KEY_LEN],
+    record: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    let key = derive_handshake_key(x25519_shared_secret)?;
+    key.decrypt(record, KEY_EXCHANGE_AAD)
+}
+
+fn derive_handshake_key(x25519_shared_secret: &[u8; KEY_LEN]) -> Result<RecordKey, CryptoError> {
+    if bool::from(x25519_shared_secret.ct_eq(&[0; KEY_LEN])) {
+        return Err(CryptoError::NonContributorySharedSecret);
+    }
+    RecordKey::derive(x25519_shared_secret, HANDSHAKE_KEY_INFO)
+}
+
+pub(crate) fn encode_canonical_base64(bytes: &[u8]) -> String {
+    STANDARD.encode(bytes)
+}
+
+pub(crate) fn decode_canonical_base64(encoded: &str) -> Result<Vec<u8>, CryptoError> {
+    let decoded = STANDARD
+        .decode(encoded)
+        .map_err(|_| CryptoError::InvalidBase64)?;
+    if STANDARD.encode(&decoded) != encoded {
+        return Err(CryptoError::NonCanonicalBase64);
+    }
+    Ok(decoded)
+}
+
+pub(crate) fn request_record_aad(session_id: &Uuid) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(REQUEST_RECORD_AAD.len() + 1 + 16);
+    aad.extend_from_slice(REQUEST_RECORD_AAD);
+    aad.push(0);
+    aad.extend_from_slice(session_id.as_bytes());
+    aad
+}
+
+pub(crate) fn unary_response_record_aad(session_id: &Uuid, request_id: &RequestId) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(UNARY_RESPONSE_RECORD_AAD.len() + 1 + 16 + 16);
+    aad.extend_from_slice(UNARY_RESPONSE_RECORD_AAD);
+    aad.push(0);
+    aad.extend_from_slice(session_id.as_bytes());
+    aad.extend_from_slice(request_id.as_bytes());
+    aad
+}
+
+pub(crate) fn stream_response_record_aad(
+    session_id: &Uuid,
+    request_id: &RequestId,
+    sequence: u64,
+) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(STREAM_RESPONSE_RECORD_AAD.len() + 1 + 16 + 16 + 8);
+    aad.extend_from_slice(STREAM_RESPONSE_RECORD_AAD);
+    aad.push(0);
+    aad.extend_from_slice(session_id.as_bytes());
+    aad.extend_from_slice(request_id.as_bytes());
+    aad.extend_from_slice(&sequence.to_be_bytes());
+    aad
+}
+
+fn fill_random(destination: &mut [u8]) -> Result<(), CryptoError> {
+    getrandom::getrandom(destination).map_err(|_| CryptoError::RandomnessUnavailable)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handshake_payload_has_frozen_binary_layout() {
+        let session_id = Uuid::parse_str("00112233-4455-6677-8899-aabbccddeeff").unwrap();
+        let master = SessionMaster::from_bytes([0x5a; KEY_LEN]);
+        let expiry = 0x0102_0304_0506_0708;
+        let payload = HandshakePayload::new(&session_id, &master, expiry);
+
+        assert_eq!(payload.as_bytes().len(), 57);
+        assert_eq!(payload.as_bytes()[0], 2);
+        assert_eq!(&payload.as_bytes()[1..17], session_id.as_bytes());
+        assert_eq!(&payload.as_bytes()[17..49], &[0x5a; KEY_LEN]);
+        assert_eq!(
+            &payload.as_bytes()[49..57],
+            &0x0102_0304_0506_0708_u64.to_be_bytes()
+        );
+    }
+
+    #[test]
+    fn canonical_base64_rejects_alternate_text() {
+        let bytes = b"transport-v2!";
+        let canonical = encode_canonical_base64(bytes);
+        assert_eq!(decode_canonical_base64(&canonical).unwrap(), bytes);
+
+        let unpadded = canonical.trim_end_matches('=');
+        assert_ne!(unpadded, canonical);
+        assert!(matches!(
+            decode_canonical_base64(unpadded),
+            Err(CryptoError::InvalidBase64 | CryptoError::NonCanonicalBase64)
+        ));
+    }
+
+    #[test]
+    fn records_require_nonce_and_tag() {
+        let master = SessionMaster::from_bytes([0x42; KEY_LEN]);
+        let keys = DirectionalKeys::derive(&master).unwrap();
+        let session_id = Uuid::nil();
+
+        assert_eq!(
+            keys.decrypt_request_record(&session_id, &[0; MIN_RECORD_LEN - 1]),
+            Err(CryptoError::RecordTooShort)
+        );
+    }
+
+    #[test]
+    fn request_record_authenticates_session_and_direction() {
+        let master = SessionMaster::from_bytes([0x24; KEY_LEN]);
+        let keys = DirectionalKeys::derive(&master).unwrap();
+        let session_id = Uuid::parse_str("00112233-4455-6677-8899-aabbccddeeff").unwrap();
+        let other_session = Uuid::parse_str("10112233-4455-6677-8899-aabbccddeeff").unwrap();
+        let plaintext = br#"{"version":2}"#;
+        let record = keys
+            .encrypt_request_record_with_nonce(&session_id, plaintext, [7; RECORD_NONCE_LEN])
+            .unwrap();
+
+        assert_eq!(
+            keys.decrypt_request_record(&session_id, &record).unwrap(),
+            plaintext
+        );
+        assert_eq!(
+            keys.decrypt_request_record(&other_session, &record),
+            Err(CryptoError::DecryptionFailed)
+        );
+    }
+
+    #[test]
+    fn key_exchange_uses_fixed_nonce_record_shape_and_aad() {
+        let shared_secret = [0x11; KEY_LEN];
+        let session_id = Uuid::nil();
+        let master = SessionMaster::from_bytes([0x22; KEY_LEN]);
+        let payload = HandshakePayload::new(&session_id, &master, 1234);
+        let nonce = [0x33; RECORD_NONCE_LEN];
+
+        let record =
+            encrypt_key_exchange_record_with_nonce(&shared_secret, &payload, nonce).unwrap();
+        assert_eq!(&record[..RECORD_NONCE_LEN], &nonce);
+        assert_eq!(record.len(), RECORD_NONCE_LEN + 57 + RECORD_TAG_LEN);
+        assert_eq!(
+            decrypt_key_exchange_record(&shared_secret, &record).unwrap(),
+            payload.as_bytes()
+        );
+
+        let mut tampered = record;
+        *tampered.last_mut().unwrap() ^= 1;
+        assert_eq!(
+            decrypt_key_exchange_record(&shared_secret, &tampered),
+            Err(CryptoError::DecryptionFailed)
+        );
+    }
+
+    #[test]
+    fn key_exchange_rejects_non_contributory_shared_secret() {
+        let master = SessionMaster::from_bytes([0x22; KEY_LEN]);
+        let payload = HandshakePayload::new(&Uuid::nil(), &master, 1234);
+
+        assert_eq!(
+            encrypt_key_exchange_record_with_nonce(
+                &[0; KEY_LEN],
+                &payload,
+                [0x33; RECORD_NONCE_LEN]
+            ),
+            Err(CryptoError::NonContributorySharedSecret)
+        );
+    }
+
+    #[test]
+    fn secret_types_have_redacted_debug_output() {
+        let master = SessionMaster::from_bytes([0xaa; KEY_LEN]);
+        let payload = HandshakePayload::new(&Uuid::nil(), &master, 0);
+        let keys = DirectionalKeys::derive(&master).unwrap();
+
+        assert_eq!(format!("{master:?}"), "SessionMaster([REDACTED])");
+        assert_eq!(format!("{payload:?}"), "HandshakePayload([REDACTED])");
+        assert_eq!(format!("{keys:?}"), "DirectionalKeys([REDACTED])");
+    }
+}

--- a/src/transport_v2/crypto.rs
+++ b/src/transport_v2/crypto.rs
@@ -229,6 +229,16 @@ impl DirectionalKeys {
     }
 
     #[cfg(test)]
+    pub(crate) fn encrypt_request_record(
+        &self,
+        session_id: &Uuid,
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, CryptoError> {
+        self.request
+            .encrypt(plaintext, &request_record_aad(session_id))
+    }
+
+    #[cfg(test)]
     pub(crate) fn encrypt_request_record_with_nonce(
         &self,
         session_id: &Uuid,
@@ -450,9 +460,7 @@ mod tests {
         let session_id = Uuid::parse_str("00112233-4455-6677-8899-aabbccddeeff").unwrap();
         let other_session = Uuid::parse_str("10112233-4455-6677-8899-aabbccddeeff").unwrap();
         let plaintext = br#"{"version":2}"#;
-        let record = keys
-            .encrypt_request_record_with_nonce(&session_id, plaintext, [7; RECORD_NONCE_LEN])
-            .unwrap();
+        let record = keys.encrypt_request_record(&session_id, plaintext).unwrap();
 
         assert_eq!(
             keys.decrypt_request_record(&session_id, &record).unwrap(),
@@ -465,16 +473,13 @@ mod tests {
     }
 
     #[test]
-    fn key_exchange_uses_fixed_nonce_record_shape_and_aad() {
+    fn key_exchange_uses_nonce_record_shape_and_aad() {
         let shared_secret = [0x11; KEY_LEN];
         let session_id = Uuid::nil();
         let master = SessionMaster::from_bytes([0x22; KEY_LEN]);
         let payload = HandshakePayload::new(&session_id, &master, 1234);
-        let nonce = [0x33; RECORD_NONCE_LEN];
 
-        let record =
-            encrypt_key_exchange_record_with_nonce(&shared_secret, &payload, nonce).unwrap();
-        assert_eq!(&record[..RECORD_NONCE_LEN], &nonce);
+        let record = encrypt_key_exchange_record(&shared_secret, &payload).unwrap();
         assert_eq!(record.len(), RECORD_NONCE_LEN + 57 + RECORD_TAG_LEN);
         assert_eq!(
             decrypt_key_exchange_record(&shared_secret, &record).unwrap(),
@@ -495,11 +500,7 @@ mod tests {
         let payload = HandshakePayload::new(&Uuid::nil(), &master, 1234);
 
         assert_eq!(
-            encrypt_key_exchange_record_with_nonce(
-                &[0; KEY_LEN],
-                &payload,
-                [0x33; RECORD_NONCE_LEN]
-            ),
+            encrypt_key_exchange_record(&[0; KEY_LEN], &payload),
             Err(CryptoError::NonContributorySharedSecret)
         );
     }

--- a/src/transport_v2/envelope.rs
+++ b/src/transport_v2/envelope.rs
@@ -1,0 +1,1045 @@
+use std::fmt;
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+const MIB: usize = 1024 * 1024;
+const KIB: usize = 1024;
+
+/// Resource ceilings for one decrypted transport-v2 envelope.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct EnvelopeLimits {
+    pub(crate) envelope_bytes: usize,
+    pub(crate) logical_body_bytes: usize,
+    pub(crate) path_bytes: usize,
+    pub(crate) query_bytes: usize,
+    pub(crate) header_count: usize,
+    pub(crate) header_name_bytes: usize,
+    pub(crate) header_value_bytes: usize,
+    pub(crate) aggregate_header_bytes: usize,
+}
+
+impl EnvelopeLimits {
+    pub(crate) const DEFAULT: Self = Self {
+        envelope_bytes: 50 * MIB,
+        logical_body_bytes: 28 * MIB,
+        path_bytes: 4096,
+        query_bytes: 8192,
+        header_count: 64,
+        header_name_bytes: 128,
+        header_value_bytes: 16 * KIB,
+        aggregate_header_bytes: 64 * KIB,
+    };
+}
+
+impl Default for EnvelopeLimits {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum EnvelopeError {
+    #[error("transport-v2 envelope exceeds the configured {field} limit of {limit} bytes")]
+    LimitExceeded { field: &'static str, limit: usize },
+    #[error("invalid transport-v2 JSON")]
+    InvalidJson(#[source] serde_json::Error),
+    #[error("invalid transport-v2 path: {0}")]
+    InvalidPath(&'static str),
+    #[error("invalid transport-v2 query: {0}")]
+    InvalidQuery(&'static str),
+    #[error("invalid transport-v2 header name")]
+    InvalidHeaderName,
+    #[error("invalid transport-v2 header value")]
+    InvalidHeaderValue,
+    #[error("invalid transport-v2 response status")]
+    InvalidStatus,
+    #[error("invalid transport-v2 stream sequence")]
+    InvalidStreamSequence,
+}
+
+/// The protocol version has no invalid in-memory representation.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct Version2;
+
+impl Version2 {
+    pub(crate) const VALUE: u8 = 2;
+}
+
+impl Serialize for Version2 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u8(Self::VALUE)
+    }
+}
+
+impl<'de> Deserialize<'de> for Version2 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let version = u8::deserialize(deserializer)?;
+        if version == Self::VALUE {
+            Ok(Self)
+        } else {
+            Err(de::Error::custom("transport version must be exactly 2"))
+        }
+    }
+}
+
+/// A full 128-bit, per-session replay identifier.
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct RequestId([u8; 16]);
+
+impl RequestId {
+    pub(crate) const fn from_bytes(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+
+    pub(crate) const fn as_bytes(&self) -> &[u8; 16] {
+        &self.0
+    }
+
+    pub(crate) const fn into_bytes(self) -> [u8; 16] {
+        self.0
+    }
+}
+
+impl fmt::Debug for RequestId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, formatter)
+    }
+}
+
+impl fmt::Display for RequestId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&hex::encode(self.0))
+    }
+}
+
+impl Serialize for RequestId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&hex::encode(self.0))
+    }
+}
+
+impl<'de> Deserialize<'de> for RequestId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct RequestIdVisitor;
+
+        impl de::Visitor<'_> for RequestIdVisitor {
+            type Value = RequestId;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("exactly 32 lowercase hexadecimal characters")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                parse_request_id(value).ok_or_else(|| E::custom("non-canonical request ID"))
+            }
+        }
+
+        deserializer.deserialize_str(RequestIdVisitor)
+    }
+}
+
+fn parse_request_id(value: &str) -> Option<RequestId> {
+    let encoded = value.as_bytes();
+    if encoded.len() != 32
+        || !encoded
+            .iter()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return None;
+    }
+
+    let mut decoded = [0_u8; 16];
+    for (destination, pair) in decoded.iter_mut().zip(encoded.chunks_exact(2)) {
+        *destination = (hex_nibble(pair[0])? << 4) | hex_nibble(pair[1])?;
+    }
+    Some(RequestId(decoded))
+}
+
+fn hex_nibble(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        _ => None,
+    }
+}
+
+/// Exact bytes represented on the wire as padded standard base64.
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) struct EncodedBytes(Vec<u8>);
+
+impl EncodedBytes {
+    pub(crate) fn from_bytes(bytes: impl Into<Vec<u8>>) -> Self {
+        Self(bytes.into())
+    }
+
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub(crate) fn into_bytes(self) -> Vec<u8> {
+        self.0
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl fmt::Debug for EncodedBytes {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EncodedBytes")
+            .field("len", &self.0.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Serialize for EncodedBytes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&STANDARD.encode(&self.0))
+    }
+}
+
+impl<'de> Deserialize<'de> for EncodedBytes {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct EncodedBytesVisitor;
+
+        impl de::Visitor<'_> for EncodedBytesVisitor {
+            type Value = EncodedBytes;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("canonical padded standard base64")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let bytes = STANDARD
+                    .decode(value)
+                    .map_err(|_| E::custom("invalid standard base64"))?;
+                if STANDARD.encode(&bytes) != value {
+                    return Err(E::custom("non-canonical standard base64"));
+                }
+                Ok(EncodedBytes(bytes))
+            }
+        }
+
+        deserializer.deserialize_str(EncodedBytesVisitor)
+    }
+}
+
+/// Authentication material permitted only during an anonymous session transition.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub(crate) enum Credential {
+    ApiKey { value_base64: EncodedBytes },
+    Resumption { value_base64: EncodedBytes },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ResponseMode {
+    Unary,
+    Stream,
+    Auto,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub(crate) enum LogicalMethod {
+    #[serde(rename = "GET")]
+    Get,
+    #[serde(rename = "POST")]
+    Post,
+    #[serde(rename = "PUT")]
+    Put,
+    #[serde(rename = "PATCH")]
+    Patch,
+    #[serde(rename = "DELETE")]
+    Delete,
+}
+
+impl LogicalMethod {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Get => "GET",
+            Self::Post => "POST",
+            Self::Put => "PUT",
+            Self::Patch => "PATCH",
+            Self::Delete => "DELETE",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct HeaderField {
+    pub(crate) name: String,
+    pub(crate) value_base64: EncodedBytes,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct LogicalRequest {
+    pub(crate) method: LogicalMethod,
+    pub(crate) path: String,
+    #[serde(deserialize_with = "deserialize_required_nullable")]
+    pub(crate) query: Option<String>,
+    pub(crate) headers: Vec<HeaderField>,
+    #[serde(deserialize_with = "deserialize_required_nullable")]
+    pub(crate) body_base64: Option<EncodedBytes>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RequestEnvelope {
+    pub(crate) version: Version2,
+    pub(crate) request_id: RequestId,
+    pub(crate) response_mode: ResponseMode,
+    #[serde(deserialize_with = "deserialize_required_nullable")]
+    pub(crate) credential: Option<Credential>,
+    pub(crate) request: LogicalRequest,
+}
+
+impl RequestEnvelope {
+    pub(crate) fn from_json_slice(
+        input: &[u8],
+        limits: &EnvelopeLimits,
+    ) -> Result<Self, EnvelopeError> {
+        check_limit(input.len(), limits.envelope_bytes, "envelope")?;
+        let envelope: Self = serde_json::from_slice(input).map_err(EnvelopeError::InvalidJson)?;
+        envelope.validate(limits)?;
+        Ok(envelope)
+    }
+
+    pub(crate) fn validate(&self, limits: &EnvelopeLimits) -> Result<(), EnvelopeError> {
+        self.request.validate(limits)
+    }
+}
+
+impl LogicalRequest {
+    pub(crate) fn validate(&self, limits: &EnvelopeLimits) -> Result<(), EnvelopeError> {
+        validate_path(&self.path, limits)?;
+        if let Some(query) = self.query.as_deref() {
+            validate_query(query, limits)?;
+        }
+        validate_headers(&self.headers, limits)?;
+        if let Some(body) = &self.body_base64 {
+            check_limit(body.len(), limits.logical_body_bytes, "logical body")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct UnaryResponseEnvelope {
+    pub(crate) version: Version2,
+    pub(crate) request_id: RequestId,
+    pub(crate) status: u16,
+    pub(crate) headers: Vec<HeaderField>,
+    #[serde(deserialize_with = "deserialize_required_nullable")]
+    pub(crate) body_base64: Option<EncodedBytes>,
+}
+
+impl UnaryResponseEnvelope {
+    pub(crate) fn from_json_slice(
+        input: &[u8],
+        limits: &EnvelopeLimits,
+    ) -> Result<Self, EnvelopeError> {
+        check_limit(input.len(), limits.envelope_bytes, "envelope")?;
+        let envelope: Self = serde_json::from_slice(input).map_err(EnvelopeError::InvalidJson)?;
+        envelope.validate(limits)?;
+        Ok(envelope)
+    }
+
+    pub(crate) fn validate(&self, limits: &EnvelopeLimits) -> Result<(), EnvelopeError> {
+        validate_status(self.status)?;
+        validate_headers(&self.headers, limits)?;
+        if let Some(body) = &self.body_base64 {
+            check_limit(body.len(), limits.logical_body_bytes, "logical body")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub(crate) enum StreamRecord {
+    Start {
+        version: Version2,
+        request_id: RequestId,
+        sequence: u64,
+        status: u16,
+        headers: Vec<HeaderField>,
+    },
+    Chunk {
+        version: Version2,
+        request_id: RequestId,
+        sequence: u64,
+        body_base64: EncodedBytes,
+    },
+    End {
+        version: Version2,
+        request_id: RequestId,
+        sequence: u64,
+    },
+    Error {
+        version: Version2,
+        request_id: RequestId,
+        sequence: u64,
+        status: u16,
+        body_base64: EncodedBytes,
+    },
+}
+
+impl StreamRecord {
+    pub(crate) fn from_json_slice(
+        input: &[u8],
+        limits: &EnvelopeLimits,
+    ) -> Result<Self, EnvelopeError> {
+        check_limit(input.len(), limits.envelope_bytes, "envelope")?;
+        let record: Self = serde_json::from_slice(input).map_err(EnvelopeError::InvalidJson)?;
+        record.validate(limits)?;
+        Ok(record)
+    }
+
+    pub(crate) fn validate(&self, limits: &EnvelopeLimits) -> Result<(), EnvelopeError> {
+        match self {
+            Self::Start {
+                sequence,
+                status,
+                headers,
+                ..
+            } => {
+                if *sequence != 0 {
+                    return Err(EnvelopeError::InvalidStreamSequence);
+                }
+                validate_status(*status)?;
+                validate_headers(headers, limits)
+            }
+            Self::Chunk {
+                sequence,
+                body_base64,
+                ..
+            } => {
+                validate_non_initial_sequence(*sequence)?;
+                check_limit(body_base64.len(), limits.logical_body_bytes, "logical body")
+            }
+            Self::End { sequence, .. } => validate_non_initial_sequence(*sequence),
+            Self::Error {
+                sequence,
+                status,
+                body_base64,
+                ..
+            } => {
+                validate_non_initial_sequence(*sequence)?;
+                validate_status(*status)?;
+                check_limit(body_base64.len(), limits.logical_body_bytes, "logical body")
+            }
+        }
+    }
+}
+
+fn deserialize_required_nullable<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Option::<T>::deserialize(deserializer)
+}
+
+fn check_limit(actual: usize, limit: usize, field: &'static str) -> Result<(), EnvelopeError> {
+    if actual > limit {
+        Err(EnvelopeError::LimitExceeded { field, limit })
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_status(status: u16) -> Result<(), EnvelopeError> {
+    if (100..=599).contains(&status) {
+        Ok(())
+    } else {
+        Err(EnvelopeError::InvalidStatus)
+    }
+}
+
+fn validate_non_initial_sequence(sequence: u64) -> Result<(), EnvelopeError> {
+    if sequence == 0 {
+        Err(EnvelopeError::InvalidStreamSequence)
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_path(path: &str, limits: &EnvelopeLimits) -> Result<(), EnvelopeError> {
+    check_limit(path.len(), limits.path_bytes, "path")?;
+    if !path.starts_with('/') {
+        return Err(EnvelopeError::InvalidPath("path must start with '/'"));
+    }
+    if path.starts_with("//") {
+        return Err(EnvelopeError::InvalidPath(
+            "path must not contain an authority",
+        ));
+    }
+    if path.contains('?') || path.contains('#') {
+        return Err(EnvelopeError::InvalidPath(
+            "path must not contain a query or fragment",
+        ));
+    }
+    if path.contains('\\') {
+        return Err(EnvelopeError::InvalidPath(
+            "path must not contain a backslash",
+        ));
+    }
+
+    let bytes = path.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'%' => {
+                let decoded = decode_percent_triplet(bytes, index)
+                    .ok_or(EnvelopeError::InvalidPath("invalid percent encoding"))?;
+                if matches!(decoded, b'/' | b'\\') {
+                    return Err(EnvelopeError::InvalidPath(
+                        "path must not contain an encoded separator",
+                    ));
+                }
+                index += 3;
+            }
+            byte if is_path_character(byte) => index += 1,
+            _ => return Err(EnvelopeError::InvalidPath("invalid URI path character")),
+        }
+    }
+
+    for segment in path.split('/') {
+        if is_dot_segment(segment)? {
+            return Err(EnvelopeError::InvalidPath(
+                "path must not contain dot-segments",
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_query(query: &str, limits: &EnvelopeLimits) -> Result<(), EnvelopeError> {
+    check_limit(query.len(), limits.query_bytes, "query")?;
+    if query.starts_with('?') || query.starts_with('#') {
+        return Err(EnvelopeError::InvalidQuery(
+            "query must not include a leading delimiter",
+        ));
+    }
+    if query.contains('#') {
+        return Err(EnvelopeError::InvalidQuery(
+            "query must not contain a fragment",
+        ));
+    }
+
+    let bytes = query.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'%' => {
+                decode_percent_triplet(bytes, index)
+                    .ok_or(EnvelopeError::InvalidQuery("invalid percent encoding"))?;
+                index += 3;
+            }
+            byte if is_query_character(byte) => index += 1,
+            _ => return Err(EnvelopeError::InvalidQuery("invalid URI query character")),
+        }
+    }
+    Ok(())
+}
+
+fn decode_percent_triplet(bytes: &[u8], percent_index: usize) -> Option<u8> {
+    let high = *bytes.get(percent_index + 1)?;
+    let low = *bytes.get(percent_index + 2)?;
+    Some((uri_hex_nibble(high)? << 4) | uri_hex_nibble(low)?)
+}
+
+fn uri_hex_nibble(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn is_dot_segment(segment: &str) -> Result<bool, EnvelopeError> {
+    let bytes = segment.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            let byte = decode_percent_triplet(bytes, index)
+                .ok_or(EnvelopeError::InvalidPath("invalid percent encoding"))?;
+            decoded.push(byte);
+            index += 3;
+        } else {
+            decoded.push(bytes[index]);
+            index += 1;
+        }
+    }
+    Ok(matches!(decoded.as_slice(), b"." | b".."))
+}
+
+fn is_path_character(byte: u8) -> bool {
+    byte == b'/' || is_uri_pchar(byte)
+}
+
+fn is_query_character(byte: u8) -> bool {
+    matches!(byte, b'/' | b'?') || is_uri_pchar(byte)
+}
+
+fn is_uri_pchar(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric()
+        || matches!(
+            byte,
+            b'-' | b'.'
+                | b'_'
+                | b'~'
+                | b'!'
+                | b'$'
+                | b'&'
+                | b'\''
+                | b'('
+                | b')'
+                | b'*'
+                | b'+'
+                | b','
+                | b';'
+                | b'='
+                | b':'
+                | b'@'
+        )
+}
+
+fn validate_headers(headers: &[HeaderField], limits: &EnvelopeLimits) -> Result<(), EnvelopeError> {
+    if headers.len() > limits.header_count {
+        return Err(EnvelopeError::LimitExceeded {
+            field: "header count",
+            limit: limits.header_count,
+        });
+    }
+
+    let mut aggregate_bytes = 0_usize;
+    for header in headers {
+        check_limit(header.name.len(), limits.header_name_bytes, "header name")?;
+        if header.name.is_empty() || !header.name.bytes().all(is_lowercase_http_token) {
+            return Err(EnvelopeError::InvalidHeaderName);
+        }
+
+        check_limit(
+            header.value_base64.len(),
+            limits.header_value_bytes,
+            "header value",
+        )?;
+        if header
+            .value_base64
+            .as_slice()
+            .iter()
+            .any(|byte| matches!(byte, b'\r' | b'\n' | 0))
+        {
+            return Err(EnvelopeError::InvalidHeaderValue);
+        }
+
+        aggregate_bytes = aggregate_bytes
+            .checked_add(header.name.len())
+            .and_then(|total| total.checked_add(header.value_base64.len()))
+            .ok_or(EnvelopeError::LimitExceeded {
+                field: "aggregate headers",
+                limit: limits.aggregate_header_bytes,
+            })?;
+        check_limit(
+            aggregate_bytes,
+            limits.aggregate_header_bytes,
+            "aggregate headers",
+        )?;
+    }
+    Ok(())
+}
+
+fn is_lowercase_http_token(byte: u8) -> bool {
+    byte.is_ascii_lowercase()
+        || byte.is_ascii_digit()
+        || matches!(
+            byte,
+            b'!' | b'#'
+                | b'$'
+                | b'%'
+                | b'&'
+                | b'\''
+                | b'*'
+                | b'+'
+                | b'-'
+                | b'.'
+                | b'^'
+                | b'_'
+                | b'`'
+                | b'|'
+                | b'~'
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const REQUEST_ID: &str = "00112233445566778899aabbccddeeff";
+
+    fn request_json(body: &str) -> String {
+        format!(
+            r#"{{
+                "version":2,
+                "request_id":"{REQUEST_ID}",
+                "response_mode":"auto",
+                "credential":null,
+                "request":{{
+                    "method":"POST",
+                    "path":"/v1/responses",
+                    "query":null,
+                    "headers":[{{"name":"content-type","value_base64":"YXBwbGljYXRpb24vanNvbg=="}}],
+                    "body_base64":{body}
+                }}
+            }}"#
+        )
+    }
+
+    #[test]
+    fn request_id_requires_exact_lowercase_hex() {
+        let request_id: RequestId = serde_json::from_str(&format!(r#""{REQUEST_ID}""#)).unwrap();
+        assert_eq!(request_id.as_bytes(), &hex::decode(REQUEST_ID).unwrap()[..]);
+        assert_eq!(
+            serde_json::to_string(&request_id).unwrap(),
+            format!(r#""{REQUEST_ID}""#)
+        );
+
+        for invalid in [
+            "00112233445566778899AABBCCDDEEFF",
+            "00112233445566778899aabbccddeef",
+            "00112233445566778899aabbccddeeff00",
+            "00112233445566778899aabbccddeefg",
+        ] {
+            assert!(serde_json::from_str::<RequestId>(&format!(r#""{invalid}""#)).is_err());
+        }
+    }
+
+    #[test]
+    fn encoded_bytes_require_canonical_padded_standard_base64() {
+        let bytes: EncodedBytes = serde_json::from_str(r#""YQ==""#).unwrap();
+        assert_eq!(bytes.as_slice(), b"a");
+        assert_eq!(serde_json::to_string(&bytes).unwrap(), r#""YQ==""#);
+        assert!(serde_json::from_str::<EncodedBytes>(r#""""#)
+            .unwrap()
+            .is_empty());
+
+        for invalid in [r#""YQ""#, r#""YR==""#, r#""YQ==\n""#, r#""_w==""#] {
+            assert!(serde_json::from_str::<EncodedBytes>(invalid).is_err());
+        }
+    }
+
+    #[test]
+    fn required_nullable_body_distinguishes_absent_null_and_empty() {
+        let no_body = RequestEnvelope::from_json_slice(
+            request_json("null").as_bytes(),
+            &EnvelopeLimits::default(),
+        )
+        .unwrap();
+        assert!(no_body.request.body_base64.is_none());
+
+        let empty_body = RequestEnvelope::from_json_slice(
+            request_json(r#""""#).as_bytes(),
+            &EnvelopeLimits::default(),
+        )
+        .unwrap();
+        assert!(empty_body.request.body_base64.as_ref().unwrap().is_empty());
+
+        let missing =
+            request_json("null").replace(",\n                    \"body_base64\":null", "");
+        assert!(
+            RequestEnvelope::from_json_slice(missing.as_bytes(), &EnvelopeLimits::default())
+                .is_err()
+        );
+
+        let missing_query = request_json("null").replace("\"query\":null,", "");
+        assert!(RequestEnvelope::from_json_slice(
+            missing_query.as_bytes(),
+            &EnvelopeLimits::default()
+        )
+        .is_err());
+
+        let missing_credential = request_json("null").replace("\"credential\":null,", "");
+        assert!(RequestEnvelope::from_json_slice(
+            missing_credential.as_bytes(),
+            &EnvelopeLimits::default()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn typed_json_rejects_duplicate_and_unknown_fields_at_every_level() {
+        let duplicate =
+            request_json("null").replace("\"version\":2,", "\"version\":2,\"version\":2,");
+        assert!(
+            RequestEnvelope::from_json_slice(duplicate.as_bytes(), &EnvelopeLimits::default())
+                .is_err()
+        );
+
+        let duplicate_nested = request_json("null").replace(
+            "\"method\":\"POST\",",
+            "\"method\":\"POST\",\"method\":\"POST\",",
+        );
+        assert!(RequestEnvelope::from_json_slice(
+            duplicate_nested.as_bytes(),
+            &EnvelopeLimits::default()
+        )
+        .is_err());
+
+        let unknown = request_json("null").replace(
+            "\"response_mode\":\"auto\",",
+            "\"response_mode\":\"auto\",\"extra\":true,",
+        );
+        assert!(
+            RequestEnvelope::from_json_slice(unknown.as_bytes(), &EnvelopeLimits::default())
+                .is_err()
+        );
+
+        let unknown_header = request_json("null").replace(
+            "\"name\":\"content-type\",",
+            "\"name\":\"content-type\",\"extra\":true,",
+        );
+        assert!(RequestEnvelope::from_json_slice(
+            unknown_header.as_bytes(),
+            &EnvelopeLimits::default()
+        )
+        .is_err());
+
+        let credential_unknown = request_json("null").replace(
+            "\"credential\":null",
+            "\"credential\":{\"kind\":\"api_key\",\"value_base64\":\"YQ==\",\"extra\":true}",
+        );
+        assert!(RequestEnvelope::from_json_slice(
+            credential_unknown.as_bytes(),
+            &EnvelopeLimits::default()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn methods_paths_and_queries_are_structurally_strict() {
+        for invalid_method in ["get", "HEAD", "OPTIONS"] {
+            let json = request_json("null").replace(
+                "\"method\":\"POST\"",
+                &format!("\"method\":\"{invalid_method}\""),
+            );
+            assert!(
+                RequestEnvelope::from_json_slice(json.as_bytes(), &EnvelopeLimits::default())
+                    .is_err()
+            );
+        }
+
+        for invalid_path in [
+            "https://example.test/x",
+            "//example.test/x",
+            "/a?b",
+            "/a#b",
+            "/a\\b",
+            "/a/../b",
+            "/a/%2e%2E/b",
+            "/a%2fb",
+            "/a%5Cb",
+            "/a%zz",
+        ] {
+            assert!(
+                validate_path(invalid_path, &EnvelopeLimits::default()).is_err(),
+                "{invalid_path}"
+            );
+        }
+        validate_path("/v1/a%20b/~ok", &EnvelopeLimits::default()).unwrap();
+
+        for invalid_query in ["?a=b", "#fragment", "a=b#fragment", "a=%zz"] {
+            assert!(validate_query(invalid_query, &EnvelopeLimits::default()).is_err());
+        }
+        validate_query(
+            "a=b&next=%2Fv1%2Fmodels?raw=true",
+            &EnvelopeLimits::default(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn header_syntax_and_each_header_limit_are_enforced() {
+        let valid = HeaderField {
+            name: "x-provider-beta".to_owned(),
+            value_base64: EncodedBytes::from_bytes(b"one".to_vec()),
+        };
+        validate_headers(std::slice::from_ref(&valid), &EnvelopeLimits::default()).unwrap();
+
+        for name in ["Content-Type", "bad:name", "", "café"] {
+            let header = HeaderField {
+                name: name.to_owned(),
+                value_base64: EncodedBytes::from_bytes(Vec::new()),
+            };
+            assert!(validate_headers(&[header], &EnvelopeLimits::default()).is_err());
+        }
+        for value in [b"bad\rvalue".as_slice(), b"bad\nvalue", b"bad\0value"] {
+            let header = HeaderField {
+                name: "x-test".to_owned(),
+                value_base64: EncodedBytes::from_bytes(value.to_vec()),
+            };
+            assert!(validate_headers(&[header], &EnvelopeLimits::default()).is_err());
+        }
+
+        let limits = EnvelopeLimits {
+            header_count: 1,
+            header_name_bytes: 3,
+            header_value_bytes: 2,
+            aggregate_header_bytes: 4,
+            ..EnvelopeLimits::default()
+        };
+        assert!(validate_headers(&[valid.clone(), valid.clone()], &limits).is_err());
+        assert!(validate_headers(
+            &[HeaderField {
+                name: "long".to_owned(),
+                value_base64: EncodedBytes::from_bytes(Vec::new()),
+            }],
+            &limits
+        )
+        .is_err());
+        assert!(validate_headers(
+            &[HeaderField {
+                name: "x".to_owned(),
+                value_base64: EncodedBytes::from_bytes(b"abc".to_vec()),
+            }],
+            &limits
+        )
+        .is_err());
+        assert!(validate_headers(
+            &[HeaderField {
+                name: "abc".to_owned(),
+                value_base64: EncodedBytes::from_bytes(b"ab".to_vec()),
+            }],
+            &limits
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn path_body_and_envelope_limits_are_checked() {
+        let limits = EnvelopeLimits {
+            envelope_bytes: 1024,
+            logical_body_bytes: 1,
+            path_bytes: 3,
+            query_bytes: 2,
+            ..EnvelopeLimits::default()
+        };
+        validate_path("/ab", &limits).unwrap();
+        assert!(validate_path("/abc", &limits).is_err());
+        validate_query("ab", &limits).unwrap();
+        assert!(validate_query("abc", &limits).is_err());
+
+        let oversized_body = request_json(r#""YWI=""#);
+        assert!(RequestEnvelope::from_json_slice(oversized_body.as_bytes(), &limits).is_err());
+        assert!(RequestEnvelope::from_json_slice(&vec![b' '; 1025], &limits).is_err());
+    }
+
+    #[test]
+    fn unary_and_stream_records_are_strict_typed_objects() {
+        let limits = EnvelopeLimits::default();
+        let unary = format!(
+            r#"{{"version":2,"request_id":"{REQUEST_ID}","status":200,"headers":[],"body_base64":null}}"#
+        );
+        assert!(UnaryResponseEnvelope::from_json_slice(unary.as_bytes(), &limits).is_ok());
+        assert!(UnaryResponseEnvelope::from_json_slice(
+            unary.replace("\"status\":200", "\"status\":99").as_bytes(),
+            &limits
+        )
+        .is_err());
+        assert!(UnaryResponseEnvelope::from_json_slice(
+            unary.replace("\"version\":2", "\"version\":3").as_bytes(),
+            &limits
+        )
+        .is_err());
+
+        let records = [
+            format!(
+                r#"{{"version":2,"request_id":"{REQUEST_ID}","sequence":0,"kind":"start","status":200,"headers":[]}}"#
+            ),
+            format!(
+                r#"{{"version":2,"request_id":"{REQUEST_ID}","sequence":1,"kind":"chunk","body_base64":"YQ=="}}"#
+            ),
+            format!(r#"{{"version":2,"request_id":"{REQUEST_ID}","sequence":2,"kind":"end"}}"#),
+            format!(
+                r#"{{"version":2,"request_id":"{REQUEST_ID}","sequence":2,"kind":"error","status":500,"body_base64":"YQ=="}}"#
+            ),
+        ];
+        for record in records {
+            assert!(StreamRecord::from_json_slice(record.as_bytes(), &limits).is_ok());
+        }
+
+        let unknown = format!(
+            r#"{{"version":2,"request_id":"{REQUEST_ID}","sequence":2,"kind":"end","extra":true}}"#
+        );
+        assert!(StreamRecord::from_json_slice(unknown.as_bytes(), &limits).is_err());
+        let duplicate = format!(
+            r#"{{"version":2,"request_id":"{REQUEST_ID}","sequence":2,"sequence":3,"kind":"end"}}"#
+        );
+        assert!(StreamRecord::from_json_slice(duplicate.as_bytes(), &limits).is_err());
+
+        let non_initial_start = format!(
+            r#"{{"version":2,"request_id":"{REQUEST_ID}","sequence":1,"kind":"start","status":200,"headers":[]}}"#
+        );
+        assert!(StreamRecord::from_json_slice(non_initial_start.as_bytes(), &limits).is_err());
+        for kind_and_fields in [
+            r#""kind":"chunk","body_base64":"YQ==""#,
+            r#""kind":"end""#,
+            r#""kind":"error","status":500,"body_base64":"YQ==""#,
+        ] {
+            let invalid = format!(
+                r#"{{"version":2,"request_id":"{REQUEST_ID}","sequence":0,{kind_and_fields}}}"#
+            );
+            assert!(StreamRecord::from_json_slice(invalid.as_bytes(), &limits).is_err());
+        }
+    }
+
+    #[test]
+    fn default_limits_match_the_protocol_contract() {
+        assert_eq!(EnvelopeLimits::DEFAULT.envelope_bytes, 50 * 1024 * 1024);
+        assert_eq!(EnvelopeLimits::DEFAULT.logical_body_bytes, 28 * 1024 * 1024);
+        assert_eq!(EnvelopeLimits::DEFAULT.path_bytes, 4096);
+        assert_eq!(EnvelopeLimits::DEFAULT.query_bytes, 8192);
+        assert_eq!(EnvelopeLimits::DEFAULT.header_count, 64);
+        assert_eq!(EnvelopeLimits::DEFAULT.header_name_bytes, 128);
+        assert_eq!(EnvelopeLimits::DEFAULT.header_value_bytes, 16 * 1024);
+        assert_eq!(EnvelopeLimits::DEFAULT.aggregate_header_bytes, 64 * 1024);
+    }
+}

--- a/src/transport_v2/mod.rs
+++ b/src/transport_v2/mod.rs
@@ -1,0 +1,30 @@
+//! Dormant implementation core for the additive encrypted transport protocol.
+//!
+//! This module is intentionally compiled but not wired into [`crate::AppState`]
+//! or any router yet. The next stacked change activates it after its wire bytes,
+//! parsing, replay, expiry, and state-machine behavior are independently fixed
+//! by tests.
+
+#![allow(dead_code)]
+
+mod crypto;
+mod envelope;
+mod session;
+mod session_cache;
+
+pub(crate) const MAX_PENDING_ATTESTATIONS: usize = 65_536;
+pub(crate) const MAX_LIVE_SESSIONS: usize = 65_536;
+
+pub(crate) const V2_MEMORY_BUDGET_BYTES: usize = 256 * 1024 * 1024;
+pub(crate) const ACCOUNTED_BYTES_PER_PENDING_ATTESTATION: usize = 192;
+pub(crate) const ACCOUNTED_BYTES_PER_LIVE_SESSION: usize = 512;
+pub(crate) const ACCOUNTED_BYTES_PER_REPLAY_ID: usize = 64;
+
+pub(crate) const fn maximum_accounted_memory_bytes() -> usize {
+    MAX_PENDING_ATTESTATIONS * ACCOUNTED_BYTES_PER_PENDING_ATTESTATION
+        + MAX_LIVE_SESSIONS * ACCOUNTED_BYTES_PER_LIVE_SESSION
+        + session::DEFAULT_GLOBAL_REPLAY_IDS * ACCOUNTED_BYTES_PER_REPLAY_ID
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/transport_v2/session.rs
+++ b/src/transport_v2/session.rs
@@ -1,0 +1,1506 @@
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+
+use uuid::Uuid;
+
+use super::crypto::{CryptoError, DirectionalKeys};
+use super::envelope::RequestId;
+
+pub(crate) const DEFAULT_ABSOLUTE_SESSION_LIFETIME: Duration = Duration::from_secs(3_900);
+pub(crate) const DEFAULT_REPLAY_IDS_PER_SESSION: usize = 65_536;
+pub(crate) const DEFAULT_GLOBAL_REPLAY_IDS: usize = 2_097_152;
+pub(crate) const DEFAULT_REQUEST_RECORDS_PER_SESSION: usize = 65_536;
+pub(crate) const DEFAULT_RESPONSE_RECORDS_PER_SESSION: usize = 65_536;
+
+#[derive(Clone, Copy)]
+pub(crate) struct SessionLimits {
+    replay_ids: usize,
+    request_records: usize,
+    response_records: usize,
+}
+
+impl SessionLimits {
+    #[cfg(test)]
+    pub(super) const fn new(
+        replay_ids: usize,
+        request_records: usize,
+        response_records: usize,
+    ) -> Self {
+        Self {
+            replay_ids,
+            request_records,
+            response_records,
+        }
+    }
+}
+
+impl Default for SessionLimits {
+    fn default() -> Self {
+        Self {
+            replay_ids: DEFAULT_REPLAY_IDS_PER_SESSION,
+            request_records: DEFAULT_REQUEST_RECORDS_PER_SESSION,
+            response_records: DEFAULT_RESPONSE_RECORDS_PER_SESSION,
+        }
+    }
+}
+
+/// Shared accounting for exact replay identifiers retained across all live v2
+/// sessions.
+///
+/// A successful reservation belongs to one [`ReplayRegistry`] until that
+/// registry is dropped. A registry which once observes global exhaustion is
+/// permanently exhausted even if another session later releases capacity.
+pub(crate) struct GlobalReplayBudget {
+    limit: usize,
+    used: AtomicUsize,
+}
+
+impl GlobalReplayBudget {
+    pub(crate) const fn new(limit: usize) -> Self {
+        Self {
+            limit,
+            used: AtomicUsize::new(0),
+        }
+    }
+
+    fn try_reserve_one(&self) -> bool {
+        let mut current = self.used.load(Ordering::Acquire);
+        loop {
+            if current >= self.limit {
+                return false;
+            }
+
+            match self.used.compare_exchange_weak(
+                current,
+                current + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    fn release(&self, count: usize) {
+        if count == 0 {
+            return;
+        }
+
+        let released = self
+            .used
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                current.checked_sub(count)
+            });
+        debug_assert!(released.is_ok(), "global replay accounting underflow");
+    }
+
+    pub(crate) fn used(&self) -> usize {
+        self.used.load(Ordering::Acquire)
+    }
+
+    pub(crate) const fn limit(&self) -> usize {
+        self.limit
+    }
+}
+
+impl Default for GlobalReplayBudget {
+    fn default() -> Self {
+        Self::new(DEFAULT_GLOBAL_REPLAY_IDS)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ReplayClaim {
+    Claimed,
+    Duplicate,
+    Exhausted,
+}
+
+/// The exact, unordered request identifiers claimed by one session/key epoch.
+///
+/// The set is allocated only when the first identifier is accepted. Individual
+/// identifiers are never evicted. Capacity failure permanently exhausts this
+/// registry, while duplicates consume neither local nor global capacity.
+pub(crate) struct ReplayRegistry {
+    ids: Mutex<Option<HashSet<RequestId>>>,
+    local_limit: usize,
+    global_budget: Arc<GlobalReplayBudget>,
+    exhausted: AtomicBool,
+}
+
+impl ReplayRegistry {
+    pub(crate) fn new(local_limit: usize, global_budget: Arc<GlobalReplayBudget>) -> Self {
+        Self {
+            ids: Mutex::new(None),
+            local_limit,
+            global_budget,
+            exhausted: AtomicBool::new(false),
+        }
+    }
+
+    pub(crate) fn claim(&self, request_id: RequestId) -> ReplayClaim {
+        if self.exhausted.load(Ordering::Acquire) {
+            return ReplayClaim::Exhausted;
+        }
+
+        let mut ids = lock_unpoisoned(&self.ids);
+        if self.exhausted.load(Ordering::Acquire) {
+            return ReplayClaim::Exhausted;
+        }
+
+        if ids
+            .as_ref()
+            .is_some_and(|claimed| claimed.contains(&request_id))
+        {
+            return ReplayClaim::Duplicate;
+        }
+
+        let local_count = ids.as_ref().map_or(0, HashSet::len);
+        if local_count >= self.local_limit {
+            self.exhausted.store(true, Ordering::Release);
+            return ReplayClaim::Exhausted;
+        }
+
+        if !self.global_budget.try_reserve_one() {
+            self.exhausted.store(true, Ordering::Release);
+            return ReplayClaim::Exhausted;
+        }
+
+        let inserted = ids.get_or_insert_with(HashSet::new).insert(request_id);
+        if !inserted {
+            self.global_budget.release(1);
+            return ReplayClaim::Duplicate;
+        }
+
+        ReplayClaim::Claimed
+    }
+
+    pub(crate) fn is_exhausted(&self) -> bool {
+        self.exhausted.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        lock_unpoisoned(&self.ids).as_ref().map_or(0, HashSet::len)
+    }
+}
+
+impl Drop for ReplayRegistry {
+    fn drop(&mut self) {
+        let retained = lock_unpoisoned(&self.ids).as_ref().map_or(0, HashSet::len);
+        self.global_budget.release(retained);
+    }
+}
+
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) enum BoundPrincipal {
+    User { user_id: Uuid, project_id: i32 },
+    Platform { platform_user_id: Uuid },
+    ApiKey { api_key_id: i32, user_id: Uuid },
+}
+
+/// Stable authority identity retained by the transport session.
+///
+/// Credential-derived authorization context remains an application concern in
+/// the binding PR. API keys have no independent token expiry, so their
+/// authority remains bounded by the session's absolute expiry and live
+/// database checks.
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) struct BoundAuthority {
+    principal: BoundPrincipal,
+    authentication_expires_at: Option<Instant>,
+}
+
+impl BoundAuthority {
+    pub(crate) const fn user(
+        user_id: Uuid,
+        project_id: i32,
+        authentication_expires_at: Instant,
+    ) -> Self {
+        Self {
+            principal: BoundPrincipal::User {
+                user_id,
+                project_id,
+            },
+            authentication_expires_at: Some(authentication_expires_at),
+        }
+    }
+
+    pub(crate) const fn platform(
+        platform_user_id: Uuid,
+        authentication_expires_at: Instant,
+    ) -> Self {
+        Self {
+            principal: BoundPrincipal::Platform { platform_user_id },
+            authentication_expires_at: Some(authentication_expires_at),
+        }
+    }
+
+    pub(crate) const fn api_key(api_key_id: i32, user_id: Uuid) -> Self {
+        Self {
+            principal: BoundPrincipal::ApiKey {
+                api_key_id,
+                user_id,
+            },
+            authentication_expires_at: None,
+        }
+    }
+
+    pub(crate) const fn principal(&self) -> &BoundPrincipal {
+        &self.principal
+    }
+
+    pub(crate) const fn authentication_expires_at(&self) -> Option<Instant> {
+        self.authentication_expires_at
+    }
+
+    fn is_expired_at(&self, now: Instant) -> bool {
+        self.authentication_expires_at
+            .is_some_and(|expires_at| now >= expires_at)
+    }
+}
+
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) enum AuthorityState {
+    Anonymous,
+    Authenticating(RequestId),
+    Bound(BoundAuthority),
+    Closing,
+}
+
+struct AuthorityCell {
+    state: Mutex<AuthorityState>,
+}
+
+impl AuthorityCell {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(AuthorityState::Anonymous),
+        }
+    }
+
+    fn snapshot(&self) -> AuthorityState {
+        lock_unpoisoned(&self.state).clone()
+    }
+
+    fn begin(
+        self: &Arc<Self>,
+        request_id: RequestId,
+    ) -> Result<AuthenticationReservation, AuthenticationStartError> {
+        let mut state = lock_unpoisoned(&self.state);
+        match &*state {
+            AuthorityState::Anonymous => {
+                *state = AuthorityState::Authenticating(request_id);
+                drop(state);
+                Ok(AuthenticationReservation {
+                    authority: Arc::clone(self),
+                    request_id,
+                    finalized: false,
+                })
+            }
+            AuthorityState::Authenticating(_) => {
+                Err(AuthenticationStartError::AuthenticationInProgress)
+            }
+            AuthorityState::Bound(_) => Err(AuthenticationStartError::AlreadyBound),
+            AuthorityState::Closing => Err(AuthenticationStartError::Closing),
+        }
+    }
+
+    fn close(&self) {
+        *lock_unpoisoned(&self.state) = AuthorityState::Closing;
+    }
+
+    fn expire_bound_authority_at(&self, now: Instant) -> bool {
+        let mut state = lock_unpoisoned(&self.state);
+        let expired = matches!(&*state, AuthorityState::Bound(bound) if bound.is_expired_at(now));
+        if expired {
+            *state = AuthorityState::Closing;
+        }
+        expired
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AuthenticationStartError {
+    AuthenticationInProgress,
+    AlreadyBound,
+    Closing,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AuthenticationCommitError {
+    AuthenticationExpired,
+    ReservationLost,
+}
+
+/// Cancellation-safe ownership of one `Anonymous -> Authenticating` state
+/// transition.
+///
+/// Dropping or explicitly cancelling the reservation restores `Anonymous` only
+/// if the cell still contains this exact request identifier. Committing is a
+/// single locked compare-and-transition and cannot rebind an existing session.
+pub(crate) struct AuthenticationReservation {
+    authority: Arc<AuthorityCell>,
+    request_id: RequestId,
+    finalized: bool,
+}
+
+impl AuthenticationReservation {
+    pub(crate) const fn request_id(&self) -> RequestId {
+        self.request_id
+    }
+
+    pub(crate) fn commit(self, bound: BoundAuthority) -> Result<(), AuthenticationCommitError> {
+        self.commit_at(bound, Instant::now())
+    }
+
+    pub(crate) fn commit_at(
+        mut self,
+        bound: BoundAuthority,
+        now: Instant,
+    ) -> Result<(), AuthenticationCommitError> {
+        if bound.is_expired_at(now) {
+            self.rollback_if_matching();
+            self.finalized = true;
+            return Err(AuthenticationCommitError::AuthenticationExpired);
+        }
+
+        let mut state = lock_unpoisoned(&self.authority.state);
+        if matches!(&*state, AuthorityState::Authenticating(active) if *active == self.request_id) {
+            *state = AuthorityState::Bound(bound);
+            self.finalized = true;
+            Ok(())
+        } else {
+            Err(AuthenticationCommitError::ReservationLost)
+        }
+    }
+
+    pub(crate) fn cancel(mut self) {
+        self.rollback_if_matching();
+        self.finalized = true;
+    }
+
+    fn rollback_if_matching(&self) {
+        let mut state = lock_unpoisoned(&self.authority.state);
+        if matches!(&*state, AuthorityState::Authenticating(active) if *active == self.request_id) {
+            *state = AuthorityState::Anonymous;
+        }
+    }
+}
+
+impl Drop for AuthenticationReservation {
+    fn drop(&mut self) {
+        if !self.finalized {
+            self.rollback_if_matching();
+        }
+    }
+}
+
+struct RecordBudget {
+    limit: usize,
+    used: AtomicUsize,
+}
+
+impl RecordBudget {
+    const fn new(limit: usize) -> Self {
+        Self {
+            limit,
+            used: AtomicUsize::new(0),
+        }
+    }
+
+    fn try_reserve(&self, count: usize) -> bool {
+        if count == 0 {
+            return true;
+        }
+
+        let mut current = self.used.load(Ordering::Acquire);
+        loop {
+            let Some(next) = current.checked_add(count) else {
+                return false;
+            };
+            if next > self.limit {
+                return false;
+            }
+
+            match self.used.compare_exchange_weak(
+                current,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    fn try_consume(&self) -> bool {
+        self.try_reserve(1)
+    }
+
+    fn is_full(&self) -> bool {
+        self.used.load(Ordering::Acquire) >= self.limit
+    }
+
+    fn release(&self, count: usize) {
+        if count == 0 {
+            return;
+        }
+        let released = self
+            .used
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                current.checked_sub(count)
+            });
+        debug_assert!(released.is_ok(), "response record accounting underflow");
+    }
+
+    fn used(&self) -> usize {
+        self.used.load(Ordering::Acquire)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AdmissionError {
+    AbsoluteSessionExpired,
+    AuthenticationExpired,
+    AuthenticationInProgress,
+    Closing,
+    Exhausted,
+    RequestRecordBudgetExhausted,
+    ResponseRecordBudgetExhausted,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RecordBudgetError {
+    RequestRecordsExhausted,
+    ResponseRecordsExhausted,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SessionRecordError {
+    #[error(transparent)]
+    Crypto(#[from] CryptoError),
+    #[error("request record budget exhausted")]
+    RequestRecordsExhausted,
+    #[error("response record budget exhausted")]
+    ResponseRecordsExhausted,
+    #[error("response reservation belongs to another session")]
+    ResponseReservationMismatch,
+    #[error("response reservation was already consumed")]
+    ResponseReservationConsumed,
+    #[error("stream start has not been encrypted")]
+    StreamNotStarted,
+    #[error("stream start was already encrypted")]
+    StreamAlreadyStarted,
+    #[error("stream response is already closed")]
+    StreamClosed,
+    #[error("invalid stream response sequence")]
+    InvalidStreamSequence,
+}
+
+/// One response-record slot reserved before a unary request may dispatch.
+pub(crate) struct UnaryResponseReservation {
+    response_records: Arc<RecordBudget>,
+    reserved: bool,
+}
+
+impl UnaryResponseReservation {
+    fn belongs_to(&self, response_records: &Arc<RecordBudget>) -> bool {
+        Arc::ptr_eq(&self.response_records, response_records)
+    }
+
+    fn consume(&mut self) {
+        self.reserved = false;
+    }
+}
+
+impl Drop for UnaryResponseReservation {
+    fn drop(&mut self) {
+        if self.reserved {
+            self.response_records.release(1);
+        }
+    }
+}
+
+enum StreamResponsePhase {
+    BeforeStart,
+    Started { next_sequence: u64 },
+    Failed,
+    Finished,
+}
+
+/// Start and terminal response-record slots reserved atomically before a
+/// streaming request may dispatch.
+///
+/// Later chunks charge capacity dynamically, but cannot consume either
+/// reserved slot. Dropping before an encryption attempt returns unused slots;
+/// a slot remains charged once its encryption attempt begins, including when
+/// cryptographic encryption fails.
+pub(crate) struct StreamResponseReservation {
+    response_records: Arc<RecordBudget>,
+    start_reserved: bool,
+    terminal_reserved: bool,
+    phase: StreamResponsePhase,
+}
+
+impl StreamResponseReservation {
+    fn belongs_to(&self, response_records: &Arc<RecordBudget>) -> bool {
+        Arc::ptr_eq(&self.response_records, response_records)
+    }
+
+    fn consume_start(&mut self) {
+        self.start_reserved = false;
+    }
+
+    fn consume_terminal(&mut self) {
+        self.terminal_reserved = false;
+    }
+}
+
+impl Drop for StreamResponseReservation {
+    fn drop(&mut self) {
+        let unused = usize::from(self.start_reserved) + usize::from(self.terminal_reserved);
+        self.response_records.release(unused);
+    }
+}
+
+/// Secret-bearing state for one transport-v2 session/key epoch.
+///
+/// New admissions are checked against monotonic absolute and authentication
+/// expiry. Its budget-coupled encryption methods remain accessible to an
+/// already held `Arc<V2SessionState>` so an admitted unary response or stream
+/// can finish after expiry. Final `Arc` drop zeroizes the directional keys.
+pub(crate) struct V2SessionState {
+    session_id: Uuid,
+    keys: DirectionalKeys,
+    absolute_expires_at: Instant,
+    authority: Arc<AuthorityCell>,
+    replay: ReplayRegistry,
+    request_records: RecordBudget,
+    response_records: Arc<RecordBudget>,
+    exhausted: AtomicBool,
+}
+
+impl V2SessionState {
+    pub(crate) fn new(
+        session_id: Uuid,
+        keys: DirectionalKeys,
+        absolute_expires_at: Instant,
+        global_replay_budget: Arc<GlobalReplayBudget>,
+    ) -> Self {
+        Self::new_with_limits(
+            session_id,
+            keys,
+            absolute_expires_at,
+            global_replay_budget,
+            SessionLimits::default(),
+        )
+    }
+
+    pub(crate) fn new_with_limits(
+        session_id: Uuid,
+        keys: DirectionalKeys,
+        absolute_expires_at: Instant,
+        global_replay_budget: Arc<GlobalReplayBudget>,
+        limits: SessionLimits,
+    ) -> Self {
+        Self {
+            session_id,
+            keys,
+            absolute_expires_at,
+            authority: Arc::new(AuthorityCell::new()),
+            replay: ReplayRegistry::new(limits.replay_ids, global_replay_budget),
+            request_records: RecordBudget::new(limits.request_records),
+            response_records: Arc::new(RecordBudget::new(limits.response_records)),
+            exhausted: AtomicBool::new(false),
+        }
+    }
+
+    pub(crate) const fn session_id(&self) -> Uuid {
+        self.session_id
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn keys(&self) -> &DirectionalKeys {
+        &self.keys
+    }
+
+    pub(crate) const fn absolute_expires_at(&self) -> Instant {
+        self.absolute_expires_at
+    }
+
+    pub(crate) fn authority(&self) -> AuthorityState {
+        self.authority.snapshot()
+    }
+
+    pub(crate) fn begin_authentication(
+        &self,
+        request_id: RequestId,
+    ) -> Result<AuthenticationReservation, AuthenticationStartError> {
+        self.authority.begin(request_id)
+    }
+
+    pub(crate) fn check_new_admission_at(&self, now: Instant) -> Result<(), AdmissionError> {
+        if now >= self.absolute_expires_at {
+            self.authority.close();
+            return Err(AdmissionError::AbsoluteSessionExpired);
+        }
+
+        if self.exhausted.load(Ordering::Acquire) || self.replay.is_exhausted() {
+            return Err(AdmissionError::Exhausted);
+        }
+        if self.request_records.is_full() {
+            self.exhausted.store(true, Ordering::Release);
+            return Err(AdmissionError::RequestRecordBudgetExhausted);
+        }
+        if self.response_records.is_full() {
+            return Err(AdmissionError::ResponseRecordBudgetExhausted);
+        }
+
+        let mut authority = lock_unpoisoned(&self.authority.state);
+        match &*authority {
+            AuthorityState::Anonymous | AuthorityState::Bound(_) => {
+                let auth_expired = matches!(
+                    &*authority,
+                    AuthorityState::Bound(bound) if bound.is_expired_at(now)
+                );
+                if auth_expired {
+                    *authority = AuthorityState::Closing;
+                    Err(AdmissionError::AuthenticationExpired)
+                } else {
+                    Ok(())
+                }
+            }
+            AuthorityState::Authenticating(_) => Err(AdmissionError::AuthenticationInProgress),
+            AuthorityState::Closing => Err(AdmissionError::Closing),
+        }
+    }
+
+    pub(crate) fn accepts_new_requests_at(&self, now: Instant) -> bool {
+        self.check_new_admission_at(now).is_ok()
+    }
+
+    pub(crate) fn should_retire_at(&self, now: Instant) -> bool {
+        if now >= self.absolute_expires_at || self.is_exhausted() {
+            self.authority.close();
+            return true;
+        }
+        if self.authority.expire_bound_authority_at(now) {
+            return true;
+        }
+        self.is_closing()
+    }
+
+    pub(crate) fn close(&self) {
+        self.authority.close();
+    }
+
+    pub(crate) fn is_closing(&self) -> bool {
+        matches!(self.authority.snapshot(), AuthorityState::Closing)
+    }
+
+    pub(crate) fn is_exhausted(&self) -> bool {
+        self.exhausted.load(Ordering::Acquire)
+            || self.replay.is_exhausted()
+            || self.request_records.is_full()
+            || self.response_records.is_full()
+    }
+
+    /// Authenticate a request record and charge its record slot only after AEAD
+    /// succeeds. Keeping the directional keys private makes the charge
+    /// inseparable from production request decryption.
+    pub(crate) fn decrypt_request_record(
+        &self,
+        record: &[u8],
+    ) -> Result<Vec<u8>, SessionRecordError> {
+        let plaintext = self
+            .keys
+            .decrypt_request_record(&self.session_id, record)
+            .map_err(SessionRecordError::Crypto)?;
+        self.record_authenticated_request()
+            .map_err(|_| SessionRecordError::RequestRecordsExhausted)?;
+        Ok(plaintext)
+    }
+
+    fn record_authenticated_request(&self) -> Result<(), RecordBudgetError> {
+        if self.request_records.try_consume() {
+            Ok(())
+        } else {
+            self.exhausted.store(true, Ordering::Release);
+            Err(RecordBudgetError::RequestRecordsExhausted)
+        }
+    }
+
+    fn reserve_response_records(&self, count: usize) -> Result<(), RecordBudgetError> {
+        if self.response_records.try_reserve(count) {
+            Ok(())
+        } else {
+            Err(RecordBudgetError::ResponseRecordsExhausted)
+        }
+    }
+
+    /// Reserve response capacity before a unary request may dispatch.
+    pub(crate) fn begin_unary_response(
+        &self,
+    ) -> Result<UnaryResponseReservation, SessionRecordError> {
+        self.reserve_response_records(1)
+            .map_err(|_| SessionRecordError::ResponseRecordsExhausted)?;
+        Ok(UnaryResponseReservation {
+            response_records: Arc::clone(&self.response_records),
+            reserved: true,
+        })
+    }
+
+    /// Consume a pre-dispatch unary reservation and encrypt its response.
+    ///
+    /// This intentionally does not re-check expiry or closing state. A held
+    /// response lease may finish after new admissions have stopped.
+    pub(crate) fn encrypt_unary_response_record(
+        &self,
+        reservation: &mut UnaryResponseReservation,
+        request_id: &RequestId,
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, SessionRecordError> {
+        if !reservation.belongs_to(&self.response_records) {
+            return Err(SessionRecordError::ResponseReservationMismatch);
+        }
+        if !reservation.reserved {
+            return Err(SessionRecordError::ResponseReservationConsumed);
+        }
+        reservation.consume();
+        self.keys
+            .encrypt_unary_response_record(&self.session_id, request_id, plaintext)
+            .map_err(SessionRecordError::Crypto)
+    }
+
+    /// Atomically reserve start and terminal records before a streaming request
+    /// may dispatch.
+    pub(crate) fn begin_stream_response(
+        &self,
+    ) -> Result<StreamResponseReservation, SessionRecordError> {
+        self.reserve_response_records(2)
+            .map_err(|_| SessionRecordError::ResponseRecordsExhausted)?;
+        Ok(StreamResponseReservation {
+            response_records: Arc::clone(&self.response_records),
+            start_reserved: true,
+            terminal_reserved: true,
+            phase: StreamResponsePhase::BeforeStart,
+        })
+    }
+
+    /// Consume the stream's reserved start slot. Sequence zero is fixed by this
+    /// API and cannot be caller-substituted.
+    pub(crate) fn encrypt_stream_start_record(
+        &self,
+        reservation: &mut StreamResponseReservation,
+        request_id: &RequestId,
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, SessionRecordError> {
+        if !reservation.belongs_to(&self.response_records) {
+            return Err(SessionRecordError::ResponseReservationMismatch);
+        }
+        match reservation.phase {
+            StreamResponsePhase::BeforeStart => {}
+            StreamResponsePhase::Started { .. } => {
+                return Err(SessionRecordError::StreamAlreadyStarted);
+            }
+            StreamResponsePhase::Failed | StreamResponsePhase::Finished => {
+                return Err(SessionRecordError::StreamClosed);
+            }
+        }
+        if !reservation.start_reserved {
+            return Err(SessionRecordError::ResponseReservationConsumed);
+        }
+
+        reservation.consume_start();
+        let encrypted = self
+            .keys
+            .encrypt_stream_response_record(&self.session_id, request_id, 0, plaintext)
+            .map_err(SessionRecordError::Crypto);
+        reservation.phase = if encrypted.is_ok() {
+            StreamResponsePhase::Started { next_sequence: 1 }
+        } else {
+            StreamResponsePhase::Failed
+        };
+        encrypted
+    }
+
+    /// Dynamically charge and encrypt one chunk after a successful start while
+    /// preserving the pre-reserved terminal slot.
+    pub(crate) fn encrypt_stream_chunk_record(
+        &self,
+        reservation: &mut StreamResponseReservation,
+        request_id: &RequestId,
+        sequence: u64,
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, SessionRecordError> {
+        if !reservation.belongs_to(&self.response_records) {
+            return Err(SessionRecordError::ResponseReservationMismatch);
+        }
+        let next_sequence = match reservation.phase {
+            StreamResponsePhase::BeforeStart => return Err(SessionRecordError::StreamNotStarted),
+            StreamResponsePhase::Started { next_sequence } => next_sequence,
+            StreamResponsePhase::Failed | StreamResponsePhase::Finished => {
+                return Err(SessionRecordError::StreamClosed);
+            }
+        };
+        if sequence != next_sequence || sequence == u64::MAX {
+            return Err(SessionRecordError::InvalidStreamSequence);
+        }
+
+        self.reserve_response_records(1)
+            .map_err(|_| SessionRecordError::ResponseRecordsExhausted)?;
+        let encrypted = self
+            .keys
+            .encrypt_stream_response_record(&self.session_id, request_id, sequence, plaintext)
+            .map_err(SessionRecordError::Crypto);
+        reservation.phase = if encrypted.is_ok() {
+            StreamResponsePhase::Started {
+                next_sequence: sequence + 1,
+            }
+        } else {
+            StreamResponsePhase::Failed
+        };
+        encrypted
+    }
+
+    /// Consume the stream's pre-reserved terminal slot and encrypt its terminal
+    /// record. The slot remains charged after this call, including on a crypto
+    /// failure, so a failing RNG cannot reopen budget for another response.
+    pub(crate) fn encrypt_stream_terminal_record(
+        &self,
+        reservation: &mut StreamResponseReservation,
+        request_id: &RequestId,
+        sequence: u64,
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, SessionRecordError> {
+        if !reservation.belongs_to(&self.response_records) {
+            return Err(SessionRecordError::ResponseReservationMismatch);
+        }
+        let next_sequence = match reservation.phase {
+            StreamResponsePhase::BeforeStart => return Err(SessionRecordError::StreamNotStarted),
+            StreamResponsePhase::Started { next_sequence } => next_sequence,
+            StreamResponsePhase::Failed | StreamResponsePhase::Finished => {
+                return Err(SessionRecordError::StreamClosed);
+            }
+        };
+        if sequence != next_sequence {
+            return Err(SessionRecordError::InvalidStreamSequence);
+        }
+        if !reservation.terminal_reserved {
+            return Err(SessionRecordError::ResponseReservationConsumed);
+        }
+        reservation.consume_terminal();
+        reservation.phase = StreamResponsePhase::Finished;
+        self.keys
+            .encrypt_stream_response_record(&self.session_id, request_id, sequence, plaintext)
+            .map_err(SessionRecordError::Crypto)
+    }
+
+    pub(crate) fn claim_request_id(&self, request_id: RequestId) -> ReplayClaim {
+        let claim = self.replay.claim(request_id);
+        if claim == ReplayClaim::Exhausted {
+            self.exhausted.store(true, Ordering::Release);
+        }
+        claim
+    }
+
+    pub(crate) fn request_record_count(&self) -> usize {
+        self.request_records.used()
+    }
+
+    pub(crate) fn response_record_count(&self) -> usize {
+        self.response_records.used()
+    }
+
+    pub(crate) fn replay_id_count(&self) -> usize {
+        self.replay.len()
+    }
+}
+
+fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Barrier;
+    use std::thread;
+
+    use super::super::crypto::SessionMaster;
+    use super::*;
+
+    fn request_id(value: u128) -> RequestId {
+        RequestId::from_bytes(value.to_be_bytes())
+    }
+
+    fn session(
+        absolute_expires_at: Instant,
+        limits: SessionLimits,
+        global: Arc<GlobalReplayBudget>,
+    ) -> V2SessionState {
+        let master = SessionMaster::from_bytes([0x5a; 32]);
+        let keys = DirectionalKeys::derive(&master).expect("derive test session keys");
+        V2SessionState::new_with_limits(
+            Uuid::from_bytes([0x11; 16]),
+            keys,
+            absolute_expires_at,
+            global,
+            limits,
+        )
+    }
+
+    #[test]
+    fn default_limits_match_the_protocol_contract() {
+        assert_eq!(
+            DEFAULT_ABSOLUTE_SESSION_LIFETIME,
+            Duration::from_secs(3_900)
+        );
+        assert_eq!(DEFAULT_REPLAY_IDS_PER_SESSION, 65_536);
+        assert_eq!(DEFAULT_GLOBAL_REPLAY_IDS, 2_097_152);
+        assert_eq!(DEFAULT_REQUEST_RECORDS_PER_SESSION, 65_536);
+        assert_eq!(DEFAULT_RESPONSE_RECORDS_PER_SESSION, 65_536);
+    }
+
+    #[test]
+    fn replay_registry_is_exact_unordered_and_duplicates_are_free() {
+        let global = Arc::new(GlobalReplayBudget::new(8));
+        let registry = ReplayRegistry::new(3, Arc::clone(&global));
+
+        assert_eq!(registry.claim(request_id(9)), ReplayClaim::Claimed);
+        assert_eq!(registry.claim(request_id(1)), ReplayClaim::Claimed);
+        assert_eq!(registry.claim(request_id(9)), ReplayClaim::Duplicate);
+        assert_eq!(registry.claim(request_id(5)), ReplayClaim::Claimed);
+        assert_eq!(registry.len(), 3);
+        assert_eq!(global.used(), 3);
+
+        assert_eq!(registry.claim(request_id(2)), ReplayClaim::Exhausted);
+        assert_eq!(registry.claim(request_id(9)), ReplayClaim::Exhausted);
+        assert_eq!(registry.len(), 3);
+        assert_eq!(global.used(), 3);
+    }
+
+    #[test]
+    fn global_exhaustion_is_permanent_for_the_observing_session() {
+        let global = Arc::new(GlobalReplayBudget::new(2));
+        let first = ReplayRegistry::new(2, Arc::clone(&global));
+        let second = ReplayRegistry::new(2, Arc::clone(&global));
+        let exhausted = ReplayRegistry::new(2, Arc::clone(&global));
+
+        assert_eq!(first.claim(request_id(1)), ReplayClaim::Claimed);
+        assert_eq!(second.claim(request_id(2)), ReplayClaim::Claimed);
+        assert_eq!(exhausted.claim(request_id(3)), ReplayClaim::Exhausted);
+        assert_eq!(global.used(), 2);
+
+        drop(first);
+        assert_eq!(global.used(), 1);
+        assert_eq!(exhausted.claim(request_id(3)), ReplayClaim::Exhausted);
+
+        let replacement = ReplayRegistry::new(2, Arc::clone(&global));
+        assert_eq!(replacement.claim(request_id(4)), ReplayClaim::Claimed);
+        assert_eq!(global.used(), 2);
+
+        drop(second);
+        drop(exhausted);
+        drop(replacement);
+        assert_eq!(global.used(), 0);
+    }
+
+    #[test]
+    fn concurrent_duplicate_has_exactly_one_winner() {
+        const WORKERS: usize = 32;
+        let global = Arc::new(GlobalReplayBudget::new(WORKERS));
+        let registry = Arc::new(ReplayRegistry::new(WORKERS, Arc::clone(&global)));
+        let start = Arc::new(Barrier::new(WORKERS));
+
+        let handles: Vec<_> = (0..WORKERS)
+            .map(|_| {
+                let registry = Arc::clone(&registry);
+                let start = Arc::clone(&start);
+                thread::spawn(move || {
+                    start.wait();
+                    registry.claim(request_id(7))
+                })
+            })
+            .collect();
+
+        let claims: Vec<_> = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("replay worker panicked"))
+            .collect();
+        assert_eq!(
+            claims
+                .iter()
+                .filter(|claim| **claim == ReplayClaim::Claimed)
+                .count(),
+            1
+        );
+        assert_eq!(
+            claims
+                .iter()
+                .filter(|claim| **claim == ReplayClaim::Duplicate)
+                .count(),
+            WORKERS - 1
+        );
+        assert_eq!(global.used(), 1);
+    }
+
+    #[test]
+    fn authentication_reservation_drop_and_cancel_restore_anonymous() {
+        let authority = Arc::new(AuthorityCell::new());
+
+        {
+            let reservation = authority.begin(request_id(1)).expect("reserve auth");
+            assert_eq!(reservation.request_id(), request_id(1));
+            assert!(matches!(
+                authority.snapshot(),
+                AuthorityState::Authenticating(active) if active == request_id(1)
+            ));
+        }
+        assert!(matches!(authority.snapshot(), AuthorityState::Anonymous));
+
+        authority
+            .begin(request_id(2))
+            .expect("reserve second auth")
+            .cancel();
+        assert!(matches!(authority.snapshot(), AuthorityState::Anonymous));
+    }
+
+    #[test]
+    fn authentication_commit_is_request_owned_and_cannot_rebind() {
+        let authority = Arc::new(AuthorityCell::new());
+        let now = Instant::now();
+        let user = Uuid::new_v4();
+
+        authority
+            .begin(request_id(1))
+            .expect("reserve auth")
+            .commit_at(
+                BoundAuthority::user(user, 17, now + Duration::from_secs(30)),
+                now,
+            )
+            .expect("commit auth");
+
+        match authority.snapshot() {
+            AuthorityState::Bound(bound) => {
+                assert!(matches!(
+                    bound.principal(),
+                    BoundPrincipal::User { user_id, project_id }
+                        if *user_id == user && *project_id == 17
+                ));
+            }
+            _ => panic!("authority was not bound"),
+        }
+        assert_eq!(
+            authority.begin(request_id(2)).err(),
+            Some(AuthenticationStartError::AlreadyBound)
+        );
+    }
+
+    #[test]
+    fn authentication_commit_rejects_exact_expiry_and_rolls_back() {
+        let authority = Arc::new(AuthorityCell::new());
+        let now = Instant::now();
+
+        let error = authority
+            .begin(request_id(1))
+            .expect("reserve auth")
+            .commit_at(BoundAuthority::platform(Uuid::new_v4(), now), now)
+            .expect_err("expired auth must fail");
+        assert_eq!(error, AuthenticationCommitError::AuthenticationExpired);
+        assert!(matches!(authority.snapshot(), AuthorityState::Anonymous));
+    }
+
+    #[test]
+    fn authentication_commit_only_changes_its_matching_request() {
+        let authority = Arc::new(AuthorityCell::new());
+        let now = Instant::now();
+        let reservation = authority.begin(request_id(1)).expect("reserve auth");
+
+        *lock_unpoisoned(&authority.state) = AuthorityState::Authenticating(request_id(2));
+        let error = reservation
+            .commit_at(
+                BoundAuthority::user(Uuid::new_v4(), 7, now + Duration::from_secs(30)),
+                now,
+            )
+            .expect_err("stale reservation must not commit");
+
+        assert_eq!(error, AuthenticationCommitError::ReservationLost);
+        assert!(matches!(
+            authority.snapshot(),
+            AuthorityState::Authenticating(active) if active == request_id(2)
+        ));
+    }
+
+    #[test]
+    fn only_one_concurrent_authentication_reservation_wins() {
+        const WORKERS: usize = 16;
+        let authority = Arc::new(AuthorityCell::new());
+        let start = Arc::new(Barrier::new(WORKERS));
+        let reserved = Arc::new(Barrier::new(WORKERS));
+
+        let handles: Vec<_> = (0..WORKERS)
+            .map(|worker| {
+                let authority = Arc::clone(&authority);
+                let start = Arc::clone(&start);
+                let reserved = Arc::clone(&reserved);
+                thread::spawn(move || {
+                    start.wait();
+                    let reservation = authority.begin(request_id(worker as u128));
+                    reserved.wait();
+                    reservation.is_ok()
+                })
+            })
+            .collect();
+
+        let winners = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("authentication worker panicked"))
+            .filter(|won| *won)
+            .count();
+        assert_eq!(winners, 1);
+        assert!(matches!(authority.snapshot(), AuthorityState::Anonymous));
+    }
+
+    #[test]
+    fn record_budget_is_atomic_at_the_exact_boundary() {
+        const WORKERS: usize = 32;
+        const LIMIT: usize = 11;
+        let budget = Arc::new(RecordBudget::new(LIMIT));
+        let start = Arc::new(Barrier::new(WORKERS));
+
+        let handles: Vec<_> = (0..WORKERS)
+            .map(|_| {
+                let budget = Arc::clone(&budget);
+                let start = Arc::clone(&start);
+                thread::spawn(move || {
+                    start.wait();
+                    budget.try_consume()
+                })
+            })
+            .collect();
+
+        let admitted = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("record worker panicked"))
+            .filter(|admitted| *admitted)
+            .count();
+        assert_eq!(admitted, LIMIT);
+        assert_eq!(budget.used(), LIMIT);
+        assert!(budget.is_full());
+    }
+
+    #[test]
+    fn new_admission_rejects_exact_absolute_expiry_but_held_response_can_finish() {
+        let expiry = Instant::now() + Duration::from_secs(30);
+        let state = session(
+            expiry,
+            SessionLimits::new(4, 4, 2),
+            Arc::new(GlobalReplayBudget::new(4)),
+        );
+
+        assert!(state.accepts_new_requests_at(expiry - Duration::from_nanos(1)));
+        let mut response = state
+            .begin_unary_response()
+            .expect("reserve response before dispatch");
+        assert_eq!(
+            state.check_new_admission_at(expiry),
+            Err(AdmissionError::AbsoluteSessionExpired)
+        );
+        assert!(state.is_closing());
+
+        state
+            .encrypt_unary_response_record(&mut response, &request_id(1), b"late but admitted")
+            .expect("held response context remains usable after expiry");
+    }
+
+    #[test]
+    fn bound_authentication_expiry_is_exact_and_closes_fail_closed() {
+        let now = Instant::now();
+        let auth_expiry = now + Duration::from_secs(10);
+        let state = session(
+            now + Duration::from_secs(30),
+            SessionLimits::new(4, 4, 4),
+            Arc::new(GlobalReplayBudget::new(4)),
+        );
+
+        state
+            .begin_authentication(request_id(1))
+            .expect("reserve auth")
+            .commit_at(BoundAuthority::user(Uuid::new_v4(), 3, auth_expiry), now)
+            .expect("bind authority");
+
+        assert!(state.accepts_new_requests_at(auth_expiry - Duration::from_nanos(1)));
+        let mut response = state
+            .begin_unary_response()
+            .expect("reserve response before dispatch");
+        assert_eq!(
+            state.check_new_admission_at(auth_expiry),
+            Err(AdmissionError::AuthenticationExpired)
+        );
+        assert!(state.is_closing());
+        state
+            .encrypt_unary_response_record(&mut response, &request_id(1), b"admitted response")
+            .expect("held response remains usable after auth expiry");
+    }
+
+    #[test]
+    fn authenticating_blocks_new_admission_and_drop_reopens_anonymous_session() {
+        let now = Instant::now();
+        let state = session(
+            now + Duration::from_secs(30),
+            SessionLimits::new(4, 4, 4),
+            Arc::new(GlobalReplayBudget::new(4)),
+        );
+        let reservation = state
+            .begin_authentication(request_id(1))
+            .expect("reserve auth");
+
+        assert_eq!(
+            state.check_new_admission_at(now),
+            Err(AdmissionError::AuthenticationInProgress)
+        );
+        assert!(!state.should_retire_at(now));
+        drop(reservation);
+        assert!(state.accepts_new_requests_at(now));
+    }
+
+    #[test]
+    fn request_records_count_only_after_successful_aead_and_stop_at_limit() {
+        let now = Instant::now();
+        let state = session(
+            now + Duration::from_secs(30),
+            SessionLimits::new(4, 2, 4),
+            Arc::new(GlobalReplayBudget::new(4)),
+        );
+
+        let valid_record = state
+            .keys()
+            .encrypt_request_record_with_nonce(
+                &state.session_id(),
+                b"authenticated request",
+                [0x44; 12],
+            )
+            .expect("encrypt test request");
+        assert!(state.decrypt_request_record(&[0u8; 28]).is_err());
+        assert_eq!(state.request_record_count(), 0);
+
+        state
+            .decrypt_request_record(&valid_record)
+            .expect("first authenticated record");
+        state
+            .decrypt_request_record(&valid_record)
+            .expect("second authenticated record");
+        assert_eq!(state.request_record_count(), 2);
+        assert!(matches!(
+            state.decrypt_request_record(&valid_record),
+            Err(SessionRecordError::RequestRecordsExhausted)
+        ));
+        assert!(state.is_exhausted());
+        assert!(!state.accepts_new_requests_at(now));
+    }
+
+    #[test]
+    fn response_record_budget_is_exact_and_fail_closed() {
+        let now = Instant::now();
+        let state = session(
+            now + Duration::from_secs(30),
+            SessionLimits::new(4, 4, 2),
+            Arc::new(GlobalReplayBudget::new(4)),
+        );
+
+        let mut first = state
+            .begin_unary_response()
+            .expect("reserve first response before dispatch");
+        let mut second = state
+            .begin_unary_response()
+            .expect("reserve second response before dispatch");
+        assert!(matches!(
+            state.begin_unary_response(),
+            Err(SessionRecordError::ResponseRecordsExhausted)
+        ));
+        assert_eq!(state.response_record_count(), 2);
+        state
+            .encrypt_unary_response_record(&mut first, &request_id(1), b"first")
+            .expect("encrypt first reserved response");
+        state
+            .encrypt_unary_response_record(&mut second, &request_id(2), b"second")
+            .expect("encrypt second reserved response");
+        assert!(state.is_exhausted());
+    }
+
+    #[test]
+    fn concurrent_unary_capacity_is_won_before_dispatch() {
+        const WORKERS: usize = 16;
+        const LIMIT: usize = 3;
+        let now = Instant::now();
+        let state = Arc::new(session(
+            now + Duration::from_secs(30),
+            SessionLimits::new(4, 4, LIMIT),
+            Arc::new(GlobalReplayBudget::new(4)),
+        ));
+        let start = Arc::new(Barrier::new(WORKERS));
+        let reserved = Arc::new(Barrier::new(WORKERS));
+
+        let handles: Vec<_> = (0..WORKERS)
+            .map(|_| {
+                let state = Arc::clone(&state);
+                let start = Arc::clone(&start);
+                let reserved = Arc::clone(&reserved);
+                thread::spawn(move || {
+                    start.wait();
+                    let reservation = state.begin_unary_response();
+                    reserved.wait();
+                    reservation.is_ok()
+                })
+            })
+            .collect();
+
+        let winners = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("response reservation worker panicked"))
+            .filter(|won| *won)
+            .count();
+        assert_eq!(winners, LIMIT);
+        assert_eq!(state.response_record_count(), 0);
+        assert!(state.accepts_new_requests_at(now));
+    }
+
+    #[test]
+    fn stream_reserves_start_and_terminal_before_dispatch() {
+        let now = Instant::now();
+        let too_small = session(
+            now + Duration::from_secs(30),
+            SessionLimits::new(4, 4, 1),
+            Arc::new(GlobalReplayBudget::new(4)),
+        );
+        assert!(matches!(
+            too_small.begin_stream_response(),
+            Err(SessionRecordError::ResponseRecordsExhausted)
+        ));
+        assert_eq!(too_small.response_record_count(), 0);
+
+        let state = session(
+            now + Duration::from_secs(30),
+            SessionLimits::new(4, 4, 2),
+            Arc::new(GlobalReplayBudget::new(4)),
+        );
+        let mut reservation = state
+            .begin_stream_response()
+            .expect("atomically reserve start and terminal records");
+        assert_eq!(state.response_record_count(), 2);
+
+        state
+            .encrypt_stream_start_record(&mut reservation, &request_id(1), b"start")
+            .expect("pre-reserved start remains available");
+        assert!(state.is_exhausted());
+
+        state
+            .encrypt_stream_terminal_record(&mut reservation, &request_id(1), 1, b"end")
+            .expect("pre-reserved terminal remains available at the limit");
+        assert_eq!(state.response_record_count(), 2);
+    }
+
+    #[test]
+    fn dropping_unstarted_stream_returns_both_reservations() {
+        let now = Instant::now();
+        let state = session(
+            now + Duration::from_secs(30),
+            SessionLimits::new(4, 4, 2),
+            Arc::new(GlobalReplayBudget::new(4)),
+        );
+
+        let reservation = state
+            .begin_stream_response()
+            .expect("reserve start and terminal response records");
+        assert_eq!(state.response_record_count(), 2);
+        drop(reservation);
+        assert_eq!(state.response_record_count(), 0);
+        assert!(state.accepts_new_requests_at(now));
+    }
+
+    #[test]
+    fn stream_requires_matching_reservation_start_and_exact_sequence() {
+        let now = Instant::now();
+        let state = session(
+            now + Duration::from_secs(30),
+            SessionLimits::new(4, 4, 3),
+            Arc::new(GlobalReplayBudget::new(4)),
+        );
+        let other = session(
+            now + Duration::from_secs(30),
+            SessionLimits::new(4, 4, 3),
+            Arc::new(GlobalReplayBudget::new(4)),
+        );
+        let mut reservation = state
+            .begin_stream_response()
+            .expect("reserve stream response");
+
+        assert!(matches!(
+            state.encrypt_stream_chunk_record(&mut reservation, &request_id(1), 1, b"chunk"),
+            Err(SessionRecordError::StreamNotStarted)
+        ));
+        assert!(matches!(
+            state.encrypt_stream_terminal_record(&mut reservation, &request_id(1), 1, b"end"),
+            Err(SessionRecordError::StreamNotStarted)
+        ));
+        assert!(matches!(
+            other.encrypt_stream_start_record(&mut reservation, &request_id(1), b"start"),
+            Err(SessionRecordError::ResponseReservationMismatch)
+        ));
+
+        state
+            .encrypt_stream_start_record(&mut reservation, &request_id(1), b"start")
+            .expect("encrypt start");
+        assert!(matches!(
+            state.encrypt_stream_chunk_record(&mut reservation, &request_id(1), 2, b"out of order"),
+            Err(SessionRecordError::InvalidStreamSequence)
+        ));
+        state
+            .encrypt_stream_chunk_record(&mut reservation, &request_id(1), 1, b"chunk")
+            .expect("encrypt next chunk");
+        assert!(matches!(
+            state.encrypt_stream_terminal_record(
+                &mut reservation,
+                &request_id(1),
+                3,
+                b"out of order end"
+            ),
+            Err(SessionRecordError::InvalidStreamSequence)
+        ));
+        state
+            .encrypt_stream_terminal_record(&mut reservation, &request_id(1), 2, b"end")
+            .expect("encrypt exact next terminal");
+        assert_eq!(state.response_record_count(), 3);
+    }
+
+    #[test]
+    fn replay_exhaustion_closes_only_new_admission_not_an_admitted_response() {
+        let now = Instant::now();
+        let state = session(
+            now + Duration::from_secs(30),
+            SessionLimits::new(1, 4, 2),
+            Arc::new(GlobalReplayBudget::new(1)),
+        );
+
+        assert_eq!(state.claim_request_id(request_id(1)), ReplayClaim::Claimed);
+        assert_eq!(
+            state.claim_request_id(request_id(2)),
+            ReplayClaim::Exhausted
+        );
+        assert_eq!(state.replay_id_count(), 1);
+        let mut response = state
+            .begin_unary_response()
+            .expect("reserve response for admitted request");
+        assert!(!state.accepts_new_requests_at(now));
+        state
+            .encrypt_unary_response_record(&mut response, &request_id(1), b"admitted response")
+            .expect("already-admitted response remains possible");
+    }
+}

--- a/src/transport_v2/session.rs
+++ b/src/transport_v2/session.rs
@@ -1282,11 +1282,7 @@ mod tests {
 
         let valid_record = state
             .keys()
-            .encrypt_request_record_with_nonce(
-                &state.session_id(),
-                b"authenticated request",
-                [0x44; 12],
-            )
+            .encrypt_request_record(&state.session_id(), b"authenticated request")
             .expect("encrypt test request");
         assert!(state.decrypt_request_record(&[0u8; 28]).is_err());
         assert_eq!(state.request_record_count(), 0);

--- a/src/transport_v2/session_cache.rs
+++ b/src/transport_v2/session_cache.rs
@@ -1,0 +1,532 @@
+use super::session::V2SessionState;
+use clru::CLruCache;
+use std::collections::hash_map::RandomState;
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::time::Instant;
+use uuid::Uuid;
+
+/// How a successfully inserted v2 session affected cache residency.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum V2SessionInsertOutcome {
+    Inserted,
+    EvictedLeastRecentlyUsed,
+}
+
+/// Why a v2 session could not be inserted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum V2SessionInsertError {
+    DuplicateSession,
+    AllSessionsLeased,
+}
+
+/// A rejected insertion that retains the caller's session allocation.
+///
+/// Keeping the rejected `Arc` in the return value prevents key destruction or
+/// a large replay-registry drop while a future outer cache mutex is held.
+#[must_use = "release the rejected session after releasing the cache lock"]
+pub(crate) struct RejectedV2Session {
+    reason: V2SessionInsertError,
+    session: Arc<V2SessionState>,
+}
+
+impl fmt::Debug for RejectedV2Session {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RejectedV2Session")
+            .field("reason", &self.reason)
+            .field("session", &"[REDACTED]")
+            .finish()
+    }
+}
+
+impl RejectedV2Session {
+    pub(crate) fn reason(&self) -> V2SessionInsertError {
+        self.reason
+    }
+
+    pub(crate) fn into_session(self) -> Arc<V2SessionState> {
+        self.session
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transport_v2::crypto::{DirectionalKeys, SessionMaster};
+    use crate::transport_v2::envelope::RequestId;
+    use crate::transport_v2::session::{
+        GlobalReplayBudget, ReplayClaim, DEFAULT_GLOBAL_REPLAY_IDS,
+    };
+    use std::time::Duration;
+
+    fn cache(capacity: usize) -> V2SessionCache {
+        V2SessionCache::new(NonZeroUsize::new(capacity).expect("test capacity must be nonzero"))
+    }
+
+    fn session(session_id: Uuid, absolute_expires_at: Instant) -> Arc<V2SessionState> {
+        session_with_global_budget(
+            session_id,
+            absolute_expires_at,
+            Arc::new(GlobalReplayBudget::new(DEFAULT_GLOBAL_REPLAY_IDS)),
+        )
+    }
+
+    fn session_with_global_budget(
+        session_id: Uuid,
+        absolute_expires_at: Instant,
+        global_replay_budget: Arc<GlobalReplayBudget>,
+    ) -> Arc<V2SessionState> {
+        let master = SessionMaster::from_bytes([session_id.as_bytes()[15]; 32]);
+        let keys = DirectionalKeys::derive(&master).expect("derive test keys");
+        Arc::new(V2SessionState::new(
+            session_id,
+            keys,
+            absolute_expires_at,
+            global_replay_budget,
+        ))
+    }
+
+    fn insert_new(cache: &mut V2SessionCache, session: Arc<V2SessionState>) {
+        let insertion = cache.insert(session).expect("insert test session");
+        assert_eq!(insertion.outcome(), V2SessionInsertOutcome::Inserted);
+        assert!(insertion.retired.is_empty());
+    }
+
+    #[test]
+    fn exact_absolute_expiry_boundary_rejects_and_cleans_up() {
+        let start = Instant::now();
+        let expiry = start + Duration::from_secs(10);
+        let session_id = Uuid::new_v4();
+        let mut cache = cache(1);
+        insert_new(&mut cache, session(session_id, expiry));
+
+        let before_expiry = expiry
+            .checked_sub(Duration::from_nanos(1))
+            .expect("test instant supports subtraction");
+        assert!(cache.acquire_at(&session_id, before_expiry).is_some());
+        assert!(cache.acquire_at(&session_id, expiry).is_none());
+
+        let retired = cache.cleanup_at(expiry);
+        assert_eq!(retired.removed_count(), 1);
+        assert!(!cache.contains(&session_id));
+    }
+
+    #[test]
+    fn held_old_lease_blocks_removal_but_not_expiry_rejection() {
+        let start = Instant::now();
+        let expiry = start + Duration::from_secs(10);
+        let session_id = Uuid::new_v4();
+        let mut cache = cache(1);
+        insert_new(&mut cache, session(session_id, expiry));
+
+        let lease = cache
+            .acquire_at(&session_id, start)
+            .expect("pre-expiry lease");
+        assert!(cache.acquire_at(&session_id, expiry).is_none());
+
+        let retired = cache.cleanup_at(expiry);
+        assert!(retired.is_empty());
+        assert!(cache.contains(&session_id));
+
+        // Expiry stops new admission; it does not invalidate response keys on
+        // the already-admitted exact session.
+        assert_eq!(lease.state().session_id(), session_id);
+        let _response_keys = lease.state().keys();
+
+        drop(lease);
+        let retired = cache.cleanup_at(expiry);
+        assert_eq!(retired.removed_count(), 1);
+        assert!(!cache.contains(&session_id));
+    }
+
+    #[test]
+    fn acquire_does_not_promote_but_mark_admitted_does() {
+        let expiry = Instant::now() + Duration::from_secs(60);
+        let first_id = Uuid::new_v4();
+        let second_id = Uuid::new_v4();
+        let third_id = Uuid::new_v4();
+
+        let mut unadmitted = cache(2);
+        insert_new(&mut unadmitted, session(first_id, expiry));
+        insert_new(&mut unadmitted, session(second_id, expiry));
+        let lease = unadmitted
+            .acquire_at(&first_id, Instant::now())
+            .expect("lease first session");
+        drop(lease);
+        let insertion = unadmitted
+            .insert(session(third_id, expiry))
+            .expect("insert third session");
+        assert_eq!(
+            insertion.outcome(),
+            V2SessionInsertOutcome::EvictedLeastRecentlyUsed
+        );
+        assert_eq!(insertion.retired.sessions[0].session_id(), first_id);
+
+        let mut admitted = cache(2);
+        insert_new(&mut admitted, session(first_id, expiry));
+        insert_new(&mut admitted, session(second_id, expiry));
+        let lease = admitted
+            .acquire_at(&first_id, Instant::now())
+            .expect("lease first session");
+        assert!(admitted.mark_admitted(&lease));
+        drop(lease);
+        let insertion = admitted
+            .insert(session(third_id, expiry))
+            .expect("insert third session");
+        assert_eq!(
+            insertion.outcome(),
+            V2SessionInsertOutcome::EvictedLeastRecentlyUsed
+        );
+        assert_eq!(insertion.retired.sessions[0].session_id(), second_id);
+    }
+
+    #[test]
+    fn full_cache_with_only_leased_sessions_reports_overload() {
+        let now = Instant::now();
+        let expiry = now + Duration::from_secs(60);
+        let first_id = Uuid::new_v4();
+        let second_id = Uuid::new_v4();
+        let rejected_id = Uuid::new_v4();
+        let mut cache = cache(2);
+        insert_new(&mut cache, session(first_id, expiry));
+        insert_new(&mut cache, session(second_id, expiry));
+
+        let first_lease = cache.acquire_at(&first_id, now).expect("first lease");
+        let second_lease = cache.acquire_at(&second_id, now).expect("second lease");
+        let rejected = match cache.insert(session(rejected_id, expiry)) {
+            Ok(_) => panic!("all leased cache must reject insertion"),
+            Err(rejected) => rejected,
+        };
+
+        assert_eq!(rejected.reason(), V2SessionInsertError::AllSessionsLeased);
+        assert_eq!(rejected.into_session().session_id(), rejected_id);
+        assert_eq!(cache.len(), 2);
+        assert!(cache.contains(&first_id));
+        assert!(cache.contains(&second_id));
+
+        drop(first_lease);
+        drop(second_lease);
+    }
+
+    #[test]
+    fn leased_lru_is_preserved_and_retired_arc_drops_later() {
+        let now = Instant::now();
+        let expiry = now + Duration::from_secs(60);
+        let first_id = Uuid::new_v4();
+        let second_id = Uuid::new_v4();
+        let third_id = Uuid::new_v4();
+        let mut cache = cache(2);
+        insert_new(&mut cache, session(first_id, expiry));
+
+        let second = session(second_id, expiry);
+        let evicted_lifetime = Arc::downgrade(&second);
+        insert_new(&mut cache, second);
+
+        let first_lease = cache.acquire_at(&first_id, now).expect("first lease");
+        let insertion = cache
+            .insert(session(third_id, expiry))
+            .expect("one unleased session leaves capacity");
+
+        assert_eq!(
+            insertion.outcome(),
+            V2SessionInsertOutcome::EvictedLeastRecentlyUsed
+        );
+        assert_eq!(insertion.retired.sessions[0].session_id(), second_id);
+        assert!(cache.contains(&first_id));
+        assert!(cache.contains(&third_id));
+        assert!(evicted_lifetime.upgrade().is_some());
+
+        let retired = insertion.into_retired();
+        assert!(evicted_lifetime.upgrade().is_some());
+        drop(retired);
+        assert!(evicted_lifetime.upgrade().is_none());
+        drop(first_lease);
+    }
+
+    #[test]
+    fn duplicate_insert_never_replaces_the_original_arc() {
+        let now = Instant::now();
+        let expiry = now + Duration::from_secs(60);
+        let session_id = Uuid::new_v4();
+        let original = session(session_id, expiry);
+        let original_pointer = Arc::as_ptr(&original);
+        let mut cache = cache(1);
+        insert_new(&mut cache, original);
+
+        let replacement = session(session_id, expiry);
+        let replacement_pointer = Arc::as_ptr(&replacement);
+        let rejected = match cache.insert(replacement) {
+            Ok(_) => panic!("duplicate session must not replace the original"),
+            Err(rejected) => rejected,
+        };
+        assert_eq!(rejected.reason(), V2SessionInsertError::DuplicateSession);
+        assert_eq!(Arc::as_ptr(&rejected.into_session()), replacement_pointer);
+
+        let lease = cache.acquire_at(&session_id, now).expect("original lease");
+        assert_eq!(lease.state() as *const V2SessionState, original_pointer);
+    }
+
+    #[test]
+    fn cleanup_removes_expired_closed_and_exhausted_unleased_sessions() {
+        let now = Instant::now();
+        let cutoff = now + Duration::from_secs(10);
+        let expired_id = Uuid::new_v4();
+        let closed_id = Uuid::new_v4();
+        let exhausted_id = Uuid::new_v4();
+        let live_id = Uuid::new_v4();
+        let mut cache = cache(4);
+
+        insert_new(&mut cache, session(expired_id, cutoff));
+
+        let closed = session(closed_id, cutoff + Duration::from_secs(60));
+        closed.close();
+        insert_new(&mut cache, closed);
+
+        let exhausted = session_with_global_budget(
+            exhausted_id,
+            cutoff + Duration::from_secs(60),
+            Arc::new(GlobalReplayBudget::new(0)),
+        );
+        assert_eq!(
+            exhausted.claim_request_id(RequestId::from_bytes([1; 16])),
+            ReplayClaim::Exhausted
+        );
+        assert!(exhausted.is_exhausted());
+        insert_new(&mut cache, exhausted);
+
+        insert_new(
+            &mut cache,
+            session(live_id, cutoff + Duration::from_secs(60)),
+        );
+
+        let retired = cache.cleanup_at(cutoff);
+        assert_eq!(retired.removed_count(), 3);
+        let retired_ids = retired
+            .sessions
+            .iter()
+            .map(|state| state.session_id())
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(
+            retired_ids,
+            std::collections::HashSet::from([expired_id, closed_id, exhausted_id])
+        );
+        assert_eq!(cache.len(), 1);
+        assert!(cache.contains(&live_id));
+    }
+
+    #[test]
+    fn lease_and_clone_preserve_exact_arc_for_response_continuity() {
+        let now = Instant::now();
+        let session_id = Uuid::new_v4();
+        let state = session(session_id, now + Duration::from_secs(60));
+        let expected = Arc::as_ptr(&state);
+        let mut cache = cache(1);
+        insert_new(&mut cache, state);
+
+        let lease = cache.acquire_at(&session_id, now).expect("lease session");
+        let cloned = lease.clone();
+        assert_eq!(lease.state() as *const V2SessionState, expected);
+        assert_eq!(cloned.state() as *const V2SessionState, expected);
+        assert!(cache.mark_admitted(&lease));
+    }
+}
+
+/// Sessions detached from the cache for destruction outside its future mutex.
+#[must_use = "keep retired sessions alive until after releasing the cache lock"]
+pub(crate) struct RetiredV2Sessions {
+    sessions: Vec<Arc<V2SessionState>>,
+}
+
+impl RetiredV2Sessions {
+    fn empty() -> Self {
+        Self {
+            sessions: Vec::new(),
+        }
+    }
+
+    pub(crate) fn removed_count(&self) -> usize {
+        self.sessions.len()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.sessions.is_empty()
+    }
+}
+
+/// The result of inserting a session, including any cache-owned state that was
+/// detached and must be dropped after the caller releases its outer lock.
+#[must_use = "release retired sessions after releasing the cache lock"]
+pub(crate) struct InsertedV2Session {
+    outcome: V2SessionInsertOutcome,
+    retired: RetiredV2Sessions,
+}
+
+impl InsertedV2Session {
+    pub(crate) fn outcome(&self) -> V2SessionInsertOutcome {
+        self.outcome
+    }
+
+    pub(crate) fn into_retired(self) -> RetiredV2Sessions {
+        self.retired
+    }
+}
+
+/// A request-lifetime reference to the exact cryptographic session selected at
+/// admission. Cloning the lease keeps that same state alive for response bodies
+/// and streams without a second lookup by attacker-visible session UUID.
+#[derive(Clone)]
+pub(crate) struct V2SessionLease {
+    session_id: Uuid,
+    state: Arc<V2SessionState>,
+}
+
+impl V2SessionLease {
+    pub(crate) fn state(&self) -> &V2SessionState {
+        &self.state
+    }
+}
+
+/// A fixed-capacity v2-only session cache.
+///
+/// The cache deliberately has no global instance and exposes no resizing. It
+/// is compiled route-free in this stack layer so allocating its production
+/// capacity cannot change startup memory or transport-v1 behavior.
+pub(crate) struct V2SessionCache {
+    entries: CLruCache<Uuid, Arc<V2SessionState>, RandomState>,
+}
+
+impl V2SessionCache {
+    pub(crate) fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            entries: CLruCache::with_memory(capacity, capacity.get()),
+        }
+    }
+
+    /// Inserts without replacing an existing session ID.
+    ///
+    /// At capacity, the least-recently-used session without any external `Arc`
+    /// is detached. A cache containing only leased sessions rejects admission
+    /// rather than invalidating in-flight response encryption.
+    pub(crate) fn insert(
+        &mut self,
+        session: Arc<V2SessionState>,
+    ) -> Result<InsertedV2Session, RejectedV2Session> {
+        let session_id = session.session_id();
+        if self.entries.peek(&session_id).is_some() {
+            return Err(RejectedV2Session {
+                reason: V2SessionInsertError::DuplicateSession,
+                session,
+            });
+        }
+
+        let mut retired = RetiredV2Sessions::empty();
+        let outcome = if self.entries.is_full() {
+            // Scan from LRU to MRU without altering recency. Any external Arc
+            // may be an active request/response lease, so only the cache's sole
+            // Arc is safe to detach.
+            let eviction_id = self
+                .entries
+                .iter()
+                .rev()
+                .find(|(_, state)| Arc::strong_count(state) == 1)
+                .map(|(candidate_id, _)| *candidate_id);
+
+            let Some(eviction_id) = eviction_id else {
+                return Err(RejectedV2Session {
+                    reason: V2SessionInsertError::AllSessionsLeased,
+                    session,
+                });
+            };
+
+            let evicted = self
+                .entries
+                .pop(&eviction_id)
+                .expect("selected unleased v2 session must remain present");
+            debug_assert_eq!(Arc::strong_count(&evicted), 1);
+            retired.sessions.push(evicted);
+            V2SessionInsertOutcome::EvictedLeastRecentlyUsed
+        } else {
+            V2SessionInsertOutcome::Inserted
+        };
+
+        let previous = self.entries.put(session_id, session);
+        debug_assert!(previous.is_none());
+        debug_assert!(self.entries.len() <= self.entries.capacity());
+
+        Ok(InsertedV2Session { outcome, retired })
+    }
+
+    /// Leases the exact session state without refreshing its LRU position.
+    ///
+    /// Admission is checked on every call, even when an older request still
+    /// holds a lease. Thus `now >= absolute_expiry`, authentication expiry,
+    /// exhaustion, or closing rejects new work while the older lease remains
+    /// available to finish its already-admitted response.
+    pub(crate) fn acquire_at(&self, session_id: &Uuid, now: Instant) -> Option<V2SessionLease> {
+        let state = self.entries.peek(session_id)?;
+        if !state.accepts_new_requests_at(now) {
+            return None;
+        }
+
+        Some(V2SessionLease {
+            session_id: *session_id,
+            state: Arc::clone(state),
+        })
+    }
+
+    /// Marks an exact leased session as recently used only after the request
+    /// has passed AEAD, structural validation, and the replay gate.
+    ///
+    /// Pointer equality prevents a stale lease from promoting a different
+    /// session that happens to reuse the same UUID.
+    pub(crate) fn mark_admitted(&mut self, lease: &V2SessionLease) -> bool {
+        let same_session = self
+            .entries
+            .peek(&lease.session_id)
+            .is_some_and(|cached| Arc::ptr_eq(cached, &lease.state));
+        if !same_session {
+            return false;
+        }
+
+        self.entries.get(&lease.session_id).is_some()
+    }
+
+    /// Detaches terminal or expired sessions that have no active lease.
+    ///
+    /// Session state can become closing or exhausted independently of LRU
+    /// order, so cleanup examines every v2 entry. It never touches the
+    /// transport-v1 cache.
+    pub(crate) fn cleanup_at(&mut self, now: Instant) -> RetiredV2Sessions {
+        let removable_ids = self
+            .entries
+            .iter()
+            .filter(|(_, state)| Arc::strong_count(state) == 1 && state.should_retire_at(now))
+            .map(|(session_id, _)| *session_id)
+            .collect::<Vec<_>>();
+
+        let mut retired = RetiredV2Sessions {
+            sessions: Vec::with_capacity(removable_ids.len()),
+        };
+        for session_id in removable_ids {
+            let session = self
+                .entries
+                .pop(&session_id)
+                .expect("selected removable v2 session must remain present");
+            debug_assert_eq!(Arc::strong_count(&session), 1);
+            retired.sessions.push(session);
+        }
+        retired
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    #[cfg(test)]
+    fn contains(&self, session_id: &Uuid) -> bool {
+        self.entries.peek(session_id).is_some()
+    }
+}

--- a/src/transport_v2/tests.rs
+++ b/src/transport_v2/tests.rs
@@ -1,0 +1,312 @@
+//! Cross-module transport-v2 vectors and invariants.
+
+use serde::Deserialize;
+use uuid::Uuid;
+
+use super::{
+    crypto::{
+        decode_canonical_base64, decrypt_key_exchange_record, encode_canonical_base64,
+        encrypt_key_exchange_record_with_nonce, request_record_aad, stream_response_record_aad,
+        unary_response_record_aad, CryptoError, DirectionalKeys, HandshakePayload, SessionMaster,
+    },
+    envelope::{EnvelopeLimits, LogicalMethod, RequestEnvelope, RequestId, ResponseMode},
+    maximum_accounted_memory_bytes, V2_MEMORY_BUDGET_BYTES,
+};
+
+#[derive(Deserialize)]
+struct GoldenVectors {
+    shared_secret_hex: String,
+    session_master_hex: String,
+    session_id: String,
+    expires_at_unix_seconds: u64,
+    request_id_hex: String,
+    stream_sequence: u64,
+    handshake: HandshakeVector,
+    request: DirectionalVector,
+    unary_response: DirectionalVector,
+    stream_response: RecordVector,
+    request_without_body_json: String,
+    request_with_empty_body_json: String,
+}
+
+#[derive(Deserialize)]
+struct HandshakeVector {
+    aad_hex: String,
+    nonce_hex: String,
+    plaintext_hex: String,
+    record_hex: String,
+    record_base64: String,
+}
+
+#[derive(Deserialize)]
+struct DirectionalVector {
+    derived_key_hex: String,
+    aad_hex: String,
+    nonce_hex: String,
+    plaintext_utf8: String,
+    plaintext_hex: String,
+    record_hex: String,
+    record_base64: String,
+}
+
+#[derive(Deserialize)]
+struct RecordVector {
+    aad_hex: String,
+    nonce_hex: String,
+    plaintext_utf8: String,
+    plaintext_hex: String,
+    record_hex: String,
+    record_base64: String,
+}
+
+fn vectors() -> GoldenVectors {
+    serde_json::from_str(include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/testdata/transport-v2-golden-vectors.json"
+    )))
+    .unwrap()
+}
+
+fn fixed_hex<const N: usize>(encoded: &str) -> [u8; N] {
+    hex::decode(encoded).unwrap().try_into().unwrap()
+}
+
+fn assert_record(record: &[u8], expected_hex: &str, expected_base64: &str) {
+    assert_eq!(record, hex::decode(expected_hex).unwrap());
+    assert_eq!(encode_canonical_base64(record), expected_base64);
+    assert_eq!(decode_canonical_base64(expected_base64).unwrap(), record);
+}
+
+#[test]
+fn golden_vectors_fix_key_derivation_aad_and_record_bytes() {
+    let fixture = vectors();
+    let shared_secret = fixed_hex::<32>(&fixture.shared_secret_hex);
+    let master = SessionMaster::from_bytes(fixed_hex(&fixture.session_master_hex));
+    let session_id = Uuid::parse_str(&fixture.session_id).unwrap();
+    let request_id = RequestId::from_bytes(fixed_hex(&fixture.request_id_hex));
+
+    let handshake = HandshakePayload::new(&session_id, &master, fixture.expires_at_unix_seconds);
+    assert_eq!(
+        handshake.as_bytes().as_slice(),
+        hex::decode(&fixture.handshake.plaintext_hex).unwrap()
+    );
+    assert_eq!(
+        b"opensecret/transport-v2/key-exchange",
+        hex::decode(&fixture.handshake.aad_hex).unwrap().as_slice()
+    );
+    let handshake_record = encrypt_key_exchange_record_with_nonce(
+        &shared_secret,
+        &handshake,
+        fixed_hex(&fixture.handshake.nonce_hex),
+    )
+    .unwrap();
+    assert_record(
+        &handshake_record,
+        &fixture.handshake.record_hex,
+        &fixture.handshake.record_base64,
+    );
+    assert_eq!(
+        decrypt_key_exchange_record(&shared_secret, &handshake_record).unwrap(),
+        handshake.as_bytes()
+    );
+
+    let keys = DirectionalKeys::derive(&master).unwrap();
+    assert_eq!(
+        keys.request_key_bytes(),
+        &fixed_hex::<32>(&fixture.request.derived_key_hex)
+    );
+    assert_eq!(
+        keys.response_key_bytes(),
+        &fixed_hex::<32>(&fixture.unary_response.derived_key_hex)
+    );
+
+    assert_eq!(
+        request_record_aad(&session_id),
+        hex::decode(&fixture.request.aad_hex).unwrap()
+    );
+    let request_plaintext = fixture.request.plaintext_utf8.as_bytes();
+    assert_eq!(
+        request_plaintext,
+        hex::decode(&fixture.request.plaintext_hex).unwrap()
+    );
+    let request_record = keys
+        .encrypt_request_record_with_nonce(
+            &session_id,
+            request_plaintext,
+            fixed_hex(&fixture.request.nonce_hex),
+        )
+        .unwrap();
+    assert_record(
+        &request_record,
+        &fixture.request.record_hex,
+        &fixture.request.record_base64,
+    );
+    assert_eq!(
+        keys.decrypt_request_record(&session_id, &request_record)
+            .unwrap(),
+        request_plaintext
+    );
+
+    assert_eq!(
+        unary_response_record_aad(&session_id, &request_id),
+        hex::decode(&fixture.unary_response.aad_hex).unwrap()
+    );
+    let unary_plaintext = fixture.unary_response.plaintext_utf8.as_bytes();
+    assert_eq!(
+        unary_plaintext,
+        hex::decode(&fixture.unary_response.plaintext_hex).unwrap()
+    );
+    let unary_record = keys
+        .encrypt_unary_response_record_with_nonce(
+            &session_id,
+            &request_id,
+            unary_plaintext,
+            fixed_hex(&fixture.unary_response.nonce_hex),
+        )
+        .unwrap();
+    assert_record(
+        &unary_record,
+        &fixture.unary_response.record_hex,
+        &fixture.unary_response.record_base64,
+    );
+    assert_eq!(
+        keys.decrypt_unary_response_record(&session_id, &request_id, &unary_record)
+            .unwrap(),
+        unary_plaintext
+    );
+
+    assert_eq!(
+        stream_response_record_aad(&session_id, &request_id, fixture.stream_sequence),
+        hex::decode(&fixture.stream_response.aad_hex).unwrap()
+    );
+    let stream_plaintext = fixture.stream_response.plaintext_utf8.as_bytes();
+    assert_eq!(
+        stream_plaintext,
+        hex::decode(&fixture.stream_response.plaintext_hex).unwrap()
+    );
+    let stream_record = keys
+        .encrypt_stream_response_record_with_nonce(
+            &session_id,
+            &request_id,
+            fixture.stream_sequence,
+            stream_plaintext,
+            fixed_hex(&fixture.stream_response.nonce_hex),
+        )
+        .unwrap();
+    assert_record(
+        &stream_record,
+        &fixture.stream_response.record_hex,
+        &fixture.stream_response.record_base64,
+    );
+    assert_eq!(
+        keys.decrypt_stream_response_record(
+            &session_id,
+            &request_id,
+            fixture.stream_sequence,
+            &stream_record,
+        )
+        .unwrap(),
+        stream_plaintext
+    );
+}
+
+#[test]
+fn records_fail_closed_when_direction_or_binding_changes() {
+    let fixture = vectors();
+    let master = SessionMaster::from_bytes(fixed_hex(&fixture.session_master_hex));
+    let keys = DirectionalKeys::derive(&master).unwrap();
+    let session_id = Uuid::parse_str(&fixture.session_id).unwrap();
+    let other_session_id = Uuid::from_bytes([0x55; 16]);
+    let request_id = RequestId::from_bytes(fixed_hex(&fixture.request_id_hex));
+    let other_request_id = RequestId::from_bytes([0x66; 16]);
+
+    let request_record = hex::decode(&fixture.request.record_hex).unwrap();
+    assert_eq!(
+        keys.decrypt_request_record(&other_session_id, &request_record),
+        Err(CryptoError::DecryptionFailed)
+    );
+    assert_eq!(
+        keys.decrypt_unary_response_record(&session_id, &request_id, &request_record),
+        Err(CryptoError::DecryptionFailed)
+    );
+
+    let unary_record = hex::decode(&fixture.unary_response.record_hex).unwrap();
+    assert_eq!(
+        keys.decrypt_request_record(&session_id, &unary_record),
+        Err(CryptoError::DecryptionFailed)
+    );
+    assert_eq!(
+        keys.decrypt_unary_response_record(&other_session_id, &request_id, &unary_record),
+        Err(CryptoError::DecryptionFailed)
+    );
+    assert_eq!(
+        keys.decrypt_unary_response_record(&session_id, &other_request_id, &unary_record),
+        Err(CryptoError::DecryptionFailed)
+    );
+
+    let stream_record = hex::decode(&fixture.stream_response.record_hex).unwrap();
+    assert_eq!(
+        keys.decrypt_stream_response_record(
+            &session_id,
+            &request_id,
+            fixture.stream_sequence + 1,
+            &stream_record,
+        ),
+        Err(CryptoError::DecryptionFailed)
+    );
+
+    let mut tampered_request = request_record;
+    *tampered_request.last_mut().unwrap() ^= 1;
+    assert_eq!(
+        keys.decrypt_request_record(&session_id, &tampered_request),
+        Err(CryptoError::DecryptionFailed)
+    );
+
+    let mut tampered_stream = stream_record;
+    *tampered_stream.last_mut().unwrap() ^= 1;
+    assert_eq!(
+        keys.decrypt_stream_response_record(
+            &session_id,
+            &request_id,
+            fixture.stream_sequence,
+            &tampered_stream,
+        ),
+        Err(CryptoError::DecryptionFailed)
+    );
+}
+
+#[test]
+fn envelope_preserves_no_body_distinct_from_an_explicit_empty_body() {
+    let fixture = vectors();
+    let limits = EnvelopeLimits::DEFAULT;
+
+    let without_body =
+        RequestEnvelope::from_json_slice(fixture.request_without_body_json.as_bytes(), &limits)
+            .unwrap();
+    assert_eq!(without_body.response_mode, ResponseMode::Unary);
+    assert_eq!(without_body.request.method, LogicalMethod::Get);
+    assert!(without_body.request.body_base64.is_none());
+
+    let with_empty_body =
+        RequestEnvelope::from_json_slice(fixture.request_with_empty_body_json.as_bytes(), &limits)
+            .unwrap();
+    assert_eq!(with_empty_body.response_mode, ResponseMode::Unary);
+    assert_eq!(with_empty_body.request.method, LogicalMethod::Post);
+    assert_eq!(
+        with_empty_body
+            .request
+            .body_base64
+            .as_ref()
+            .unwrap()
+            .as_slice(),
+        b""
+    );
+}
+
+#[test]
+fn maximum_accounted_core_state_stays_within_the_fixed_memory_budget() {
+    const MIB: usize = 1024 * 1024;
+
+    assert_eq!(maximum_accounted_memory_bytes(), 172 * MIB);
+    assert!(maximum_accounted_memory_bytes() <= V2_MEMORY_BUDGET_BYTES);
+}

--- a/testdata/transport-v2-golden-vectors.json
+++ b/testdata/transport-v2-golden-vectors.json
@@ -1,0 +1,50 @@
+{
+  "fixture_version": 1,
+  "protocol_version": 2,
+  "shared_secret_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+  "session_master_hex": "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f",
+  "session_id": "00112233-4455-6677-8899-aabbccddeeff",
+  "session_id_hex": "00112233445566778899aabbccddeeff",
+  "expires_at_unix_seconds": 1800003900,
+  "request_id_hex": "ffeeddccbbaa99887766554433221100",
+  "stream_sequence": 7,
+  "handshake": {
+    "info_utf8": "opensecret/transport-v2/handshake-key",
+    "derived_key_hex": "d534157fe075f3c5c13899ec5cabf66121006330a15a9e340132aaec235fb634",
+    "aad_hex": "6f70656e7365637265742f7472616e73706f72742d76322f6b65792d65786368616e6765",
+    "nonce_hex": "000102030405060708090a0b",
+    "plaintext_hex": "0200112233445566778899aabbccddeeff202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f000000006b49e13c",
+    "record_hex": "000102030405060708090a0bb88afcfdf3ec719871b6844fbfd510210dcef6c86b1e217bd66a24ef9be9746e784de2d83125ec52cfe009e0826bb85bd029744bd2759acd8dd698091d54b34fa9dfe9b6f26138375b",
+    "record_base64": "AAECAwQFBgcICQoLuIr8/fPscZhxtoRPv9UQIQ3O9shrHiF71mok75vpdG54TeLYMSXsUs/gCeCCa7hb0Cl0S9J1ms2N1pgJHVSzT6nf6bbyYTg3Ww=="
+  },
+  "request": {
+    "info_utf8": "opensecret/transport-v2/client-request",
+    "derived_key_hex": "c8865e05fdd7c0a8eada79cb117e97b1c11aeee640fd315f5971a89b3c8504f3",
+    "aad_hex": "6f70656e7365637265742f7472616e73706f72742d76322f726571756573742d7265636f72640000112233445566778899aabbccddeeff",
+    "nonce_hex": "0c0d0e0f1011121314151617",
+    "plaintext_utf8": "transport-v2 request vector",
+    "plaintext_hex": "7472616e73706f72742d7632207265717565737420766563746f72",
+    "record_hex": "0c0d0e0f1011121314151617ccab23f6818e4331eb8a631f5d0fb5c874bb20cc11efce9deeda2c8747fe81729890b1638dfac9cbc222f8",
+    "record_base64": "DA0ODxAREhMUFRYXzKsj9oGOQzHrimMfXQ+1yHS7IMwR786d7tosh0f+gXKYkLFjjfrJy8Ii+A=="
+  },
+  "unary_response": {
+    "info_utf8": "opensecret/transport-v2/enclave-response",
+    "derived_key_hex": "ac0b87b944dd080ed214ee042458f159df7dad0bca10c3bb1caee552d8633a0a",
+    "aad_hex": "6f70656e7365637265742f7472616e73706f72742d76322f756e6172792d726573706f6e73652d7265636f72640000112233445566778899aabbccddeeffffeeddccbbaa99887766554433221100",
+    "nonce_hex": "18191a1b1c1d1e1f20212223",
+    "plaintext_utf8": "transport-v2 unary response vector",
+    "plaintext_hex": "7472616e73706f72742d763220756e61727920726573706f6e736520766563746f72",
+    "record_hex": "18191a1b1c1d1e1f2021222356b4bfabc752cd7a75ac37c452d93ca225ddacf1a266267a17c5fdfec9945ace742d11a6a91de3d90e475fe7455bab8ecdd1",
+    "record_base64": "GBkaGxwdHh8gISIjVrS/q8dSzXp1rDfEUtk8oiXdrPGiZiZ6F8X9/smUWs50LRGmqR3j2Q5HX+dFW6uOzdE="
+  },
+  "stream_response": {
+    "aad_hex": "6f70656e7365637265742f7472616e73706f72742d76322f73747265616d2d726573706f6e73652d7265636f72640000112233445566778899aabbccddeeffffeeddccbbaa998877665544332211000000000000000007",
+    "nonce_hex": "2425262728292a2b2c2d2e2f",
+    "plaintext_utf8": "transport-v2 stream record vector",
+    "plaintext_hex": "7472616e73706f72742d76322073747265616d207265636f726420766563746f72",
+    "record_hex": "2425262728292a2b2c2d2e2f7f7818dab8d77e819361a2b9cb7fbccc2ba70f4bb6b751e1329622624dfa35cefb9031a6e93e608bc9777a57a7f35480ba",
+    "record_base64": "JCUmJygpKissLS4vf3gY2rjXfoGTYaK5y3+8zCunD0u2t1HhMpYiYk36Nc77kDGm6T5gi8l3elen81SAug=="
+  },
+  "request_without_body_json": "{\"version\":2,\"request_id\":\"ffeeddccbbaa99887766554433221100\",\"response_mode\":\"unary\",\"credential\":null,\"request\":{\"method\":\"GET\",\"path\":\"/v1/models\",\"query\":\"limit=10\",\"headers\":[{\"name\":\"x-provider-beta\",\"value_base64\":\"YmV0YQ==\"}],\"body_base64\":null}}",
+  "request_with_empty_body_json": "{\"version\":2,\"request_id\":\"ffeeddccbbaa99887766554433221100\",\"response_mode\":\"unary\",\"credential\":null,\"request\":{\"method\":\"POST\",\"path\":\"/v1/responses\",\"query\":null,\"headers\":[{\"name\":\"content-type\",\"value_base64\":\"YXBwbGljYXRpb24vanNvbg==\"}],\"body_base64\":\"\"}}"
+}


### PR DESCRIPTION
## Stack

- #307 protocol contract
- #308 behavior-neutral v1 response/session seam
- **This PR:** dormant transport-v2 core

Base: `codex-session-v2-transport-seam`. Please review only this PR's incremental diff.

## What this adds

- Frozen v2 handshake payload, HKDF labels, directional ChaCha20-Poly1305 records, AAD, and cross-language golden bytes.
- Strict whole-request, unary-response, and ordered-stream envelope types with canonical encodings and resource limits.
- Exact unordered replay IDs with per-session and global bounded accounting.
- Cancellation-safe anonymous-to-bound authority state for user, platform, and existing API-key principals.
- Absolute monotonic expiry, record budgets, pre-dispatch response reservations, and exact-session response continuity.
- A separate lease-aware v2 session cache and explicit 256 MiB accounting ceiling.

This core is intentionally dormant. It adds no v2 routes, `AppState` field, startup task, cache allocation, dependency, or transport-v1 code-path change.

## Review corrections already applied

A focused security review found that response capacity was initially charged too late. Unary now reserves one response record before dispatch; streaming atomically reserves start and terminal records before dispatch, so concurrent work cannot execute and then lose required response capacity.

## Validation

- `cargo fmt --all -- --check`
- strict all-target/all-feature Clippy with warnings denied
- full Rust suite: 481 passed, 20 ignored, 0 failed
- focused transport-v2 suite: 48 passed
- independent Node recomputation of every golden key/AAD/record byte
- focused security review: material response-capacity race fixed and re-reviewed
- focused compatibility review: no v1 runtime/startup/API impact
- managed OpenSecret smoke passed
- existing TypeScript guest signup/login runtime test passed against the modified server
- existing Rust guest password-change/bodyless user-read runtime test passed against the modified server
- `/v2/key_exchange` and `/v2/request` remain unregistered (404)

No merge, release, or deployment is part of this PR.
