### PR TITLE
feat: project KV mutations over transport v2

### DIFF
--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -662,27 +662,37 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    exact v2-only plaintext ceiling derived from AES-GCM, base64, and JSON
    expansion. Logical JSON serialization writes through a bounded buffer so a
    highly escaped decrypted string cannot allocate beyond the response limit.
-8. **Remaining protected user operations**: project KV, account-lifecycle, and
-   user API-key-management families in reviewable sub-stacks. Dynamic path
-   parameters must preserve released SDK semantics without weakening the v2
-   route classifier, and password/account deletion must explicitly close the
-   now-invalid bound session.
-9. **Stored user unary operations**: project conversations, conversation
+8. **Dynamic-path and response-resource seams**: admit only route-scoped,
+   canonical KV item segments and retain request working-set reservations
+   through final response serialization/body lifetime. Tiny-request operations
+   with uncorrelated stored output remain unsupported until they reserve that
+   output before dispatch.
+9. **KV mutations**: project PUT item, DELETE item, and DELETE all through
+   transport-neutral helpers. Preserve existing response and error behavior,
+   claim replay identifiers before every mutation, sanitize storage errors, and
+   wipe decoded keys and values. GET item and list remain unsupported here.
+10. **Bounded KV reads**: project GET item and list only after ciphertext/output
+   admission and bounded row processing prevent a tiny request from building an
+   unbounded decrypted result in enclave memory.
+11. **Remaining protected user operations**: project account-lifecycle and user
+   API-key-management families in reviewable sub-stacks. Password/account
+   deletion must explicitly close the now-invalid bound session.
+12. **Stored user unary operations**: project conversations, conversation
    projects, instructions, response control, and web-provider unary routes in
    ownership-preserving families before the client cutover.
-10. **API-key and platform binding**: bind existing raw API keys inside
+13. **API-key and platform binding**: bind existing raw API keys inside
    ciphertext without rotating them, enforce their current inference-only
    scope, and add platform authentication/authorization with live organization
    checks. OAuth continuation receives an explicit session-binding design in
    this layer rather than being inferred from password login.
-11. **Streaming projection**: project current inference streams with ordered,
+14. **Streaming projection**: project current inference streams with ordered,
    request-bound, authenticated terminal records while preserving the SDK's
    caller-visible SSE behavior.
-12. **Additive SDK v2 internals**: TypeScript and Rust codecs/session managers
+15. **Additive SDK v2 internals**: TypeScript and Rust codecs/session managers
    behind private seams, still not selected by public calls.
-13. **Atomic SDK cutover**: v2-only network behavior, no downgrade, one-time
+16. **Atomic SDK cutover**: v2-only network behavior, no downgrade, one-time
    fresh login, and Maple/proxy integration.
-14. **SDK major/version packaging**: package metadata, locks, integration pin,
+17. **SDK major/version packaging**: package metadata, locks, integration pin,
    compatibility matrix, and release rehearsal. Publication/deployment remain
    separate authorized actions.
 

