### PR TITLE
fix: retain v2 response working set

### DIFF
--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -547,7 +547,11 @@ At minimum v2 bounds:
 
 The initial outer ceiling may retain the current 50 MiB limit. Base64 expansion
 and simultaneous outer/decoded/decrypted buffers must be included in memory
-accounting rather than described as only wire overhead.
+accounting rather than described as only wire overhead. The request working-set
+reservation remains held while the final encrypted response is JSON/base64
+serialized and until its HTTP body is consumed or dropped. Operations whose
+maximum output is not correlated with their request size require an additional
+route-specific output reservation before dispatch.
 
 The initial v2-core limits are:
 

--- a/src/transport_v2/gateway.rs
+++ b/src/transport_v2/gateway.rs
@@ -26,6 +26,7 @@ use zeroize::Zeroize;
 
 use crate::encrypt::CustomRng;
 use crate::web::attestation_routes;
+use crate::web::encryption_middleware::hold_resource_through_response_body;
 use crate::{AppState, AsyncRngWrapper};
 
 use super::application::{
@@ -587,7 +588,7 @@ async fn key_exchange(
 async fn encrypted_request(
     State(app_state): State<Arc<AppState>>,
     request: Request<Body>,
-) -> Result<Json<EncryptedOuterResponse>, GatewayError> {
+) -> Result<Response, GatewayError> {
     let session_id = parse_request_session_id(request.uri(), request.headers())?;
     validate_json_content_type(request.headers())?;
     let working_set_permit = app_state
@@ -612,8 +613,15 @@ async fn encrypted_request(
         )
         .await?;
     drop(encrypted);
-    drop(working_set_permit);
-    Ok(Json(response))
+    Ok(encrypted_outer_http_response(response, working_set_permit))
+}
+
+fn encrypted_outer_http_response(
+    response: EncryptedOuterResponse,
+    working_set_permit: OwnedSemaphorePermit,
+) -> Response {
+    let response = Json(response).into_response();
+    hold_resource_through_response_body(response, working_set_permit)
 }
 
 #[derive(Deserialize)]
@@ -1292,6 +1300,29 @@ mod tests {
         assert!(Arc::clone(&state.request_working_set)
             .try_acquire_many_owned(maximum_units)
             .is_ok());
+    }
+
+    #[tokio::test]
+    async fn encrypted_outer_response_holds_working_set_through_body_lifetime() {
+        let working_set = Arc::new(Semaphore::new(1));
+        let response_value = || EncryptedOuterResponse {
+            encrypted: EncodedBytes::from_bytes(vec![1, 2, 3]),
+        };
+
+        let permit = Arc::clone(&working_set).try_acquire_owned().unwrap();
+        let response = encrypted_outer_http_response(response_value(), permit);
+        assert_eq!(working_set.available_permits(), 0);
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()[header::CONTENT_TYPE], "application/json");
+        let body = to_bytes(response.into_body(), 1024).await.unwrap();
+        assert_eq!(&body[..], br#"{"encrypted":"AQID"}"#);
+        assert_eq!(working_set.available_permits(), 1);
+
+        let permit = Arc::clone(&working_set).try_acquire_owned().unwrap();
+        let response = encrypted_outer_http_response(response_value(), permit);
+        assert_eq!(working_set.available_permits(), 0);
+        drop(response);
+        assert_eq!(working_set.available_permits(), 1);
     }
 
     #[test]

--- a/src/web/encryption_middleware.rs
+++ b/src/web/encryption_middleware.rs
@@ -173,7 +173,10 @@ where
     Ok(hold_resource_through_response_body(response, session_lease))
 }
 
-fn hold_resource_through_response_body<T>(mut response: Response, resource: T) -> Response
+pub(crate) fn hold_resource_through_response_body<T>(
+    mut response: Response,
+    resource: T,
+) -> Response
 where
     T: Send + Unpin + 'static,
 {


### PR DESCRIPTION
## Summary

- serialize the final encrypted transport-v2 JSON/base64 response while its request working-set permit is still held
- retain that permit through HTTP response-body consumption or cancellation using the existing body-lifetime resource wrapper
- preserve exact successful v2 status, headers, JSON bytes, frame delegation, trailers, errors, and size hints
- document that tiny-request/large-output operations still require a separate route-specific output reservation before dispatch

## Stack

- base: `codex-session-v2-kv-path` / #314
- this PR fixes only final response-allocation lifetime accounting
- KV mutations and output-admitted KV reads remain separate later stacked PRs

## Validation

- strict Clippy with `RUSTFLAGS=-D warnings`
- full backend suite: 514 passed, 20 ignored, 0 failed
- focused lifetime test proves retention after response construction and release after both body consumption and abandonment
- existing response-body wrapper tests continue to cover payload, exact size hints, trailers, and streaming lifetime
- independent security and compatibility reviews found no material issue

## Compatibility

Transport v1 behavior is unchanged; only the existing resource-wrapper helper's crate visibility changes. Transport v2 continues to return the same `200`, `application/json`, and exact `{"encrypted":"..."}` bytes. Pre-response failures and cancellations release permits normally through RAII.
