### PR TITLE
Bind user sessions and project sensitive operations over transport v2

### DIFF
--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -627,15 +627,28 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
 4. **Isolated v2 gateway**: separate attestation/key-exchange/request endpoints,
    bounded session allocation, strict outer parsing, exact-session decryption,
    and encrypted unsupported-operation responses; no application dispatch.
-5. **Session binding**: atomic anonymous authentication transitions, v2-only
-   resumption, and immutable user, platform, and API-key authority.
-6. **Application projection and streaming**: existing operation families over
-   v2, live authorization checks, unary responses, and ordered streaming.
-7. **Additive SDK v2 internals**: TypeScript and Rust codecs/session managers
+5. **User binding and first unary slice**: password login, registration,
+   v2-only resumption, immutable user/project/`AuthContext` authority, live
+   seed-wrap revalidation, and bodyless `GET /protected/user`. This layer also
+   activates exact unordered replay claims for supported operations. Platform,
+   API-key, OAuth, and all other application paths still receive the encrypted
+   unsupported-operation response.
+6. **Protected user unary projection**: project the remaining user-authorized
+   unary operation families, including third-party token issuance, through the
+   live bound-user checks without changing their application semantics.
+7. **API-key and platform binding**: bind existing raw API keys inside
+   ciphertext without rotating them, enforce their current inference-only
+   scope, and add platform authentication/authorization with live organization
+   checks. OAuth continuation receives an explicit session-binding design in
+   this layer rather than being inferred from password login.
+8. **Streaming projection**: project current inference streams with ordered,
+   request-bound, authenticated terminal records while preserving the SDK's
+   caller-visible SSE behavior.
+9. **Additive SDK v2 internals**: TypeScript and Rust codecs/session managers
    behind private seams, still not selected by public calls.
-8. **Atomic SDK cutover**: v2-only network behavior, no downgrade, one-time
+10. **Atomic SDK cutover**: v2-only network behavior, no downgrade, one-time
    fresh login, and Maple/proxy integration.
-9. **SDK major/version packaging**: package metadata, locks, integration pin,
+11. **SDK major/version packaging**: package metadata, locks, integration pin,
    compatibility matrix, and release rehearsal. Publication/deployment remain
    separate authorized actions.
 

--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -633,22 +633,35 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    activates exact unordered replay claims for supported operations. Platform,
    API-key, OAuth, and all other application paths still receive the encrypted
    unsupported-operation response.
-6. **Protected user unary projection**: project the remaining user-authorized
-   unary operation families, including third-party token issuance, through the
-   live bound-user checks without changing their application semantics.
-7. **API-key and platform binding**: bind existing raw API keys inside
+6. **Sensitive user-key projection**: project root/derived mnemonic and private
+   key export, public-key derivation, signing, and third-party token issuance
+   through the live bound-user check. Sensitive intermediate response values
+   are zeroized, decoded byte fields and prepared sensitive operations wipe on
+   drop across rejection/cancellation paths, and serialized logical responses
+   are bounded before gateway encryption. Large encrypt/decrypt utilities
+   remain unsupported until their base64 and JSON expansion has an exact
+   pre-dispatch limit.
+7. **Remaining protected user operations**: project bounded crypto/KV,
+   account-lifecycle, and user API-key-management families in reviewable
+   sub-stacks. Dynamic path parameters must preserve released SDK semantics
+   without weakening the v2 route classifier, and password/account deletion
+   must explicitly close the now-invalid bound session.
+8. **Stored user unary operations**: project conversations, conversation
+   projects, instructions, response control, and web-provider unary routes in
+   ownership-preserving families before the client cutover.
+9. **API-key and platform binding**: bind existing raw API keys inside
    ciphertext without rotating them, enforce their current inference-only
    scope, and add platform authentication/authorization with live organization
    checks. OAuth continuation receives an explicit session-binding design in
    this layer rather than being inferred from password login.
-8. **Streaming projection**: project current inference streams with ordered,
+10. **Streaming projection**: project current inference streams with ordered,
    request-bound, authenticated terminal records while preserving the SDK's
    caller-visible SSE behavior.
-9. **Additive SDK v2 internals**: TypeScript and Rust codecs/session managers
+11. **Additive SDK v2 internals**: TypeScript and Rust codecs/session managers
    behind private seams, still not selected by public calls.
-10. **Atomic SDK cutover**: v2-only network behavior, no downgrade, one-time
+12. **Atomic SDK cutover**: v2-only network behavior, no downgrade, one-time
    fresh login, and Maple/proxy integration.
-11. **SDK major/version packaging**: package metadata, locks, integration pin,
+13. **SDK major/version packaging**: package metadata, locks, integration pin,
    compatibility matrix, and release rehearsal. Publication/deployment remain
    separate authorized actions.
 

--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -641,27 +641,31 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    are bounded before gateway encryption. Large encrypt/decrypt utilities
    remain unsupported until their base64 and JSON expansion has an exact
    pre-dispatch limit.
-7. **Remaining protected user operations**: project bounded crypto/KV,
-   account-lifecycle, and user API-key-management families in reviewable
-   sub-stacks. Dynamic path parameters must preserve released SDK semantics
-   without weakening the v2 route classifier, and password/account deletion
-   must explicitly close the now-invalid bound session.
-8. **Stored user unary operations**: project conversations, conversation
+7. **Bounded user crypto utilities**: project user-key encrypt/decrypt with an
+   exact v2-only plaintext ceiling derived from AES-GCM, base64, and JSON
+   expansion. Logical JSON serialization writes through a bounded buffer so a
+   highly escaped decrypted string cannot allocate beyond the response limit.
+8. **Remaining protected user operations**: project KV, account-lifecycle, and
+   user API-key-management families in reviewable sub-stacks. Dynamic path
+   parameters must preserve released SDK semantics without weakening the v2
+   route classifier, and password/account deletion must explicitly close the
+   now-invalid bound session.
+9. **Stored user unary operations**: project conversations, conversation
    projects, instructions, response control, and web-provider unary routes in
    ownership-preserving families before the client cutover.
-9. **API-key and platform binding**: bind existing raw API keys inside
+10. **API-key and platform binding**: bind existing raw API keys inside
    ciphertext without rotating them, enforce their current inference-only
    scope, and add platform authentication/authorization with live organization
    checks. OAuth continuation receives an explicit session-binding design in
    this layer rather than being inferred from password login.
-10. **Streaming projection**: project current inference streams with ordered,
+11. **Streaming projection**: project current inference streams with ordered,
    request-bound, authenticated terminal records while preserving the SDK's
    caller-visible SSE behavior.
-11. **Additive SDK v2 internals**: TypeScript and Rust codecs/session managers
+12. **Additive SDK v2 internals**: TypeScript and Rust codecs/session managers
    behind private seams, still not selected by public calls.
-12. **Atomic SDK cutover**: v2-only network behavior, no downgrade, one-time
+13. **Atomic SDK cutover**: v2-only network behavior, no downgrade, one-time
    fresh login, and Maple/proxy integration.
-13. **SDK major/version packaging**: package metadata, locks, integration pin,
+14. **SDK major/version packaging**: package metadata, locks, integration pin,
    compatibility matrix, and release rehearsal. Publication/deployment remain
    separate authorized actions.
 