--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -332,8 +332,8 @@ async fn db_copied_kv_rows_do_not_decrypt_under_attacker_auth_context() {
         .put(
             &victim_login.user,
             &victim_login.auth_context,
-            "copied-kv-secret".to_string(),
-            "victim plaintext must not leak".to_string(),
+            "copied-kv-secret",
+            "victim plaintext must not leak",
         )
         .await
         .expect("victim KV insert should succeed");
@@ -353,7 +353,7 @@ async fn db_copied_kv_rows_do_not_decrypt_under_attacker_auth_context() {
         .get(
             &attacker_login.user,
             &attacker_login.auth_context,
-            "copied-kv-secret".to_string(),
+            "copied-kv-secret",
         )
         .await
         .expect("attacker get should not error for a missing attacker-encrypted key");

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -15,8 +15,8 @@ use uuid::Uuid;
 
 #[derive(Error, Debug)]
 pub enum StoreError {
-    #[error("Key not found: {0}")]
-    KeyNotFound(String),
+    #[error("Key not found")]
+    KeyNotFound,
     #[error("Unauthorized access")]
     Unauthorized,
     #[error("Decryption error")]
@@ -74,8 +74,8 @@ pub fn get(
 pub async fn put(
     pool: &diesel::r2d2::Pool<diesel::r2d2::ConnectionManager<PgConnection>>,
     user_id: Uuid,
-    key: String,
-    value: String,
+    key: &str,
+    value: &str,
     encryption_key: &SecretKey,
     _aws_credential_manager: Arc<tokio::sync::RwLock<Option<AwsCredentialManager>>>,
 ) -> StoreResult<()> {
@@ -109,13 +109,13 @@ pub fn delete(
 
     let encrypted_key = encrypt_key_deterministic(user_secret_key, key.as_bytes());
 
-    let user_kv = UserKV::get_by_user_and_key(&mut conn, user_id, &encrypted_key)?;
+    let user_kv_id = UserKV::get_id_by_user_and_key(&mut conn, user_id, &encrypted_key)?;
 
-    if let Some(user_kv) = user_kv {
-        user_kv.delete(&mut conn)?;
+    if let Some(user_kv_id) = user_kv_id {
+        UserKV::delete_by_id(&mut conn, user_kv_id)?;
         Ok(())
     } else {
-        Err(StoreError::KeyNotFound(key.to_string()))
+        Err(StoreError::KeyNotFound)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1922,21 +1922,21 @@ impl AppState {
         &self,
         user: &User,
         auth_context: &AuthContext,
-        key: String,
+        key: &str,
     ) -> StoreResult<Option<String>> {
         let user_key = self
             .get_user_key(user, auth_context, None, None)
             .await
             .map_err(|_| StoreError::Unauthorized)?;
-        kv::get(self.db.get_pool(), user.uuid, &key, &user_key)
+        kv::get(self.db.get_pool(), user.uuid, key, &user_key)
     }
 
     async fn put(
         &self,
         user: &User,
         auth_context: &AuthContext,
-        key: String,
-        value: String,
+        key: &str,
+        value: &str,
     ) -> StoreResult<()> {
         let user_key = self
             .get_user_key(user, auth_context, None, None)
@@ -1953,17 +1953,12 @@ impl AppState {
         .await
     }
 
-    async fn delete(
-        &self,
-        user: &User,
-        auth_context: &AuthContext,
-        key: String,
-    ) -> StoreResult<()> {
+    async fn delete(&self, user: &User, auth_context: &AuthContext, key: &str) -> StoreResult<()> {
         let user_key = self
             .get_user_key(user, auth_context, None, None)
             .await
             .map_err(|_| StoreError::Unauthorized)?;
-        kv::delete(self.db.get_pool(), user.uuid, &key, &user_key)
+        kv::delete(self.db.get_pool(), user.uuid, key, &user_key)
     }
 
     async fn delete_all(&self, user_id: Uuid) -> StoreResult<()> {

--- a/src/models/user_kv.rs
+++ b/src/models/user_kv.rs
@@ -1,6 +1,7 @@
 use crate::models::schema::user_kv;
 use chrono::{DateTime, Utc};
 use diesel::prelude::*;
+use diesel::upsert::excluded;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
@@ -47,6 +48,20 @@ impl UserKV {
             .map_err(UserKVError::DatabaseError)
     }
 
+    pub fn get_id_by_user_and_key(
+        conn: &mut PgConnection,
+        lookup_user_id: Uuid,
+        lookup_key: &[u8],
+    ) -> Result<Option<i64>, UserKVError> {
+        user_kv::table
+            .filter(user_kv::user_id.eq(lookup_user_id))
+            .filter(user_kv::key_enc.eq(lookup_key))
+            .select(user_kv::id)
+            .first::<i64>(conn)
+            .optional()
+            .map_err(UserKVError::DatabaseError)
+    }
+
     pub fn get_all_for_user(
         conn: &mut PgConnection,
         lookup_user_id: Uuid,
@@ -67,8 +82,12 @@ impl UserKV {
     }
 
     pub fn delete(&self, conn: &mut PgConnection) -> Result<(), UserKVError> {
+        Self::delete_by_id(conn, self.id)
+    }
+
+    pub fn delete_by_id(conn: &mut PgConnection, lookup_id: i64) -> Result<(), UserKVError> {
         diesel::delete(user_kv::table)
-            .filter(user_kv::id.eq(self.id))
+            .filter(user_kv::id.eq(lookup_id))
             .execute(conn)
             .map(|_| ())
             .map_err(UserKVError::DatabaseError)
@@ -103,13 +122,14 @@ impl NewUserKV {
         }
     }
 
-    pub fn insert(&self, conn: &mut PgConnection) -> Result<UserKV, UserKVError> {
+    pub fn insert(&self, conn: &mut PgConnection) -> Result<(), UserKVError> {
         diesel::insert_into(user_kv::table)
             .values(self)
             .on_conflict((user_kv::user_id, user_kv::key_enc))
             .do_update()
-            .set(user_kv::value_enc.eq(self.value_enc.clone()))
-            .get_result::<UserKV>(conn)
+            .set(user_kv::value_enc.eq(excluded(user_kv::value_enc)))
+            .execute(conn)
+            .map(|_| ())
             .map_err(UserKVError::DatabaseError)
     }
 }

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -25,16 +25,16 @@ use crate::web::login_routes::{
     RegisterCredentials,
 };
 use crate::web::protected_routes::{
-    decrypt_data_value, encrypt_data_value, private_key_bytes_data, private_key_data,
-    protected_user_data, public_key_data, sign_message_data, third_party_token_data,
-    DecryptDataRequest, DerivationPathQuery, EncryptDataRequest, PublicKeyQuery,
-    SignMessageRequest, ThirdPartyTokenRequest,
+    decrypt_data_value, delete_all_kv_values, delete_kv_value, encrypt_data_value,
+    private_key_bytes_data, private_key_data, protected_user_data, public_key_data, put_kv_value,
+    sign_message_data, third_party_token_data, DecryptDataRequest, DerivationPathQuery,
+    EncryptDataRequest, KvValue, PublicKeyQuery, SignMessageRequest, ThirdPartyTokenRequest,
 };
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
 use super::envelope::{
-    Credential, EncodedBytes, EnvelopeLimits, HeaderField, LogicalMethod, RequestEnvelope,
-    RequestId, ResponseMode,
+    decode_canonical_kv_item_path, Credential, EncodedBytes, EnvelopeLimits, HeaderField,
+    LogicalMethod, RequestEnvelope, RequestId, ResponseMode,
 };
 use super::session::{
     AuthenticationReservation, AuthenticationStartError, AuthorityState, BoundAuthority,
@@ -76,13 +76,35 @@ pub(crate) enum UserOperation {
 
 pub(crate) enum ProtectedUserOperation {
     GetUser,
-    GetPrivateKey { query: Option<String> },
-    GetPrivateKeyBytes { query: Option<String> },
-    GetPublicKey { query: Option<String> },
-    SignMessage { body: SensitiveBytes },
-    IssueThirdPartyToken { body: SensitiveBytes },
-    EncryptData { body: SensitiveBytes },
-    DecryptData { body: SensitiveBytes },
+    GetPrivateKey {
+        query: Option<String>,
+    },
+    GetPrivateKeyBytes {
+        query: Option<String>,
+    },
+    GetPublicKey {
+        query: Option<String>,
+    },
+    SignMessage {
+        body: SensitiveBytes,
+    },
+    IssueThirdPartyToken {
+        body: SensitiveBytes,
+    },
+    EncryptData {
+        body: SensitiveBytes,
+    },
+    DecryptData {
+        body: SensitiveBytes,
+    },
+    PutKv {
+        key: Zeroizing<String>,
+        body: SensitiveBytes,
+    },
+    DeleteKv {
+        key: Zeroizing<String>,
+    },
+    DeleteAllKv,
 }
 
 #[derive(Clone)]
@@ -151,7 +173,7 @@ impl UserOperation {
 pub(crate) struct LogicalUnaryResponse {
     pub(crate) status: StatusCode,
     pub(crate) headers: Vec<HeaderField>,
-    pub(crate) body: Option<Vec<u8>>,
+    pub(crate) body: Option<Zeroizing<Vec<u8>>>,
 }
 
 impl LogicalUnaryResponse {
@@ -182,7 +204,7 @@ impl LogicalUnaryResponse {
                 name: "content-type".to_owned(),
                 value_base64: EncodedBytes::from_bytes(JSON_CONTENT_TYPE.to_vec()),
             }],
-            body: Some(body),
+            body: Some(Zeroizing::new(body)),
         })
     }
 
@@ -219,7 +241,7 @@ impl LogicalUnaryResponse {
                 name: "content-type".to_owned(),
                 value_base64: EncodedBytes::from_bytes(JSON_CONTENT_TYPE.to_vec()),
             }],
-            body: Some(body),
+            body: Some(Zeroizing::new(body)),
         }
     }
 }
@@ -252,7 +274,7 @@ pub(crate) fn prepare_user_operation(
     let RequestEnvelope {
         response_mode,
         credential,
-        request,
+        mut request,
         ..
     } = envelope;
 
@@ -269,21 +291,40 @@ pub(crate) fn prepare_user_operation(
         IssueThirdPartyToken,
         EncryptData,
         DecryptData,
+        PutKv,
+        DeleteKv,
+        DeleteAllKv,
     }
 
+    let kv_key = match decode_canonical_kv_item_path(request.method, &request.path) {
+        Ok(key) => key,
+        Err(_) => {
+            request.path.zeroize();
+            return rejected_bad_request();
+        }
+    };
     let route = match (request.method, request.path.as_str()) {
-        (LogicalMethod::Post, "/login") => Route::Login,
-        (LogicalMethod::Post, "/register") => Route::Register,
-        (LogicalMethod::Post, "/refresh") => Route::Resume,
-        (LogicalMethod::Get, "/protected/user") => Route::GetUser,
-        (LogicalMethod::Get, "/protected/private_key") => Route::GetPrivateKey,
-        (LogicalMethod::Get, "/protected/private_key_bytes") => Route::GetPrivateKeyBytes,
-        (LogicalMethod::Get, "/protected/public_key") => Route::GetPublicKey,
-        (LogicalMethod::Post, "/protected/sign_message") => Route::SignMessage,
-        (LogicalMethod::Post, "/protected/third_party_token") => Route::IssueThirdPartyToken,
-        (LogicalMethod::Post, "/protected/encrypt") => Route::EncryptData,
-        (LogicalMethod::Post, "/protected/decrypt") => Route::DecryptData,
-        _ => return OperationPreparation::Unsupported,
+        (LogicalMethod::Post, "/login") => Some(Route::Login),
+        (LogicalMethod::Post, "/register") => Some(Route::Register),
+        (LogicalMethod::Post, "/refresh") => Some(Route::Resume),
+        (LogicalMethod::Get, "/protected/user") => Some(Route::GetUser),
+        (LogicalMethod::Get, "/protected/private_key") => Some(Route::GetPrivateKey),
+        (LogicalMethod::Get, "/protected/private_key_bytes") => Some(Route::GetPrivateKeyBytes),
+        (LogicalMethod::Get, "/protected/public_key") => Some(Route::GetPublicKey),
+        (LogicalMethod::Post, "/protected/sign_message") => Some(Route::SignMessage),
+        (LogicalMethod::Post, "/protected/third_party_token") => Some(Route::IssueThirdPartyToken),
+        (LogicalMethod::Post, "/protected/encrypt") => Some(Route::EncryptData),
+        (LogicalMethod::Post, "/protected/decrypt") => Some(Route::DecryptData),
+        (LogicalMethod::Delete, "/protected/kv") => Some(Route::DeleteAllKv),
+        (LogicalMethod::Put, _) if kv_key.is_some() => Some(Route::PutKv),
+        (LogicalMethod::Delete, _) if kv_key.is_some() => Some(Route::DeleteKv),
+        _ => None,
+    };
+    if kv_key.is_some() {
+        request.path.zeroize();
+    }
+    let Some(route) = route else {
+        return OperationPreparation::Unsupported;
     };
 
     if response_mode != ResponseMode::Unary {
@@ -406,6 +447,58 @@ pub(crate) fn prepare_user_operation(
                 Route::EncryptData => ProtectedUserOperation::EncryptData { body },
                 Route::DecryptData => ProtectedUserOperation::DecryptData { body },
                 _ => unreachable!("fixed protected POST classifier is exhaustive"),
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation,
+            })
+        }
+        Route::PutKv => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            let body = request
+                .body_base64
+                .expect("validated KV value body presence")
+                .into_bytes();
+            let operation = ProtectedUserOperation::PutKv {
+                key: kv_key.expect("classified KV item route must have a decoded key"),
+                body: Zeroizing::new(body),
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation,
+            })
+        }
+        Route::DeleteKv | Route::DeleteAllKv => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            let operation = if matches!(route, Route::DeleteKv) {
+                ProtectedUserOperation::DeleteKv {
+                    key: kv_key.expect("classified KV item route must have a decoded key"),
+                }
+            } else {
+                ProtectedUserOperation::DeleteAllKv
             };
             OperationPreparation::Ready(UserOperation::Protected {
                 authority,
@@ -631,6 +724,30 @@ async fn execute_protected_user_operation(
             }
             let value = decrypt_data_value(app_state, user, auth_context, request).await?;
             LogicalUnaryResponse::json(StatusCode::OK, &*value)
+        }
+        ProtectedUserOperation::PutKv { key, body } => {
+            let value = parse_json_body::<KvValue>(body)?;
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value)?;
+            put_kv_value(app_state, user, auth_context, &key, value.as_str()).await?;
+            Ok(response)
+        }
+        ProtectedUserOperation::DeleteKv { key } => {
+            let response = LogicalUnaryResponse::json(
+                StatusCode::OK,
+                &serde_json::json!({ "message": "Resource deleted successfully" }),
+            )?;
+            delete_kv_value(app_state, user, auth_context, &key).await?;
+            Ok(response)
+        }
+        ProtectedUserOperation::DeleteAllKv => {
+            let response = LogicalUnaryResponse::json(
+                StatusCode::OK,
+                &serde_json::json!({
+                    "message": "All key-value pairs deleted successfully"
+                }),
+            )?;
+            delete_all_kv_values(app_state, user.uuid).await?;
+            Ok(response)
         }
     }
 }
@@ -1013,6 +1130,96 @@ mod tests {
     }
 
     #[test]
+    fn exact_kv_mutation_contracts_are_admitted_with_decoded_keys() {
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Put,
+                    "/protected/kv/key%2Fpart",
+                    json_header(),
+                    Some(br#""value""#),
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::PutKv { key, .. },
+                ..
+            }) if &*key == "key/part"
+        ));
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Put,
+                    "/protected/kv/empty",
+                    json_header(),
+                    Some(br#""""#),
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::PutKv { .. },
+                ..
+            })
+        ));
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Delete,
+                    "/protected/kv/%252F",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::DeleteKv { key },
+                ..
+            }) if &*key == "%2F"
+        ));
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Delete,
+                    "/protected/kv",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::DeleteAllKv,
+                ..
+            })
+        ));
+
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Get,
+                    "/protected/kv/key%2Fpart",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Unsupported
+        ));
+    }
+
+    #[test]
+    fn kv_value_keeps_the_existing_json_string_wire_shape() {
+        let wire = "\"line\\né\"";
+        let value: KvValue = serde_json::from_slice(wire.as_bytes()).unwrap();
+        assert_eq!(value.as_str(), "line\né");
+        assert_eq!(serde_json::to_vec(&value).unwrap(), wire.as_bytes());
+    }
+
+    #[test]
     fn near_miss_user_operations_are_rejected_before_dispatch() {
         let mut wrong_mode = envelope(
             LogicalMethod::Post,
@@ -1179,6 +1386,117 @@ mod tests {
                 ));
             }
         }
