### PR TITLE
Transport v2: project sensitive user operations

### DIFF
--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -633,22 +633,35 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    activates exact unordered replay claims for supported operations. Platform,
    API-key, OAuth, and all other application paths still receive the encrypted
    unsupported-operation response.
-6. **Protected user unary projection**: project the remaining user-authorized
-   unary operation families, including third-party token issuance, through the
-   live bound-user checks without changing their application semantics.
-7. **API-key and platform binding**: bind existing raw API keys inside
+6. **Sensitive user-key projection**: project root/derived mnemonic and private
+   key export, public-key derivation, signing, and third-party token issuance
+   through the live bound-user check. Sensitive intermediate response values
+   are zeroized, decoded byte fields and prepared sensitive operations wipe on
+   drop across rejection/cancellation paths, and serialized logical responses
+   are bounded before gateway encryption. Large encrypt/decrypt utilities
+   remain unsupported until their base64 and JSON expansion has an exact
+   pre-dispatch limit.
+7. **Remaining protected user operations**: project bounded crypto/KV,
+   account-lifecycle, and user API-key-management families in reviewable
+   sub-stacks. Dynamic path parameters must preserve released SDK semantics
+   without weakening the v2 route classifier, and password/account deletion
+   must explicitly close the now-invalid bound session.
+8. **Stored user unary operations**: project conversations, conversation
+   projects, instructions, response control, and web-provider unary routes in
+   ownership-preserving families before the client cutover.
+9. **API-key and platform binding**: bind existing raw API keys inside
    ciphertext without rotating them, enforce their current inference-only
    scope, and add platform authentication/authorization with live organization
    checks. OAuth continuation receives an explicit session-binding design in
    this layer rather than being inferred from password login.
-8. **Streaming projection**: project current inference streams with ordered,
+10. **Streaming projection**: project current inference streams with ordered,
    request-bound, authenticated terminal records while preserving the SDK's
    caller-visible SSE behavior.
-9. **Additive SDK v2 internals**: TypeScript and Rust codecs/session managers
+11. **Additive SDK v2 internals**: TypeScript and Rust codecs/session managers
    behind private seams, still not selected by public calls.
-10. **Atomic SDK cutover**: v2-only network behavior, no downgrade, one-time
+12. **Atomic SDK cutover**: v2-only network behavior, no downgrade, one-time
    fresh login, and Maple/proxy integration.
-11. **SDK major/version packaging**: package metadata, locks, integration pin,
+13. **SDK major/version packaging**: package metadata, locks, integration pin,
    compatibility matrix, and release rehearsal. Publication/deployment remain
    separate authorized actions.
 

--- a/src/security_invariants.rs
+++ b/src/security_invariants.rs
@@ -442,11 +442,14 @@ fn legacy_token_constructor_is_only_used_for_third_party_tokens() {
     let protected_routes = manifest_dir.join("src/web/protected_routes.rs");
     let contents =
         fs::read_to_string(&protected_routes).expect("protected route source should be readable");
-    let third_party_body =
+    let third_party_route =
         extract_function_body(&contents, "pub async fn generate_third_party_token");
+    assert!(third_party_route.contains("third_party_token_data(&data, &user, request)"));
+    assert!(third_party_route.contains("encrypt_response(&data, &session_id, &response).await"));
 
-    assert!(third_party_body.contains("NewToken::new("));
-    assert!(third_party_body.contains("TokenType::ThirdParty"));
+    let third_party_core = extract_function_body(&contents, "pub(crate) fn third_party_token_data");
+    assert!(third_party_core.contains("NewToken::new("));
+    assert!(third_party_core.contains("TokenType::ThirdParty"));
 }
 
 #[test]

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -8,8 +8,11 @@
 use std::sync::Arc;
 use std::time::Instant;
 
+use axum::extract::Query;
 use axum::http::StatusCode;
+use axum::http::Uri;
 use chrono::{DateTime, Utc};
+use serde::de::DeserializeOwned;
 use serde::Serialize;
 use zeroize::{Zeroize, Zeroizing};
 
@@ -20,11 +23,16 @@ use crate::web::login_routes::{
     authenticate_login, register_and_authenticate, AuthResponse, Credentials, RefreshResponse,
     RegisterCredentials,
 };
