### PR TITLE
refactor: share bounded transport JSON writer

### DIFF
--- a/src/bounded_json.rs
+++ b/src/bounded_json.rs
@@ -1,0 +1,88 @@
+use std::io::{self, Write};
+
+use zeroize::Zeroizing;
+
+/// Zeroizing writer that never retains more than the configured JSON limit.
+///
+/// Callers may serialize one value or incrementally build a JSON sequence. A
+/// write that would cross the limit fails before appending any of that chunk,
+/// and the retained bytes are wiped when the buffer is dropped.
+pub(crate) struct BoundedJsonBuffer {
+    bytes: Zeroizing<Vec<u8>>,
+    limit: usize,
+    exceeded: bool,
+}
+
+impl BoundedJsonBuffer {
+    pub(crate) fn new(limit: usize) -> Self {
+        Self {
+            bytes: Zeroizing::new(Vec::new()),
+            limit,
+            exceeded: false,
+        }
+    }
+
+    pub(crate) fn into_bytes(mut self) -> Zeroizing<Vec<u8>> {
+        Zeroizing::new(std::mem::take(&mut *self.bytes))
+    }
+
+    pub(crate) const fn exceeded(&self) -> bool {
+        self.exceeded
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.bytes.len()
+    }
+}
+
+impl Write for BoundedJsonBuffer {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        let Some(next) = self.bytes.len().checked_add(buffer.len()) else {
+            self.exceeded = true;
+            return Err(io::Error::other("serialized JSON length overflow"));
+        };
+        if next > self.limit {
+            self.exceeded = true;
+            return Err(io::Error::other(
+                "serialized JSON exceeds logical response limit",
+            ));
+        }
+        self.bytes.extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeroize::Zeroize;
+
+    #[test]
+    fn exact_limit_succeeds_and_overflow_retains_only_bounded_bytes() {
+        let mut exact = BoundedJsonBuffer::new(4);
+        exact.write_all(b"1234").unwrap();
+        assert_eq!(&*exact.into_bytes(), b"1234");
+
+        let mut overflow = BoundedJsonBuffer::new(4);
+        overflow.write_all(b"12").unwrap();
+        assert!(overflow.write_all(b"345").is_err());
+        assert!(overflow.exceeded());
+        assert_eq!(overflow.len(), 2);
+    }
+
+    #[test]
+    fn returned_bytes_remain_zeroizing() {
+        fn assert_zeroize<T: Zeroize>() {}
+
+        let mut buffer = BoundedJsonBuffer::new(2);
+        buffer.write_all(b"[]").unwrap();
+        let bytes = buffer.into_bytes();
+        assert_zeroize::<Zeroizing<Vec<u8>>>();
+        assert_eq!(&*bytes, b"[]");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,7 @@ use x25519_dalek::{EphemeralSecret, PublicKey};
 mod apple_signin;
 mod aws_credentials;
 mod billing;
+mod bounded_json;
 mod bounded_ttl_cache;
 #[cfg(test)]
 mod crypto_property_tests;

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -5,7 +5,6 @@
 //! functions, and returns plaintext logical results for the gateway to encrypt
 //! through the request's original session lease.
 
-use std::io::{self, Write};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -17,6 +16,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use zeroize::{Zeroize, Zeroizing};
 
+use crate::bounded_json::BoundedJsonBuffer;
 use crate::jwt::{
     issue_transport_v2_user_tokens, validate_transport_v2_user_resumption, AuthContext,
 };
@@ -114,53 +114,6 @@ pub(crate) struct BoundUserAuthority {
     auth_context: AuthContext,
 }
 
-struct BoundedJsonBuffer {
-    bytes: Vec<u8>,
-    limit: usize,
-    exceeded: bool,
-}
-
-impl BoundedJsonBuffer {
-    fn new(limit: usize) -> Self {
-        Self {
-            bytes: Vec::new(),
-            limit,
-            exceeded: false,
-        }
-    }
-
-    fn into_bytes(mut self) -> Vec<u8> {
-        std::mem::take(&mut self.bytes)
-    }
-}
-
-impl Write for BoundedJsonBuffer {
-    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
-        let Some(next) = self.bytes.len().checked_add(buffer.len()) else {
-            self.exceeded = true;
-            return Err(io::Error::other("serialized JSON length overflow"));
-        };
-        if next > self.limit {
-            self.exceeded = true;
-            return Err(io::Error::other(
-                "serialized JSON exceeds logical response limit",
-            ));
-        }
-        self.bytes.extend_from_slice(buffer);
-        Ok(buffer.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
-impl Drop for BoundedJsonBuffer {
-    fn drop(&mut self) {
-        self.bytes.zeroize();
-    }
-}
-
 impl UserOperation {
     pub(crate) const fn requires_authentication_transition(&self) -> bool {
         matches!(
@@ -188,7 +141,7 @@ impl LogicalUnaryResponse {
     ) -> Result<Self, ApiError> {
         let mut buffer = BoundedJsonBuffer::new(logical_body_bytes);
         if let Err(error) = serde_json::to_writer(&mut buffer, value) {
-            if buffer.exceeded {
+            if buffer.exceeded() {
                 return Err(ApiError::PayloadTooLarge);
             }
             tracing::error!(
@@ -204,7 +157,7 @@ impl LogicalUnaryResponse {
                 name: "content-type".to_owned(),
                 value_base64: EncodedBytes::from_bytes(JSON_CONTENT_TYPE.to_vec()),
             }],
-            body: Some(Zeroizing::new(body)),
+            body: Some(body),
         })
     }
 
@@ -1546,8 +1499,8 @@ mod tests {
 
         let mut buffer = BoundedJsonBuffer::new(7);
         assert!(serde_json::to_writer(&mut buffer, &escaped).is_err());
-        assert!(buffer.exceeded);
-        assert!(buffer.bytes.len() <= 7);
+        assert!(buffer.exceeded());
+        assert!(buffer.len() <= 7);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- extract the transport-v2 bounded JSON writer into a reusable crate-local module
- preserve the existing logical-response byte limit, overflow classification, and exact JSON wire output
- keep serialized plaintext zeroizing throughout ownership transfer without adding a copy
- establish the narrow serialization seam needed for bounded incremental stored-output reads

## Security properties

- refuses each write fragment before it would cross the configured byte limit
- fails closed on checked length overflow
- wipes retained plaintext on success, error, cancellation, and unwind through `Zeroizing<Vec<u8>>`
- retains the existing 413 response for bounded-output overflow and 500 response for unrelated serialization failures

## Compatibility

- no v1 route, middleware, session, ciphertext, or application behavior changes
- no transport-v2 route or wire-shape changes
- this PR is a behavior-preserving prerequisite only; KV reads remain unsupported

## Validation

- `cargo fmt --all` and `git diff --check`
- strict all-target/all-feature Clippy with warnings denied
- full Rust suite: 519 passed, 20 ignored
- focused exact-limit, overflow, escaped-JSON, and zeroizing-buffer tests
- independent compatibility and security reviews found no material issues

## Stack

- base: #316 (`codex-session-v2-kv-mutations`)
- next: bounded transport-v2 KV reads and stored-output admission