+    }
+
+    #[test]
+    fn kv_mutations_reject_unbound_and_transplanted_metadata() {
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Put,
+                    "/protected/kv/key",
+                    json_header(),
+                    Some(br#""value""#),
+                    None,
+                ),
+                AuthorityState::Anonymous,
+            ),
+            OperationPreparation::Rejected(_)
+        ));
+
+        let mut put_query = envelope(
+            LogicalMethod::Put,
+            "/protected/kv/key",
+            json_header(),
+            Some(br#""value""#),
+            None,
+        );
+        put_query.request.query = Some("x=1".to_owned());
+        for request in [
+            envelope(
+                LogicalMethod::Put,
+                "/protected/kv/key",
+                Vec::new(),
+                Some(br#""value""#),
+                None,
+            ),
+            envelope(
+                LogicalMethod::Put,
+                "/protected/kv/key",
+                json_header(),
+                None,
+                None,
+            ),
+            put_query,
+            envelope(
+                LogicalMethod::Put,
+                "/protected/kv/key",
+                json_header(),
+                Some(br#""value""#),
+                Some(Credential::Resumption {
+                    value_base64: EncodedBytes::from_bytes(b"token".to_vec()),
+                }),
+            ),
+        ] {
+            assert!(matches!(
+                prepare_user_operation(request, bound_user_authority()),
+                OperationPreparation::Rejected(_)
+            ));
+        }
+
+        let mut delete_query = envelope(
+            LogicalMethod::Delete,
+            "/protected/kv/key",
+            Vec::new(),
+            None,
+            None,
+        );
+        delete_query.request.query = Some("x=1".to_owned());
+        for request in [
+            envelope(
+                LogicalMethod::Delete,
+                "/protected/kv/key",
+                json_header(),
+                None,
+                None,
+            ),
+            envelope(
+                LogicalMethod::Delete,
+                "/protected/kv/key",
+                Vec::new(),
+                Some(b""),
+                None,
+            ),
+            delete_query,
+            envelope(
+                LogicalMethod::Delete,
+                "/protected/kv",
+                Vec::new(),
+                None,
+                Some(Credential::ApiKey {
+                    value_base64: EncodedBytes::from_bytes(b"key".to_vec()),
+                }),
+            ),
+        ] {
+            assert!(matches!(
+                prepare_user_operation(request, bound_user_authority()),
+                OperationPreparation::Rejected(_)
+            ));
+        }
+
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Delete,
+                    "/protected/kv/%2f",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Rejected(_)
+        ));
     }
 
     #[test]