-use crate::web::protected_routes::protected_user_data;
+use crate::web::protected_routes::{
+    private_key_bytes_data, private_key_data, protected_user_data, public_key_data,
+    sign_message_data, third_party_token_data, DerivationPathQuery, PublicKeyQuery,
+    SignMessageRequest, ThirdPartyTokenRequest,
+};
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
 use super::envelope::{
-    Credential, EncodedBytes, HeaderField, LogicalMethod, RequestEnvelope, RequestId, ResponseMode,
+    Credential, EncodedBytes, EnvelopeLimits, HeaderField, LogicalMethod, RequestEnvelope,
+    RequestId, ResponseMode,
 };
 use super::session::{
     AuthenticationReservation, AuthenticationStartError, AuthorityState, BoundAuthority,
@@ -34,6 +42,8 @@ use super::session_cache::V2SessionLease;
 
 const JSON_CONTENT_TYPE: &[u8] = b"application/json";
 
+type SensitiveBytes = Zeroizing<Vec<u8>>;
+
 pub(crate) enum OperationPreparation {
     Unsupported,
     Rejected(LogicalUnaryResponse),
@@ -41,10 +51,28 @@ pub(crate) enum OperationPreparation {
 }
 
 pub(crate) enum UserOperation {
-    Login { body: Vec<u8> },
-    Register { body: Vec<u8> },
-    Resume { credential: Vec<u8> },
-    GetUser(BoundUserAuthority),
+    Login {
+        body: SensitiveBytes,
+    },
+    Register {
+        body: SensitiveBytes,
+    },
+    Resume {
+        credential: SensitiveBytes,
+    },
+    Protected {
+        authority: BoundUserAuthority,
+        operation: ProtectedUserOperation,
+    },
+}
+
+pub(crate) enum ProtectedUserOperation {
+    GetUser,
+    GetPrivateKey { query: Option<String> },
+    GetPrivateKeyBytes { query: Option<String> },
+    GetPublicKey { query: Option<String> },
+    SignMessage { body: SensitiveBytes },
+    IssueThirdPartyToken { body: SensitiveBytes },
 }
 
 #[derive(Clone)]
@@ -71,13 +99,25 @@ pub(crate) struct LogicalUnaryResponse {
 
 impl LogicalUnaryResponse {
     pub(crate) fn json<T: Serialize>(status: StatusCode, value: &T) -> Result<Self, ApiError> {
-        let body = serde_json::to_vec(value).map_err(|error| {
+        Self::json_with_limit(status, value, EnvelopeLimits::default().logical_body_bytes)
+    }
+
+    fn json_with_limit<T: Serialize>(
+        status: StatusCode,
+        value: &T,
+        logical_body_bytes: usize,
+    ) -> Result<Self, ApiError> {
+        let mut body = serde_json::to_vec(value).map_err(|error| {
             tracing::error!(
                 "Could not serialize transport-v2 logical response: {:?}",
                 error
             );
             ApiError::InternalServerError
         })?;
+        if body.len() > logical_body_bytes {
+            body.zeroize();
+            return Err(ApiError::PayloadTooLarge);
+        }
         Ok(Self {
             status,
             headers: vec![HeaderField {
@@ -158,21 +198,40 @@ pub(crate) fn prepare_user_operation(
         ..
     } = envelope;
 
-    let operation = match (request.method, request.path.as_str()) {
-        (LogicalMethod::Post, "/login") => 0,
-        (LogicalMethod::Post, "/register") => 1,
-        (LogicalMethod::Post, "/refresh") => 2,
-        (LogicalMethod::Get, "/protected/user") => 3,
+    #[derive(Clone, Copy)]
+    enum Route {
+        Login,
+        Register,
+        Resume,
+        GetUser,
+        GetPrivateKey,
+        GetPrivateKeyBytes,
+        GetPublicKey,
+        SignMessage,
+        IssueThirdPartyToken,
+    }
+
+    let route = match (request.method, request.path.as_str()) {
+        (LogicalMethod::Post, "/login") => Route::Login,
+        (LogicalMethod::Post, "/register") => Route::Register,
+        (LogicalMethod::Post, "/refresh") => Route::Resume,
+        (LogicalMethod::Get, "/protected/user") => Route::GetUser,
+        (LogicalMethod::Get, "/protected/private_key") => Route::GetPrivateKey,
+        (LogicalMethod::Get, "/protected/private_key_bytes") => Route::GetPrivateKeyBytes,
+        (LogicalMethod::Get, "/protected/public_key") => Route::GetPublicKey,
+        (LogicalMethod::Post, "/protected/sign_message") => Route::SignMessage,
+        (LogicalMethod::Post, "/protected/third_party_token") => Route::IssueThirdPartyToken,
         _ => return OperationPreparation::Unsupported,
     };
 
-    if response_mode != ResponseMode::Unary || request.query.is_some() {
+    if response_mode != ResponseMode::Unary {
         return rejected_bad_request();
     }
 
-    match operation {
-        0 | 1 => {
+    match route {
+        Route::Login | Route::Register => {
             if credential.is_some()
+                || request.query.is_some()
                 || !has_exact_json_content_type(&request.headers)
                 || request
                     .body_base64
@@ -193,14 +252,18 @@ pub(crate) fn prepare_user_operation(
                 .body_base64
                 .expect("validated body presence")
                 .into_bytes();
-            if operation == 0 {
+            let body = Zeroizing::new(body);
+            if matches!(route, Route::Login) {
                 OperationPreparation::Ready(UserOperation::Login { body })
             } else {
                 OperationPreparation::Ready(UserOperation::Register { body })
             }
         }
-        2 => {
-            if !request.headers.is_empty() || request.body_base64.is_some() {
+        Route::Resume => {
+            if request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
                 return rejected_bad_request();
             }
             if !matches!(authority, AuthorityState::Anonymous) {
@@ -217,33 +280,93 @@ pub(crate) fn prepare_user_operation(
                 return rejected_bad_request();
             }
             OperationPreparation::Ready(UserOperation::Resume {
-                credential: value_base64.into_bytes(),
+                credential: Zeroizing::new(value_base64.into_bytes()),
             })
         }
-        3 => {
+        Route::GetUser | Route::GetPrivateKey | Route::GetPrivateKeyBytes | Route::GetPublicKey => {
             if credential.is_some() || !request.headers.is_empty() || request.body_base64.is_some()
             {
                 return rejected_bad_request();
             }
-            let AuthorityState::Bound(bound) = authority else {
-                return rejected_authentication_required();
+            if matches!(route, Route::GetUser) && request.query.is_some() {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
             };
-            let BoundPrincipal::User {
-                user_id,
-                project_id,
-                auth_context,
-            } = bound.principal()
-            else {
-                return rejected_authentication_required();
+            let operation = match route {
+                Route::GetUser => ProtectedUserOperation::GetUser,
+                Route::GetPrivateKey => ProtectedUserOperation::GetPrivateKey {
+                    query: request.query,
+                },
+                Route::GetPrivateKeyBytes => ProtectedUserOperation::GetPrivateKeyBytes {
+                    query: request.query,
+                },
+                Route::GetPublicKey => ProtectedUserOperation::GetPublicKey {
+                    query: request.query,
+                },
+                _ => unreachable!("fixed protected GET classifier is exhaustive"),
             };
-            OperationPreparation::Ready(UserOperation::GetUser(BoundUserAuthority {
-                user_id: *user_id,
-                project_id: *project_id,
-                auth_context: auth_context.clone(),
-            }))
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation,
+            })
         }
-        _ => unreachable!("operation classifier is exhaustive"),
+        Route::SignMessage | Route::IssueThirdPartyToken => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            let body = request
+                .body_base64
+                .expect("validated protected JSON body presence")
+                .into_bytes();
+            let body = Zeroizing::new(body);
+            let operation = match route {
+                Route::SignMessage => ProtectedUserOperation::SignMessage { body },
+                Route::IssueThirdPartyToken => {
+                    ProtectedUserOperation::IssueThirdPartyToken { body }
+                }
+                _ => unreachable!("fixed protected POST classifier is exhaustive"),
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation,
+            })
+        }
     }
+}
+
+fn bound_user_authority(
+    authority: AuthorityState,
+) -> Result<BoundUserAuthority, OperationPreparation> {
+    let AuthorityState::Bound(bound) = authority else {
+        return Err(rejected_authentication_required());
+    };
+    let BoundPrincipal::User {
+        user_id,
+        project_id,
+        auth_context,
+    } = bound.principal()
+    else {
+        return Err(rejected_authentication_required());
+    };
+    Ok(BoundUserAuthority {
+        user_id: *user_id,
+        project_id: *project_id,
+        auth_context: auth_context.clone(),
+    })
 }
 
 pub(crate) fn begin_authentication_transition(
@@ -284,10 +407,9 @@ pub(crate) async fn execute_user_operation(
     monotonic_now: Instant,
 ) -> ApplicationOutcome {
     match operation {
-        UserOperation::Login { mut body } => {
+        UserOperation::Login { body } => {
             let parsed =
                 serde_json::from_slice::<Credentials>(&body).map_err(|_| ApiError::BadRequest);
-            body.zeroize();
             let credentials = match parsed {
                 Ok(credentials) => credentials,
                 Err(error) => return ApplicationOutcome::error(error),
@@ -305,10 +427,9 @@ pub(crate) async fn execute_user_operation(
                 UserAuthResponseKind::Login,
             )
         }
-        UserOperation::Register { mut body } => {
+        UserOperation::Register { body } => {
             let parsed = serde_json::from_slice::<RegisterCredentials>(&body)
                 .map_err(|_| ApiError::BadRequest);
-            body.zeroize();
             let credentials = match parsed {
                 Ok(credentials) => credentials,
                 Err(error) => return ApplicationOutcome::error(error),
@@ -327,8 +448,9 @@ pub(crate) async fn execute_user_operation(
                 UserAuthResponseKind::Login,
             )
         }
-        UserOperation::Resume { credential } => {
-            let credential = match String::from_utf8(credential) {
+        UserOperation::Resume { mut credential } => {
+            let bytes = std::mem::take(&mut *credential);
+            let credential = match String::from_utf8(bytes) {
                 Ok(credential) => Zeroizing::new(credential),
                 Err(error) => {
                     let mut bytes = error.into_bytes();
@@ -349,12 +471,15 @@ pub(crate) async fn execute_user_operation(
                 UserAuthResponseKind::Refresh,
             )
         }
-        UserOperation::GetUser(bound) => {
+        UserOperation::Protected {
+            authority,
+            operation,
+        } => {
             debug_assert!(authentication.is_none());
             let user = match app_state.verify_bound_user(
-                bound.user_id,
-                bound.project_id,
-                &bound.auth_context,
+                authority.user_id,
+                authority.project_id,
+                &authority.auth_context,
             ) {
                 Ok(user) => user,
                 Err(error) => {
@@ -364,15 +489,81 @@ pub(crate) async fn execute_user_operation(
                     return ApplicationOutcome::error(error);
                 }
             };
-            let response = match protected_user_data(&app_state, &user)
-                .and_then(|value| LogicalUnaryResponse::json(StatusCode::OK, &value))
+            let response = match execute_protected_user_operation(
+                &app_state,
+                &user,
+                &authority.auth_context,
+                operation,
+            )
+            .await
             {
                 Ok(response) => response,
-                Err(error) => return ApplicationOutcome::error(error),
+                Err(error) => {
+                    if matches!(error, ApiError::Unauthorized | ApiError::InvalidJwt) {
+                        lease.state().close();
+                    }
+                    return ApplicationOutcome::error(error);
+                }
             };
             ApplicationOutcome::success(response, false)
         }
     }
+}
+
+async fn execute_protected_user_operation(
+    app_state: &AppState,
+    user: &crate::User,
+    auth_context: &AuthContext,
+    operation: ProtectedUserOperation,
+) -> Result<LogicalUnaryResponse, ApiError> {
+    match operation {
+        ProtectedUserOperation::GetUser => {
+            let value = protected_user_data(app_state, user)?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::GetPrivateKey { query } => {
+            let query = parse_logical_query::<DerivationPathQuery>(query)?;
+            let value = private_key_data(app_state, user, auth_context, query)?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::GetPrivateKeyBytes { query } => {
+            let query = parse_logical_query::<DerivationPathQuery>(query)?;
+            let value = private_key_bytes_data(app_state, user, auth_context, query).await?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::GetPublicKey { query } => {
+            let query = parse_logical_query::<PublicKeyQuery>(query)?;
+            let value = public_key_data(app_state, user, auth_context, query).await?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::SignMessage { body } => {
+            let request = parse_json_body::<SignMessageRequest>(body)?;
+            let value = sign_message_data(app_state, user, auth_context, request).await?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::IssueThirdPartyToken { body } => {
+            let request = parse_json_body::<ThirdPartyTokenRequest>(body)?;
+            let value = third_party_token_data(app_state, user, request)?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+    }
+}
+
+fn parse_json_body<T: DeserializeOwned>(body: SensitiveBytes) -> Result<T, ApiError> {
+    serde_json::from_slice::<T>(&body).map_err(|_| ApiError::BadRequest)
+}
+
+fn parse_logical_query<T: DeserializeOwned>(query: Option<String>) -> Result<T, ApiError> {
+    let path_and_query = match query {
+        Some(query) => format!("/?{query}"),
+        None => "/".to_owned(),
+    };
+    let uri = path_and_query
+        .parse::<Uri>()
+        .map_err(|_| ApiError::BadRequest)?;
+    Query::<T>::try_from_uri(&uri)
+        .map(|Query(value)| value)
+        .map_err(|_| ApiError::BadRequest)
 }
 
 enum UserAuthResponseKind {
@@ -613,8 +804,105 @@ mod tests {
                 ),
                 bound_user_authority(),
             ),
-            OperationPreparation::Ready(UserOperation::GetUser(_))
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::GetUser,
+                ..
+            })
         ));
+    }
+
+    #[test]
+    fn exact_sensitive_user_operation_contracts_are_admitted() {
+        let mut private_key = envelope(
+            LogicalMethod::Get,
+            "/protected/private_key",
+            Vec::new(),
+            None,
+            None,
+        );
+        let private_key_query =
+            "seed_phrase_derivation_path=m%2F83696968%27%2F39%27%2F0%27%2F12%27%2F0%27".to_owned();
+        private_key.request.query = Some(private_key_query.clone());
+        assert!(matches!(
+            prepare_user_operation(private_key, bound_user_authority()),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::GetPrivateKey { query: Some(query) },
+                ..
+            }) if query == private_key_query
+        ));
+
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Get,
+                    "/protected/private_key_bytes",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::GetPrivateKeyBytes { .. },
+                ..
+            })
+        ));
+
+        let mut public_key = envelope(
+            LogicalMethod::Get,
+            "/protected/public_key",
+            Vec::new(),
+            None,
+            None,
+        );
+        let public_key_query = "algorithm=schnorr".to_owned();
+        public_key.request.query = Some(public_key_query.clone());
+        assert!(matches!(
+            prepare_user_operation(public_key, bound_user_authority()),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::GetPublicKey { query: Some(query) },
+                ..
+            }) if query == public_key_query
+        ));
+
+        for (path, expected) in [
+            ("/protected/sign_message", "sign"),
+            ("/protected/third_party_token", "third_party"),
+        ] {
+            let prepared = prepare_user_operation(
+                envelope(LogicalMethod::Post, path, json_header(), Some(b"{}"), None),
+                bound_user_authority(),
+            );
+            assert!(
+                matches!(
+                    (&prepared, expected),
+                    (
+                        OperationPreparation::Ready(UserOperation::Protected {
+                            operation: ProtectedUserOperation::SignMessage { .. },
+                            ..
+                        }),
+                        "sign"
+                    ) | (
+                        OperationPreparation::Ready(UserOperation::Protected {
+                            operation: ProtectedUserOperation::IssueThirdPartyToken { .. },
+                            ..
+                        }),
+                        "third_party"
+                    )
+                ),
+                "{path}"
+            );
+        }
+
+        for path in ["/protected/encrypt", "/protected/decrypt"] {
+            assert!(matches!(
+                prepare_user_operation(
+                    envelope(LogicalMethod::Post, path, json_header(), Some(b"{}"), None,),
+                    bound_user_authority(),
+                ),
+                OperationPreparation::Unsupported
+            ));
+        }
     }
 
     #[test]
@@ -723,5 +1011,100 @@ mod tests {
                 OperationPreparation::Rejected(_)
             ));
         }
+    }
+
+    #[test]
+    fn sensitive_user_contracts_reject_unbound_and_transplanted_metadata() {
+        for path in [
+            "/protected/private_key",
+            "/protected/private_key_bytes",
+            "/protected/public_key",
+        ] {
+            assert!(matches!(
+                prepare_user_operation(
+                    envelope(LogicalMethod::Get, path, Vec::new(), None, None),
+                    AuthorityState::Anonymous,
+                ),
+                OperationPreparation::Rejected(_)
+            ));
+            assert!(matches!(
+                prepare_user_operation(
+                    envelope(LogicalMethod::Get, path, json_header(), None, None),
+                    bound_user_authority(),
+                ),
+                OperationPreparation::Rejected(_)
+            ));
+        }
+
+        for path in ["/protected/sign_message", "/protected/third_party_token"] {
+            assert!(matches!(
+                prepare_user_operation(
+                    envelope(LogicalMethod::Post, path, json_header(), Some(b"{}"), None),
+                    AuthorityState::Anonymous,
+                ),
+                OperationPreparation::Rejected(_)
+            ));
+
+            let mut query = envelope(LogicalMethod::Post, path, json_header(), Some(b"{}"), None);
+            query.request.query = Some("x=1".to_owned());
+            for request in [
+                envelope(LogicalMethod::Post, path, Vec::new(), Some(b"{}"), None),
+                envelope(LogicalMethod::Post, path, json_header(), None, None),
+                query,
+                envelope(
+                    LogicalMethod::Post,
+                    path,
+                    json_header(),
+                    Some(b"{}"),
+                    Some(Credential::Resumption {
+                        value_base64: EncodedBytes::from_bytes(b"token".to_vec()),
+                    }),
+                ),
+            ] {
+                assert!(matches!(
+                    prepare_user_operation(request, bound_user_authority()),
+                    OperationPreparation::Rejected(_)
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn logical_query_parsing_matches_axum_query_semantics() {
+        let no_derivation = parse_logical_query::<DerivationPathQuery>(None)
+            .expect("absent derivation query uses the existing default key options");
+        assert!(no_derivation
+            .key_options
+            .seed_phrase_derivation_path
+            .is_none());
+        assert!(no_derivation
+            .key_options
+            .private_key_derivation_path
+            .is_none());
+
+        let parsed = parse_logical_query::<DerivationPathQuery>(Some(
+            "private_key_derivation_path=m%2F44%27%2F0%27%2F0%27%2F0%2F0".to_owned(),
+        ))
+        .expect("valid encoded derivation path query");
+        assert_eq!(
+            parsed.key_options.private_key_derivation_path.as_deref(),
+            Some("m/44'/0'/0'/0/0")
+        );
+        assert!(
+            parse_logical_query::<PublicKeyQuery>(Some("algorithm=schnorr".to_owned())).is_ok()
+        );
+        assert!(parse_logical_query::<PublicKeyQuery>(None).is_err());
+        assert!(
+            parse_logical_query::<PublicKeyQuery>(Some("algorithm=unknown".to_owned())).is_err()
+        );
+    }
+
+    #[test]
+    fn oversized_logical_json_response_fails_before_gateway_encryption() {
+        assert!(LogicalUnaryResponse::json_with_limit(StatusCode::OK, &"abc", 5).is_ok());
+        assert!(matches!(
+            LogicalUnaryResponse::json_with_limit(StatusCode::OK, &"abcd", 5),
+            Err(ApiError::PayloadTooLarge)
+        ));
     }
 }

--- a/src/transport_v2/envelope.rs
+++ b/src/transport_v2/envelope.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 const MIB: usize = 1024 * 1024;
 const KIB: usize = 1024;
@@ -182,7 +183,7 @@ fn hex_nibble(byte: u8) -> Option<u8> {
 }
 
 /// Exact bytes represented on the wire as padded standard base64.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Zeroize, ZeroizeOnDrop)]
 pub(crate) struct EncodedBytes(Vec<u8>);
 
 impl EncodedBytes {
@@ -194,8 +195,8 @@ impl EncodedBytes {
         &self.0
     }
 
-    pub(crate) fn into_bytes(self) -> Vec<u8> {
-        self.0
+    pub(crate) fn into_bytes(mut self) -> Vec<u8> {
+        std::mem::take(&mut self.0)
     }
 
     pub(crate) fn len(&self) -> usize {
@@ -726,6 +727,13 @@ mod tests {
     use super::*;
 
     const REQUEST_ID: &str = "00112233445566778899aabbccddeeff";
+
+    #[test]
+    fn decoded_byte_fields_zeroize_on_drop() {
+        fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
+
+        assert_zeroize_on_drop::<EncodedBytes>();
+    }
 
     fn request_json(body: &str) -> String {
         format!(

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -35,6 +35,7 @@ use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 use validator::Validate;
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -100,7 +101,7 @@ pub struct ConfirmAccountDeletionRequest {
     pub plaintext_secret: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Zeroize, ZeroizeOnDrop)]
 pub struct PrivateKeyResponse {
     /// Root mnemonic or derived mnemonic if BIP-85 path is specified
     mnemonic: String,
@@ -108,7 +109,7 @@ pub struct PrivateKeyResponse {
 
 /// Response struct for the private key bytes endpoint.
 /// Contains the private key encoded as a hexadecimal string.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Zeroize, ZeroizeOnDrop)]
 pub struct PrivateKeyBytesResponse {
     /// The private key as a 64-character hexadecimal string (32 bytes).
     /// This is the standard secp256k1 private key format.
@@ -349,7 +350,7 @@ pub struct ThirdPartyTokenRequest {
     pub audience: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Zeroize, ZeroizeOnDrop)]
 pub struct ThirdPartyTokenResponse {
     pub token: String,
 }
@@ -857,11 +858,21 @@ pub async fn get_private_key(
     Extension(session_id): Extension<TransportSession>,
     Query(query): Query<DerivationPathQuery>,
 ) -> Result<Json<EncryptedResponse<PrivateKeyResponse>>, ApiError> {
+    let response = private_key_data(&data, &user, &auth_context, query)?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) fn private_key_data(
+    data: &AppState,
+    user: &User,
+    auth_context: &AuthContext,
+    query: DerivationPathQuery,
+) -> Result<PrivateKeyResponse, ApiError> {
     // Validate paths if present
     query.validate()?;
 
     let plaintext_seed = data
-        .decrypt_seed_for_auth_context(&user, &auth_context)
+        .decrypt_seed_for_auth_context(user, auth_context)
         .map_err(|e| {
             error!("Failed to decrypt authenticated seed wrap: {:?}", e);
             ApiError::Unauthorized
@@ -884,14 +895,14 @@ pub async fn get_private_key(
             mnemonic: child_mnemonic.to_string(),
         };
 
-        encrypt_response(&data, &session_id, &response).await
+        Ok(response)
     } else {
         // Return root mnemonic
         let response = PrivateKeyResponse {
             mnemonic: root_mnemonic.to_string(),
         };
 
-        encrypt_response(&data, &session_id, &response).await
+        Ok(response)
     }
 }
 
@@ -902,14 +913,24 @@ pub async fn get_private_key_bytes(
     Extension(session_id): Extension<TransportSession>,
     Query(query): Query<DerivationPathQuery>,
 ) -> Result<Json<EncryptedResponse<PrivateKeyBytesResponse>>, ApiError> {
+    let response = private_key_bytes_data(&data, &user, &auth_context, query).await?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn private_key_bytes_data(
+    data: &AppState,
+    user: &User,
+    auth_context: &AuthContext,
+    query: DerivationPathQuery,
+) -> Result<PrivateKeyBytesResponse, ApiError> {
     // Validate derivation path if present
     query.validate()?;
 
     // Use the method that supports both BIP-85 and BIP-32 derivation
     let secret_key = data
         .get_user_key(
-            &user,
-            &auth_context,
+            user,
+            auth_context,
             query.key_options.private_key_derivation_path.as_deref(),
             query.key_options.seed_phrase_derivation_path.as_deref(),
         )
@@ -934,7 +955,7 @@ pub async fn get_private_key_bytes(
         private_key: secret_key.display_secret().to_string(),
     };
 
-    encrypt_response(&data, &session_id, &response).await
+    Ok(response)
 }
 
 pub async fn sign_message(
@@ -944,6 +965,16 @@ pub async fn sign_message(
     Extension(sign_request): Extension<SignMessageRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<SignMessageResponseJson>>, ApiError> {
+    let response = sign_message_data(&data, &user, &auth_context, sign_request).await?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn sign_message_data(
+    data: &AppState,
+    user: &User,
+    auth_context: &AuthContext,
+    mut sign_request: SignMessageRequest,
+) -> Result<SignMessageResponseJson, ApiError> {
     // Validate key_options
     let validation_query = DerivationPathQuery {
         key_options: sign_request.key_options.clone(),
@@ -960,17 +991,20 @@ pub async fn sign_message(
         .seed_phrase_derivation_path
         .as_deref();
 
-    let message_bytes = general_purpose::STANDARD
-        .decode(&sign_request.message_base64)
-        .map_err(|e| {
-            error!("Failed to decode base64 message: {:?}", e);
-            ApiError::BadRequest
-        })?;
+    let message_base64 = Zeroizing::new(std::mem::take(&mut sign_request.message_base64));
+    let message_bytes = Zeroizing::new(
+        general_purpose::STANDARD
+            .decode(message_base64.as_bytes())
+            .map_err(|e| {
+                error!("Failed to decode base64 message: {:?}", e);
+                ApiError::BadRequest
+            })?,
+    );
 
     let response = data
         .sign_message(
-            &user,
-            &auth_context,
+            user,
+            auth_context,
             &message_bytes,
             sign_request.algorithm,
             derivation_path,
@@ -987,7 +1021,7 @@ pub async fn sign_message(
         message_hash: hex::encode(response.message_hash),
     };
 
-    encrypt_response(&data, &session_id, &json_response).await
+    Ok(json_response)
 }
 
 pub async fn get_public_key(
@@ -997,6 +1031,16 @@ pub async fn get_public_key(
     Extension(session_id): Extension<TransportSession>,
     Query(query): Query<PublicKeyQuery>,
 ) -> Result<Json<EncryptedResponse<PublicKeyResponseJson>>, ApiError> {
+    let response = public_key_data(&data, &user, &auth_context, query).await?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn public_key_data(
+    data: &AppState,
+    user: &User,
+    auth_context: &AuthContext,
+    query: PublicKeyQuery,
+) -> Result<PublicKeyResponseJson, ApiError> {
     // Validate the key_options
     let validation_query = DerivationPathQuery {
         key_options: query.key_options.clone(),
@@ -1009,8 +1053,8 @@ pub async fn get_public_key(
 
     let user_secret_key = data
         .get_user_key(
-            &user,
-            &auth_context,
+            user,
+            auth_context,
             derivation_path,
             seed_phrase_derivation_path,
         )
@@ -1039,7 +1083,7 @@ pub async fn get_public_key(
         public_key: public_key_str,
         algorithm: query.algorithm,
     };
-    encrypt_response(&data, &session_id, &response).await
+    Ok(response)
 }
 
 pub async fn generate_third_party_token(
@@ -1048,6 +1092,15 @@ pub async fn generate_third_party_token(
     Extension(request): Extension<ThirdPartyTokenRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<ThirdPartyTokenResponse>>, ApiError> {
+    let response = third_party_token_data(&data, &user, request)?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) fn third_party_token_data(
+    data: &AppState,
+    user: &User,
+    request: ThirdPartyTokenRequest,
+) -> Result<ThirdPartyTokenResponse, ApiError> {
     // Validate the audience
     if let Some(audience) = request.audience.as_ref() {
         if audience.is_empty() || (audience.contains(':') && url::Url::parse(audience).is_err()) {
@@ -1059,12 +1112,12 @@ pub async fn generate_third_party_token(
     let project = data.db.get_org_project_by_id(user.project_id)?;
 
     let token = match NewToken::new(
-        &user,
+        user,
         TokenType::ThirdParty {
             aud: request.audience,
             azp: project.client_id.to_string(),
         },
-        &data,
+        data,
     ) {
         Ok(token) => token,
         Err(e) => {
@@ -1074,7 +1127,7 @@ pub async fn generate_third_party_token(
     };
 
     let response = ThirdPartyTokenResponse { token: token.token };
-    encrypt_response(&data, &session_id, &response).await
+    Ok(response)
 }
 
 pub async fn encrypt_data(
@@ -1399,6 +1452,15 @@ mod tests {
     use super::*;
     use crate::encrypt::{decrypt_with_key, encrypt_with_key};
     use secp256k1::SecretKey;
+
+    #[test]
+    fn sensitive_response_types_zeroize_on_drop() {
+        fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
+
+        assert_zeroize_on_drop::<PrivateKeyResponse>();
+        assert_zeroize_on_drop::<PrivateKeyBytesResponse>();
+        assert_zeroize_on_drop::<ThirdPartyTokenResponse>();
+    }
 
     #[test]
     fn test_derivation_path_validation() {


### PR DESCRIPTION
## Summary

- Project the first maximally sensitive bound-user operations through the isolated encrypted transport-v2 gateway:
  - `GET /protected/private_key`
  - `GET /protected/private_key_bytes`
  - `GET /protected/public_key`
  - `POST /protected/sign_message`
  - `POST /protected/third_party_token`
- Route every operation through one live bound-user/project/AuthContext verification path before dispatch.
- Extract transport-neutral application helpers while preserving the existing v1 handlers, inputs, errors, response shapes, and encryption path.
- Bound serialized logical responses before gateway encryption and drop-wipe decoded byte fields, prepared credentials/bodies, and sensitive response values.
- Keep third-party JWTs as outbound application artifacts only; they remain unusable as transport-v2 credentials.

## Security and compatibility

- Anonymous, non-user, credential-transplant, header-transplant, query-transplant, and body-transplant attempts fail closed.
- Existing exact unordered replay admission remains before application dispatch.
- Responses continue to use the exact leased session and request ID that authenticated the request.
- Transport v1 routing, middleware, handler signatures, application behavior, wire shapes, and encryption are unchanged.

## Deliberately deferred

- `/protected/encrypt` and `/protected/decrypt`: valid near-limit inputs can expand through base64/JSON beyond the logical response ceiling; they need route-specific pre-dispatch bounds.
- KV and other dynamic-path families: released SDK path semantics and bounded list responses need an explicit design rather than weakening the v2 path classifier.

## Validation

- `cargo fmt --all -- --check`
- strict `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features`: 510 passed, 20 environment-gated ignored
- disposable database validation: 17 AEAD/tamper tests + 2 OAuth database tests passed, no skips, temporary cluster removed
- managed local smoke: OpenSecret API, all migrations, Continuum models, and Tinfoil extended health passed
- encrypted-v2 live checks covered root/derived key export, both public-key algorithms, verified signing, exact replay rejection, third-party-token claims/purpose separation, anonymous rejection, and response request/session binding
- released v1 SDK live regression covered private-key export, public keys, verified signing, and third-party-token issuance

## Stack

Base: #311 (`codex-session-v2-user-binding`)