--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -398,6 +398,9 @@ async fn db_password_change_invalidates_old_auth_context_and_preserves_seed() {
         .get_user_key(&old_login.user, &old_login.auth_context, None, None)
         .await
         .expect("old key should derive before password change");
+    app_state
+        .verify_bound_user(old_login.user.uuid, project.id, &old_login.auth_context)
+        .expect("transport-v2 bound authority should be live before password change");
 
     let new_auth_context = app_state
         .update_user_password_and_seed_wrap(
@@ -414,6 +417,10 @@ async fn db_password_change_invalidates_old_auth_context_and_preserves_seed() {
         matches!(old_context_after_change, Err(Error::AuthenticationError)),
         "old password auth context must not unwrap after password change"
     );
+    assert!(matches!(
+        app_state.verify_bound_user(old_login.user.uuid, project.id, &old_login.auth_context,),
+        Err(crate::ApiError::Unauthorized)
+    ));
 
     let old_password_login_after_change = app_state
         .authenticate_user(

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -11,7 +11,7 @@ use axum::{
     response::IntoResponse,
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, Utc};
 use jwt_compact::{alg::Es256k, prelude::*, AlgorithmExt};
 use secp256k1::{All, PublicKey, Secp256k1, SecretKey};
 use serde::{Deserialize, Serialize};
@@ -19,7 +19,7 @@ use sha2::Sha256;
 use uuid::Uuid;
 
 use crate::db::DBError;
-use crate::{ApiError, AppState};
+use crate::{ApiError, AppState, VerifiedUserAuthentication};
 use jsonwebtoken::{
     encode as jwt_encode, Algorithm as JwtAlgorithm, EncodingKey, Header as JwtHeader,
 };
@@ -32,6 +32,13 @@ pub const USER_REFRESH: &str = "refresh";
 
 pub const PLATFORM_ACCESS: &str = "platform_access";
 pub const PLATFORM_REFRESH: &str = "platform_refresh";
+
+pub(crate) const TRANSPORT_V2_USER_ACCESS_AUDIENCE: &str =
+    "urn:opensecret:internal:transport-v2:user:access-descriptor";
+pub(crate) const TRANSPORT_V2_USER_RESUMPTION_AUDIENCE: &str =
+    "urn:opensecret:internal:transport-v2:user:resumption";
+const TRANSPORT_V2_TOKEN_ISSUER: &str = "urn:opensecret:transport-v2";
+const TRANSPORT_V2_TOKEN_VERSION: u8 = 2;
 
 pub const USER_TOKEN_FORMAT_V2: u8 = 2;
 
@@ -172,11 +179,54 @@ impl AuthContext {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum TransportV2TokenKind {
+    AccessDescriptor,
+    Resumption,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum TransportV2PrincipalKind {
+    User,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct TransportV2UserClaims {
+    sub: String,
+    iss: String,
+    aud: String,
+    tv: u8,
+    tk: TransportV2TokenKind,
+    pk: TransportV2PrincipalKind,
+    #[serde(rename = "tf")]
+    token_format: u8,
+    #[serde(rename = "am")]
+    auth_method: String,
+    #[serde(rename = "pid")]
+    project_id: i32,
+    #[serde(rename = "ab")]
+    auth_binding: String,
+}
+
+pub(crate) struct IssuedTransportV2UserTokens {
+    pub(crate) access_token: String,
+    pub(crate) resumption_token: String,
+    pub(crate) access_expires_at: DateTime<Utc>,
+}
+
 impl TokenType {
     pub fn validate_third_party_audience(aud: &str) -> Result<(), ApiError> {
         // Validate third party audience can't use our internal audience types
-        const RESERVED_AUDIENCES: [&str; 4] =
-            [USER_ACCESS, USER_REFRESH, PLATFORM_ACCESS, PLATFORM_REFRESH];
+        const RESERVED_AUDIENCES: [&str; 6] = [
+            USER_ACCESS,
+            USER_REFRESH,
+            PLATFORM_ACCESS,
+            PLATFORM_REFRESH,
+            TRANSPORT_V2_USER_ACCESS_AUDIENCE,
+            TRANSPORT_V2_USER_RESUMPTION_AUDIENCE,
+        ];
 
         // 1. Check for reserved audiences
         if RESERVED_AUDIENCES.contains(&aud) {
@@ -555,6 +605,175 @@ impl NewToken {
     }
 }
 
+pub(crate) fn issue_transport_v2_user_tokens(
+    user: &User,
+    auth_context: &AuthContext,
+    app_state: &AppState,
+) -> Result<IssuedTransportV2UserTokens, ApiError> {
+    if user.project_id != auth_context.project_id {
+        tracing::error!("Transport-v2 user token auth context project mismatch");
+        return Err(ApiError::BadRequest);
+    }
+
+    let (access_token, access_expires_at) = issue_transport_v2_user_token(
+        user,
+        auth_context,
+        app_state,
+        TransportV2TokenKind::AccessDescriptor,
+        TRANSPORT_V2_USER_ACCESS_AUDIENCE,
+        Duration::minutes(app_state.config.access_token_maxage),
+    )?;
+    let (resumption_token, _) = issue_transport_v2_user_token(
+        user,
+        auth_context,
+        app_state,
+        TransportV2TokenKind::Resumption,
+        TRANSPORT_V2_USER_RESUMPTION_AUDIENCE,
+        Duration::days(app_state.config.refresh_token_maxage),
+    )?;
+
+    Ok(IssuedTransportV2UserTokens {
+        access_token,
+        resumption_token,
+        access_expires_at,
+    })
+}
+
+fn issue_transport_v2_user_token(
+    user: &User,
+    auth_context: &AuthContext,
+    app_state: &AppState,
+    token_kind: TransportV2TokenKind,
+    audience: &str,
+    duration: Duration,
+) -> Result<(String, DateTime<Utc>), ApiError> {
+    let custom_claims = TransportV2UserClaims {
+        sub: user.get_id().to_string(),
+        iss: TRANSPORT_V2_TOKEN_ISSUER.to_owned(),
+        aud: audience.to_owned(),
+        tv: TRANSPORT_V2_TOKEN_VERSION,
+        tk: token_kind,
+        pk: TransportV2PrincipalKind::User,
+        token_format: auth_context.token_format,
+        auth_method: auth_context.method.as_str().to_owned(),
+        project_id: auth_context.project_id,
+        auth_binding: URL_SAFE_NO_PAD.encode(auth_context.auth_binding),
+    };
+
+    // Match the existing first-party clock-skew policy without changing the
+    // v1 token constructors.
+    let issued_at = Utc::now() - Duration::minutes(1);
+    let expiration = issued_at + duration;
+    let mut claims = Claims::new(custom_claims);
+    claims.issued_at = Some(issued_at);
+    claims.not_before = Some(issued_at);
+    claims.expiration = Some(expiration);
+
+    let header = Header::empty().with_token_type("JWT");
+    let es256k = Es256k::<Sha256>::new(app_state.config.jwt_keys.secp.clone());
+    let token = es256k
+        .token(&header, &claims, &app_state.config.jwt_keys.signing_key)
+        .map_err(|error| {
+            tracing::error!("Error creating transport-v2 user token: {:?}", error);
+            ApiError::InternalServerError
+        })?;
+
+    Ok((token, expiration))
+}
+
+pub(crate) fn validate_transport_v2_user_resumption(
+    original_token: &str,
+    data: &AppState,
+) -> Result<VerifiedUserAuthentication, ApiError> {
+    let claims =
+        validate_transport_v2_user_resumption_claims(original_token, &data.config.jwt_keys)?;
+    let user_id = Uuid::parse_str(&claims.sub).map_err(|_| ApiError::InvalidJwt)?;
+    let auth_context = transport_v2_auth_context(&claims)?;
+    let user = match data.verify_bound_user(user_id, claims.project_id, &auth_context) {
+        Ok(user) => user,
+        Err(ApiError::InternalServerError) => return Err(ApiError::InternalServerError),
+        Err(_) => return Err(ApiError::InvalidJwt),
+    };
+
+    Ok(VerifiedUserAuthentication { user, auth_context })
+}
+
+fn validate_transport_v2_user_resumption_claims(
+    original_token: &str,
+    jwt_keys: &JwtKeys,
+) -> Result<TransportV2UserClaims, ApiError> {
+    let parsed_token = UntrustedToken::new(original_token).map_err(|error| {
+        tracing::error!("Failed to parse transport-v2 resumption token: {:?}", error);
+        ApiError::InvalidJwt
+    })?;
+    let es256k = Es256k::<Sha256>::new(jwt_keys.secp.clone());
+    let public_key = jwt_keys.public_key();
+    let token: Token<TransportV2UserClaims> = es256k
+        .validator(&public_key)
+        .validate(&parsed_token)
+        .map_err(|error| {
+            tracing::debug!(
+                "Transport-v2 resumption signature validation failed: {:?}",
+                error
+            );
+            ApiError::InvalidJwt
+        })?;
+    let claims = token.claims();
+
+    if claims.custom.iss != TRANSPORT_V2_TOKEN_ISSUER
+        || claims.custom.aud != TRANSPORT_V2_USER_RESUMPTION_AUDIENCE
+        || claims.custom.tv != TRANSPORT_V2_TOKEN_VERSION
+        || claims.custom.tk != TransportV2TokenKind::Resumption
+        || claims.custom.pk != TransportV2PrincipalKind::User
+    {
+        return Err(ApiError::InvalidJwt);
+    }
+
+    let time_options = TimeOptions::default();
+    claims
+        .validate_expiration(&time_options)
+        .and_then(|claims| claims.validate_maturity(&time_options))
+        .map_err(|error| {
+            tracing::error!(
+                "Transport-v2 resumption time validation failed: {:?}",
+                error
+            );
+            ApiError::InvalidJwt
+        })?;
+
+    let issued_at = claims.issued_at.ok_or(ApiError::InvalidJwt)?;
+    let not_before = claims.not_before.ok_or(ApiError::InvalidJwt)?;
+    let expiration = claims.expiration.ok_or(ApiError::InvalidJwt)?;
+    let latest_acceptable_issuance = Utc::now()
+        .checked_add_signed(time_options.leeway)
+        .ok_or(ApiError::InvalidJwt)?;
+    if issued_at > latest_acceptable_issuance || issued_at > not_before || not_before >= expiration
+    {
+        return Err(ApiError::InvalidJwt);
+    }
+
+    Ok(claims.custom.clone())
+}
+
+fn transport_v2_auth_context(claims: &TransportV2UserClaims) -> Result<AuthContext, ApiError> {
+    if claims.token_format != USER_TOKEN_FORMAT_V2 {
+        return Err(ApiError::InvalidJwt);
+    }
+    let method = AuthMethod::from_str(&claims.auth_method)?;
+    let auth_binding_bytes = URL_SAFE_NO_PAD
+        .decode(&claims.auth_binding)
+        .map_err(|_| ApiError::InvalidJwt)?;
+    let auth_binding: [u8; 32] = auth_binding_bytes
+        .try_into()
+        .map_err(|_| ApiError::InvalidJwt)?;
+    Ok(AuthContext {
+        token_format: USER_TOKEN_FORMAT_V2,
+        method,
+        project_id: claims.project_id,
+        auth_binding,
+    })
+}
+
 pub async fn generate_jwt_secret(
     aws_credential_manager: Arc<tokio::sync::RwLock<Option<AwsCredentialManager>>>,
 ) -> Result<Vec<u8>, Error> {
@@ -804,6 +1023,7 @@ fn validate_token_with_keys_for_auth(
 mod tests {
     use super::*;
     use jsonwebtoken::{decode as jwt_decode, DecodingKey, Validation};
+    use serde::Serialize;
 
     fn test_keys(byte: u8) -> JwtKeys {
         JwtKeys::new(vec![byte; 32]).unwrap()
@@ -850,6 +1070,58 @@ mod tests {
                 &keys.signing_key,
             )
             .unwrap()
+    }
+
+    fn transport_v2_test_claims(
+        token_kind: TransportV2TokenKind,
+        audience: &str,
+    ) -> TransportV2UserClaims {
+        TransportV2UserClaims {
+            sub: Uuid::nil().to_string(),
+            iss: TRANSPORT_V2_TOKEN_ISSUER.to_owned(),
+            aud: audience.to_owned(),
+            tv: TRANSPORT_V2_TOKEN_VERSION,
+            tk: token_kind,
+            pk: TransportV2PrincipalKind::User,
+            token_format: USER_TOKEN_FORMAT_V2,
+            auth_method: AuthMethod::Password.as_str().to_owned(),
+            project_id: 1,
+            auth_binding: URL_SAFE_NO_PAD.encode([7_u8; 32]),
+        }
+    }
+
+    fn signed_transport_v2_test_token<T: Serialize>(
+        keys: &JwtKeys,
+        custom: T,
+        issued_at: Option<DateTime<Utc>>,
+        not_before: Option<DateTime<Utc>>,
+        expiration: Option<DateTime<Utc>>,
+    ) -> String {
+        let mut claims = Claims::new(custom);
+        claims.issued_at = issued_at;
+        claims.not_before = not_before;
+        claims.expiration = expiration;
+        Es256k::<Sha256>::new(keys.secp.clone())
+            .token(
+                &Header::empty().with_token_type("JWT"),
+                &claims,
+                &keys.signing_key,
+            )
+            .unwrap()
+    }
+
+    fn valid_transport_v2_resumption(keys: &JwtKeys) -> String {
+        let now = Utc::now();
+        signed_transport_v2_test_token(
+            keys,
+            transport_v2_test_claims(
+                TransportV2TokenKind::Resumption,
+                TRANSPORT_V2_USER_RESUMPTION_AUDIENCE,
+            ),
+            Some(now - Duration::minutes(2)),
+            Some(now - Duration::minutes(2)),
+            Some(now + Duration::minutes(5)),
+        )
     }
 
     #[test]
@@ -1052,5 +1324,193 @@ mod tests {
         claims.auth_binding = Some(URL_SAFE_NO_PAD.encode([5u8; 31]));
 
         assert!(AuthContext::from_claims(&claims).is_err());
+    }
+
+    #[test]
+    fn transport_v2_tokens_are_cryptographically_separate_from_v1_tokens() {
+        let keys = test_keys(6);
+        let now = Utc::now();
+        let resumption = valid_transport_v2_resumption(&keys);
+        assert!(validate_transport_v2_user_resumption_claims(&resumption, &keys).is_ok());
+        assert!(matches!(
+            validate_token_with_keys(&resumption, &keys, USER_ACCESS),
+            Err(ApiError::InvalidJwt)
+        ));
+        assert!(matches!(
+            validate_token_with_keys(&resumption, &keys, USER_REFRESH),
+            Err(ApiError::InvalidJwt)
+        ));
+
+        let descriptor = signed_transport_v2_test_token(
+            &keys,
+            transport_v2_test_claims(
+                TransportV2TokenKind::AccessDescriptor,
+                TRANSPORT_V2_USER_ACCESS_AUDIENCE,
+            ),
+            Some(now - Duration::minutes(2)),
+            Some(now - Duration::minutes(2)),
+            Some(now + Duration::minutes(5)),
+        );
+        assert!(matches!(
+            validate_transport_v2_user_resumption_claims(&descriptor, &keys),
+            Err(ApiError::InvalidJwt)
+        ));
+        assert!(matches!(
+            validate_token_with_keys(&descriptor, &keys, USER_ACCESS),
+            Err(ApiError::InvalidJwt)
+        ));
+
+        for audience in [USER_ACCESS, USER_REFRESH] {
+            let legacy = signed_test_token(&keys, audience, Some(now + Duration::minutes(5)));
+            assert!(matches!(
+                validate_transport_v2_user_resumption_claims(&legacy, &keys),
+                Err(ApiError::InvalidJwt)
+            ));
+        }
+
+        for audience in [
+            TRANSPORT_V2_USER_ACCESS_AUDIENCE,
+            TRANSPORT_V2_USER_RESUMPTION_AUDIENCE,
+        ] {
+            assert!(matches!(
+                TokenType::validate_third_party_audience(audience),
+                Err(ApiError::BadRequest)
+            ));
+        }
+    }
+
+    #[test]
+    fn transport_v2_resumption_rejects_wrong_identity_and_purpose_claims() {
+        let keys = test_keys(7);
+        let now = Utc::now();
+        let sign = |claims: TransportV2UserClaims| {
+            signed_transport_v2_test_token(
+                &keys,
+                claims,
+                Some(now - Duration::minutes(2)),
+                Some(now - Duration::minutes(2)),
+                Some(now + Duration::minutes(5)),
+            )
+        };
+
+        let mut wrong_issuer = transport_v2_test_claims(
+            TransportV2TokenKind::Resumption,
+            TRANSPORT_V2_USER_RESUMPTION_AUDIENCE,
+        );
+        wrong_issuer.iss = "urn:attacker".to_owned();
+        let mut wrong_audience = transport_v2_test_claims(
+            TransportV2TokenKind::Resumption,
+            TRANSPORT_V2_USER_RESUMPTION_AUDIENCE,
+        );
+        wrong_audience.aud = TRANSPORT_V2_USER_ACCESS_AUDIENCE.to_owned();
+        let mut wrong_version = transport_v2_test_claims(
+            TransportV2TokenKind::Resumption,
+            TRANSPORT_V2_USER_RESUMPTION_AUDIENCE,
+        );
+        wrong_version.tv += 1;
+        let mut wrong_kind = transport_v2_test_claims(
+            TransportV2TokenKind::Resumption,
+            TRANSPORT_V2_USER_RESUMPTION_AUDIENCE,
+        );
+        wrong_kind.tk = TransportV2TokenKind::AccessDescriptor;
+
+        for token in [
+            sign(wrong_issuer),
+            sign(wrong_audience),
+            sign(wrong_version),
+            sign(wrong_kind),
+        ] {
+            assert!(matches!(
+                validate_transport_v2_user_resumption_claims(&token, &keys),
+                Err(ApiError::InvalidJwt)
+            ));
+        }
+
+        let mut wrong_principal = serde_json::to_value(transport_v2_test_claims(
+            TransportV2TokenKind::Resumption,
+            TRANSPORT_V2_USER_RESUMPTION_AUDIENCE,
+        ))
+        .unwrap();
+        wrong_principal["pk"] = serde_json::Value::String("platform".to_owned());
+        let token = signed_transport_v2_test_token(
+            &keys,
+            wrong_principal,
+            Some(now - Duration::minutes(2)),
+            Some(now - Duration::minutes(2)),
+            Some(now + Duration::minutes(5)),
+        );
+        assert!(matches!(
+            validate_transport_v2_user_resumption_claims(&token, &keys),
+            Err(ApiError::InvalidJwt)
+        ));
+
+        let other_keys = test_keys(8);
+        assert!(matches!(
+            validate_transport_v2_user_resumption_claims(
+                &valid_transport_v2_resumption(&other_keys),
+                &keys
+            ),
+            Err(ApiError::InvalidJwt)
+        ));
+    }
+
+    #[test]
+    fn transport_v2_resumption_requires_strict_freshness_and_auth_binding() {
+        let keys = test_keys(9);
+        let now = Utc::now();
+        let claims = || {
+            transport_v2_test_claims(
+                TransportV2TokenKind::Resumption,
+                TRANSPORT_V2_USER_RESUMPTION_AUDIENCE,
+            )
+        };
+        let cases = [
+            (None, Some(now), Some(now + Duration::minutes(5))),
+            (Some(now), None, Some(now + Duration::minutes(5))),
+            (Some(now), Some(now), None),
+            (
+                Some(now - Duration::minutes(10)),
+                Some(now - Duration::minutes(10)),
+                Some(now - Duration::minutes(5)),
+            ),
+            (
+                Some(now + Duration::minutes(10)),
+                Some(now + Duration::minutes(10)),
+                Some(now + Duration::minutes(15)),
+            ),
+        ];
+        for (issued_at, not_before, expiration) in cases {
+            let token =
+                signed_transport_v2_test_token(&keys, claims(), issued_at, not_before, expiration);
+            assert!(matches!(
+                validate_transport_v2_user_resumption_claims(&token, &keys),
+                Err(ApiError::InvalidJwt)
+            ));
+        }
+
+        let mut malformed_base64 = claims();
+        malformed_base64.auth_binding = "not-base64".to_owned();
+        assert!(matches!(
+            transport_v2_auth_context(&malformed_base64),
+            Err(ApiError::InvalidJwt)
+        ));
+        let mut wrong_length = claims();
+        wrong_length.auth_binding = URL_SAFE_NO_PAD.encode([1_u8; 31]);
+        assert!(matches!(
+            transport_v2_auth_context(&wrong_length),
+            Err(ApiError::InvalidJwt)
+        ));
+        let mut wrong_format = claims();
+        wrong_format.token_format += 1;
+        assert!(matches!(
+            transport_v2_auth_context(&wrong_format),
+            Err(ApiError::InvalidJwt)
+        ));
+        let mut wrong_method = claims();
+        wrong_method.auth_method = "api_key".to_owned();
+        assert!(matches!(
+            transport_v2_auth_context(&wrong_method),
+            Err(ApiError::InvalidJwt)
+        ));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -431,9 +431,9 @@ pub enum ApiError {
     TooManyRequests,
 }
 
-impl IntoResponse for ApiError {
-    fn into_response(self) -> axum::response::Response {
-        let status = match &self {
+impl ApiError {
+    pub(crate) fn status_code(&self) -> StatusCode {
+        match self {
             ApiError::InvalidUsernameOrPassword => StatusCode::UNAUTHORIZED,
             ApiError::InvalidJwt => StatusCode::UNAUTHORIZED,
             ApiError::AccessTokenExpired => StatusCode::UNAUTHORIZED,
@@ -460,21 +460,32 @@ impl IntoResponse for ApiError {
             ApiError::UnprocessableEntity => StatusCode::UNPROCESSABLE_ENTITY,
             ApiError::PayloadTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
             ApiError::TooManyRequests => StatusCode::TOO_MANY_REQUESTS,
-        };
-        let error_code = match &self {
+        }
+    }
+
+    pub(crate) fn response_body(&self) -> ErrorResponse {
+        let status = self.status_code();
+        ErrorResponse {
+            status: status.as_u16(),
+            message: self.to_string(),
+        }
+    }
+
+    fn error_code(&self) -> Option<&'static str> {
+        match self {
             ApiError::SessionNotFound => Some(SESSION_NOT_FOUND_ERROR_CODE),
             ApiError::AccessTokenExpired => Some(ACCESS_TOKEN_EXPIRED_ERROR_CODE),
             ApiError::ImageDescriptionUnavailable => Some(IMAGE_DESCRIPTION_UNAVAILABLE_ERROR_CODE),
             _ => None,
-        };
-        let mut response = (
-            status,
-            Json(ErrorResponse {
-                status: status.as_u16(),
-                message: self.to_string(),
-            }),
-        )
-            .into_response();
+        }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> axum::response::Response {
+        let status = self.status_code();
+        let error_code = self.error_code();
+        let mut response = (status, Json(self.response_body())).into_response();
         response.headers_mut().insert(
             ERROR_CONTRACT_HEADER,
             HeaderValue::from_static(ERROR_CONTRACT_VERSION),
@@ -794,9 +805,9 @@ pub struct AppState {
 }
 
 #[derive(Debug, Clone)]
-struct AuthenticatedUser {
-    user: User,
-    auth_context: AuthContext,
+pub(crate) struct VerifiedUserAuthentication {
+    pub(crate) user: User,
+    pub(crate) auth_context: AuthContext,
 }
 
 #[derive(Default)]
@@ -1695,7 +1706,7 @@ impl AppState {
         user_id: Option<Uuid>,
         user_password: String,
         user_project_id: i32,
-    ) -> Result<Option<AuthenticatedUser>, Error> {
+    ) -> Result<Option<VerifiedUserAuthentication>, Error> {
         // Ensure at least one identifier is provided
         if user_email.is_none() && user_id.is_none() {
             return Err(Error::AuthenticationError);
@@ -1743,7 +1754,7 @@ impl AppState {
                 let auth_context =
                     self.password_auth_context_for_user(&user, &verifier_for_binding)?;
                 self.verify_seed_wrap_for_auth_context(&user, &auth_context)?;
-                Ok(Some(AuthenticatedUser { user, auth_context }))
+                Ok(Some(VerifiedUserAuthentication { user, auth_context }))
             }
             Err(_) => Ok(None),
         }
@@ -1754,6 +1765,51 @@ impl AppState {
             .db
             .get_user_by_uuid(user_uuid)
             .map_err(|_| Error::UserNotFound)?;
+        Ok(user)
+    }
+
+    /// Reloads and validates the live authority retained by a transport-v2 user session.
+    ///
+    /// The session stores only immutable identity and the credential-derived
+    /// `AuthContext`; the current user row and active seed wrapping remain
+    /// authoritative for every protected operation.
+    pub(crate) fn verify_bound_user(
+        &self,
+        user_uuid: Uuid,
+        expected_project_id: i32,
+        auth_context: &AuthContext,
+    ) -> Result<User, ApiError> {
+        let user = match self.db.get_user_by_uuid(user_uuid) {
+            Ok(user) => user,
+            Err(DBError::UserNotFound) => return Err(ApiError::Unauthorized),
+            Err(error) => {
+                tracing::error!(
+                    "Error reloading transport-v2 bound user {}: {:?}",
+                    user_uuid,
+                    error
+                );
+                return Err(ApiError::InternalServerError);
+            }
+        };
+
+        if user.project_id != expected_project_id || auth_context.project_id != expected_project_id
+        {
+            tracing::error!(
+                "Transport-v2 bound user/project/auth context no longer agree for {}",
+                user_uuid
+            );
+            return Err(ApiError::Unauthorized);
+        }
+
+        self.verify_seed_wrap_for_auth_context(&user, auth_context)
+            .map_err(|error| {
+                tracing::error!(
+                    "Transport-v2 bound user no longer has an active seed wrap: {:?}",
+                    error
+                );
+                ApiError::Unauthorized
+            })?;
+
         Ok(user)
     }
 

--- a/src/security_invariants.rs
+++ b/src/security_invariants.rs
@@ -442,11 +442,14 @@ fn legacy_token_constructor_is_only_used_for_third_party_tokens() {
     let protected_routes = manifest_dir.join("src/web/protected_routes.rs");
     let contents =
         fs::read_to_string(&protected_routes).expect("protected route source should be readable");
-    let third_party_body =
+    let third_party_route =
         extract_function_body(&contents, "pub async fn generate_third_party_token");
+    assert!(third_party_route.contains("third_party_token_data(&data, &user, request)"));
+    assert!(third_party_route.contains("encrypt_response(&data, &session_id, &response).await"));
 
-    assert!(third_party_body.contains("NewToken::new("));
-    assert!(third_party_body.contains("TokenType::ThirdParty"));
+    let third_party_core = extract_function_body(&contents, "pub(crate) fn third_party_token_data");
+    assert!(third_party_core.contains("NewToken::new("));
+    assert!(third_party_core.contains("TokenType::ThirdParty"));
 }
 
 #[test]

--- a/src/security_invariants.rs
+++ b/src/security_invariants.rs
@@ -913,9 +913,9 @@ fn password_registration_and_login_issue_tokens_only_after_seed_wrap_verificatio
 
     let register_route = extract_function_body(&login_contents, "pub async fn register");
     for required_pattern in [
-        "data.register_user(creds.clone()).await",
-        "login_internal(",
-        "password: creds.password",
+        "register_and_authenticate(data.clone(), creds).await",
+        "v1_auth_response(&data, &verified)",
+        "encrypt_response(&data, &session_id, &auth_response).await",
     ] {
         assert!(
             register_route.contains(required_pattern),
@@ -923,13 +923,27 @@ fn password_registration_and_login_issue_tokens_only_after_seed_wrap_verificatio
         );
     }
 
+    let register_and_authenticate = extract_function_body(
+        &login_contents,
+        "pub(crate) async fn register_and_authenticate",
+    );
+    assert_patterns_in_order(
+        register_and_authenticate,
+        &[
+            "data.register_user(creds.clone()).await",
+            "handle_new_user_registration(&data, &user, true).await",
+            "authenticate_login(",
+            "password: creds.password",
+        ],
+    );
+
     let authenticate_body = extract_function_body(&main_contents, "async fn authenticate_user");
     for required_pattern in [
         "decrypt_with_key(&secret_key, user.password_enc.as_ref().unwrap())",
         "verify_password(user_password, &decrypted_password_hash)",
         "password_auth_context_for_user(&user, &verifier_for_binding)",
         "verify_seed_wrap_for_auth_context(&user, &auth_context)",
-        "AuthenticatedUser { user, auth_context }",
+        "VerifiedUserAuthentication { user, auth_context }",
     ] {
         assert!(
             authenticate_body.contains(required_pattern),
@@ -938,16 +952,34 @@ fn password_registration_and_login_issue_tokens_only_after_seed_wrap_verificatio
     }
 
     let login_internal_body = extract_function_body(&login_contents, "async fn login_internal");
+    assert_patterns_in_order(
+        login_internal_body,
+        &[
+            "authenticate_login(data.clone(), creds).await",
+            "v1_auth_response(&data, &verified)",
+        ],
+    );
+
+    let authenticate_login_body =
+        extract_function_body(&login_contents, "pub(crate) async fn authenticate_login");
+    for required_pattern in [".authenticate_user(", "Ok(Some(authenticated_user))"] {
+        assert!(
+            authenticate_login_body.contains(required_pattern),
+            "password login verification must contain `{required_pattern}`"
+        );
+    }
+
+    let v1_auth_response_body =
+        extract_function_body(&login_contents, "pub(crate) fn v1_auth_response");
     for required_pattern in [
-        ".authenticate_user(",
         "NewToken::new_with_auth_context(",
         "TokenType::Access",
         "TokenType::Refresh",
-        "&authenticated_user.auth_context",
+        "&verified.auth_context",
     ] {
         assert!(
-            login_internal_body.contains(required_pattern),
-            "password login must contain `{required_pattern}`"
+            v1_auth_response_body.contains(required_pattern),
+            "v1 token response must contain `{required_pattern}`"
         );
     }
 }

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -1,0 +1,727 @@
+//! Explicit application projection for the first transport-v2 user slice.
+//!
+//! This module does not re-enter the transport-v1 router. It validates a small
+//! exact operation allowlist, calls shared transport-neutral application
+//! functions, and returns plaintext logical results for the gateway to encrypt
+//! through the request's original session lease.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use axum::http::StatusCode;
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use zeroize::{Zeroize, Zeroizing};
+
+use crate::jwt::{
+    issue_transport_v2_user_tokens, validate_transport_v2_user_resumption, AuthContext,
+};
+use crate::web::login_routes::{
+    authenticate_login, register_and_authenticate, AuthResponse, Credentials, RefreshResponse,
+    RegisterCredentials,
+};
+use crate::web::protected_routes::protected_user_data;
+use crate::{ApiError, AppState, VerifiedUserAuthentication};
+
+use super::envelope::{
+    Credential, EncodedBytes, HeaderField, LogicalMethod, RequestEnvelope, RequestId, ResponseMode,
+};
+use super::session::{
+    AuthenticationReservation, AuthenticationStartError, AuthorityState, BoundAuthority,
+    BoundPrincipal,
+};
+use super::session_cache::V2SessionLease;
+
+const JSON_CONTENT_TYPE: &[u8] = b"application/json";
+
+pub(crate) enum OperationPreparation {
+    Unsupported,
+    Rejected(LogicalUnaryResponse),
+    Ready(UserOperation),
+}
+
+pub(crate) enum UserOperation {
+    Login { body: Vec<u8> },
+    Register { body: Vec<u8> },
+    Resume { credential: Vec<u8> },
+    GetUser(BoundUserAuthority),
+}
+
+#[derive(Clone)]
+pub(crate) struct BoundUserAuthority {
+    user_id: uuid::Uuid,
+    project_id: i32,
+    auth_context: AuthContext,
+}
+
+impl UserOperation {
+    pub(crate) const fn requires_authentication_transition(&self) -> bool {
+        matches!(
+            self,
+            Self::Login { .. } | Self::Register { .. } | Self::Resume { .. }
+        )
+    }
+}
+
+pub(crate) struct LogicalUnaryResponse {
+    pub(crate) status: StatusCode,
+    pub(crate) headers: Vec<HeaderField>,
+    pub(crate) body: Option<Vec<u8>>,
+}
+
+impl LogicalUnaryResponse {
+    pub(crate) fn json<T: Serialize>(status: StatusCode, value: &T) -> Result<Self, ApiError> {
+        let body = serde_json::to_vec(value).map_err(|error| {
+            tracing::error!(
+                "Could not serialize transport-v2 logical response: {:?}",
+                error
+            );
+            ApiError::InternalServerError
+        })?;
+        Ok(Self {
+            status,
+            headers: vec![HeaderField {
+                name: "content-type".to_owned(),
+                value_base64: EncodedBytes::from_bytes(JSON_CONTENT_TYPE.to_vec()),
+            }],
+            body: Some(body),
+        })
+    }
+
+    pub(crate) fn api_error(error: &ApiError) -> Self {
+        match Self::json(error.status_code(), &error.response_body()) {
+            Ok(response) => response,
+            Err(_) => Self::protocol_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_error",
+                "Internal server error",
+            ),
+        }
+    }
+
+    pub(crate) fn protocol_error(status: StatusCode, code: &str, message: &str) -> Self {
+        #[derive(Serialize)]
+        struct ErrorBody<'a> {
+            error: ErrorDetails<'a>,
+        }
+
+        #[derive(Serialize)]
+        struct ErrorDetails<'a> {
+            code: &'a str,
+            message: &'a str,
+        }
+
+        let body = serde_json::to_vec(&ErrorBody {
+            error: ErrorDetails { code, message },
+        })
+        .expect("fixed transport-v2 error body must serialize");
+        Self {
+            status,
+            headers: vec![HeaderField {
+                name: "content-type".to_owned(),
+                value_base64: EncodedBytes::from_bytes(JSON_CONTENT_TYPE.to_vec()),
+            }],
+            body: Some(body),
+        }
+    }
+}
+
+pub(crate) struct ApplicationOutcome {
+    pub(crate) response: LogicalUnaryResponse,
+    pub(crate) bound_session: bool,
+}
+
+impl ApplicationOutcome {
+    fn success(response: LogicalUnaryResponse, bound_session: bool) -> Self {
+        Self {
+            response,
+            bound_session,
+        }
+    }
+
+    fn error(error: ApiError) -> Self {
+        Self {
+            response: LogicalUnaryResponse::api_error(&error),
+            bound_session: false,
+        }
+    }
+}
+
+pub(crate) fn prepare_user_operation(
+    envelope: RequestEnvelope,
+    authority: AuthorityState,
+) -> OperationPreparation {
+    let RequestEnvelope {
+        response_mode,
+        credential,
+        request,
+        ..
+    } = envelope;
+
+    let operation = match (request.method, request.path.as_str()) {
+        (LogicalMethod::Post, "/login") => 0,
+        (LogicalMethod::Post, "/register") => 1,
+        (LogicalMethod::Post, "/refresh") => 2,
+        (LogicalMethod::Get, "/protected/user") => 3,
+        _ => return OperationPreparation::Unsupported,
+    };
+
+    if response_mode != ResponseMode::Unary || request.query.is_some() {
+        return rejected_bad_request();
+    }
+
+    match operation {
+        0 | 1 => {
+            if credential.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            if !matches!(authority, AuthorityState::Anonymous) {
+                return OperationPreparation::Rejected(LogicalUnaryResponse::protocol_error(
+                    StatusCode::CONFLICT,
+                    "session_already_bound",
+                    "Session is already authenticated",
+                ));
+            }
+
+            let body = request
+                .body_base64
+                .expect("validated body presence")
+                .into_bytes();
+            if operation == 0 {
+                OperationPreparation::Ready(UserOperation::Login { body })
+            } else {
+                OperationPreparation::Ready(UserOperation::Register { body })
+            }
+        }
+        2 => {
+            if !request.headers.is_empty() || request.body_base64.is_some() {
+                return rejected_bad_request();
+            }
+            if !matches!(authority, AuthorityState::Anonymous) {
+                return OperationPreparation::Rejected(LogicalUnaryResponse::protocol_error(
+                    StatusCode::CONFLICT,
+                    "session_already_bound",
+                    "Session is already authenticated",
+                ));
+            }
+            let Some(Credential::Resumption { value_base64 }) = credential else {
+                return rejected_bad_request();
+            };
+            if value_base64.is_empty() {
+                return rejected_bad_request();
+            }
+            OperationPreparation::Ready(UserOperation::Resume {
+                credential: value_base64.into_bytes(),
+            })
+        }
+        3 => {
+            if credential.is_some() || !request.headers.is_empty() || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            let AuthorityState::Bound(bound) = authority else {
+                return rejected_authentication_required();
+            };
+            let BoundPrincipal::User {
+                user_id,
+                project_id,
+                auth_context,
+            } = bound.principal()
+            else {
+                return rejected_authentication_required();
+            };
+            OperationPreparation::Ready(UserOperation::GetUser(BoundUserAuthority {
+                user_id: *user_id,
+                project_id: *project_id,
+                auth_context: auth_context.clone(),
+            }))
+        }
+        _ => unreachable!("operation classifier is exhaustive"),
+    }
+}
+
+pub(crate) fn begin_authentication_transition(
+    operation: &UserOperation,
+    lease: &V2SessionLease,
+    request_id: RequestId,
+) -> Result<Option<AuthenticationReservation>, LogicalUnaryResponse> {
+    if !operation.requires_authentication_transition() {
+        return Ok(None);
+    }
+
+    lease
+        .state()
+        .begin_authentication(request_id)
+        .map(Some)
+        .map_err(authentication_start_error)
+}
+
+fn authentication_start_error(error: AuthenticationStartError) -> LogicalUnaryResponse {
+    let (code, message) = match error {
+        AuthenticationStartError::AuthenticationInProgress => (
+            "authentication_in_progress",
+            "Session authentication is already in progress",
+        ),
+        AuthenticationStartError::AlreadyBound => {
+            ("session_already_bound", "Session is already authenticated")
+        }
+        AuthenticationStartError::Closing => ("session_closed", "Session is closed"),
+    };
+    LogicalUnaryResponse::protocol_error(StatusCode::CONFLICT, code, message)
+}
+
+pub(crate) async fn execute_user_operation(
+    app_state: Arc<AppState>,
+    lease: V2SessionLease,
+    operation: UserOperation,
+    authentication: Option<AuthenticationReservation>,
+    monotonic_now: Instant,
+) -> ApplicationOutcome {
+    match operation {
+        UserOperation::Login { mut body } => {
+            let parsed =
+                serde_json::from_slice::<Credentials>(&body).map_err(|_| ApiError::BadRequest);
+            body.zeroize();
+            let credentials = match parsed {
+                Ok(credentials) => credentials,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            let verified = match authenticate_login(Arc::clone(&app_state), credentials).await {
+                Ok(verified) => verified,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            finish_user_binding(
+                &app_state,
+                &lease,
+                verified,
+                authentication.expect("login requires authentication reservation"),
+                monotonic_now,
+                UserAuthResponseKind::Login,
+            )
+        }
+        UserOperation::Register { mut body } => {
+            let parsed = serde_json::from_slice::<RegisterCredentials>(&body)
+                .map_err(|_| ApiError::BadRequest);
+            body.zeroize();
+            let credentials = match parsed {
+                Ok(credentials) => credentials,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            let verified =
+                match register_and_authenticate(Arc::clone(&app_state), credentials).await {
+                    Ok(verified) => verified,
+                    Err(error) => return ApplicationOutcome::error(error),
+                };
+            finish_user_binding(
+                &app_state,
+                &lease,
+                verified,
+                authentication.expect("registration requires authentication reservation"),
+                monotonic_now,
+                UserAuthResponseKind::Login,
+            )
+        }
+        UserOperation::Resume { credential } => {
+            let credential = match String::from_utf8(credential) {
+                Ok(credential) => Zeroizing::new(credential),
+                Err(error) => {
+                    let mut bytes = error.into_bytes();
+                    bytes.zeroize();
+                    return ApplicationOutcome::error(ApiError::InvalidJwt);
+                }
+            };
+            let verified = match validate_transport_v2_user_resumption(&credential, &app_state) {
+                Ok(verified) => verified,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            finish_user_binding(
+                &app_state,
+                &lease,
+                verified,
+                authentication.expect("resumption requires authentication reservation"),
+                monotonic_now,
+                UserAuthResponseKind::Refresh,
+            )
+        }
+        UserOperation::GetUser(bound) => {
+            debug_assert!(authentication.is_none());
+            let user = match app_state.verify_bound_user(
+                bound.user_id,
+                bound.project_id,
+                &bound.auth_context,
+            ) {
+                Ok(user) => user,
+                Err(error) => {
+                    if matches!(error, ApiError::Unauthorized | ApiError::InvalidJwt) {
+                        lease.state().close();
+                    }
+                    return ApplicationOutcome::error(error);
+                }
+            };
+            let response = match protected_user_data(&app_state, &user)
+                .and_then(|value| LogicalUnaryResponse::json(StatusCode::OK, &value))
+            {
+                Ok(response) => response,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            ApplicationOutcome::success(response, false)
+        }
+    }
+}
+
+enum UserAuthResponseKind {
+    Login,
+    Refresh,
+}
+
+fn finish_user_binding(
+    app_state: &AppState,
+    lease: &V2SessionLease,
+    verified: VerifiedUserAuthentication,
+    authentication: AuthenticationReservation,
+    monotonic_now: Instant,
+    response_kind: UserAuthResponseKind,
+) -> ApplicationOutcome {
+    let issued =
+        match issue_transport_v2_user_tokens(&verified.user, &verified.auth_context, app_state) {
+            Ok(issued) => issued,
+            Err(error) => return ApplicationOutcome::error(error),
+        };
+    let authentication_expires_at = match monotonic_authentication_expiry(
+        issued.access_expires_at,
+        monotonic_now,
+        lease.state().absolute_expires_at(),
+    ) {
+        Ok(expiry) => expiry,
+        Err(error) => return ApplicationOutcome::error(error),
+    };
+
+    let mut access_token = issued.access_token;
+    let mut resumption_token = issued.resumption_token;
+    let response = match response_kind {
+        UserAuthResponseKind::Login => {
+            let mut value = AuthResponse {
+                id: verified.user.get_id(),
+                email: verified.user.get_email().map(str::to_owned),
+                access_token: access_token.clone(),
+                refresh_token: resumption_token.clone(),
+            };
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value);
+            value.access_token.zeroize();
+            value.refresh_token.zeroize();
+            response
+        }
+        UserAuthResponseKind::Refresh => {
+            let mut value = RefreshResponse {
+                access_token: access_token.clone(),
+                refresh_token: resumption_token.clone(),
+            };
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value);
+            value.access_token.zeroize();
+            value.refresh_token.zeroize();
+            response
+        }
+    };
+    access_token.zeroize();
+    resumption_token.zeroize();
+    let response = match response {
+        Ok(response) => response,
+        Err(error) => return ApplicationOutcome::error(error),
+    };
+
+    let authority = BoundAuthority::verified_user(&verified, authentication_expires_at);
+    if authentication.commit_at(authority, monotonic_now).is_err() {
+        return ApplicationOutcome::error(ApiError::InternalServerError);
+    }
+
+    ApplicationOutcome::success(response, true)
+}
+
+fn monotonic_authentication_expiry(
+    wall_expiry: DateTime<Utc>,
+    monotonic_now: Instant,
+    absolute_session_expiry: Instant,
+) -> Result<Instant, ApiError> {
+    let remaining = wall_expiry
+        .signed_duration_since(Utc::now())
+        .to_std()
+        .map_err(|_| ApiError::InternalServerError)?;
+    let authentication_expiry = monotonic_now
+        .checked_add(remaining)
+        .ok_or(ApiError::InternalServerError)?;
+    let capped = authentication_expiry.min(absolute_session_expiry);
+    if capped <= monotonic_now {
+        return Err(ApiError::InternalServerError);
+    }
+    Ok(capped)
+}
+
+fn rejected_bad_request() -> OperationPreparation {
+    OperationPreparation::Rejected(LogicalUnaryResponse::protocol_error(
+        StatusCode::BAD_REQUEST,
+        "invalid_request",
+        "Invalid request",
+    ))
+}
+
+fn rejected_authentication_required() -> OperationPreparation {
+    OperationPreparation::Rejected(LogicalUnaryResponse::protocol_error(
+        StatusCode::UNAUTHORIZED,
+        "authentication_required",
+        "Authentication required",
+    ))
+}
+
+fn has_exact_json_content_type(headers: &[HeaderField]) -> bool {
+    let [header] = headers else {
+        return false;
+    };
+    if header.name != "content-type" {
+        return false;
+    }
+    let Ok(value) = std::str::from_utf8(header.value_base64.as_slice()) else {
+        return false;
+    };
+    let mut parts = value.split(';');
+    if !parts
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .eq_ignore_ascii_case("application/json")
+    {
+        return false;
+    }
+
+    let mut saw_charset = false;
+    for parameter in parts {
+        let Some((name, value)) = parameter.trim().split_once('=') else {
+            return false;
+        };
+        if saw_charset
+            || !name.trim().eq_ignore_ascii_case("charset")
+            || !value.trim().eq_ignore_ascii_case("utf-8")
+        {
+            return false;
+        }
+        saw_charset = true;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jwt::AuthMethod;
+    use crate::transport_v2::envelope::{LogicalRequest, Version2};
+
+    fn envelope(
+        method: LogicalMethod,
+        path: &str,
+        headers: Vec<HeaderField>,
+        body: Option<&[u8]>,
+        credential: Option<Credential>,
+    ) -> RequestEnvelope {
+        RequestEnvelope {
+            version: Version2,
+            request_id: RequestId::from_bytes([0x31; 16]),
+            response_mode: ResponseMode::Unary,
+            credential,
+            request: LogicalRequest {
+                method,
+                path: path.to_owned(),
+                query: None,
+                headers,
+                body_base64: body.map(|body| EncodedBytes::from_bytes(body.to_vec())),
+            },
+        }
+    }
+
+    fn json_header() -> Vec<HeaderField> {
+        vec![HeaderField {
+            name: "content-type".to_owned(),
+            value_base64: EncodedBytes::from_bytes(JSON_CONTENT_TYPE.to_vec()),
+        }]
+    }
+
+    fn bound_user_authority() -> AuthorityState {
+        let auth_context = AuthContext::new(AuthMethod::Password, 7, [0x32; 32]);
+        AuthorityState::Bound(BoundAuthority::user(
+            uuid::Uuid::from_bytes([0x33; 16]),
+            7,
+            &auth_context,
+            Instant::now() + std::time::Duration::from_secs(60),
+        ))
+    }
+
+    #[test]
+    fn exact_user_operation_contracts_are_admitted() {
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Post,
+                    "/login",
+                    json_header(),
+                    Some(br#"{"id":"00000000-0000-0000-0000-000000000000","password":"p","client_id":"00000000-0000-0000-0000-000000000000"}"#),
+                    None,
+                ),
+                AuthorityState::Anonymous,
+            ),
+            OperationPreparation::Ready(UserOperation::Login { .. })
+        ));
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Post,
+                    "/register",
+                    json_header(),
+                    Some(br#"{"password":"p","client_id":"00000000-0000-0000-0000-000000000000","inviteCode":"ignored"}"#),
+                    None,
+                ),
+                AuthorityState::Anonymous,
+            ),
+            OperationPreparation::Ready(UserOperation::Register { .. })
+        ));
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Post,
+                    "/refresh",
+                    Vec::new(),
+                    None,
+                    Some(Credential::Resumption {
+                        value_base64: EncodedBytes::from_bytes(b"token".to_vec()),
+                    }),
+                ),
+                AuthorityState::Anonymous,
+            ),
+            OperationPreparation::Ready(UserOperation::Resume { .. })
+        ));
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Get,
+                    "/protected/user",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::GetUser(_))
+        ));
+    }
+
+    #[test]
+    fn near_miss_user_operations_are_rejected_before_dispatch() {
+        let mut wrong_mode = envelope(
+            LogicalMethod::Post,
+            "/login",
+            json_header(),
+            Some(b"{}"),
+            None,
+        );
+        wrong_mode.response_mode = ResponseMode::Auto;
+        assert!(matches!(
+            prepare_user_operation(wrong_mode, AuthorityState::Anonymous),
+            OperationPreparation::Rejected(_)
+        ));
+
+        for request in [
+            envelope(LogicalMethod::Post, "/login", Vec::new(), Some(b"{}"), None),
+            envelope(LogicalMethod::Post, "/login", json_header(), None, None),
+            envelope(
+                LogicalMethod::Post,
+                "/refresh",
+                Vec::new(),
+                Some(b"{}"),
+                Some(Credential::Resumption {
+                    value_base64: EncodedBytes::from_bytes(b"token".to_vec()),
+                }),
+            ),
+            envelope(
+                LogicalMethod::Get,
+                "/protected/user",
+                Vec::new(),
+                Some(b""),
+                None,
+            ),
+        ] {
+            assert!(matches!(
+                prepare_user_operation(request, AuthorityState::Anonymous),
+                OperationPreparation::Rejected(_)
+            ));
+        }
+    }
+
+    #[test]
+    fn register_preserves_legacy_unknown_invite_code_tolerance() {
+        let parsed: RegisterCredentials = serde_json::from_slice(
+            br#"{"password":"p","client_id":"00000000-0000-0000-0000-000000000000","inviteCode":"legacy"}"#,
+        )
+        .expect("legacy SDK inviteCode remains ignored by application payload parsing");
+        assert_eq!(parsed.password, "p");
+    }
+
+    #[test]
+    fn bound_user_contract_rejects_rebinding_and_metadata_transplants() {
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Post,
+                    "/login",
+                    json_header(),
+                    Some(b"{}"),
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Rejected(_)
+        ));
+
+        let mut query = envelope(
+            LogicalMethod::Get,
+            "/protected/user",
+            Vec::new(),
+            None,
+            None,
+        );
+        query.request.query = Some("x=1".to_owned());
+        for request in [
+            query,
+            envelope(
+                LogicalMethod::Get,
+                "/protected/user",
+                json_header(),
+                None,
+                None,
+            ),
+            envelope(
+                LogicalMethod::Get,
+                "/protected/user",
+                Vec::new(),
+                Some(b""),
+                None,
+            ),
+            envelope(
+                LogicalMethod::Get,
+                "/protected/user",
+                Vec::new(),
+                None,
+                Some(Credential::ApiKey {
+                    value_base64: EncodedBytes::from_bytes(b"key".to_vec()),
+                }),
+            ),
+        ] {
+            assert!(matches!(
+                prepare_user_operation(request, bound_user_authority()),
+                OperationPreparation::Rejected(_)
+            ));
+        }
+    }
+}

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -5,6 +5,7 @@
 //! functions, and returns plaintext logical results for the gateway to encrypt
 //! through the request's original session lease.
 
+use std::io::{self, Write};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -24,8 +25,9 @@ use crate::web::login_routes::{
     RegisterCredentials,
 };
 use crate::web::protected_routes::{
-    private_key_bytes_data, private_key_data, protected_user_data, public_key_data,
-    sign_message_data, third_party_token_data, DerivationPathQuery, PublicKeyQuery,
+    decrypt_data_value, encrypt_data_value, private_key_bytes_data, private_key_data,
+    protected_user_data, public_key_data, sign_message_data, third_party_token_data,
+    DecryptDataRequest, DerivationPathQuery, EncryptDataRequest, PublicKeyQuery,
     SignMessageRequest, ThirdPartyTokenRequest,
 };
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
@@ -41,6 +43,12 @@ use super::session::{
 use super::session_cache::V2SessionLease;
 
 const JSON_CONTENT_TYPE: &[u8] = b"application/json";
+const AES_GCM_NONCE_AND_TAG_BYTES: usize = 12 + 16;
+const ENCRYPTED_DATA_JSON_OVERHEAD_BYTES: usize = "{\"encrypted_data\":\"".len() + "\"}".len();
+const MAX_ENCRYPTED_DATA_BASE64_BYTES: usize =
+    ((EnvelopeLimits::DEFAULT.logical_body_bytes - ENCRYPTED_DATA_JSON_OVERHEAD_BYTES) / 4) * 4;
+const MAX_ENCRYPTION_PLAINTEXT_BYTES: usize =
+    (MAX_ENCRYPTED_DATA_BASE64_BYTES / 4) * 3 - AES_GCM_NONCE_AND_TAG_BYTES;
 
 type SensitiveBytes = Zeroizing<Vec<u8>>;
 
@@ -73,6 +81,8 @@ pub(crate) enum ProtectedUserOperation {
     GetPublicKey { query: Option<String> },
     SignMessage { body: SensitiveBytes },
     IssueThirdPartyToken { body: SensitiveBytes },
+    EncryptData { body: SensitiveBytes },
+    DecryptData { body: SensitiveBytes },
 }
 
 #[derive(Clone)]
@@ -80,6 +90,53 @@ pub(crate) struct BoundUserAuthority {
     user_id: uuid::Uuid,
     project_id: i32,
     auth_context: AuthContext,
+}
+
+struct BoundedJsonBuffer {
+    bytes: Vec<u8>,
+    limit: usize,
+    exceeded: bool,
+}
+
+impl BoundedJsonBuffer {
+    fn new(limit: usize) -> Self {
+        Self {
+            bytes: Vec::new(),
+            limit,
+            exceeded: false,
+        }
+    }
+
+    fn into_bytes(mut self) -> Vec<u8> {
+        std::mem::take(&mut self.bytes)
+    }
+}
+
+impl Write for BoundedJsonBuffer {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        let Some(next) = self.bytes.len().checked_add(buffer.len()) else {
+            self.exceeded = true;
+            return Err(io::Error::other("serialized JSON length overflow"));
+        };
+        if next > self.limit {
+            self.exceeded = true;
+            return Err(io::Error::other(
+                "serialized JSON exceeds logical response limit",
+            ));
+        }
+        self.bytes.extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Drop for BoundedJsonBuffer {
+    fn drop(&mut self) {
+        self.bytes.zeroize();
+    }
 }
 
 impl UserOperation {
@@ -107,17 +164,18 @@ impl LogicalUnaryResponse {
         value: &T,
         logical_body_bytes: usize,
     ) -> Result<Self, ApiError> {
-        let mut body = serde_json::to_vec(value).map_err(|error| {
+        let mut buffer = BoundedJsonBuffer::new(logical_body_bytes);
+        if let Err(error) = serde_json::to_writer(&mut buffer, value) {
+            if buffer.exceeded {
+                return Err(ApiError::PayloadTooLarge);
+            }
             tracing::error!(
                 "Could not serialize transport-v2 logical response: {:?}",
                 error
             );
-            ApiError::InternalServerError
-        })?;
-        if body.len() > logical_body_bytes {
-            body.zeroize();
-            return Err(ApiError::PayloadTooLarge);
+            return Err(ApiError::InternalServerError);
         }
+        let body = buffer.into_bytes();
         Ok(Self {
             status,
             headers: vec![HeaderField {
@@ -209,6 +267,8 @@ pub(crate) fn prepare_user_operation(
         GetPublicKey,
         SignMessage,
         IssueThirdPartyToken,
+        EncryptData,
+        DecryptData,
     }
 
     let route = match (request.method, request.path.as_str()) {
@@ -221,6 +281,8 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Get, "/protected/public_key") => Route::GetPublicKey,
         (LogicalMethod::Post, "/protected/sign_message") => Route::SignMessage,
         (LogicalMethod::Post, "/protected/third_party_token") => Route::IssueThirdPartyToken,
+        (LogicalMethod::Post, "/protected/encrypt") => Route::EncryptData,
+        (LogicalMethod::Post, "/protected/decrypt") => Route::DecryptData,
         _ => return OperationPreparation::Unsupported,
     };
 
@@ -313,7 +375,10 @@ pub(crate) fn prepare_user_operation(
                 operation,
             })
         }
-        Route::SignMessage | Route::IssueThirdPartyToken => {
+        Route::SignMessage
+        | Route::IssueThirdPartyToken
+        | Route::EncryptData
+        | Route::DecryptData => {
             if credential.is_some()
                 || request.query.is_some()
                 || !has_exact_json_content_type(&request.headers)
@@ -338,6 +403,8 @@ pub(crate) fn prepare_user_operation(
                 Route::IssueThirdPartyToken => {
                     ProtectedUserOperation::IssueThirdPartyToken { body }
                 }
+                Route::EncryptData => ProtectedUserOperation::EncryptData { body },
+                Route::DecryptData => ProtectedUserOperation::DecryptData { body },
                 _ => unreachable!("fixed protected POST classifier is exhaustive"),
             };
             OperationPreparation::Ready(UserOperation::Protected {
@@ -546,6 +613,25 @@ async fn execute_protected_user_operation(
             let value = third_party_token_data(app_state, user, request)?;
             LogicalUnaryResponse::json(StatusCode::OK, &value)
         }
+        ProtectedUserOperation::EncryptData { body } => {
+            let mut request = parse_json_body::<EncryptDataRequest>(body)?;
+            if let Err(error) = validate_encryption_plaintext_length(request.data.len()) {
+                request.data.zeroize();
+                return Err(error);
+            }
+            let value = encrypt_data_value(app_state, user, auth_context, request).await?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::DecryptData { body } => {
+            let mut request = parse_json_body::<DecryptDataRequest>(body)?;
+            if let Err(error) = validate_encrypted_data_base64_length(request.encrypted_data.len())
+            {
+                request.encrypted_data.zeroize();
+                return Err(error);
+            }
+            let value = decrypt_data_value(app_state, user, auth_context, request).await?;
+            LogicalUnaryResponse::json(StatusCode::OK, &*value)
+        }
     }
 }
 
@@ -564,6 +650,22 @@ fn parse_logical_query<T: DeserializeOwned>(query: Option<String>) -> Result<T, 
     Query::<T>::try_from_uri(&uri)
         .map(|Query(value)| value)
         .map_err(|_| ApiError::BadRequest)
+}
+
+fn validate_encryption_plaintext_length(length: usize) -> Result<(), ApiError> {
+    if length > MAX_ENCRYPTION_PLAINTEXT_BYTES {
+        Err(ApiError::PayloadTooLarge)
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_encrypted_data_base64_length(length: usize) -> Result<(), ApiError> {
+    if length > MAX_ENCRYPTED_DATA_BASE64_BYTES {
+        Err(ApiError::PayloadTooLarge)
+    } else {
+        Ok(())
+    }
 }
 
 enum UserAuthResponseKind {
@@ -709,7 +811,8 @@ fn has_exact_json_content_type(headers: &[HeaderField]) -> bool {
 mod tests {
     use super::*;
     use crate::jwt::AuthMethod;
-    use crate::transport_v2::envelope::{LogicalRequest, Version2};
+    use crate::transport_v2::envelope::{LogicalRequest, UnaryResponseEnvelope, Version2};
+    use crate::web::protected_routes::EncryptDataResponse;
 
     fn envelope(
         method: LogicalMethod,
@@ -868,6 +971,8 @@ mod tests {
         for (path, expected) in [
             ("/protected/sign_message", "sign"),
             ("/protected/third_party_token", "third_party"),
+            ("/protected/encrypt", "encrypt"),
+            ("/protected/decrypt", "decrypt"),
         ] {
             let prepared = prepare_user_operation(
                 envelope(LogicalMethod::Post, path, json_header(), Some(b"{}"), None),
@@ -888,20 +993,22 @@ mod tests {
                             ..
                         }),
                         "third_party"
+                    ) | (
+                        OperationPreparation::Ready(UserOperation::Protected {
+                            operation: ProtectedUserOperation::EncryptData { .. },
+                            ..
+                        }),
+                        "encrypt"
+                    ) | (
+                        OperationPreparation::Ready(UserOperation::Protected {
+                            operation: ProtectedUserOperation::DecryptData { .. },
+                            ..
+                        }),
+                        "decrypt"
                     )
                 ),
                 "{path}"
             );
-        }
-
-        for path in ["/protected/encrypt", "/protected/decrypt"] {
-            assert!(matches!(
-                prepare_user_operation(
-                    envelope(LogicalMethod::Post, path, json_header(), Some(b"{}"), None,),
-                    bound_user_authority(),
-                ),
-                OperationPreparation::Unsupported
-            ));
         }
     }
 
@@ -1036,7 +1143,12 @@ mod tests {
             ));
         }
 
-        for path in ["/protected/sign_message", "/protected/third_party_token"] {
+        for path in [
+            "/protected/sign_message",
+            "/protected/third_party_token",
+            "/protected/encrypt",
+            "/protected/decrypt",
+        ] {
             assert!(matches!(
                 prepare_user_operation(
                     envelope(LogicalMethod::Post, path, json_header(), Some(b"{}"), None),
@@ -1104,6 +1216,72 @@ mod tests {
         assert!(LogicalUnaryResponse::json_with_limit(StatusCode::OK, &"abc", 5).is_ok());
         assert!(matches!(
             LogicalUnaryResponse::json_with_limit(StatusCode::OK, &"abcd", 5),
+            Err(ApiError::PayloadTooLarge)
+        ));
+
+        let escaped = "\0";
+        assert!(LogicalUnaryResponse::json_with_limit(StatusCode::OK, &escaped, 8).is_ok());
+        assert!(matches!(
+            LogicalUnaryResponse::json_with_limit(StatusCode::OK, &escaped, 7),
+            Err(ApiError::PayloadTooLarge)
+        ));
+
+        let mut buffer = BoundedJsonBuffer::new(7);
+        assert!(serde_json::to_writer(&mut buffer, &escaped).is_err());
+        assert!(buffer.exceeded);
+        assert!(buffer.bytes.len() <= 7);
+    }
+
+    #[test]
+    fn crypto_utility_response_bounds_are_exact() {
+        let empty_response = EncryptDataResponse {
+            encrypted_data: String::new(),
+        };
+        assert_eq!(
+            serde_json::to_vec(&empty_response).unwrap().len(),
+            ENCRYPTED_DATA_JSON_OVERHEAD_BYTES
+        );
+
+        let max_encrypted_bytes = MAX_ENCRYPTION_PLAINTEXT_BYTES + AES_GCM_NONCE_AND_TAG_BYTES;
+        let encoded_bytes = max_encrypted_bytes.div_ceil(3) * 4;
+        assert_eq!(encoded_bytes, MAX_ENCRYPTED_DATA_BASE64_BYTES);
+        assert_eq!(
+            encoded_bytes + ENCRYPTED_DATA_JSON_OVERHEAD_BYTES,
+            EnvelopeLimits::DEFAULT.logical_body_bytes - 3
+        );
+
+        let next_encoded_bytes = (max_encrypted_bytes + 1).div_ceil(3) * 4;
+        assert_eq!(
+            next_encoded_bytes + ENCRYPTED_DATA_JSON_OVERHEAD_BYTES,
+            EnvelopeLimits::DEFAULT.logical_body_bytes + 1
+        );
+
+        let response_envelope_overhead = serde_json::to_vec(&UnaryResponseEnvelope {
+            version: Version2,
+            request_id: RequestId::from_bytes([0x31; 16]),
+            status: StatusCode::OK.as_u16(),
+            headers: json_header(),
+            body_base64: Some(EncodedBytes::from_bytes(Vec::new())),
+        })
+        .unwrap()
+        .len();
+        let logical_response_bytes = encoded_bytes + ENCRYPTED_DATA_JSON_OVERHEAD_BYTES;
+        let response_record_plaintext_bytes =
+            response_envelope_overhead + logical_response_bytes.div_ceil(3) * 4;
+        let response_record_bytes = response_record_plaintext_bytes + 12 + 16;
+        let encrypted_outer_response_bytes =
+            "{\"encrypted\":\"\"}".len() + response_record_bytes.div_ceil(3) * 4;
+        assert_eq!(encrypted_outer_response_bytes, 52_196_060);
+        assert!(encrypted_outer_response_bytes <= 50 * 1024 * 1024);
+
+        assert!(validate_encryption_plaintext_length(MAX_ENCRYPTION_PLAINTEXT_BYTES).is_ok());
+        assert!(matches!(
+            validate_encryption_plaintext_length(MAX_ENCRYPTION_PLAINTEXT_BYTES + 1),
+            Err(ApiError::PayloadTooLarge)
+        ));
+        assert!(validate_encrypted_data_base64_length(MAX_ENCRYPTED_DATA_BASE64_BYTES).is_ok());
+        assert!(matches!(
+            validate_encrypted_data_base64_length(MAX_ENCRYPTED_DATA_BASE64_BYTES + 1),
             Err(ApiError::PayloadTooLarge)
         ));
     }

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -8,8 +8,11 @@
 use std::sync::Arc;
 use std::time::Instant;
 
+use axum::extract::Query;
 use axum::http::StatusCode;
+use axum::http::Uri;
 use chrono::{DateTime, Utc};
+use serde::de::DeserializeOwned;
 use serde::Serialize;
 use zeroize::{Zeroize, Zeroizing};
 
@@ -20,11 +23,16 @@ use crate::web::login_routes::{
     authenticate_login, register_and_authenticate, AuthResponse, Credentials, RefreshResponse,
     RegisterCredentials,
 };
-use crate::web::protected_routes::protected_user_data;
+use crate::web::protected_routes::{
+    private_key_bytes_data, private_key_data, protected_user_data, public_key_data,
+    sign_message_data, third_party_token_data, DerivationPathQuery, PublicKeyQuery,
+    SignMessageRequest, ThirdPartyTokenRequest,
+};
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
 use super::envelope::{
-    Credential, EncodedBytes, HeaderField, LogicalMethod, RequestEnvelope, RequestId, ResponseMode,
+    Credential, EncodedBytes, EnvelopeLimits, HeaderField, LogicalMethod, RequestEnvelope,
+    RequestId, ResponseMode,
 };
 use super::session::{
     AuthenticationReservation, AuthenticationStartError, AuthorityState, BoundAuthority,
@@ -34,6 +42,8 @@ use super::session_cache::V2SessionLease;
 
 const JSON_CONTENT_TYPE: &[u8] = b"application/json";
 
+type SensitiveBytes = Zeroizing<Vec<u8>>;
+
 pub(crate) enum OperationPreparation {
     Unsupported,
     Rejected(LogicalUnaryResponse),
@@ -41,10 +51,28 @@ pub(crate) enum OperationPreparation {
 }
 
 pub(crate) enum UserOperation {
-    Login { body: Vec<u8> },
-    Register { body: Vec<u8> },
-    Resume { credential: Vec<u8> },
-    GetUser(BoundUserAuthority),
+    Login {
+        body: SensitiveBytes,
+    },
+    Register {
+        body: SensitiveBytes,
+    },
+    Resume {
+        credential: SensitiveBytes,
+    },
+    Protected {
+        authority: BoundUserAuthority,
+        operation: ProtectedUserOperation,
+    },
+}
+
+pub(crate) enum ProtectedUserOperation {
+    GetUser,
+    GetPrivateKey { query: Option<String> },
+    GetPrivateKeyBytes { query: Option<String> },
+    GetPublicKey { query: Option<String> },
+    SignMessage { body: SensitiveBytes },
+    IssueThirdPartyToken { body: SensitiveBytes },
 }
 
 #[derive(Clone)]
@@ -71,13 +99,25 @@ pub(crate) struct LogicalUnaryResponse {
 
 impl LogicalUnaryResponse {
     pub(crate) fn json<T: Serialize>(status: StatusCode, value: &T) -> Result<Self, ApiError> {
-        let body = serde_json::to_vec(value).map_err(|error| {
+        Self::json_with_limit(status, value, EnvelopeLimits::default().logical_body_bytes)
+    }
+
+    fn json_with_limit<T: Serialize>(
+        status: StatusCode,
+        value: &T,
+        logical_body_bytes: usize,
+    ) -> Result<Self, ApiError> {
+        let mut body = serde_json::to_vec(value).map_err(|error| {
             tracing::error!(
                 "Could not serialize transport-v2 logical response: {:?}",
                 error
             );
             ApiError::InternalServerError
         })?;
+        if body.len() > logical_body_bytes {
+            body.zeroize();
+            return Err(ApiError::PayloadTooLarge);
+        }
         Ok(Self {
             status,
             headers: vec![HeaderField {
@@ -158,21 +198,40 @@ pub(crate) fn prepare_user_operation(
         ..
     } = envelope;
 
-    let operation = match (request.method, request.path.as_str()) {
-        (LogicalMethod::Post, "/login") => 0,
-        (LogicalMethod::Post, "/register") => 1,
-        (LogicalMethod::Post, "/refresh") => 2,
-        (LogicalMethod::Get, "/protected/user") => 3,
+    #[derive(Clone, Copy)]
+    enum Route {
+        Login,
+        Register,
+        Resume,
+        GetUser,
+        GetPrivateKey,
+        GetPrivateKeyBytes,
+        GetPublicKey,
+        SignMessage,
+        IssueThirdPartyToken,
+    }
+
+    let route = match (request.method, request.path.as_str()) {
+        (LogicalMethod::Post, "/login") => Route::Login,
+        (LogicalMethod::Post, "/register") => Route::Register,
+        (LogicalMethod::Post, "/refresh") => Route::Resume,
+        (LogicalMethod::Get, "/protected/user") => Route::GetUser,
+        (LogicalMethod::Get, "/protected/private_key") => Route::GetPrivateKey,
+        (LogicalMethod::Get, "/protected/private_key_bytes") => Route::GetPrivateKeyBytes,
+        (LogicalMethod::Get, "/protected/public_key") => Route::GetPublicKey,
+        (LogicalMethod::Post, "/protected/sign_message") => Route::SignMessage,
+        (LogicalMethod::Post, "/protected/third_party_token") => Route::IssueThirdPartyToken,
         _ => return OperationPreparation::Unsupported,
     };
 
-    if response_mode != ResponseMode::Unary || request.query.is_some() {
+    if response_mode != ResponseMode::Unary {
         return rejected_bad_request();
     }
 
-    match operation {
-        0 | 1 => {
+    match route {
+        Route::Login | Route::Register => {
             if credential.is_some()
+                || request.query.is_some()
                 || !has_exact_json_content_type(&request.headers)
                 || request
                     .body_base64
@@ -193,14 +252,18 @@ pub(crate) fn prepare_user_operation(
                 .body_base64
                 .expect("validated body presence")
                 .into_bytes();
-            if operation == 0 {
+            let body = Zeroizing::new(body);
+            if matches!(route, Route::Login) {
                 OperationPreparation::Ready(UserOperation::Login { body })
             } else {
                 OperationPreparation::Ready(UserOperation::Register { body })
             }
         }
-        2 => {
-            if !request.headers.is_empty() || request.body_base64.is_some() {
+        Route::Resume => {
+            if request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
                 return rejected_bad_request();
             }
             if !matches!(authority, AuthorityState::Anonymous) {
@@ -217,33 +280,93 @@ pub(crate) fn prepare_user_operation(
                 return rejected_bad_request();
             }
             OperationPreparation::Ready(UserOperation::Resume {
-                credential: value_base64.into_bytes(),
+                credential: Zeroizing::new(value_base64.into_bytes()),
             })
         }
-        3 => {
+        Route::GetUser | Route::GetPrivateKey | Route::GetPrivateKeyBytes | Route::GetPublicKey => {
             if credential.is_some() || !request.headers.is_empty() || request.body_base64.is_some()
             {
                 return rejected_bad_request();
             }
-            let AuthorityState::Bound(bound) = authority else {
-                return rejected_authentication_required();
+            if matches!(route, Route::GetUser) && request.query.is_some() {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
             };
-            let BoundPrincipal::User {
-                user_id,
-                project_id,
-                auth_context,
-            } = bound.principal()
-            else {
-                return rejected_authentication_required();
+            let operation = match route {
+                Route::GetUser => ProtectedUserOperation::GetUser,
+                Route::GetPrivateKey => ProtectedUserOperation::GetPrivateKey {
+                    query: request.query,
+                },
+                Route::GetPrivateKeyBytes => ProtectedUserOperation::GetPrivateKeyBytes {
+                    query: request.query,
+                },
+                Route::GetPublicKey => ProtectedUserOperation::GetPublicKey {
+                    query: request.query,
+                },
+                _ => unreachable!("fixed protected GET classifier is exhaustive"),
             };
-            OperationPreparation::Ready(UserOperation::GetUser(BoundUserAuthority {
-                user_id: *user_id,
-                project_id: *project_id,
-                auth_context: auth_context.clone(),
-            }))
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation,
+            })
         }
-        _ => unreachable!("operation classifier is exhaustive"),
+        Route::SignMessage | Route::IssueThirdPartyToken => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            let body = request
+                .body_base64
+                .expect("validated protected JSON body presence")
+                .into_bytes();
+            let body = Zeroizing::new(body);
+            let operation = match route {
+                Route::SignMessage => ProtectedUserOperation::SignMessage { body },
+                Route::IssueThirdPartyToken => {
+                    ProtectedUserOperation::IssueThirdPartyToken { body }
+                }
+                _ => unreachable!("fixed protected POST classifier is exhaustive"),
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation,
+            })
+        }
     }
+}
+
+fn bound_user_authority(
+    authority: AuthorityState,
+) -> Result<BoundUserAuthority, OperationPreparation> {
+    let AuthorityState::Bound(bound) = authority else {
+        return Err(rejected_authentication_required());
+    };
+    let BoundPrincipal::User {
+        user_id,
+        project_id,
+        auth_context,
+    } = bound.principal()
+    else {
+        return Err(rejected_authentication_required());
+    };
+    Ok(BoundUserAuthority {
+        user_id: *user_id,
+        project_id: *project_id,
+        auth_context: auth_context.clone(),
+    })
 }
 
 pub(crate) fn begin_authentication_transition(
@@ -284,10 +407,9 @@ pub(crate) async fn execute_user_operation(
     monotonic_now: Instant,
 ) -> ApplicationOutcome {
     match operation {
-        UserOperation::Login { mut body } => {
+        UserOperation::Login { body } => {
             let parsed =
                 serde_json::from_slice::<Credentials>(&body).map_err(|_| ApiError::BadRequest);
-            body.zeroize();
             let credentials = match parsed {
                 Ok(credentials) => credentials,
                 Err(error) => return ApplicationOutcome::error(error),
@@ -305,10 +427,9 @@ pub(crate) async fn execute_user_operation(
                 UserAuthResponseKind::Login,
             )
         }
-        UserOperation::Register { mut body } => {
+        UserOperation::Register { body } => {
             let parsed = serde_json::from_slice::<RegisterCredentials>(&body)
                 .map_err(|_| ApiError::BadRequest);
-            body.zeroize();
             let credentials = match parsed {
                 Ok(credentials) => credentials,
                 Err(error) => return ApplicationOutcome::error(error),
@@ -327,8 +448,9 @@ pub(crate) async fn execute_user_operation(
                 UserAuthResponseKind::Login,
             )
         }
-        UserOperation::Resume { credential } => {
-            let credential = match String::from_utf8(credential) {
+        UserOperation::Resume { mut credential } => {
+            let bytes = std::mem::take(&mut *credential);
+            let credential = match String::from_utf8(bytes) {
                 Ok(credential) => Zeroizing::new(credential),
                 Err(error) => {
                     let mut bytes = error.into_bytes();
@@ -349,12 +471,15 @@ pub(crate) async fn execute_user_operation(
                 UserAuthResponseKind::Refresh,
             )
         }
-        UserOperation::GetUser(bound) => {
+        UserOperation::Protected {
+            authority,
+            operation,
+        } => {
             debug_assert!(authentication.is_none());
             let user = match app_state.verify_bound_user(
-                bound.user_id,
-                bound.project_id,
-                &bound.auth_context,
+                authority.user_id,
+                authority.project_id,
+                &authority.auth_context,
             ) {
                 Ok(user) => user,
                 Err(error) => {
@@ -364,15 +489,81 @@ pub(crate) async fn execute_user_operation(
                     return ApplicationOutcome::error(error);
                 }
             };
-            let response = match protected_user_data(&app_state, &user)
-                .and_then(|value| LogicalUnaryResponse::json(StatusCode::OK, &value))
+            let response = match execute_protected_user_operation(
+                &app_state,
+                &user,
+                &authority.auth_context,
+                operation,
+            )
+            .await
             {
                 Ok(response) => response,
-                Err(error) => return ApplicationOutcome::error(error),
+                Err(error) => {
+                    if matches!(error, ApiError::Unauthorized | ApiError::InvalidJwt) {
+                        lease.state().close();
+                    }
+                    return ApplicationOutcome::error(error);
+                }
             };
             ApplicationOutcome::success(response, false)
         }
     }
+}
+
+async fn execute_protected_user_operation(
+    app_state: &AppState,
+    user: &crate::User,
+    auth_context: &AuthContext,
+    operation: ProtectedUserOperation,
+) -> Result<LogicalUnaryResponse, ApiError> {
+    match operation {
+        ProtectedUserOperation::GetUser => {
+            let value = protected_user_data(app_state, user)?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::GetPrivateKey { query } => {
+            let query = parse_logical_query::<DerivationPathQuery>(query)?;
+            let value = private_key_data(app_state, user, auth_context, query)?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::GetPrivateKeyBytes { query } => {
+            let query = parse_logical_query::<DerivationPathQuery>(query)?;
+            let value = private_key_bytes_data(app_state, user, auth_context, query).await?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::GetPublicKey { query } => {
+            let query = parse_logical_query::<PublicKeyQuery>(query)?;
+            let value = public_key_data(app_state, user, auth_context, query).await?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::SignMessage { body } => {
+            let request = parse_json_body::<SignMessageRequest>(body)?;
+            let value = sign_message_data(app_state, user, auth_context, request).await?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::IssueThirdPartyToken { body } => {
+            let request = parse_json_body::<ThirdPartyTokenRequest>(body)?;
+            let value = third_party_token_data(app_state, user, request)?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+    }
+}
+
+fn parse_json_body<T: DeserializeOwned>(body: SensitiveBytes) -> Result<T, ApiError> {
+    serde_json::from_slice::<T>(&body).map_err(|_| ApiError::BadRequest)
+}
+
+fn parse_logical_query<T: DeserializeOwned>(query: Option<String>) -> Result<T, ApiError> {
+    let path_and_query = match query {
+        Some(query) => format!("/?{query}"),
+        None => "/".to_owned(),
+    };
+    let uri = path_and_query
+        .parse::<Uri>()
+        .map_err(|_| ApiError::BadRequest)?;
+    Query::<T>::try_from_uri(&uri)
+        .map(|Query(value)| value)
+        .map_err(|_| ApiError::BadRequest)
 }
 
 enum UserAuthResponseKind {
@@ -613,8 +804,105 @@ mod tests {
                 ),
                 bound_user_authority(),
             ),
-            OperationPreparation::Ready(UserOperation::GetUser(_))
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::GetUser,
+                ..
+            })
         ));
+    }
+
+    #[test]
+    fn exact_sensitive_user_operation_contracts_are_admitted() {
+        let mut private_key = envelope(
+            LogicalMethod::Get,
+            "/protected/private_key",
+            Vec::new(),
+            None,
+            None,
+        );
+        let private_key_query =
+            "seed_phrase_derivation_path=m%2F83696968%27%2F39%27%2F0%27%2F12%27%2F0%27".to_owned();
+        private_key.request.query = Some(private_key_query.clone());
+        assert!(matches!(
+            prepare_user_operation(private_key, bound_user_authority()),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::GetPrivateKey { query: Some(query) },
+                ..
+            }) if query == private_key_query
+        ));
+
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Get,
+                    "/protected/private_key_bytes",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::GetPrivateKeyBytes { .. },
+                ..
+            })
+        ));
+
+        let mut public_key = envelope(
+            LogicalMethod::Get,
+            "/protected/public_key",
+            Vec::new(),
+            None,
+            None,
+        );
+        let public_key_query = "algorithm=schnorr".to_owned();
+        public_key.request.query = Some(public_key_query.clone());
+        assert!(matches!(
+            prepare_user_operation(public_key, bound_user_authority()),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::GetPublicKey { query: Some(query) },
+                ..
+            }) if query == public_key_query
+        ));
+
+        for (path, expected) in [
+            ("/protected/sign_message", "sign"),
+            ("/protected/third_party_token", "third_party"),
+        ] {
+            let prepared = prepare_user_operation(
+                envelope(LogicalMethod::Post, path, json_header(), Some(b"{}"), None),
+                bound_user_authority(),
+            );
+            assert!(
+                matches!(
+                    (&prepared, expected),
+                    (
+                        OperationPreparation::Ready(UserOperation::Protected {
+                            operation: ProtectedUserOperation::SignMessage { .. },
+                            ..
+                        }),
+                        "sign"
+                    ) | (
+                        OperationPreparation::Ready(UserOperation::Protected {
+                            operation: ProtectedUserOperation::IssueThirdPartyToken { .. },
+                            ..
+                        }),
+                        "third_party"
+                    )
+                ),
+                "{path}"
+            );
+        }
+
+        for path in ["/protected/encrypt", "/protected/decrypt"] {
+            assert!(matches!(
+                prepare_user_operation(
+                    envelope(LogicalMethod::Post, path, json_header(), Some(b"{}"), None,),
+                    bound_user_authority(),
+                ),
+                OperationPreparation::Unsupported
+            ));
+        }
     }
 
     #[test]
@@ -723,5 +1011,100 @@ mod tests {
                 OperationPreparation::Rejected(_)
             ));
         }
+    }
+
+    #[test]
+    fn sensitive_user_contracts_reject_unbound_and_transplanted_metadata() {
+        for path in [
+            "/protected/private_key",
+            "/protected/private_key_bytes",
+            "/protected/public_key",
+        ] {
+            assert!(matches!(
+                prepare_user_operation(
+                    envelope(LogicalMethod::Get, path, Vec::new(), None, None),
+                    AuthorityState::Anonymous,
+                ),
+                OperationPreparation::Rejected(_)
+            ));
+            assert!(matches!(
+                prepare_user_operation(
+                    envelope(LogicalMethod::Get, path, json_header(), None, None),
+                    bound_user_authority(),
+                ),
+                OperationPreparation::Rejected(_)
+            ));
+        }
+
+        for path in ["/protected/sign_message", "/protected/third_party_token"] {
+            assert!(matches!(
+                prepare_user_operation(
+                    envelope(LogicalMethod::Post, path, json_header(), Some(b"{}"), None),
+                    AuthorityState::Anonymous,
+                ),
+                OperationPreparation::Rejected(_)
+            ));
+
+            let mut query = envelope(LogicalMethod::Post, path, json_header(), Some(b"{}"), None);
+            query.request.query = Some("x=1".to_owned());
+            for request in [
+                envelope(LogicalMethod::Post, path, Vec::new(), Some(b"{}"), None),
+                envelope(LogicalMethod::Post, path, json_header(), None, None),
+                query,
+                envelope(
+                    LogicalMethod::Post,
+                    path,
+                    json_header(),
+                    Some(b"{}"),
+                    Some(Credential::Resumption {
+                        value_base64: EncodedBytes::from_bytes(b"token".to_vec()),
+                    }),
+                ),
+            ] {
+                assert!(matches!(
+                    prepare_user_operation(request, bound_user_authority()),
+                    OperationPreparation::Rejected(_)
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn logical_query_parsing_matches_axum_query_semantics() {
+        let no_derivation = parse_logical_query::<DerivationPathQuery>(None)
+            .expect("absent derivation query uses the existing default key options");
+        assert!(no_derivation
+            .key_options
+            .seed_phrase_derivation_path
+            .is_none());
+        assert!(no_derivation
+            .key_options
+            .private_key_derivation_path
+            .is_none());
+
+        let parsed = parse_logical_query::<DerivationPathQuery>(Some(
+            "private_key_derivation_path=m%2F44%27%2F0%27%2F0%27%2F0%2F0".to_owned(),
+        ))
+        .expect("valid encoded derivation path query");
+        assert_eq!(
+            parsed.key_options.private_key_derivation_path.as_deref(),
+            Some("m/44'/0'/0'/0/0")
+        );
+        assert!(
+            parse_logical_query::<PublicKeyQuery>(Some("algorithm=schnorr".to_owned())).is_ok()
+        );
+        assert!(parse_logical_query::<PublicKeyQuery>(None).is_err());
+        assert!(
+            parse_logical_query::<PublicKeyQuery>(Some("algorithm=unknown".to_owned())).is_err()
+        );
+    }
+
+    #[test]
+    fn oversized_logical_json_response_fails_before_gateway_encryption() {
+        assert!(LogicalUnaryResponse::json_with_limit(StatusCode::OK, &"abc", 5).is_ok());
+        assert!(matches!(
+            LogicalUnaryResponse::json_with_limit(StatusCode::OK, &"abcd", 5),
+            Err(ApiError::PayloadTooLarge)
+        ));
     }
 }

--- a/src/transport_v2/envelope.rs
+++ b/src/transport_v2/envelope.rs
@@ -17,6 +17,7 @@ pub(crate) struct EnvelopeLimits {
     pub(crate) header_name_bytes: usize,
     pub(crate) header_value_bytes: usize,
     pub(crate) aggregate_header_bytes: usize,
+    pub(crate) credential_bytes: usize,
 }
 
 impl EnvelopeLimits {
@@ -29,6 +30,7 @@ impl EnvelopeLimits {
         header_name_bytes: 128,
         header_value_bytes: 16 * KIB,
         aggregate_header_bytes: 64 * KIB,
+        credential_bytes: 16 * KIB,
     };
 }
 
@@ -339,7 +341,16 @@ impl RequestEnvelope {
     }
 
     pub(crate) fn validate(&self, limits: &EnvelopeLimits) -> Result<(), EnvelopeError> {
-        self.request.validate(limits)
+        self.request.validate(limits)?;
+        if let Some(credential) = &self.credential {
+            let credential_bytes = match credential {
+                Credential::ApiKey { value_base64 } | Credential::Resumption { value_base64 } => {
+                    value_base64.len()
+                }
+            };
+            check_limit(credential_bytes, limits.credential_bytes, "credential")?;
+        }
+        Ok(())
     }
 }
 
@@ -970,6 +981,27 @@ mod tests {
         let oversized_body = request_json(r#""YWI=""#);
         assert!(RequestEnvelope::from_json_slice(oversized_body.as_bytes(), &limits).is_err());
         assert!(RequestEnvelope::from_json_slice(&vec![b' '; 1025], &limits).is_err());
+    }
+
+    #[test]
+    fn credential_bytes_have_an_independent_limit() {
+        let limits = EnvelopeLimits {
+            credential_bytes: 2,
+            ..EnvelopeLimits::default()
+        };
+        for kind in ["api_key", "resumption"] {
+            let at_limit = request_json("null").replace(
+                "\"credential\":null",
+                &format!("\"credential\":{{\"kind\":\"{kind}\",\"value_base64\":\"YWI=\"}}"),
+            );
+            assert!(RequestEnvelope::from_json_slice(at_limit.as_bytes(), &limits).is_ok());
+
+            let oversized = request_json("null").replace(
+                "\"credential\":null",
+                &format!("\"credential\":{{\"kind\":\"{kind}\",\"value_base64\":\"YWJj\"}}"),
+            );
+            assert!(RequestEnvelope::from_json_slice(oversized.as_bytes(), &limits).is_err());
+        }
     }
 
     #[test]

--- a/src/transport_v2/envelope.rs
+++ b/src/transport_v2/envelope.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 const MIB: usize = 1024 * 1024;
 const KIB: usize = 1024;
@@ -182,7 +183,7 @@ fn hex_nibble(byte: u8) -> Option<u8> {
 }
 
 /// Exact bytes represented on the wire as padded standard base64.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Zeroize, ZeroizeOnDrop)]
 pub(crate) struct EncodedBytes(Vec<u8>);
 
 impl EncodedBytes {
@@ -194,8 +195,8 @@ impl EncodedBytes {
         &self.0
     }
 
-    pub(crate) fn into_bytes(self) -> Vec<u8> {
-        self.0
+    pub(crate) fn into_bytes(mut self) -> Vec<u8> {
+        std::mem::take(&mut self.0)
     }
 
     pub(crate) fn len(&self) -> usize {
@@ -726,6 +727,13 @@ mod tests {
     use super::*;
 
     const REQUEST_ID: &str = "00112233445566778899aabbccddeeff";
+
+    #[test]
+    fn decoded_byte_fields_zeroize_on_drop() {
+        fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
+
+        assert_zeroize_on_drop::<EncodedBytes>();
+    }
 
     fn request_json(body: &str) -> String {
         format!(

--- a/src/transport_v2/gateway.rs
+++ b/src/transport_v2/gateway.rs
@@ -1426,7 +1426,7 @@ mod tests {
         let master = SessionMaster::from_bytes(master_bytes);
         let client_keys = DirectionalKeys::derive(&master).unwrap();
         let encrypted = client_keys
-            .encrypt_request_record_with_nonce(&session_id, &plaintext, [0x53; 12])
+            .encrypt_request_record(&session_id, &plaintext)
             .unwrap();
         let dispatches = Arc::new(AtomicUsize::new(0));
 
@@ -1529,7 +1529,7 @@ mod tests {
         let invalid_plaintext =
             serde_json::to_vec(&get_user_envelope(request_id, Some(Vec::new()))).unwrap();
         let invalid_encrypted = client_keys
-            .encrypt_request_record_with_nonce(&session_id, &invalid_plaintext, [0x66; 12])
+            .encrypt_request_record(&session_id, &invalid_plaintext)
             .unwrap();
         let (lease, envelope) = state
             .decrypt_request_envelope(session_id, &invalid_encrypted, now)
@@ -1549,7 +1549,7 @@ mod tests {
 
         let valid_plaintext = serde_json::to_vec(&get_user_envelope(request_id, None)).unwrap();
         let valid_encrypted = client_keys
-            .encrypt_request_record_with_nonce(&session_id, &valid_plaintext, [0x67; 12])
+            .encrypt_request_record(&session_id, &valid_plaintext)
             .unwrap();
         let (lease, envelope) = state
             .decrypt_request_envelope(session_id, &valid_encrypted, now)

--- a/src/transport_v2/gateway.rs
+++ b/src/transport_v2/gateway.rs
@@ -1,13 +1,13 @@
 //! Isolated HTTP gateway for encrypted transport v2.
 //!
-//! This layer deliberately exposes no application operations yet. It owns the
-//! v2-only attestation and session caches, authenticates a complete encrypted
-//! request envelope, and returns an authenticated logical 404 through the exact
-//! session lease that decrypted the request. Later stack layers add explicit
-//! authentication and application-operation projections without re-entering
-//! the transport-v1 router.
+//! This layer owns the v2-only attestation and session caches, authenticates a
+//! complete encrypted request envelope, and dispatches only the explicitly
+//! projected application operations. Unsupported operations receive an
+//! authenticated logical 404 through the exact session lease that decrypted
+//! the request; transport v1 is never re-entered.
 
 use std::collections::hash_map::RandomState;
+use std::future::Future;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -28,15 +28,19 @@ use crate::encrypt::CustomRng;
 use crate::web::attestation_routes;
 use crate::{AppState, AsyncRngWrapper};
 
+use super::application::{
+    begin_authentication_transition, execute_user_operation, prepare_user_operation,
+    LogicalUnaryResponse, OperationPreparation,
+};
 use super::crypto::{
     encrypt_key_exchange_record, CryptoError, DirectionalKeys, HandshakePayload, SessionMaster,
 };
 use super::envelope::{
-    EncodedBytes, EnvelopeLimits, HeaderField, RequestEnvelope, UnaryResponseEnvelope, Version2,
+    EncodedBytes, EnvelopeLimits, RequestEnvelope, UnaryResponseEnvelope, Version2,
 };
 use super::session::{
-    GlobalReplayBudget, SessionRecordError, V2SessionState, DEFAULT_ABSOLUTE_SESSION_LIFETIME,
-    DEFAULT_GLOBAL_REPLAY_IDS,
+    GlobalReplayBudget, ReplayClaim, SessionRecordError, UnaryResponseReservation, V2SessionState,
+    DEFAULT_ABSOLUTE_SESSION_LIFETIME, DEFAULT_GLOBAL_REPLAY_IDS,
 };
 use super::session_cache::{V2SessionCache, V2SessionInsertError, V2SessionLease};
 use super::{MAX_LIVE_SESSIONS, MAX_PENDING_ATTESTATIONS};
@@ -353,26 +357,152 @@ impl TransportV2State {
 
     async fn process_encrypted_request(
         &self,
+        app_state: Arc<AppState>,
         session_id: Uuid,
         encrypted: &[u8],
         now: Instant,
     ) -> Result<EncryptedOuterResponse, GatewayError> {
+        let (lease, envelope) = self
+            .decrypt_request_envelope(session_id, encrypted, now)
+            .await?;
+        let request_id = envelope.request_id;
+
+        let operation = match prepare_user_operation(envelope, lease.state().authority()) {
+            OperationPreparation::Unsupported => {
+                return encrypt_new_logical_response(
+                    &lease,
+                    request_id,
+                    LogicalUnaryResponse::protocol_error(
+                        StatusCode::NOT_FOUND,
+                        "not_found",
+                        "Not found",
+                    ),
+                );
+            }
+            OperationPreparation::Rejected(response) => {
+                return encrypt_new_logical_response(&lease, request_id, response);
+            }
+            OperationPreparation::Ready(operation) => operation,
+        };
+
+        self.process_ready_operation(
+            &lease,
+            request_id,
+            operation,
+            now,
+            move |dispatch_lease, operation, authentication, admitted_at| {
+                execute_user_operation(
+                    app_state,
+                    dispatch_lease,
+                    operation,
+                    authentication,
+                    admitted_at,
+                )
+            },
+        )
+        .await
+    }
+
+    async fn process_ready_operation<Dispatch, DispatchFuture>(
+        &self,
+        lease: &V2SessionLease,
+        request_id: super::envelope::RequestId,
+        operation: super::application::UserOperation,
+        now: Instant,
+        dispatch: Dispatch,
+    ) -> Result<EncryptedOuterResponse, GatewayError>
+    where
+        Dispatch: FnOnce(
+            V2SessionLease,
+            super::application::UserOperation,
+            Option<super::session::AuthenticationReservation>,
+            Instant,
+        ) -> DispatchFuture,
+        DispatchFuture: Future<Output = super::application::ApplicationOutcome>,
+    {
+        // Reserve a response before consuming replay capacity or dispatching
+        // application work. Every admitted request can therefore receive one
+        // authenticated terminal result through this exact session lease.
+        let reservation = lease
+            .state()
+            .begin_unary_response()
+            .map_err(GatewayError::from_session_record)?;
+        match lease.state().claim_request_id(request_id) {
+            ReplayClaim::Claimed => {}
+            ReplayClaim::Duplicate => {
+                return encrypt_reserved_logical_response(
+                    lease,
+                    request_id,
+                    reservation,
+                    LogicalUnaryResponse::protocol_error(
+                        StatusCode::CONFLICT,
+                        "replay_detected",
+                        "Request identifier has already been used",
+                    ),
+                );
+            }
+            ReplayClaim::Exhausted => {
+                return encrypt_reserved_logical_response(
+                    lease,
+                    request_id,
+                    reservation,
+                    LogicalUnaryResponse::protocol_error(
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        "session_exhausted",
+                        "Session request capacity is exhausted",
+                    ),
+                );
+            }
+        }
+
+        let authentication = match begin_authentication_transition(&operation, lease, request_id) {
+            Ok(authentication) => authentication,
+            Err(response) => {
+                return encrypt_reserved_logical_response(lease, request_id, reservation, response);
+            }
+        };
+
+        if !self.mark_admitted(lease).await {
+            lease.state().close();
+            return encrypt_reserved_logical_response(
+                lease,
+                request_id,
+                reservation,
+                LogicalUnaryResponse::protocol_error(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "session_unavailable",
+                    "Session is unavailable",
+                ),
+            );
+        }
+
+        let outcome = dispatch(lease.clone(), operation, authentication, now).await;
+        let bound_session = outcome.bound_session;
+        let encrypted =
+            encrypt_reserved_logical_response(lease, request_id, reservation, outcome.response);
+        if encrypted.is_err() && bound_session {
+            // Never leave a newly authenticated session reachable when its
+            // only binding response could not be authenticated to the client.
+            lease.state().close();
+        }
+        encrypted
+    }
+
+    async fn decrypt_request_envelope(
+        &self,
+        session_id: Uuid,
+        encrypted: &[u8],
+        now: Instant,
+    ) -> Result<(V2SessionLease, RequestEnvelope), GatewayError> {
         let lease = self.acquire_session(&session_id, now).await?;
-        let plaintext = lease
+        let mut plaintext = lease
             .state()
             .decrypt_request_record(encrypted)
             .map_err(GatewayError::from_session_record)?;
-        let envelope = RequestEnvelope::from_json_slice(&plaintext, &EnvelopeLimits::default())
-            .map_err(|_| GatewayError::InvalidRequest)?;
-        drop(plaintext);
-        let request_id = envelope.request_id;
-        drop(envelope);
-
-        // This gateway stack intentionally exposes no application operations.
-        // Route validation therefore fails before the replay gate and before
-        // LRU promotion. The recovered request ID still permits an authenticated
-        // logical error through the exact lease selected above.
-        encrypt_unsupported_route(&lease, request_id)
+        let parsed = RequestEnvelope::from_json_slice(&plaintext, &EnvelopeLimits::default());
+        plaintext.zeroize();
+        let envelope = parsed.map_err(|_| GatewayError::InvalidRequest)?;
+        Ok((lease, envelope))
     }
 }
 
@@ -474,7 +604,12 @@ async fn encrypted_request(
 
     let response = app_state
         .transport_v2_state
-        .process_encrypted_request(session_id, &encrypted, Instant::now())
+        .process_encrypted_request(
+            Arc::clone(&app_state),
+            session_id,
+            &encrypted,
+            Instant::now(),
+        )
         .await?;
     drop(encrypted);
     drop(working_set_permit);
@@ -558,55 +693,61 @@ struct EncryptedOuterResponse {
     encrypted: EncodedBytes,
 }
 
-#[derive(Serialize)]
-struct LogicalErrorBody<'a> {
-    error: LogicalError<'a>,
-}
-
-#[derive(Serialize)]
-struct LogicalError<'a> {
-    code: &'a str,
-    message: &'a str,
-}
-
-fn encrypt_unsupported_route(
+fn encrypt_new_logical_response(
     lease: &V2SessionLease,
     request_id: super::envelope::RequestId,
+    response: LogicalUnaryResponse,
 ) -> Result<EncryptedOuterResponse, GatewayError> {
-    let body = serde_json::to_vec(&LogicalErrorBody {
-        error: LogicalError {
-            code: "not_found",
-            message: "Not found",
-        },
-    })
-    .map_err(|_| GatewayError::Internal)?;
-    let response = UnaryResponseEnvelope {
-        version: Version2,
-        request_id,
-        status: StatusCode::NOT_FOUND.as_u16(),
-        headers: vec![HeaderField {
-            name: "content-type".to_owned(),
-            value_base64: EncodedBytes::from_bytes(b"application/json".to_vec()),
-        }],
-        body_base64: Some(EncodedBytes::from_bytes(body)),
-    };
-    response
-        .validate(&EnvelopeLimits::default())
-        .map_err(|_| GatewayError::Internal)?;
-    let plaintext = serde_json::to_vec(&response).map_err(|_| GatewayError::Internal)?;
-
-    let mut reservation = lease
+    let reservation = lease
         .state()
         .begin_unary_response()
         .map_err(GatewayError::from_session_record)?;
-    let encrypted = lease
+    encrypt_reserved_logical_response(lease, request_id, reservation, response)
+}
+
+fn encrypt_reserved_logical_response(
+    lease: &V2SessionLease,
+    request_id: super::envelope::RequestId,
+    mut reservation: UnaryResponseReservation,
+    response: LogicalUnaryResponse,
+) -> Result<EncryptedOuterResponse, GatewayError> {
+    let mut response = UnaryResponseEnvelope {
+        version: Version2,
+        request_id,
+        status: response.status.as_u16(),
+        headers: response.headers,
+        body_base64: response.body.map(EncodedBytes::from_bytes),
+    };
+    if response.validate(&EnvelopeLimits::default()).is_err() {
+        zeroize_response_body(&mut response);
+        return Err(GatewayError::Internal);
+    }
+    let mut plaintext = match serde_json::to_vec(&response) {
+        Ok(plaintext) => plaintext,
+        Err(_) => {
+            zeroize_response_body(&mut response);
+            return Err(GatewayError::Internal);
+        }
+    };
+    zeroize_response_body(&mut response);
+
+    let result = lease
         .state()
         .encrypt_unary_response_record(&mut reservation, &request_id, &plaintext)
-        .map_err(GatewayError::from_session_record)?;
+        .map_err(GatewayError::from_session_record);
+    plaintext.zeroize();
+    let encrypted = result?;
 
     Ok(EncryptedOuterResponse {
         encrypted: EncodedBytes::from_bytes(encrypted),
     })
+}
+
+fn zeroize_response_body(response: &mut UnaryResponseEnvelope) {
+    if let Some(body) = response.body_base64.take() {
+        let mut bytes = body.into_bytes();
+        bytes.zeroize();
+    }
 }
 
 fn parse_key_exchange_request(
@@ -823,9 +964,15 @@ impl IntoResponse for GatewayError {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use super::*;
+    use crate::jwt::{AuthContext, AuthMethod};
     use crate::transport_v2::crypto::{decrypt_key_exchange_record, SessionMaster};
-    use crate::transport_v2::envelope::{LogicalMethod, LogicalRequest, RequestId, ResponseMode};
+    use crate::transport_v2::envelope::{
+        HeaderField, LogicalMethod, LogicalRequest, RequestId, ResponseMode,
+    };
+    use crate::transport_v2::session::{AuthorityState, BoundAuthority};
 
     fn test_session(
         session_id: Uuid,
@@ -857,6 +1004,66 @@ mod tests {
                 body_base64: None,
             },
         }
+    }
+
+    fn login_envelope(request_id: RequestId) -> RequestEnvelope {
+        RequestEnvelope {
+            version: Version2,
+            request_id,
+            response_mode: ResponseMode::Unary,
+            credential: None,
+            request: LogicalRequest {
+                method: LogicalMethod::Post,
+                path: "/login".to_owned(),
+                query: None,
+                headers: vec![HeaderField {
+                    name: "content-type".to_owned(),
+                    value_base64: EncodedBytes::from_bytes(b"application/json".to_vec()),
+                }],
+                body_base64: Some(EncodedBytes::from_bytes(b"{}".to_vec())),
+            },
+        }
+    }
+
+    fn get_user_envelope(request_id: RequestId, body: Option<Vec<u8>>) -> RequestEnvelope {
+        RequestEnvelope {
+            version: Version2,
+            request_id,
+            response_mode: ResponseMode::Unary,
+            credential: None,
+            request: LogicalRequest {
+                method: LogicalMethod::Get,
+                path: "/protected/user".to_owned(),
+                query: None,
+                headers: Vec::new(),
+                body_base64: body.map(EncodedBytes::from_bytes),
+            },
+        }
+    }
+
+    fn successful_test_outcome() -> super::super::application::ApplicationOutcome {
+        super::super::application::ApplicationOutcome {
+            response: LogicalUnaryResponse {
+                status: StatusCode::OK,
+                headers: Vec::new(),
+                body: Some(br#"{"ok":true}"#.to_vec()),
+            },
+            bound_session: false,
+        }
+    }
+
+    fn response_status(
+        keys: &DirectionalKeys,
+        session_id: &Uuid,
+        request_id: &RequestId,
+        response: &EncryptedOuterResponse,
+    ) -> u16 {
+        let plaintext = keys
+            .decrypt_unary_response_record(session_id, request_id, response.encrypted.as_slice())
+            .expect("decrypt authenticated unary response");
+        UnaryResponseEnvelope::from_json_slice(&plaintext, &EnvelopeLimits::default())
+            .expect("parse authenticated unary response")
+            .status
     }
 
     #[test]
@@ -1157,10 +1364,21 @@ mod tests {
             .encrypt_request_record(&first_id, &request_plaintext)
             .unwrap();
 
-        let response = state
-            .process_encrypted_request(first_id, &encrypted_request, now)
+        let (lease, envelope) = state
+            .decrypt_request_envelope(first_id, &encrypted_request, now)
             .await
-            .expect("authenticated logical error");
+            .expect("authenticated logical request");
+        let request_id = envelope.request_id;
+        assert!(matches!(
+            prepare_user_operation(envelope, lease.state().authority()),
+            OperationPreparation::Unsupported
+        ));
+        let response = encrypt_new_logical_response(
+            &lease,
+            request_id,
+            LogicalUnaryResponse::protocol_error(StatusCode::NOT_FOUND, "not_found", "Not found"),
+        )
+        .expect("authenticated logical error");
         let response_plaintext = client_keys
             .decrypt_unary_response_record(&first_id, &request_id, response.encrypted.as_slice())
             .expect("first session opens its response");
@@ -1185,6 +1403,181 @@ mod tests {
         // admission promotion.
         let first_lease = state.acquire_session(&first_id, now).await.unwrap();
         assert_eq!(first_lease.state().replay_id_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn duplicate_request_id_dispatches_exactly_once() {
+        let state = TransportV2State::new();
+        let now = Instant::now();
+        let session_id = Uuid::new_v4();
+        let master_bytes = [0x51; 32];
+        state
+            .insert_session(test_session(
+                session_id,
+                master_bytes,
+                now + Duration::from_secs(60),
+                Arc::clone(&state.global_replay_budget),
+            ))
+            .await
+            .unwrap();
+
+        let request_id = RequestId::from_bytes([0x52; 16]);
+        let plaintext = serde_json::to_vec(&login_envelope(request_id)).unwrap();
+        let master = SessionMaster::from_bytes(master_bytes);
+        let client_keys = DirectionalKeys::derive(&master).unwrap();
+        let encrypted = client_keys
+            .encrypt_request_record_with_nonce(&session_id, &plaintext, [0x53; 12])
+            .unwrap();
+        let dispatches = Arc::new(AtomicUsize::new(0));
+
+        let (lease, envelope) = state
+            .decrypt_request_envelope(session_id, &encrypted, now)
+            .await
+            .unwrap();
+        let OperationPreparation::Ready(operation) =
+            prepare_user_operation(envelope, lease.state().authority())
+        else {
+            panic!("valid login operation must be ready");
+        };
+        let first_dispatches = Arc::clone(&dispatches);
+        let first = state
+            .process_ready_operation(
+                &lease,
+                request_id,
+                operation,
+                now,
+                move |_lease, _operation, authentication, _| async move {
+                    first_dispatches.fetch_add(1, Ordering::SeqCst);
+                    drop(authentication);
+                    successful_test_outcome()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response_status(&client_keys, &session_id, &request_id, &first),
+            200
+        );
+
+        let (lease, envelope) = state
+            .decrypt_request_envelope(session_id, &encrypted, now)
+            .await
+            .unwrap();
+        let OperationPreparation::Ready(operation) =
+            prepare_user_operation(envelope, lease.state().authority())
+        else {
+            panic!("failed authentication reservation must restore anonymous authority");
+        };
+        let second_dispatches = Arc::clone(&dispatches);
+        let duplicate = state
+            .process_ready_operation(
+                &lease,
+                request_id,
+                operation,
+                now,
+                move |_lease, _operation, authentication, _| async move {
+                    second_dispatches.fetch_add(1, Ordering::SeqCst);
+                    drop(authentication);
+                    successful_test_outcome()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response_status(&client_keys, &session_id, &request_id, &duplicate),
+            409
+        );
+        assert_eq!(dispatches.load(Ordering::SeqCst), 1);
+        assert_eq!(lease.state().replay_id_count(), 1);
+        assert!(matches!(
+            lease.state().authority(),
+            AuthorityState::Anonymous
+        ));
+    }
+
+    #[tokio::test]
+    async fn invalid_bodyless_shape_does_not_consume_replay_id() {
+        let state = TransportV2State::new();
+        let now = Instant::now();
+        let session_id = Uuid::new_v4();
+        let master_bytes = [0x61; 32];
+        let session = test_session(
+            session_id,
+            master_bytes,
+            now + Duration::from_secs(60),
+            Arc::clone(&state.global_replay_budget),
+        );
+        let auth_context = AuthContext::new(AuthMethod::Password, 7, [0x62; 32]);
+        session
+            .begin_authentication(RequestId::from_bytes([0x63; 16]))
+            .unwrap()
+            .commit_at(
+                BoundAuthority::user(
+                    Uuid::from_bytes([0x64; 16]),
+                    7,
+                    &auth_context,
+                    now + Duration::from_secs(30),
+                ),
+                now,
+            )
+            .unwrap();
+        state.insert_session(session).await.unwrap();
+
+        let request_id = RequestId::from_bytes([0x65; 16]);
+        let master = SessionMaster::from_bytes(master_bytes);
+        let client_keys = DirectionalKeys::derive(&master).unwrap();
+        let invalid_plaintext =
+            serde_json::to_vec(&get_user_envelope(request_id, Some(Vec::new()))).unwrap();
+        let invalid_encrypted = client_keys
+            .encrypt_request_record_with_nonce(&session_id, &invalid_plaintext, [0x66; 12])
+            .unwrap();
+        let (lease, envelope) = state
+            .decrypt_request_envelope(session_id, &invalid_encrypted, now)
+            .await
+            .unwrap();
+        let OperationPreparation::Rejected(rejection) =
+            prepare_user_operation(envelope, lease.state().authority())
+        else {
+            panic!("an explicit empty body is not a bodyless request");
+        };
+        let response = encrypt_new_logical_response(&lease, request_id, rejection).unwrap();
+        assert_eq!(
+            response_status(&client_keys, &session_id, &request_id, &response),
+            400
+        );
+        assert_eq!(lease.state().replay_id_count(), 0);
+
+        let valid_plaintext = serde_json::to_vec(&get_user_envelope(request_id, None)).unwrap();
+        let valid_encrypted = client_keys
+            .encrypt_request_record_with_nonce(&session_id, &valid_plaintext, [0x67; 12])
+            .unwrap();
+        let (lease, envelope) = state
+            .decrypt_request_envelope(session_id, &valid_encrypted, now)
+            .await
+            .unwrap();
+        let OperationPreparation::Ready(operation) =
+            prepare_user_operation(envelope, lease.state().authority())
+        else {
+            panic!("a null body is a valid bodyless protected request");
+        };
+        let response = state
+            .process_ready_operation(
+                &lease,
+                request_id,
+                operation,
+                now,
+                |_lease, _operation, authentication, _| async move {
+                    assert!(authentication.is_none());
+                    successful_test_outcome()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response_status(&client_keys, &session_id, &request_id, &response),
+            200
+        );
+        assert_eq!(lease.state().replay_id_count(), 1);
     }
 
     #[tokio::test]

--- a/src/transport_v2/mod.rs
+++ b/src/transport_v2/mod.rs
@@ -6,6 +6,7 @@
 
 #![allow(dead_code)]
 
+mod application;
 mod crypto;
 mod envelope;
 mod gateway;

--- a/src/transport_v2/session.rs
+++ b/src/transport_v2/session.rs
@@ -5,6 +5,9 @@ use std::time::{Duration, Instant};
 
 use uuid::Uuid;
 
+use crate::jwt::AuthContext;
+use crate::VerifiedUserAuthentication;
+
 use super::crypto::{CryptoError, DirectionalKeys};
 use super::envelope::RequestId;
 
@@ -196,17 +199,27 @@ impl Drop for ReplayRegistry {
 
 #[derive(Clone, Eq, PartialEq)]
 pub(crate) enum BoundPrincipal {
-    User { user_id: Uuid, project_id: i32 },
-    Platform { platform_user_id: Uuid },
-    ApiKey { api_key_id: i32, user_id: Uuid },
+    User {
+        user_id: Uuid,
+        project_id: i32,
+        auth_context: AuthContext,
+    },
+    Platform {
+        platform_user_id: Uuid,
+    },
+    ApiKey {
+        api_key_id: i32,
+        user_id: Uuid,
+    },
 }
 
 /// Stable authority identity retained by the transport session.
 ///
-/// Credential-derived authorization context remains an application concern in
-/// the binding PR. API keys have no independent token expiry, so their
-/// authority remains bounded by the session's absolute expiry and live
-/// database checks.
+/// User authorities retain the exact credential-derived authorization context
+/// accepted at binding so later requests can revalidate that same authority
+/// against live application state. API keys have no independent token expiry,
+/// so their authority remains bounded by the session's absolute expiry and
+/// live database checks.
 #[derive(Clone, Eq, PartialEq)]
 pub(crate) struct BoundAuthority {
     principal: BoundPrincipal,
@@ -214,15 +227,32 @@ pub(crate) struct BoundAuthority {
 }
 
 impl BoundAuthority {
-    pub(crate) const fn user(
+    pub(crate) fn verified_user(
+        verified: &VerifiedUserAuthentication,
+        authentication_expires_at: Instant,
+    ) -> Self {
+        Self {
+            principal: BoundPrincipal::User {
+                user_id: verified.user.get_id(),
+                project_id: verified.user.project_id,
+                auth_context: verified.auth_context.clone(),
+            },
+            authentication_expires_at: Some(authentication_expires_at),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn user(
         user_id: Uuid,
         project_id: i32,
+        auth_context: &AuthContext,
         authentication_expires_at: Instant,
     ) -> Self {
         Self {
             principal: BoundPrincipal::User {
                 user_id,
                 project_id,
+                auth_context: auth_context.clone(),
             },
             authentication_expires_at: Some(authentication_expires_at),
         }
@@ -933,6 +963,8 @@ mod tests {
     use std::sync::Barrier;
     use std::thread;
 
+    use crate::jwt::AuthMethod;
+
     use super::super::crypto::SessionMaster;
     use super::*;
 
@@ -954,6 +986,10 @@ mod tests {
             global,
             limits,
         )
+    }
+
+    fn user_auth_context(project_id: i32) -> AuthContext {
+        AuthContext::new(AuthMethod::Password, project_id, [0x7a; 32])
     }
 
     #[test]
@@ -1077,22 +1113,30 @@ mod tests {
         let authority = Arc::new(AuthorityCell::new());
         let now = Instant::now();
         let user = Uuid::new_v4();
+        let mut auth_context = user_auth_context(17);
+        let expected_auth_context = auth_context.clone();
 
         authority
             .begin(request_id(1))
             .expect("reserve auth")
             .commit_at(
-                BoundAuthority::user(user, 17, now + Duration::from_secs(30)),
+                BoundAuthority::user(user, 17, &auth_context, now + Duration::from_secs(30)),
                 now,
             )
             .expect("commit auth");
+        auth_context.auth_binding = [0x33; 32];
 
         match authority.snapshot() {
             AuthorityState::Bound(bound) => {
                 assert!(matches!(
                     bound.principal(),
-                    BoundPrincipal::User { user_id, project_id }
-                        if *user_id == user && *project_id == 17
+                    BoundPrincipal::User {
+                        user_id,
+                        project_id,
+                        auth_context: bound_auth_context,
+                    } if *user_id == user
+                        && *project_id == 17
+                        && bound_auth_context == &expected_auth_context
                 ));
             }
             _ => panic!("authority was not bound"),
@@ -1122,11 +1166,17 @@ mod tests {
         let authority = Arc::new(AuthorityCell::new());
         let now = Instant::now();
         let reservation = authority.begin(request_id(1)).expect("reserve auth");
+        let auth_context = user_auth_context(7);
 
         *lock_unpoisoned(&authority.state) = AuthorityState::Authenticating(request_id(2));
         let error = reservation
             .commit_at(
-                BoundAuthority::user(Uuid::new_v4(), 7, now + Duration::from_secs(30)),
+                BoundAuthority::user(
+                    Uuid::new_v4(),
+                    7,
+                    &auth_context,
+                    now + Duration::from_secs(30),
+                ),
                 now,
             )
             .expect_err("stale reservation must not commit");
@@ -1233,7 +1283,10 @@ mod tests {
         state
             .begin_authentication(request_id(1))
             .expect("reserve auth")
-            .commit_at(BoundAuthority::user(Uuid::new_v4(), 3, auth_expiry), now)
+            .commit_at(
+                BoundAuthority::user(Uuid::new_v4(), 3, &user_auth_context(3), auth_expiry),
+                now,
+            )
             .expect("bind authority");
 
         assert!(state.accepts_new_requests_at(auth_expiry - Duration::from_nanos(1)));

--- a/src/web/login_routes.rs
+++ b/src/web/login_routes.rs
@@ -1,4 +1,3 @@
-use crate::User;
 use crate::{
     db::DBError,
     email::{send_hello_email, send_verification_email},
@@ -14,6 +13,7 @@ use crate::{
     Error,
 };
 use crate::{ApiError, AppState};
+use crate::{User, VerifiedUserAuthentication};
 use axum::{
     extract::{Path, State},
     middleware::from_fn_with_state,
@@ -125,8 +125,8 @@ pub struct RefreshRequest {
 
 #[derive(Serialize)]
 pub struct RefreshResponse {
-    access_token: String,
-    refresh_token: String,
+    pub(crate) access_token: String,
+    pub(crate) refresh_token: String,
 }
 
 #[derive(Deserialize, Clone)]
@@ -147,6 +147,14 @@ pub async fn login(
 }
 
 async fn login_internal(data: Arc<AppState>, creds: Credentials) -> Result<AuthResponse, ApiError> {
+    let verified = authenticate_login(data.clone(), creds).await?;
+    v1_auth_response(&data, &verified)
+}
+
+pub(crate) async fn authenticate_login(
+    data: Arc<AppState>,
+    creds: Credentials,
+) -> Result<VerifiedUserAuthentication, ApiError> {
     // First get the project by client_id and verify it's active
     let project = data
         .db
@@ -211,27 +219,7 @@ async fn login_internal(data: Arc<AppState>, creds: Credentials) -> Result<AuthR
         .authenticate_user(creds.email, creds.id, creds.password, project.id)
         .await
     {
-        Ok(Some(authenticated_user)) => {
-            let access_token = NewToken::new_with_auth_context(
-                &authenticated_user.user,
-                TokenType::Access,
-                &data,
-                &authenticated_user.auth_context,
-            )?;
-            let refresh_token = NewToken::new_with_auth_context(
-                &authenticated_user.user,
-                TokenType::Refresh,
-                &data,
-                &authenticated_user.auth_context,
-            )?;
-            let auth_response = AuthResponse {
-                id: authenticated_user.user.get_id(),
-                email: authenticated_user.user.get_email().map(|s| s.to_string()),
-                access_token: access_token.token,
-                refresh_token: refresh_token.token,
-            };
-            Ok(auth_response)
-        }
+        Ok(Some(authenticated_user)) => Ok(authenticated_user),
         Ok(None) => {
             error!("Invalid password attempt");
             Err(ApiError::InvalidUsernameOrPassword)
@@ -241,6 +229,30 @@ async fn login_internal(data: Arc<AppState>, creds: Credentials) -> Result<AuthR
             Err(ApiError::InternalServerError)
         }
     }
+}
+
+pub(crate) fn v1_auth_response(
+    data: &AppState,
+    verified: &VerifiedUserAuthentication,
+) -> Result<AuthResponse, ApiError> {
+    let access_token = NewToken::new_with_auth_context(
+        &verified.user,
+        TokenType::Access,
+        data,
+        &verified.auth_context,
+    )?;
+    let refresh_token = NewToken::new_with_auth_context(
+        &verified.user,
+        TokenType::Refresh,
+        data,
+        &verified.auth_context,
+    )?;
+    Ok(AuthResponse {
+        id: verified.user.get_id(),
+        email: verified.user.get_email().map(|s| s.to_string()),
+        access_token: access_token.token,
+        refresh_token: refresh_token.token,
+    })
 }
 
 pub async fn logout(
@@ -263,6 +275,17 @@ pub async fn register(
 ) -> Result<Json<EncryptedResponse<AuthResponse>>, ApiError> {
     tracing::trace!("call register");
 
+    let verified = register_and_authenticate(data.clone(), creds).await?;
+    let auth_response = v1_auth_response(&data, &verified)?;
+
+    let result = encrypt_response(&data, &session_id, &auth_response).await;
+    result
+}
+
+pub(crate) async fn register_and_authenticate(
+    data: Arc<AppState>,
+    creds: RegisterCredentials,
+) -> Result<VerifiedUserAuthentication, ApiError> {
     let user = match data.register_user(creds.clone()).await {
         Ok(user) => user,
         Err(Error::UserAlreadyExists) => {
@@ -279,7 +302,7 @@ pub async fn register(
     handle_new_user_registration(&data, &user, true).await?;
 
     // After registration, proceed with login
-    let login_result = login_internal(
+    authenticate_login(
         data.clone(),
         Credentials {
             email: creds.email,
@@ -288,10 +311,7 @@ pub async fn register(
             client_id: creds.client_id,
         },
     )
-    .await?;
-
-    let result = encrypt_response(&data, &session_id, &login_result).await;
-    result
+    .await
 }
 
 pub async fn handle_new_user_registration(

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -558,7 +558,15 @@ pub async fn user_protected(
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<ProtectedUserData>>, ApiError> {
-    let mut app_user: AppUser = AppUser::from(&user);
+    let response = protected_user_data(&data, &user)?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) fn protected_user_data(
+    data: &AppState,
+    user: &User,
+) -> Result<ProtectedUserData, ApiError> {
+    let mut app_user: AppUser = AppUser::from(user);
 
     // Set email verification status - only if not a guest user
     app_user.email_verified = if user.is_guest() {
@@ -616,8 +624,7 @@ pub async fn user_protected(
         }
     }
 
-    let response = ProtectedUserData { user: app_user };
-    encrypt_response(&data, &session_id, &response).await
+    Ok(ProtectedUserData { user: app_user })
 }
 
 pub async fn get_kv(

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -35,6 +35,7 @@ use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 use validator::Validate;
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -100,7 +101,7 @@ pub struct ConfirmAccountDeletionRequest {
     pub plaintext_secret: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Zeroize, ZeroizeOnDrop)]
 pub struct PrivateKeyResponse {
     /// Root mnemonic or derived mnemonic if BIP-85 path is specified
     mnemonic: String,
@@ -108,7 +109,7 @@ pub struct PrivateKeyResponse {
 
 /// Response struct for the private key bytes endpoint.
 /// Contains the private key encoded as a hexadecimal string.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Zeroize, ZeroizeOnDrop)]
 pub struct PrivateKeyBytesResponse {
     /// The private key as a 64-character hexadecimal string (32 bytes).
     /// This is the standard secp256k1 private key format.
@@ -349,7 +350,7 @@ pub struct ThirdPartyTokenRequest {
     pub audience: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Zeroize, ZeroizeOnDrop)]
 pub struct ThirdPartyTokenResponse {
     pub token: String,
 }
@@ -857,11 +858,21 @@ pub async fn get_private_key(
     Extension(session_id): Extension<TransportSession>,
     Query(query): Query<DerivationPathQuery>,
 ) -> Result<Json<EncryptedResponse<PrivateKeyResponse>>, ApiError> {
+    let response = private_key_data(&data, &user, &auth_context, query)?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) fn private_key_data(
+    data: &AppState,
+    user: &User,
+    auth_context: &AuthContext,
+    query: DerivationPathQuery,
+) -> Result<PrivateKeyResponse, ApiError> {
     // Validate paths if present
     query.validate()?;
 
     let plaintext_seed = data
-        .decrypt_seed_for_auth_context(&user, &auth_context)
+        .decrypt_seed_for_auth_context(user, auth_context)
         .map_err(|e| {
             error!("Failed to decrypt authenticated seed wrap: {:?}", e);
             ApiError::Unauthorized
@@ -884,14 +895,14 @@ pub async fn get_private_key(
             mnemonic: child_mnemonic.to_string(),
         };
 
-        encrypt_response(&data, &session_id, &response).await
+        Ok(response)
     } else {
         // Return root mnemonic
         let response = PrivateKeyResponse {
             mnemonic: root_mnemonic.to_string(),
         };
 
-        encrypt_response(&data, &session_id, &response).await
+        Ok(response)
     }
 }
 
@@ -902,14 +913,24 @@ pub async fn get_private_key_bytes(
     Extension(session_id): Extension<TransportSession>,
     Query(query): Query<DerivationPathQuery>,
 ) -> Result<Json<EncryptedResponse<PrivateKeyBytesResponse>>, ApiError> {
+    let response = private_key_bytes_data(&data, &user, &auth_context, query).await?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn private_key_bytes_data(
+    data: &AppState,
+    user: &User,
+    auth_context: &AuthContext,
+    query: DerivationPathQuery,
+) -> Result<PrivateKeyBytesResponse, ApiError> {
     // Validate derivation path if present
     query.validate()?;
 
     // Use the method that supports both BIP-85 and BIP-32 derivation
     let secret_key = data
         .get_user_key(
-            &user,
-            &auth_context,
+            user,
+            auth_context,
             query.key_options.private_key_derivation_path.as_deref(),
             query.key_options.seed_phrase_derivation_path.as_deref(),
         )
@@ -934,7 +955,7 @@ pub async fn get_private_key_bytes(
         private_key: secret_key.display_secret().to_string(),
     };
 
-    encrypt_response(&data, &session_id, &response).await
+    Ok(response)
 }
 
 pub async fn sign_message(
@@ -944,6 +965,16 @@ pub async fn sign_message(
     Extension(sign_request): Extension<SignMessageRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<SignMessageResponseJson>>, ApiError> {
+    let response = sign_message_data(&data, &user, &auth_context, sign_request).await?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn sign_message_data(
+    data: &AppState,
+    user: &User,
+    auth_context: &AuthContext,
+    mut sign_request: SignMessageRequest,
+) -> Result<SignMessageResponseJson, ApiError> {
     // Validate key_options
     let validation_query = DerivationPathQuery {
         key_options: sign_request.key_options.clone(),
@@ -960,17 +991,20 @@ pub async fn sign_message(
         .seed_phrase_derivation_path
         .as_deref();
 
-    let message_bytes = general_purpose::STANDARD
-        .decode(&sign_request.message_base64)
-        .map_err(|e| {
-            error!("Failed to decode base64 message: {:?}", e);
-            ApiError::BadRequest
-        })?;
+    let message_base64 = Zeroizing::new(std::mem::take(&mut sign_request.message_base64));
+    let message_bytes = Zeroizing::new(
+        general_purpose::STANDARD
+            .decode(message_base64.as_bytes())
+            .map_err(|e| {
+                error!("Failed to decode base64 message: {:?}", e);
+                ApiError::BadRequest
+            })?,
+    );
 
     let response = data
         .sign_message(
-            &user,
-            &auth_context,
+            user,
+            auth_context,
             &message_bytes,
             sign_request.algorithm,
             derivation_path,
@@ -987,7 +1021,7 @@ pub async fn sign_message(
         message_hash: hex::encode(response.message_hash),
     };
 
-    encrypt_response(&data, &session_id, &json_response).await
+    Ok(json_response)
 }
 
 pub async fn get_public_key(
@@ -997,6 +1031,16 @@ pub async fn get_public_key(
     Extension(session_id): Extension<TransportSession>,
     Query(query): Query<PublicKeyQuery>,
 ) -> Result<Json<EncryptedResponse<PublicKeyResponseJson>>, ApiError> {
+    let response = public_key_data(&data, &user, &auth_context, query).await?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn public_key_data(
+    data: &AppState,
+    user: &User,
+    auth_context: &AuthContext,
+    query: PublicKeyQuery,
+) -> Result<PublicKeyResponseJson, ApiError> {
     // Validate the key_options
     let validation_query = DerivationPathQuery {
         key_options: query.key_options.clone(),
@@ -1009,8 +1053,8 @@ pub async fn get_public_key(
 
     let user_secret_key = data
         .get_user_key(
-            &user,
-            &auth_context,
+            user,
+            auth_context,
             derivation_path,
             seed_phrase_derivation_path,
         )
@@ -1039,7 +1083,7 @@ pub async fn get_public_key(
         public_key: public_key_str,
         algorithm: query.algorithm,
     };
-    encrypt_response(&data, &session_id, &response).await
+    Ok(response)
 }
 
 pub async fn generate_third_party_token(
@@ -1048,6 +1092,15 @@ pub async fn generate_third_party_token(
     Extension(request): Extension<ThirdPartyTokenRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<ThirdPartyTokenResponse>>, ApiError> {
+    let response = third_party_token_data(&data, &user, request)?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) fn third_party_token_data(
+    data: &AppState,
+    user: &User,
+    request: ThirdPartyTokenRequest,
+) -> Result<ThirdPartyTokenResponse, ApiError> {
     // Validate the audience
     if let Some(audience) = request.audience.as_ref() {
         if audience.is_empty() || (audience.contains(':') && url::Url::parse(audience).is_err()) {
@@ -1059,12 +1112,12 @@ pub async fn generate_third_party_token(
     let project = data.db.get_org_project_by_id(user.project_id)?;
 
     let token = match NewToken::new(
-        &user,
+        user,
         TokenType::ThirdParty {
             aud: request.audience,
             azp: project.client_id.to_string(),
         },
-        &data,
+        data,
     ) {
         Ok(token) => token,
         Err(e) => {
@@ -1074,7 +1127,7 @@ pub async fn generate_third_party_token(
     };
 
     let response = ThirdPartyTokenResponse { token: token.token };
-    encrypt_response(&data, &session_id, &response).await
+    Ok(response)
 }
 
 pub async fn encrypt_data(
@@ -1399,6 +1452,15 @@ mod tests {
     use super::*;
     use crate::encrypt::{decrypt_with_key, encrypt_with_key};
     use secp256k1::SecretKey;
+
+    #[test]
+    fn sensitive_response_types_zeroize_on_drop() {
+        fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
+
+        assert_zeroize_on_drop::<PrivateKeyResponse>();
+        assert_zeroize_on_drop::<PrivateKeyBytesResponse>();
+        assert_zeroize_on_drop::<ThirdPartyTokenResponse>();
+    }
 
     #[test]
     fn test_derivation_path_validation() {

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -355,22 +355,24 @@ pub struct ThirdPartyTokenResponse {
     pub token: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct EncryptDataRequest {
     pub data: String,
     #[serde(default)]
+    #[zeroize(skip)]
     pub key_options: KeyOptions,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Zeroize, ZeroizeOnDrop)]
 pub struct EncryptDataResponse {
     pub encrypted_data: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct DecryptDataRequest {
     pub encrypted_data: String,
     #[serde(default)]
+    #[zeroize(skip)]
     pub key_options: KeyOptions,
 }
 
@@ -1137,6 +1139,18 @@ pub async fn encrypt_data(
     Extension(request): Extension<EncryptDataRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<EncryptDataResponse>>, ApiError> {
+    let response = encrypt_data_value(&data, &user, &auth_context, request).await?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn encrypt_data_value(
+    data: &AppState,
+    user: &User,
+    auth_context: &AuthContext,
+    mut request: EncryptDataRequest,
+) -> Result<EncryptDataResponse, ApiError> {
+    let plaintext = Zeroizing::new(std::mem::take(&mut request.data));
+
     // Validate key_options
     let validation_query = DerivationPathQuery {
         key_options: request.key_options.clone(),
@@ -1150,8 +1164,8 @@ pub async fn encrypt_data(
     // Get the user's key
     let user_key = data
         .get_user_key(
-            &user,
-            &auth_context,
+            user,
+            auth_context,
             derivation_path,
             seed_phrase_derivation_path,
         )
@@ -1172,8 +1186,8 @@ pub async fn encrypt_data(
         })?;
 
     // Encrypt the data
-    let data_bytes = request.data.as_bytes();
-    let encrypted_data = encrypt::encrypt_with_key(&user_key, data_bytes).await;
+    let encrypted_data =
+        Zeroizing::new(encrypt::encrypt_with_key(&user_key, plaintext.as_bytes()).await);
 
     // Convert to base64 for easy transport
     let encrypted_data_base64 = general_purpose::STANDARD.encode(&encrypted_data);
@@ -1181,7 +1195,7 @@ pub async fn encrypt_data(
     let response = EncryptDataResponse {
         encrypted_data: encrypted_data_base64,
     };
-    encrypt_response(&data, &session_id, &response).await
+    Ok(response)
 }
 
 pub async fn decrypt_data(
@@ -1191,6 +1205,18 @@ pub async fn decrypt_data(
     Extension(request): Extension<DecryptDataRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<String>>, ApiError> {
+    let response = decrypt_data_value(&data, &user, &auth_context, request).await?;
+    encrypt_response(&data, &session_id, &*response).await
+}
+
+pub(crate) async fn decrypt_data_value(
+    data: &AppState,
+    user: &User,
+    auth_context: &AuthContext,
+    mut request: DecryptDataRequest,
+) -> Result<Zeroizing<String>, ApiError> {
+    let encrypted_data_base64 = Zeroizing::new(std::mem::take(&mut request.encrypted_data));
+
     // Validate key_options
     let validation_query = DerivationPathQuery {
         key_options: request.key_options.clone(),
@@ -1204,8 +1230,8 @@ pub async fn decrypt_data(
     // Get the user's key
     let user_key = data
         .get_user_key(
-            &user,
-            &auth_context,
+            user,
+            auth_context,
             derivation_path,
             seed_phrase_derivation_path,
         )
@@ -1226,8 +1252,8 @@ pub async fn decrypt_data(
         })?;
 
     // Decode the base64 encrypted data
-    let encrypted_data = match general_purpose::STANDARD.decode(&request.encrypted_data) {
-        Ok(data) => data,
+    let encrypted_data = match general_purpose::STANDARD.decode(encrypted_data_base64.as_bytes()) {
+        Ok(data) => Zeroizing::new(data),
         Err(e) => {
             error!("Failed to decode base64 data: {e}");
             return Err(ApiError::BadRequest);
@@ -1245,13 +1271,15 @@ pub async fn decrypt_data(
 
     // Convert decrypted bytes to string
     let decrypted_string = match String::from_utf8(decrypted_data) {
-        Ok(s) => s,
+        Ok(s) => Zeroizing::new(s),
         Err(e) => {
             error!("Failed to convert decrypted data to string: {e}");
+            let mut bytes = e.into_bytes();
+            bytes.zeroize();
             return Err(ApiError::BadRequest);
         }
     };
-    encrypt_response(&data, &session_id, &decrypted_string).await
+    Ok(decrypted_string)
 }
 
 pub async fn initiate_account_deletion(
@@ -1460,6 +1488,9 @@ mod tests {
         assert_zeroize_on_drop::<PrivateKeyResponse>();
         assert_zeroize_on_drop::<PrivateKeyBytesResponse>();
         assert_zeroize_on_drop::<ThirdPartyTokenResponse>();
+        assert_zeroize_on_drop::<EncryptDataRequest>();
+        assert_zeroize_on_drop::<EncryptDataResponse>();
+        assert_zeroize_on_drop::<DecryptDataRequest>();
     }
 
     #[test]
@@ -1605,6 +1636,7 @@ mod tests {
 
         // First encryption
         let encrypted1 = encrypt_with_key(&test_key, empty_array).await;
+        assert_eq!(encrypted1.len(), empty_array.len() + 12 + 16);
         // Second encryption of the same data
         let encrypted2 = encrypt_with_key(&test_key, empty_array).await;
 


### PR DESCRIPTION
## Summary

- add encrypted user login, registration, and resumption transitions that atomically bind one immutable user authority to the admitted v2 session
- reject bearer/session recombination and preserve the exact admitted session lease through encrypted responses
- project the initial protected-user, key-export, signing, third-party-token, and bounded user-crypto operations
- revalidate live user/project/wrap authority before protected dispatch
- bound and zeroize sensitive request and response material while preserving all existing v1 application behavior

This consolidated PR contains the original commits from #311, #312, and #313.

## Security properties

- credentials exist only inside the encrypted authentication transition
- one anonymous session can bind at most once and never change principal
- replay is claimed before authentication, mutation, billing, signing, or export
- responses are encrypted to the same session and request ID that authenticated the request
- active credential-wrap checks invalidate stale authority
- user plaintext, private material, and bounded serialized responses are wiped on drop

## Compatibility

All v1 routes, JWT handling, encryption, response shapes, and published SDK behavior remain unchanged. New SDK selection remains out of scope.

## Validation

- strict formatting, Clippy, and full Rust suite
- disposable database authority and AEAD tests
- managed local stack smoke
- released v1 TypeScript/Rust compatibility proofs
- raw encrypted v2 login, binding, replay, isolation, export/signing, and crypto matrices
- independent security, compatibility, and memory-bounds reviews

The original per-commit discussion and validation records remain available in #311 and #312.