--- a/src/transport_v2/gateway.rs
+++ b/src/transport_v2/gateway.rs
@@ -724,7 +724,9 @@ fn encrypt_reserved_logical_response(
         request_id,
         status: response.status.as_u16(),
         headers: response.headers,
-        body_base64: response.body.map(EncodedBytes::from_bytes),
+        body_base64: response
+            .body
+            .map(|mut body| EncodedBytes::from_bytes(std::mem::take(&mut *body))),
     };
     if response.validate(&EnvelopeLimits::default()).is_err() {
         zeroize_response_body(&mut response);
@@ -1054,7 +1056,7 @@ mod tests {
             response: LogicalUnaryResponse {
                 status: StatusCode::OK,
                 headers: Vec::new(),
-                body: Some(br#"{"ok":true}"#.to_vec()),
+                body: Some(zeroize::Zeroizing::new(br#"{"ok":true}"#.to_vec())),
             },
             bound_session: false,
         }

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -376,6 +376,16 @@ pub struct DecryptDataRequest {
     pub key_options: KeyOptions,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
+#[serde(transparent)]
+pub(crate) struct KvValue(String);
+
+impl KvValue {
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 // API Key Management Types
 
 // Validation function for API key names
@@ -452,7 +462,7 @@ pub fn router(app_state: Arc<AppState>) -> Router<()> {
             "/protected/kv/:key",
             put(put_kv).layer(from_fn_with_state(
                 app_state.clone(),
-                decrypt_request::<String>,
+                decrypt_request::<KvValue>,
             )),
         )
         .route(
@@ -637,7 +647,8 @@ pub async fn get_kv(
     Extension(session_id): Extension<TransportSession>,
     Path(key): Path<String>,
 ) -> Result<Json<EncryptedResponse<Option<String>>>, ApiError> {
-    let value = match data.get(&user, &auth_context, key).await {
+    let key = Zeroizing::new(key);
+    let value = match data.get(&user, &auth_context, &key).await {
         Ok(kv) => kv,
         Err(e) => {
             tracing::error!("Error getting key-value pair: {:?}", e);
@@ -653,16 +664,24 @@ pub async fn put_kv(
     Extension(auth_context): Extension<AuthContext>,
     Extension(session_id): Extension<TransportSession>,
     Path(key): Path<String>,
-    Extension(value): Extension<String>,
-) -> Result<Json<EncryptedResponse<String>>, ApiError> {
-    match data.put(&user, &auth_context, key, value.clone()).await {
-        Ok(kv) => kv,
-        Err(e) => {
-            tracing::error!("Error putting key-value pair: {:?}", e);
-            return Err(ApiError::InternalServerError);
-        }
-    };
+    Extension(value): Extension<KvValue>,
+) -> Result<Json<EncryptedResponse<KvValue>>, ApiError> {
+    let key = Zeroizing::new(key);
+    put_kv_value(&data, &user, &auth_context, &key, value.as_str()).await?;
     encrypt_response(&data, &session_id, &value).await
+}
+
+pub(crate) async fn put_kv_value(
+    data: &AppState,
+    user: &User,
+    auth_context: &AuthContext,
+    key: &str,
+    value: &str,
+) -> Result<(), ApiError> {
+    data.put(user, auth_context, key, value).await.map_err(|_| {
+        tracing::error!("Error putting key-value pair");
+        ApiError::InternalServerError
+    })
 }
 
 pub async fn delete_kv(
@@ -672,16 +691,22 @@ pub async fn delete_kv(
     Extension(session_id): Extension<TransportSession>,
     Path(key): Path<String>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    match data.delete(&user, &auth_context, key).await {
-        Ok(_) => {
-            let response = json!({ "message": "Resource deleted successfully" });
-            encrypt_response(&data, &session_id, &response).await
-        }
-        Err(e) => {
-            tracing::error!("Error deleting key-value pair: {:?}", e);
-            Err(ApiError::InternalServerError)
-        }
-    }
+    let key = Zeroizing::new(key);
+    delete_kv_value(&data, &user, &auth_context, &key).await?;
+    let response = json!({ "message": "Resource deleted successfully" });
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn delete_kv_value(
+    data: &AppState,
+    user: &User,
+    auth_context: &AuthContext,
+    key: &str,
+) -> Result<(), ApiError> {
+    data.delete(user, auth_context, key).await.map_err(|_| {
+        tracing::error!("Error deleting key-value pair");
+        ApiError::InternalServerError
+    })
 }
 
 pub async fn delete_all_kv(
@@ -689,18 +714,18 @@ pub async fn delete_all_kv(
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    match data.delete_all(user.uuid).await {
-        Ok(_) => {
-            let response = json!({
-                "message": "All key-value pairs deleted successfully"
-            });
-            encrypt_response(&data, &session_id, &response).await
-        }
-        Err(e) => {
-            tracing::error!("Error deleting all key-value pairs: {:?}", e);
-            Err(ApiError::InternalServerError)
-        }
-    }
+    delete_all_kv_values(&data, user.uuid).await?;
+    let response = json!({
+        "message": "All key-value pairs deleted successfully"
+    });
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn delete_all_kv_values(data: &AppState, user_id: Uuid) -> Result<(), ApiError> {
+    data.delete_all(user_id).await.map_err(|_| {
+        tracing::error!("Error deleting all key-value pairs");
+        ApiError::InternalServerError
+    })
 }
 
 pub async fn list_kv(
@@ -1491,6 +1516,7 @@ mod tests {
         assert_zeroize_on_drop::<EncryptDataRequest>();
         assert_zeroize_on_drop::<EncryptDataResponse>();
         assert_zeroize_on_drop::<DecryptDataRequest>();
+        assert_zeroize_on_drop::<KvValue>();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- project transport-v2 `PUT /protected/kv/:key`, `DELETE /protected/kv/:key`, and `DELETE /protected/kv` through the existing bound-user authority
- preserve the released v1 JSON-string, success-body, error, and storage behavior through transport-neutral mutation helpers
- decode only canonical route-scoped KV segments, reject transplanted metadata, and retain zeroizing ownership for logical keys, values, and responses
- keep KV item/list reads unsupported until their stored-output admission is bounded separately
- avoid duplicate ciphertext bindings and full-row returns during upsert so maximum-size v2 PUTs remain inside the existing working-set reservation

## Security properties

- claims the per-session request ID before any mutation
- revalidates the immutable bound user before dispatch
- accepts no logical credential, query, unexpected header, or body shape on the mutation routes
- encrypts the response with the exact leased session and request-ID binding
- constructs the bounded success response before mutating storage
- sanitizes storage errors and avoids loading a value for point deletion
- preserves cross-user delete-all isolation

## Compatibility

- no v1 route, middleware stack, session, or ciphertext behavior changes
- released Rust SDK KV CRUD/special-key/delete-all integration tests pass unchanged
- released TypeScript SDK KV CRUD/delete-all integration test passes unchanged
- new SDK/client selection remains out of scope; v2 KV reads remain deliberately unavailable

## Validation

- `cargo fmt --all` and `git diff --check`
- strict all-target/all-feature Clippy with warnings denied
- full Rust suite: 517 passed, 20 ignored
- disposable PostgreSQL AEAD/tamper suite: 17 passed
- disposable PostgreSQL OAuth seed-wrap suite: 2 passed
- managed OpenSecret/Postgres/Continuum/Tinfoil smoke test
- raw encrypted transport-v2 live matrix covering anonymous rejection, guest binding, empty and Unicode values, canonical special keys, replay rejection, metadata transplant rejection, unsupported reads, missing-delete compatibility, and two-user delete-all isolation

## Stack

- base: #315 (`codex-session-v2-response-working-set`)
- depends on the canonical v2 KV path contract in #314
