### PR TITLE
Project the complete bounded KV family over transport v2

### DIFF
--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -662,27 +662,37 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    exact v2-only plaintext ceiling derived from AES-GCM, base64, and JSON
    expansion. Logical JSON serialization writes through a bounded buffer so a
    highly escaped decrypted string cannot allocate beyond the response limit.
-8. **Remaining protected user operations**: project KV, account-lifecycle, and
-   user API-key-management families in reviewable sub-stacks. Dynamic path
-   parameters must preserve released SDK semantics without weakening the v2
-   route classifier, and password/account deletion must explicitly close the
-   now-invalid bound session.
-9. **Stored user unary operations**: project conversations, conversation
+8. **Dynamic-path and response-resource seams**: admit only route-scoped,
+   canonical KV item segments and retain request working-set reservations
+   through final response serialization/body lifetime. Tiny-request operations
+   with uncorrelated stored output remain unsupported until they reserve that
+   output before dispatch.
+9. **KV mutations**: project PUT item, DELETE item, and DELETE all through
+   transport-neutral helpers. Preserve existing response and error behavior,
+   claim replay identifiers before every mutation, sanitize storage errors, and
+   wipe decoded keys and values. GET item and list remain unsupported here.
+10. **Bounded KV reads**: project GET item and list only after ciphertext/output
+   admission and bounded row processing prevent a tiny request from building an
+   unbounded decrypted result in enclave memory.
+11. **Remaining protected user operations**: project account-lifecycle and user
+   API-key-management families in reviewable sub-stacks. Password/account
+   deletion must explicitly close the now-invalid bound session.
+12. **Stored user unary operations**: project conversations, conversation
    projects, instructions, response control, and web-provider unary routes in
    ownership-preserving families before the client cutover.
-10. **API-key and platform binding**: bind existing raw API keys inside
+13. **API-key and platform binding**: bind existing raw API keys inside
    ciphertext without rotating them, enforce their current inference-only
    scope, and add platform authentication/authorization with live organization
    checks. OAuth continuation receives an explicit session-binding design in
    this layer rather than being inferred from password login.
-11. **Streaming projection**: project current inference streams with ordered,
+14. **Streaming projection**: project current inference streams with ordered,
    request-bound, authenticated terminal records while preserving the SDK's
    caller-visible SSE behavior.
-12. **Additive SDK v2 internals**: TypeScript and Rust codecs/session managers
+15. **Additive SDK v2 internals**: TypeScript and Rust codecs/session managers
    behind private seams, still not selected by public calls.
-13. **Atomic SDK cutover**: v2-only network behavior, no downgrade, one-time
+16. **Atomic SDK cutover**: v2-only network behavior, no downgrade, one-time
    fresh login, and Maple/proxy integration.
-14. **SDK major/version packaging**: package metadata, locks, integration pin,
+17. **SDK major/version packaging**: package metadata, locks, integration pin,
    compatibility matrix, and release rehearsal. Publication/deployment remain
    separate authorized actions.
 

--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -671,9 +671,15 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    transport-neutral helpers. Preserve existing response and error behavior,
    claim replay identifiers before every mutation, sanitize storage errors, and
    wipe decoded keys and values. GET item and list remain unsupported here.
-10. **Bounded KV reads**: project GET item and list only after ciphertext/output
-   admission and bounded row processing prevent a tiny request from building an
-   unbounded decrypted result in enclave memory.
+10. **Bounded KV reads**: project GET item and list through a v2-only,
+   read-only repeatable-read storage seam. Promote each admitted read to a
+   conservative 200 MiB reservation from the shared 256 MiB request/response
+   pool before replay claim or dispatch; contention returns an authenticated
+   503 without consuming the request identifier. Bound item ciphertext, list
+   aggregate plaintext, and list rows before loading narrow ciphertext
+   projections, then retain the merged reservation through final HTTP body
+   consumption. Preserve `null`, string, bare-array, timestamp, ordering, and
+   whole-list failure behavior from v1 while leaving every v1 query untouched.
 11. **Remaining protected user operations**: project account-lifecycle and user
    API-key-management families in reviewable sub-stacks. Password/account
    deletion must explicitly close the now-invalid bound session.

--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -547,7 +547,11 @@ At minimum v2 bounds:
 
 The initial outer ceiling may retain the current 50 MiB limit. Base64 expansion
 and simultaneous outer/decoded/decrypted buffers must be included in memory
-accounting rather than described as only wire overhead.
+accounting rather than described as only wire overhead. The request working-set
+reservation remains held while the final encrypted response is JSON/base64
+serialized and until its HTTP body is consumed or dropped. Operations whose
+maximum output is not correlated with their request size require an additional
+route-specific output reservation before dispatch.
 
 The initial v2-core limits are:
 

--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -271,10 +271,23 @@ Fields have these meanings:
   present empty body. Other values preserve exact request bytes without
   transport-layer JSON parsing or reserialization.
 
-Unknown and duplicate JSON fields are rejected. The implementation parses the
-path and query once, rejects schemes, authorities, fragments, backslashes,
+Unknown and duplicate JSON fields are rejected. The implementation validates
+the path and query once, rejects schemes, authorities, fragments, backslashes,
 dot-segments, encoded separator ambiguity, and invalid percent encoding, then
 maps `(method, path)` through an exact application allowlist.
+
+Registered routes may define an opaque dynamic segment without relaxing those
+rules for any other path. Route selection first matches an exact literal prefix
+and method. The initial exception is the final segment of
+`GET|PUT|DELETE /protected/kv/<key>`: ASCII alphanumeric key bytes remain
+literal and every other UTF-8 byte is one uppercase `%HH` triplet, matching the
+released Rust SDK's `NON_ALPHANUMERIC` encoding. The enclave rejects empty,
+noncanonical, malformed, over-encoded, or invalid-UTF-8 segments and decodes the
+accepted value exactly once after selecting the KV route. It performs no
+Unicode normalization. Thus `/`, a literal `%2F`, dot-only keys, backslashes,
+and distinct Unicode byte strings remain application data rather than routing
+syntax. The future TypeScript v2 SDK must implement the same UTF-8 byte codec;
+generic URI encoders that leave punctuation unescaped are insufficient.
 
 The gateway never hands an arbitrary URI to the full transport-v1 router.
 Application operations are projected deliberately onto shared application

--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -368,6 +368,192 @@ async fn db_copied_kv_rows_do_not_decrypt_under_attacker_auth_context() {
 
 #[tokio::test]
 #[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+async fn db_bounded_kv_reads_preserve_wire_data_and_enforce_limits() {
+    let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+        eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+        return;
+    };
+
+    let app_state = build_local_test_app_state(database_url).await;
+    let project = first_active_project(&app_state);
+    let marker = Uuid::new_v4();
+    let owner_email = format!("aead-bounded-kv-owner-{marker}@example.com");
+    let other_email = format!("aead-bounded-kv-other-{marker}@example.com");
+    let owner_password = test_credential("bounded-kv-owner");
+    let other_password = test_credential("bounded-kv-other");
+
+    let owner =
+        create_password_wrapped_user(&app_state, project.id, owner_email.clone(), owner_password)
+            .await;
+    let other =
+        create_password_wrapped_user(&app_state, project.id, other_email.clone(), other_password)
+            .await;
+
+    let owner_login = app_state
+        .authenticate_user(
+            Some(owner_email),
+            None,
+            owner_password.to_string(),
+            project.id,
+        )
+        .await
+        .expect("owner login should not error")
+        .expect("owner password should verify and unwrap");
+    let other_login = app_state
+        .authenticate_user(
+            Some(other_email),
+            None,
+            other_password.to_string(),
+            project.id,
+        )
+        .await
+        .expect("other-user login should not error")
+        .expect("other-user password should verify and unwrap");
+
+    let entries = [
+        ("bounded-kv-alpha", "first value"),
+        ("bounded-kv-beta", "quoted \"value\" and snowman ☃"),
+    ];
+    for (key, value) in entries {
+        app_state
+            .put(&owner_login.user, &owner_login.auth_context, key, value)
+            .await
+            .expect("owner KV insert should succeed");
+    }
+
+    let present = app_state
+        .get_bounded_kv(
+            &owner_login.user,
+            &owner_login.auth_context,
+            entries[1].0,
+            entries[1].1.len(),
+        )
+        .await
+        .expect("bounded GET at the exact plaintext limit should succeed")
+        .expect("stored owner value should be present");
+    assert_eq!(present.as_str(), entries[1].1);
+
+    let missing = app_state
+        .get_bounded_kv(
+            &owner_login.user,
+            &owner_login.auth_context,
+            "bounded-kv-missing",
+            0,
+        )
+        .await
+        .expect("bounded GET for a missing key should succeed");
+    assert!(
+        missing.is_none(),
+        "missing bounded GET should preserve null semantics"
+    );
+
+    let undersized_get = app_state
+        .get_bounded_kv(
+            &owner_login.user,
+            &owner_login.auth_context,
+            entries[1].0,
+            entries[1].1.len() - 1,
+        )
+        .await;
+    assert!(matches!(
+        undersized_get,
+        Err(crate::kv::StoreError::OutputTooLarge)
+    ));
+
+    let aggregate_plaintext_len = entries
+        .iter()
+        .map(|(key, value)| key.len() + value.len())
+        .sum();
+    let mut bounded_list = app_state
+        .list_bounded_kv(
+            &owner_login.user,
+            &owner_login.auth_context,
+            aggregate_plaintext_len,
+            entries.len(),
+        )
+        .await
+        .expect("bounded LIST at the exact aggregate limit should succeed");
+    let mut legacy_list = app_state
+        .list(&owner_login.user, &owner_login.auth_context)
+        .await
+        .expect("legacy LIST comparison should succeed");
+
+    bounded_list.sort_by(|left, right| left.key.cmp(&right.key));
+    legacy_list.sort_by(|left, right| left.key.cmp(&right.key));
+    assert_eq!(bounded_list.len(), entries.len());
+    assert_eq!(bounded_list.len(), legacy_list.len());
+    for (actual, expected) in bounded_list.iter().zip(&legacy_list) {
+        assert_eq!(actual.key, expected.key);
+        assert_eq!(actual.value, expected.value);
+        assert_eq!(actual.created_at, expected.created_at);
+        assert_eq!(actual.updated_at, expected.updated_at);
+        assert!(actual.created_at > 0);
+        assert!(actual.updated_at >= actual.created_at);
+        assert_eq!(
+            serde_json::to_value(actual).expect("bounded KV pair should serialize"),
+            serde_json::json!({
+                "key": expected.key,
+                "value": expected.value,
+                "created_at": expected.created_at,
+                "updated_at": expected.updated_at,
+            })
+        );
+    }
+
+    let undersized_list = app_state
+        .list_bounded_kv(
+            &owner_login.user,
+            &owner_login.auth_context,
+            aggregate_plaintext_len - 1,
+            entries.len(),
+        )
+        .await;
+    assert!(matches!(
+        undersized_list,
+        Err(crate::kv::StoreError::OutputTooLarge)
+    ));
+
+    let row_limited_list = app_state
+        .list_bounded_kv(
+            &owner_login.user,
+            &owner_login.auth_context,
+            aggregate_plaintext_len,
+            entries.len() - 1,
+        )
+        .await;
+    assert!(matches!(
+        row_limited_list,
+        Err(crate::kv::StoreError::OutputTooLarge)
+    ));
+
+    let other_get = app_state
+        .get_bounded_kv(
+            &other_login.user,
+            &other_login.auth_context,
+            entries[0].0,
+            entries[0].1.len(),
+        )
+        .await
+        .expect("cross-user bounded GET should not error");
+    assert!(
+        other_get.is_none(),
+        "bounded GET must remain scoped to its user"
+    );
+    let other_list = app_state
+        .list_bounded_kv(&other_login.user, &other_login.auth_context, 0, 0)
+        .await
+        .expect("empty cross-user bounded LIST should succeed");
+    assert!(
+        other_list.is_empty(),
+        "bounded LIST must remain scoped to its user"
+    );
+
+    let _ = app_state.db.delete_user(&owner);
+    let _ = app_state.db.delete_user(&other);
+}
+
+#[tokio::test]
+#[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
 async fn db_password_change_invalidates_old_auth_context_and_preserves_seed() {
     let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
         eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");

--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -332,8 +332,8 @@ async fn db_copied_kv_rows_do_not_decrypt_under_attacker_auth_context() {
         .put(
             &victim_login.user,
             &victim_login.auth_context,
-            "copied-kv-secret".to_string(),
-            "victim plaintext must not leak".to_string(),
+            "copied-kv-secret",
+            "victim plaintext must not leak",
         )
         .await
         .expect("victim KV insert should succeed");
@@ -353,7 +353,7 @@ async fn db_copied_kv_rows_do_not_decrypt_under_attacker_auth_context() {
         .get(
             &attacker_login.user,
             &attacker_login.auth_context,
-            "copied-kv-secret".to_string(),
+            "copied-kv-secret",
         )
         .await
         .expect("attacker get should not error for a missing attacker-encrypted key");

--- a/src/bounded_json.rs
+++ b/src/bounded_json.rs
@@ -1,0 +1,88 @@
+use std::io::{self, Write};
+
+use zeroize::Zeroizing;
+
+/// Zeroizing writer that never retains more than the configured JSON limit.
+///
+/// Callers may serialize one value or incrementally build a JSON sequence. A
+/// write that would cross the limit fails before appending any of that chunk,
+/// and the retained bytes are wiped when the buffer is dropped.
+pub(crate) struct BoundedJsonBuffer {
+    bytes: Zeroizing<Vec<u8>>,
+    limit: usize,
+    exceeded: bool,
+}
+
+impl BoundedJsonBuffer {
+    pub(crate) fn new(limit: usize) -> Self {
+        Self {
+            bytes: Zeroizing::new(Vec::new()),
+            limit,
+            exceeded: false,
+        }
+    }
+
+    pub(crate) fn into_bytes(mut self) -> Zeroizing<Vec<u8>> {
+        Zeroizing::new(std::mem::take(&mut *self.bytes))
+    }
+
+    pub(crate) const fn exceeded(&self) -> bool {
+        self.exceeded
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.bytes.len()
+    }
+}
+
+impl Write for BoundedJsonBuffer {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        let Some(next) = self.bytes.len().checked_add(buffer.len()) else {
+            self.exceeded = true;
+            return Err(io::Error::other("serialized JSON length overflow"));
+        };
+        if next > self.limit {
+            self.exceeded = true;
+            return Err(io::Error::other(
+                "serialized JSON exceeds logical response limit",
+            ));
+        }
+        self.bytes.extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zeroize::Zeroize;
+
+    #[test]
+    fn exact_limit_succeeds_and_overflow_retains_only_bounded_bytes() {
+        let mut exact = BoundedJsonBuffer::new(4);
+        exact.write_all(b"1234").unwrap();
+        assert_eq!(&*exact.into_bytes(), b"1234");
+
+        let mut overflow = BoundedJsonBuffer::new(4);
+        overflow.write_all(b"12").unwrap();
+        assert!(overflow.write_all(b"345").is_err());
+        assert!(overflow.exceeded());
+        assert_eq!(overflow.len(), 2);
+    }
+
+    #[test]
+    fn returned_bytes_remain_zeroizing() {
+        fn assert_zeroize<T: Zeroize>() {}
+
+        let mut buffer = BoundedJsonBuffer::new(2);
+        buffer.write_all(b"[]").unwrap();
+        let bytes = buffer.into_bytes();
+        assert_zeroize::<Zeroizing<Vec<u8>>>();
+        assert_eq!(&*bytes, b"[]");
+    }
+}

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -15,8 +15,8 @@ use uuid::Uuid;
 
 #[derive(Error, Debug)]
 pub enum StoreError {
-    #[error("Key not found: {0}")]
-    KeyNotFound(String),
+    #[error("Key not found")]
+    KeyNotFound,
     #[error("Unauthorized access")]
     Unauthorized,
     #[error("Decryption error")]
@@ -74,8 +74,8 @@ pub fn get(
 pub async fn put(
     pool: &diesel::r2d2::Pool<diesel::r2d2::ConnectionManager<PgConnection>>,
     user_id: Uuid,
-    key: String,
-    value: String,
+    key: &str,
+    value: &str,
     encryption_key: &SecretKey,
     _aws_credential_manager: Arc<tokio::sync::RwLock<Option<AwsCredentialManager>>>,
 ) -> StoreResult<()> {
@@ -109,13 +109,13 @@ pub fn delete(
 
     let encrypted_key = encrypt_key_deterministic(user_secret_key, key.as_bytes());
 
-    let user_kv = UserKV::get_by_user_and_key(&mut conn, user_id, &encrypted_key)?;
+    let user_kv_id = UserKV::get_id_by_user_and_key(&mut conn, user_id, &encrypted_key)?;
 
-    if let Some(user_kv) = user_kv {
-        user_kv.delete(&mut conn)?;
+    if let Some(user_kv_id) = user_kv_id {
+        UserKV::delete_by_id(&mut conn, user_kv_id)?;
         Ok(())
     } else {
-        Err(StoreError::KeyNotFound(key.to_string()))
+        Err(StoreError::KeyNotFound)
     }
 }
 

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -3,7 +3,7 @@ use crate::encrypt::{
 };
 use crate::{
     aws_credentials::AwsCredentialManager,
-    models::user_kv::{NewUserKV, UserKV, UserKVError},
+    models::user_kv::{NewUserKV, UserKV, UserKVCiphertextPair, UserKVError},
 };
 use diesel::prelude::*;
 use secp256k1::SecretKey;
@@ -12,6 +12,12 @@ use std::sync::Arc;
 use thiserror::Error;
 use tracing::{debug, error};
 use uuid::Uuid;
+use zeroize::{Zeroize, Zeroizing};
+
+const AES_GCM_STORAGE_OVERHEAD_BYTES: usize = 12 + 16;
+const AES_SIV_STORAGE_OVERHEAD_BYTES: usize = 16;
+const KV_ROW_STORAGE_OVERHEAD_BYTES: usize =
+    AES_SIV_STORAGE_OVERHEAD_BYTES + AES_GCM_STORAGE_OVERHEAD_BYTES;
 
 #[derive(Error, Debug)]
 pub enum StoreError {
@@ -21,18 +27,205 @@ pub enum StoreError {
     Unauthorized,
     #[error("Decryption error")]
     DecryptionError,
+    #[error("Stored output exceeds the requested limit")]
+    OutputTooLarge,
     #[error("Database error: {0}")]
     DatabaseError(#[from] UserKVError),
 }
 
+impl From<diesel::result::Error> for StoreError {
+    fn from(error: diesel::result::Error) -> Self {
+        Self::DatabaseError(UserKVError::DatabaseError(error))
+    }
+}
+
 pub type StoreResult<T> = Result<T, StoreError>;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Zeroize)]
 pub struct KVPair {
     pub key: String,
     pub value: String,
     pub created_at: i64,
     pub updated_at: i64,
+}
+
+fn database_connection_error() -> StoreError {
+    StoreError::DatabaseError(UserKVError::DatabaseError(diesel::result::Error::NotFound))
+}
+
+fn checked_database_len(length: i64) -> StoreResult<usize> {
+    usize::try_from(length).map_err(|_| StoreError::DecryptionError)
+}
+
+fn validate_value_ciphertext_len(
+    ciphertext_len: i64,
+    logical_body_limit: usize,
+) -> StoreResult<usize> {
+    let ciphertext_len = checked_database_len(ciphertext_len)?;
+    let plaintext_len = ciphertext_len
+        .checked_sub(AES_GCM_STORAGE_OVERHEAD_BYTES)
+        .ok_or(StoreError::DecryptionError)?;
+    if plaintext_len > logical_body_limit {
+        return Err(StoreError::OutputTooLarge);
+    }
+    Ok(ciphertext_len)
+}
+
+fn validate_list_ciphertext_aggregate(
+    row_count: i64,
+    aggregate_ciphertext_len: Option<i64>,
+    logical_body_limit: usize,
+    row_limit: usize,
+) -> StoreResult<(usize, usize)> {
+    let row_count = checked_database_len(row_count)?;
+    if row_count > row_limit {
+        return Err(StoreError::OutputTooLarge);
+    }
+
+    let aggregate_ciphertext_len = match aggregate_ciphertext_len {
+        Some(length) => checked_database_len(length)?,
+        None if row_count == 0 => 0,
+        None => return Err(StoreError::DecryptionError),
+    };
+    let aggregate_storage_overhead = row_count
+        .checked_mul(KV_ROW_STORAGE_OVERHEAD_BYTES)
+        .ok_or(StoreError::OutputTooLarge)?;
+    let aggregate_plaintext_len = aggregate_ciphertext_len
+        .checked_sub(aggregate_storage_overhead)
+        .ok_or(StoreError::DecryptionError)?;
+    if aggregate_plaintext_len > logical_body_limit {
+        return Err(StoreError::OutputTooLarge);
+    }
+
+    Ok((row_count, aggregate_ciphertext_len))
+}
+
+fn zeroizing_utf8(bytes: Vec<u8>) -> StoreResult<Zeroizing<String>> {
+    match String::from_utf8(bytes) {
+        Ok(value) => Ok(Zeroizing::new(value)),
+        Err(error) => {
+            let mut bytes = error.into_bytes();
+            bytes.zeroize();
+            Err(StoreError::DecryptionError)
+        }
+    }
+}
+
+/// Read one KV value through a bounded transport-v2 storage path.
+///
+/// The length preflight and narrow ciphertext fetch share a read-only,
+/// repeatable-read snapshot. The caller remains responsible for the final
+/// bounded JSON representation, whose escaping can be larger than plaintext.
+pub fn get_bounded(
+    pool: &diesel::r2d2::Pool<diesel::r2d2::ConnectionManager<PgConnection>>,
+    user_id: Uuid,
+    key: &str,
+    user_secret_key: &SecretKey,
+    logical_body_limit: usize,
+) -> StoreResult<Option<Zeroizing<String>>> {
+    let mut conn = pool.get().map_err(|_| database_connection_error())?;
+    let encrypted_key = Zeroizing::new(encrypt_key_deterministic(user_secret_key, key.as_bytes()));
+
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, StoreError, _>(|conn| {
+            let Some(ciphertext_len) = UserKV::get_v2_value_ciphertext_len_by_user_and_key(
+                conn,
+                user_id,
+                encrypted_key.as_slice(),
+            )?
+            else {
+                return Ok(None);
+            };
+            let expected_ciphertext_len =
+                validate_value_ciphertext_len(ciphertext_len, logical_body_limit)?;
+
+            let Some(value_enc) = UserKV::get_v2_value_ciphertext_by_user_and_key(
+                conn,
+                user_id,
+                encrypted_key.as_slice(),
+            )?
+            else {
+                return Err(StoreError::DecryptionError);
+            };
+            let value_enc = Zeroizing::new(value_enc);
+            if value_enc.len() != expected_ciphertext_len {
+                return Err(StoreError::DecryptionError);
+            }
+
+            let plaintext = decrypt_with_key(user_secret_key, value_enc.as_slice())
+                .map_err(|_| StoreError::DecryptionError)?;
+            zeroizing_utf8(plaintext).map(Some)
+        })
+}
+
+/// List KV values through a bounded transport-v2 storage path.
+///
+/// Row count and aggregate ciphertext size are measured before the narrow
+/// projection is loaded in the same read-only, repeatable-read snapshot.
+pub fn list_bounded(
+    pool: &diesel::r2d2::Pool<diesel::r2d2::ConnectionManager<PgConnection>>,
+    user_id: Uuid,
+    user_secret_key: &SecretKey,
+    logical_body_limit: usize,
+    row_limit: usize,
+) -> StoreResult<Zeroizing<Vec<KVPair>>> {
+    let mut conn = pool.get().map_err(|_| database_connection_error())?;
+
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, StoreError, _>(|conn| {
+            let (row_count, aggregate_ciphertext_len) =
+                UserKV::get_v2_ciphertext_aggregate_for_user(conn, user_id)?;
+            let (row_count, expected_ciphertext_len) = validate_list_ciphertext_aggregate(
+                row_count,
+                aggregate_ciphertext_len,
+                logical_body_limit,
+                row_limit,
+            )?;
+
+            let rows = Zeroizing::new(UserKV::get_v2_ciphertexts_for_user(conn, user_id)?);
+            if rows.len() != row_count {
+                return Err(StoreError::DecryptionError);
+            }
+            let actual_ciphertext_len = rows.iter().try_fold(0usize, |total, row| {
+                total
+                    .checked_add(row.key_enc.len())
+                    .and_then(|total| total.checked_add(row.value_enc.len()))
+                    .ok_or(StoreError::OutputTooLarge)
+            })?;
+            if actual_ciphertext_len != expected_ciphertext_len {
+                return Err(StoreError::DecryptionError);
+            }
+
+            let mut pairs = Zeroizing::new(Vec::with_capacity(row_count));
+            for UserKVCiphertextPair {
+                key_enc,
+                value_enc,
+                created_at,
+                updated_at,
+            } in rows.iter()
+            {
+                let decrypted_key = decrypt_key_deterministic(user_secret_key, key_enc)
+                    .map_err(|_| StoreError::DecryptionError)?;
+                let mut key = zeroizing_utf8(decrypted_key)?;
+
+                let decrypted_value = decrypt_with_key(user_secret_key, value_enc)
+                    .map_err(|_| StoreError::DecryptionError)?;
+                let mut value = zeroizing_utf8(decrypted_value)?;
+
+                pairs.push(KVPair {
+                    key: std::mem::take(&mut *key),
+                    value: std::mem::take(&mut *value),
+                    created_at: created_at.timestamp_millis(),
+                    updated_at: updated_at.timestamp_millis(),
+                });
+            }
+
+            Ok(pairs)
+        })
 }
 
 // Update the get function
@@ -160,4 +353,69 @@ pub fn list(
         });
     }
     Ok(pairs)
+}
+
+#[cfg(test)]
+mod bounded_read_tests {
+    use super::*;
+
+    #[test]
+    fn value_ciphertext_preflight_accounts_for_storage_overhead() {
+        assert_eq!(
+            validate_value_ciphertext_len(AES_GCM_STORAGE_OVERHEAD_BYTES as i64 + 7, 7).unwrap(),
+            AES_GCM_STORAGE_OVERHEAD_BYTES + 7
+        );
+        assert!(matches!(
+            validate_value_ciphertext_len(AES_GCM_STORAGE_OVERHEAD_BYTES as i64 + 8, 7),
+            Err(StoreError::OutputTooLarge)
+        ));
+        assert!(matches!(
+            validate_value_ciphertext_len(AES_GCM_STORAGE_OVERHEAD_BYTES as i64 - 1, 7),
+            Err(StoreError::DecryptionError)
+        ));
+    }
+
+    #[test]
+    fn list_preflight_bounds_rows_and_aggregate_plaintext() {
+        assert_eq!(
+            validate_list_ciphertext_aggregate(0, None, 0, 0).unwrap(),
+            (0, 0)
+        );
+        assert_eq!(
+            validate_list_ciphertext_aggregate(
+                1,
+                Some(KV_ROW_STORAGE_OVERHEAD_BYTES as i64 + 7),
+                7,
+                1,
+            )
+            .unwrap(),
+            (1, KV_ROW_STORAGE_OVERHEAD_BYTES + 7)
+        );
+        assert!(matches!(
+            validate_list_ciphertext_aggregate(1, Some(KV_ROW_STORAGE_OVERHEAD_BYTES as i64), 0, 0,),
+            Err(StoreError::OutputTooLarge)
+        ));
+        assert!(matches!(
+            validate_list_ciphertext_aggregate(
+                1,
+                Some(KV_ROW_STORAGE_OVERHEAD_BYTES as i64 + 8),
+                7,
+                1,
+            ),
+            Err(StoreError::OutputTooLarge)
+        ));
+        assert!(matches!(
+            validate_list_ciphertext_aggregate(
+                1,
+                Some(KV_ROW_STORAGE_OVERHEAD_BYTES as i64 - 1),
+                7,
+                1,
+            ),
+            Err(StoreError::DecryptionError)
+        ));
+        assert!(matches!(
+            validate_list_ciphertext_aggregate(1, None, 7, 1),
+            Err(StoreError::DecryptionError)
+        ));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1884,6 +1884,26 @@ impl AppState {
         kv::get(self.db.get_pool(), user.uuid, key, &user_key)
     }
 
+    async fn get_bounded_kv(
+        &self,
+        user: &User,
+        auth_context: &AuthContext,
+        key: &str,
+        logical_body_limit: usize,
+    ) -> StoreResult<Option<zeroize::Zeroizing<String>>> {
+        let user_key = self
+            .get_user_key(user, auth_context, None, None)
+            .await
+            .map_err(|_| StoreError::Unauthorized)?;
+        kv::get_bounded(
+            self.db.get_pool(),
+            user.uuid,
+            key,
+            &user_key,
+            logical_body_limit,
+        )
+    }
+
     async fn put(
         &self,
         user: &User,
@@ -1924,6 +1944,26 @@ impl AppState {
             .await
             .map_err(|_| StoreError::Unauthorized)?;
         kv::list(self.db.get_pool(), user.uuid, &user_key)
+    }
+
+    async fn list_bounded_kv(
+        &self,
+        user: &User,
+        auth_context: &AuthContext,
+        logical_body_limit: usize,
+        row_limit: usize,
+    ) -> StoreResult<zeroize::Zeroizing<Vec<KVPair>>> {
+        let user_key = self
+            .get_user_key(user, auth_context, None, None)
+            .await
+            .map_err(|_| StoreError::Unauthorized)?;
+        kv::list_bounded(
+            self.db.get_pool(),
+            user.uuid,
+            &user_key,
+            logical_body_limit,
+            row_limit,
+        )
     }
 
     pub async fn get_aws_credentials(&self) -> Option<AwsCredentials> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1874,21 +1874,21 @@ impl AppState {
         &self,
         user: &User,
         auth_context: &AuthContext,
-        key: String,
+        key: &str,
     ) -> StoreResult<Option<String>> {
         let user_key = self
             .get_user_key(user, auth_context, None, None)
             .await
             .map_err(|_| StoreError::Unauthorized)?;
-        kv::get(self.db.get_pool(), user.uuid, &key, &user_key)
+        kv::get(self.db.get_pool(), user.uuid, key, &user_key)
     }
 
     async fn put(
         &self,
         user: &User,
         auth_context: &AuthContext,
-        key: String,
-        value: String,
+        key: &str,
+        value: &str,
     ) -> StoreResult<()> {
         let user_key = self
             .get_user_key(user, auth_context, None, None)
@@ -1905,17 +1905,12 @@ impl AppState {
         .await
     }
 
-    async fn delete(
-        &self,
-        user: &User,
-        auth_context: &AuthContext,
-        key: String,
-    ) -> StoreResult<()> {
+    async fn delete(&self, user: &User, auth_context: &AuthContext, key: &str) -> StoreResult<()> {
         let user_key = self
             .get_user_key(user, auth_context, None, None)
             .await
             .map_err(|_| StoreError::Unauthorized)?;
-        kv::delete(self.db.get_pool(), user.uuid, &key, &user_key)
+        kv::delete(self.db.get_pool(), user.uuid, key, &user_key)
     }
 
     async fn delete_all(&self, user_id: Uuid) -> StoreResult<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,7 @@ use x25519_dalek::{EphemeralSecret, PublicKey};
 mod apple_signin;
 mod aws_credentials;
 mod billing;
+mod bounded_json;
 mod bounded_ttl_cache;
 #[cfg(test)]
 mod crypto_property_tests;

--- a/src/models/user_kv.rs
+++ b/src/models/user_kv.rs
@@ -1,10 +1,13 @@
 use crate::models::schema::user_kv;
 use chrono::{DateTime, Utc};
+use diesel::dsl::{count_star, sql};
 use diesel::prelude::*;
+use diesel::sql_types::{BigInt, Nullable};
 use diesel::upsert::excluded;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
+use zeroize::Zeroize;
 
 #[derive(Error, Debug)]
 pub enum UserKVError {
@@ -21,6 +24,33 @@ pub struct UserKV {
     pub value_enc: Vec<u8>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+/// Narrow ciphertext projection used only by bounded transport-v2 KV reads.
+///
+/// The custom `Zeroize` implementation deliberately wipes only encrypted
+/// user-controlled bytes. Timestamps are not sensitive allocations and do not
+/// implement `Zeroize` themselves.
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = user_kv)]
+pub struct UserKVCiphertextPair {
+    pub key_enc: Vec<u8>,
+    pub value_enc: Vec<u8>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl Zeroize for UserKVCiphertextPair {
+    fn zeroize(&mut self) {
+        self.key_enc.zeroize();
+        self.value_enc.zeroize();
+    }
+}
+
+impl Drop for UserKVCiphertextPair {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
 }
 
 impl UserKV {
@@ -69,6 +99,68 @@ impl UserKV {
         user_kv::table
             .filter(user_kv::user_id.eq(lookup_user_id))
             .load::<UserKV>(conn)
+            .map_err(UserKVError::DatabaseError)
+    }
+
+    /// Measure one stored value without loading its ciphertext.
+    ///
+    /// This is a transport-v2-only query seam. The existing v1 query methods
+    /// intentionally continue selecting the complete `UserKV` row.
+    pub fn get_v2_value_ciphertext_len_by_user_and_key(
+        conn: &mut PgConnection,
+        lookup_user_id: Uuid,
+        lookup_key: &[u8],
+    ) -> Result<Option<i64>, UserKVError> {
+        user_kv::table
+            .filter(user_kv::user_id.eq(lookup_user_id))
+            .filter(user_kv::key_enc.eq(lookup_key))
+            .select(sql::<BigInt>("octet_length(value_enc)::bigint"))
+            .first::<i64>(conn)
+            .optional()
+            .map_err(UserKVError::DatabaseError)
+    }
+
+    /// Load only one value ciphertext after its bounded v2 preflight.
+    pub fn get_v2_value_ciphertext_by_user_and_key(
+        conn: &mut PgConnection,
+        lookup_user_id: Uuid,
+        lookup_key: &[u8],
+    ) -> Result<Option<Vec<u8>>, UserKVError> {
+        user_kv::table
+            .filter(user_kv::user_id.eq(lookup_user_id))
+            .filter(user_kv::key_enc.eq(lookup_key))
+            .select(user_kv::value_enc)
+            .first::<Vec<u8>>(conn)
+            .optional()
+            .map_err(UserKVError::DatabaseError)
+    }
+
+    /// Count rows and ciphertext octets without loading either ciphertext.
+    pub fn get_v2_ciphertext_aggregate_for_user(
+        conn: &mut PgConnection,
+        lookup_user_id: Uuid,
+    ) -> Result<(i64, Option<i64>), UserKVError> {
+        user_kv::table
+            .filter(user_kv::user_id.eq(lookup_user_id))
+            .select((
+                count_star(),
+                sql::<Nullable<BigInt>>(
+                    "SUM(octet_length(key_enc)::bigint + octet_length(value_enc)::bigint)::bigint",
+                ),
+            ))
+            .first::<(i64, Option<i64>)>(conn)
+            .map_err(UserKVError::DatabaseError)
+    }
+
+    /// Load the narrow list projection after its bounded v2 preflight.
+    pub fn get_v2_ciphertexts_for_user(
+        conn: &mut PgConnection,
+        lookup_user_id: Uuid,
+    ) -> Result<Vec<UserKVCiphertextPair>, UserKVError> {
+        user_kv::table
+            .filter(user_kv::user_id.eq(lookup_user_id))
+            .select(UserKVCiphertextPair::as_select())
+            .load::<UserKVCiphertextPair>(conn)
             .map_err(UserKVError::DatabaseError)
     }
 

--- a/src/models/user_kv.rs
+++ b/src/models/user_kv.rs
@@ -1,6 +1,7 @@
 use crate::models::schema::user_kv;
 use chrono::{DateTime, Utc};
 use diesel::prelude::*;
+use diesel::upsert::excluded;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
@@ -47,6 +48,20 @@ impl UserKV {
             .map_err(UserKVError::DatabaseError)
     }
 
+    pub fn get_id_by_user_and_key(
+        conn: &mut PgConnection,
+        lookup_user_id: Uuid,
+        lookup_key: &[u8],
+    ) -> Result<Option<i64>, UserKVError> {
+        user_kv::table
+            .filter(user_kv::user_id.eq(lookup_user_id))
+            .filter(user_kv::key_enc.eq(lookup_key))
+            .select(user_kv::id)
+            .first::<i64>(conn)
+            .optional()
+            .map_err(UserKVError::DatabaseError)
+    }
+
     pub fn get_all_for_user(
         conn: &mut PgConnection,
         lookup_user_id: Uuid,
@@ -67,8 +82,12 @@ impl UserKV {
     }
 
     pub fn delete(&self, conn: &mut PgConnection) -> Result<(), UserKVError> {
+        Self::delete_by_id(conn, self.id)
+    }
+
+    pub fn delete_by_id(conn: &mut PgConnection, lookup_id: i64) -> Result<(), UserKVError> {
         diesel::delete(user_kv::table)
-            .filter(user_kv::id.eq(self.id))
+            .filter(user_kv::id.eq(lookup_id))
             .execute(conn)
             .map(|_| ())
             .map_err(UserKVError::DatabaseError)
@@ -103,13 +122,14 @@ impl NewUserKV {
         }
     }
 
-    pub fn insert(&self, conn: &mut PgConnection) -> Result<UserKV, UserKVError> {
+    pub fn insert(&self, conn: &mut PgConnection) -> Result<(), UserKVError> {
         diesel::insert_into(user_kv::table)
             .values(self)
             .on_conflict((user_kv::user_id, user_kv::key_enc))
             .do_update()
-            .set(user_kv::value_enc.eq(self.value_enc.clone()))
-            .get_result::<UserKV>(conn)
+            .set(user_kv::value_enc.eq(excluded(user_kv::value_enc)))
+            .execute(conn)
+            .map(|_| ())
             .map_err(UserKVError::DatabaseError)
     }
 }

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -20,6 +20,7 @@ use crate::bounded_json::BoundedJsonBuffer;
 use crate::jwt::{
     issue_transport_v2_user_tokens, validate_transport_v2_user_resumption, AuthContext,
 };
+use crate::kv::StoreError;
 use crate::web::login_routes::{
     authenticate_login, register_and_authenticate, AuthResponse, Credentials, RefreshResponse,
     RegisterCredentials,
@@ -49,6 +50,7 @@ const MAX_ENCRYPTED_DATA_BASE64_BYTES: usize =
     ((EnvelopeLimits::DEFAULT.logical_body_bytes - ENCRYPTED_DATA_JSON_OVERHEAD_BYTES) / 4) * 4;
 const MAX_ENCRYPTION_PLAINTEXT_BYTES: usize =
     (MAX_ENCRYPTED_DATA_BASE64_BYTES / 4) * 3 - AES_GCM_NONCE_AND_TAG_BYTES;
+const MAX_V2_KV_LIST_ROWS: usize = 65_536;
 
 type SensitiveBytes = Zeroizing<Vec<u8>>;
 
@@ -101,6 +103,10 @@ pub(crate) enum ProtectedUserOperation {
         key: Zeroizing<String>,
         body: SensitiveBytes,
     },
+    GetKv {
+        key: Zeroizing<String>,
+    },
+    ListKv,
     DeleteKv {
         key: Zeroizing<String>,
     },
@@ -119,6 +125,16 @@ impl UserOperation {
         matches!(
             self,
             Self::Login { .. } | Self::Register { .. } | Self::Resume { .. }
+        )
+    }
+
+    pub(crate) const fn requires_stored_output_reservation(&self) -> bool {
+        matches!(
+            self,
+            Self::Protected {
+                operation: ProtectedUserOperation::GetKv { .. } | ProtectedUserOperation::ListKv,
+                ..
+            }
         )
     }
 }
@@ -244,6 +260,8 @@ pub(crate) fn prepare_user_operation(
         IssueThirdPartyToken,
         EncryptData,
         DecryptData,
+        GetKv,
+        ListKv,
         PutKv,
         DeleteKv,
         DeleteAllKv,
@@ -268,7 +286,9 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Post, "/protected/third_party_token") => Some(Route::IssueThirdPartyToken),
         (LogicalMethod::Post, "/protected/encrypt") => Some(Route::EncryptData),
         (LogicalMethod::Post, "/protected/decrypt") => Some(Route::DecryptData),
+        (LogicalMethod::Get, "/protected/kv") => Some(Route::ListKv),
         (LogicalMethod::Delete, "/protected/kv") => Some(Route::DeleteAllKv),
+        (LogicalMethod::Get, _) if kv_key.is_some() => Some(Route::GetKv),
         (LogicalMethod::Put, _) if kv_key.is_some() => Some(Route::PutKv),
         (LogicalMethod::Delete, _) if kv_key.is_some() => Some(Route::DeleteKv),
         _ => None,
@@ -428,6 +448,30 @@ pub(crate) fn prepare_user_operation(
             let operation = ProtectedUserOperation::PutKv {
                 key: kv_key.expect("classified KV item route must have a decoded key"),
                 body: Zeroizing::new(body),
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation,
+            })
+        }
+        Route::GetKv | Route::ListKv => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            let operation = if matches!(route, Route::GetKv) {
+                ProtectedUserOperation::GetKv {
+                    key: kv_key.expect("classified KV item route must have a decoded key"),
+                }
+            } else {
+                ProtectedUserOperation::ListKv
             };
             OperationPreparation::Ready(UserOperation::Protected {
                 authority,
@@ -684,6 +728,30 @@ async fn execute_protected_user_operation(
             put_kv_value(app_state, user, auth_context, &key, value.as_str()).await?;
             Ok(response)
         }
+        ProtectedUserOperation::GetKv { key } => {
+            let value = app_state
+                .get_bounded_kv(
+                    user,
+                    auth_context,
+                    &key,
+                    EnvelopeLimits::default().logical_body_bytes,
+                )
+                .await
+                .map_err(map_bounded_kv_read_error)?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value.as_deref())
+        }
+        ProtectedUserOperation::ListKv => {
+            let values = app_state
+                .list_bounded_kv(
+                    user,
+                    auth_context,
+                    EnvelopeLimits::default().logical_body_bytes,
+                    MAX_V2_KV_LIST_ROWS,
+                )
+                .await
+                .map_err(map_bounded_kv_read_error)?;
+            LogicalUnaryResponse::json(StatusCode::OK, &*values)
+        }
         ProtectedUserOperation::DeleteKv { key } => {
             let response = LogicalUnaryResponse::json(
                 StatusCode::OK,
@@ -702,6 +770,15 @@ async fn execute_protected_user_operation(
             delete_all_kv_values(app_state, user.uuid).await?;
             Ok(response)
         }
+    }
+}
+
+fn map_bounded_kv_read_error(error: StoreError) -> ApiError {
+    if matches!(error, StoreError::OutputTooLarge) {
+        ApiError::PayloadTooLarge
+    } else {
+        tracing::error!("Error reading bounded key-value output");
+        ApiError::InternalServerError
     }
 }
 
@@ -1148,20 +1225,47 @@ mod tests {
                 ..
             })
         ));
+    }
 
-        assert!(matches!(
-            prepare_user_operation(
-                envelope(
-                    LogicalMethod::Get,
-                    "/protected/kv/key%2Fpart",
-                    Vec::new(),
-                    None,
-                    None,
-                ),
-                bound_user_authority(),
+    #[test]
+    fn exact_kv_read_contracts_are_admitted_and_require_stored_output_reservation() {
+        let item = prepare_user_operation(
+            envelope(
+                LogicalMethod::Get,
+                "/protected/kv/key%2Fpart",
+                Vec::new(),
+                None,
+                None,
             ),
-            OperationPreparation::Unsupported
+            bound_user_authority(),
+        );
+        assert!(matches!(
+            &item,
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::GetKv { key },
+                ..
+            }) if &**key == "key/part"
         ));
+        let OperationPreparation::Ready(item) = item else {
+            unreachable!("validated item read must be ready");
+        };
+        assert!(item.requires_stored_output_reservation());
+
+        let list = prepare_user_operation(
+            envelope(LogicalMethod::Get, "/protected/kv", Vec::new(), None, None),
+            bound_user_authority(),
+        );
+        assert!(matches!(
+            &list,
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::ListKv,
+                ..
+            })
+        ));
+        let OperationPreparation::Ready(list) = list else {
+            unreachable!("validated list read must be ready");
+        };
+        assert!(list.requires_stored_output_reservation());
     }
 
     #[test]
@@ -1170,6 +1274,31 @@ mod tests {
         let value: KvValue = serde_json::from_slice(wire.as_bytes()).unwrap();
         assert_eq!(value.as_str(), "line\né");
         assert_eq!(serde_json::to_vec(&value).unwrap(), wire.as_bytes());
+    }
+
+    #[test]
+    fn kv_reads_keep_existing_null_string_and_list_wire_shapes() {
+        let missing = LogicalUnaryResponse::json(StatusCode::OK, &Option::<&str>::None).unwrap();
+        assert_eq!(&*missing.body.unwrap(), b"null");
+
+        let present = LogicalUnaryResponse::json(StatusCode::OK, &Some("line\né")).unwrap();
+        assert_eq!(&*present.body.unwrap(), "\"line\\né\"".as_bytes());
+
+        let empty =
+            LogicalUnaryResponse::json(StatusCode::OK, &Vec::<crate::kv::KVPair>::new()).unwrap();
+        assert_eq!(&*empty.body.unwrap(), b"[]");
+
+        let rows = vec![crate::kv::KVPair {
+            key: "key".to_owned(),
+            value: "value".to_owned(),
+            created_at: 1,
+            updated_at: 2,
+        }];
+        let list = LogicalUnaryResponse::json(StatusCode::OK, &rows).unwrap();
+        assert_eq!(
+            &*list.body.unwrap(),
+            br#"[{"key":"key","value":"value","created_at":1,"updated_at":2}]"#
+        );
     }
 
     #[test]
@@ -1450,6 +1579,41 @@ mod tests {
             ),
             OperationPreparation::Rejected(_)
         ));
+    }
+
+    #[test]
+    fn kv_reads_reject_unbound_and_transplanted_metadata() {
+        for path in ["/protected/kv/key", "/protected/kv"] {
+            assert!(matches!(
+                prepare_user_operation(
+                    envelope(LogicalMethod::Get, path, Vec::new(), None, None),
+                    AuthorityState::Anonymous,
+                ),
+                OperationPreparation::Rejected(_)
+            ));
+
+            let mut query = envelope(LogicalMethod::Get, path, Vec::new(), None, None);
+            query.request.query = Some("x=1".to_owned());
+            for request in [
+                envelope(LogicalMethod::Get, path, json_header(), None, None),
+                envelope(LogicalMethod::Get, path, Vec::new(), Some(b""), None),
+                query,
+                envelope(
+                    LogicalMethod::Get,
+                    path,
+                    Vec::new(),
+                    None,
+                    Some(Credential::ApiKey {
+                        value_base64: EncodedBytes::from_bytes(b"key".to_vec()),
+                    }),
+                ),
+            ] {
+                assert!(matches!(
+                    prepare_user_operation(request, bound_user_authority()),
+                    OperationPreparation::Rejected(_)
+                ));
+            }
+        }
     }
 
     #[test]

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -25,16 +25,16 @@ use crate::web::login_routes::{
     RegisterCredentials,
 };
 use crate::web::protected_routes::{
-    decrypt_data_value, encrypt_data_value, private_key_bytes_data, private_key_data,
-    protected_user_data, public_key_data, sign_message_data, third_party_token_data,
-    DecryptDataRequest, DerivationPathQuery, EncryptDataRequest, PublicKeyQuery,
-    SignMessageRequest, ThirdPartyTokenRequest,
+    decrypt_data_value, delete_all_kv_values, delete_kv_value, encrypt_data_value,
+    private_key_bytes_data, private_key_data, protected_user_data, public_key_data, put_kv_value,
+    sign_message_data, third_party_token_data, DecryptDataRequest, DerivationPathQuery,
+    EncryptDataRequest, KvValue, PublicKeyQuery, SignMessageRequest, ThirdPartyTokenRequest,
 };
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
 use super::envelope::{
-    Credential, EncodedBytes, EnvelopeLimits, HeaderField, LogicalMethod, RequestEnvelope,
-    RequestId, ResponseMode,
+    decode_canonical_kv_item_path, Credential, EncodedBytes, EnvelopeLimits, HeaderField,
+    LogicalMethod, RequestEnvelope, RequestId, ResponseMode,
 };
 use super::session::{
     AuthenticationReservation, AuthenticationStartError, AuthorityState, BoundAuthority,
@@ -76,13 +76,35 @@ pub(crate) enum UserOperation {
 
 pub(crate) enum ProtectedUserOperation {
     GetUser,
-    GetPrivateKey { query: Option<String> },
-    GetPrivateKeyBytes { query: Option<String> },
-    GetPublicKey { query: Option<String> },
-    SignMessage { body: SensitiveBytes },
-    IssueThirdPartyToken { body: SensitiveBytes },
-    EncryptData { body: SensitiveBytes },
-    DecryptData { body: SensitiveBytes },
+    GetPrivateKey {
+        query: Option<String>,
+    },
+    GetPrivateKeyBytes {
+        query: Option<String>,
+    },
+    GetPublicKey {
+        query: Option<String>,
+    },
+    SignMessage {
+        body: SensitiveBytes,
+    },
+    IssueThirdPartyToken {
+        body: SensitiveBytes,
+    },
+    EncryptData {
+        body: SensitiveBytes,
+    },
+    DecryptData {
+        body: SensitiveBytes,
+    },
+    PutKv {
+        key: Zeroizing<String>,
+        body: SensitiveBytes,
+    },
+    DeleteKv {
+        key: Zeroizing<String>,
+    },
+    DeleteAllKv,
 }
 
 #[derive(Clone)]
@@ -151,7 +173,7 @@ impl UserOperation {
 pub(crate) struct LogicalUnaryResponse {
     pub(crate) status: StatusCode,
     pub(crate) headers: Vec<HeaderField>,
-    pub(crate) body: Option<Vec<u8>>,
+    pub(crate) body: Option<Zeroizing<Vec<u8>>>,
 }
 
 impl LogicalUnaryResponse {
@@ -182,7 +204,7 @@ impl LogicalUnaryResponse {
                 name: "content-type".to_owned(),
                 value_base64: EncodedBytes::from_bytes(JSON_CONTENT_TYPE.to_vec()),
             }],
-            body: Some(body),
+            body: Some(Zeroizing::new(body)),
         })
     }
 
@@ -219,7 +241,7 @@ impl LogicalUnaryResponse {
                 name: "content-type".to_owned(),
                 value_base64: EncodedBytes::from_bytes(JSON_CONTENT_TYPE.to_vec()),
             }],
-            body: Some(body),
+            body: Some(Zeroizing::new(body)),
         }
     }
 }
@@ -252,7 +274,7 @@ pub(crate) fn prepare_user_operation(
     let RequestEnvelope {
         response_mode,
         credential,
-        request,
+        mut request,
         ..
     } = envelope;
 
@@ -269,21 +291,40 @@ pub(crate) fn prepare_user_operation(
         IssueThirdPartyToken,
         EncryptData,
         DecryptData,
+        PutKv,
+        DeleteKv,
+        DeleteAllKv,
     }
 
+    let kv_key = match decode_canonical_kv_item_path(request.method, &request.path) {
+        Ok(key) => key,
+        Err(_) => {
+            request.path.zeroize();
+            return rejected_bad_request();
+        }
+    };
     let route = match (request.method, request.path.as_str()) {
-        (LogicalMethod::Post, "/login") => Route::Login,
-        (LogicalMethod::Post, "/register") => Route::Register,
-        (LogicalMethod::Post, "/refresh") => Route::Resume,
-        (LogicalMethod::Get, "/protected/user") => Route::GetUser,
-        (LogicalMethod::Get, "/protected/private_key") => Route::GetPrivateKey,
-        (LogicalMethod::Get, "/protected/private_key_bytes") => Route::GetPrivateKeyBytes,
-        (LogicalMethod::Get, "/protected/public_key") => Route::GetPublicKey,
-        (LogicalMethod::Post, "/protected/sign_message") => Route::SignMessage,
-        (LogicalMethod::Post, "/protected/third_party_token") => Route::IssueThirdPartyToken,
-        (LogicalMethod::Post, "/protected/encrypt") => Route::EncryptData,
-        (LogicalMethod::Post, "/protected/decrypt") => Route::DecryptData,
-        _ => return OperationPreparation::Unsupported,
+        (LogicalMethod::Post, "/login") => Some(Route::Login),
+        (LogicalMethod::Post, "/register") => Some(Route::Register),
+        (LogicalMethod::Post, "/refresh") => Some(Route::Resume),
+        (LogicalMethod::Get, "/protected/user") => Some(Route::GetUser),
+        (LogicalMethod::Get, "/protected/private_key") => Some(Route::GetPrivateKey),
+        (LogicalMethod::Get, "/protected/private_key_bytes") => Some(Route::GetPrivateKeyBytes),
+        (LogicalMethod::Get, "/protected/public_key") => Some(Route::GetPublicKey),
+        (LogicalMethod::Post, "/protected/sign_message") => Some(Route::SignMessage),
+        (LogicalMethod::Post, "/protected/third_party_token") => Some(Route::IssueThirdPartyToken),
+        (LogicalMethod::Post, "/protected/encrypt") => Some(Route::EncryptData),
+        (LogicalMethod::Post, "/protected/decrypt") => Some(Route::DecryptData),
+        (LogicalMethod::Delete, "/protected/kv") => Some(Route::DeleteAllKv),
+        (LogicalMethod::Put, _) if kv_key.is_some() => Some(Route::PutKv),
+        (LogicalMethod::Delete, _) if kv_key.is_some() => Some(Route::DeleteKv),
+        _ => None,
+    };
+    if kv_key.is_some() {
+        request.path.zeroize();
+    }
+    let Some(route) = route else {
+        return OperationPreparation::Unsupported;
     };
 
     if response_mode != ResponseMode::Unary {
@@ -406,6 +447,58 @@ pub(crate) fn prepare_user_operation(
                 Route::EncryptData => ProtectedUserOperation::EncryptData { body },
                 Route::DecryptData => ProtectedUserOperation::DecryptData { body },
                 _ => unreachable!("fixed protected POST classifier is exhaustive"),
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation,
+            })
+        }
+        Route::PutKv => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            let body = request
+                .body_base64
+                .expect("validated KV value body presence")
+                .into_bytes();
+            let operation = ProtectedUserOperation::PutKv {
+                key: kv_key.expect("classified KV item route must have a decoded key"),
+                body: Zeroizing::new(body),
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation,
+            })
+        }
+        Route::DeleteKv | Route::DeleteAllKv => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            let operation = if matches!(route, Route::DeleteKv) {
+                ProtectedUserOperation::DeleteKv {
+                    key: kv_key.expect("classified KV item route must have a decoded key"),
+                }
+            } else {
+                ProtectedUserOperation::DeleteAllKv
             };
             OperationPreparation::Ready(UserOperation::Protected {
                 authority,
@@ -631,6 +724,30 @@ async fn execute_protected_user_operation(
             }
             let value = decrypt_data_value(app_state, user, auth_context, request).await?;
             LogicalUnaryResponse::json(StatusCode::OK, &*value)
+        }
+        ProtectedUserOperation::PutKv { key, body } => {
+            let value = parse_json_body::<KvValue>(body)?;
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value)?;
+            put_kv_value(app_state, user, auth_context, &key, value.as_str()).await?;
+            Ok(response)
+        }
+        ProtectedUserOperation::DeleteKv { key } => {
+            let response = LogicalUnaryResponse::json(
+                StatusCode::OK,
+                &serde_json::json!({ "message": "Resource deleted successfully" }),
+            )?;
+            delete_kv_value(app_state, user, auth_context, &key).await?;
+            Ok(response)
+        }
+        ProtectedUserOperation::DeleteAllKv => {
+            let response = LogicalUnaryResponse::json(
+                StatusCode::OK,
+                &serde_json::json!({
+                    "message": "All key-value pairs deleted successfully"
+                }),
+            )?;
+            delete_all_kv_values(app_state, user.uuid).await?;
+            Ok(response)
         }
     }
 }
@@ -1013,6 +1130,96 @@ mod tests {
     }
 
     #[test]
+    fn exact_kv_mutation_contracts_are_admitted_with_decoded_keys() {
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Put,
+                    "/protected/kv/key%2Fpart",
+                    json_header(),
+                    Some(br#""value""#),
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::PutKv { key, .. },
+                ..
+            }) if &*key == "key/part"
+        ));
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Put,
+                    "/protected/kv/empty",
+                    json_header(),
+                    Some(br#""""#),
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::PutKv { .. },
+                ..
+            })
+        ));
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Delete,
+                    "/protected/kv/%252F",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::DeleteKv { key },
+                ..
+            }) if &*key == "%2F"
+        ));
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Delete,
+                    "/protected/kv",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::DeleteAllKv,
+                ..
+            })
+        ));
+
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Get,
+                    "/protected/kv/key%2Fpart",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Unsupported
+        ));
+    }
+
+    #[test]
+    fn kv_value_keeps_the_existing_json_string_wire_shape() {
+        let wire = "\"line\\né\"";
+        let value: KvValue = serde_json::from_slice(wire.as_bytes()).unwrap();
+        assert_eq!(value.as_str(), "line\né");
+        assert_eq!(serde_json::to_vec(&value).unwrap(), wire.as_bytes());
+    }
+
+    #[test]
     fn near_miss_user_operations_are_rejected_before_dispatch() {
         let mut wrong_mode = envelope(
             LogicalMethod::Post,
@@ -1179,6 +1386,117 @@ mod tests {
                 ));
             }
         }
+    }
+
+    #[test]
+    fn kv_mutations_reject_unbound_and_transplanted_metadata() {
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Put,
+                    "/protected/kv/key",
+                    json_header(),
+                    Some(br#""value""#),
+                    None,
+                ),
+                AuthorityState::Anonymous,
+            ),
+            OperationPreparation::Rejected(_)
+        ));
+
+        let mut put_query = envelope(
+            LogicalMethod::Put,
+            "/protected/kv/key",
+            json_header(),
+            Some(br#""value""#),
+            None,
+        );
+        put_query.request.query = Some("x=1".to_owned());
+        for request in [
+            envelope(
+                LogicalMethod::Put,
+                "/protected/kv/key",
+                Vec::new(),
+                Some(br#""value""#),
+                None,
+            ),
+            envelope(
+                LogicalMethod::Put,
+                "/protected/kv/key",
+                json_header(),
+                None,
+                None,
+            ),
+            put_query,
+            envelope(
+                LogicalMethod::Put,
+                "/protected/kv/key",
+                json_header(),
+                Some(br#""value""#),
+                Some(Credential::Resumption {
+                    value_base64: EncodedBytes::from_bytes(b"token".to_vec()),
+                }),
+            ),
+        ] {
+            assert!(matches!(
+                prepare_user_operation(request, bound_user_authority()),
+                OperationPreparation::Rejected(_)
+            ));
+        }
+
+        let mut delete_query = envelope(
+            LogicalMethod::Delete,
+            "/protected/kv/key",
+            Vec::new(),
+            None,
+            None,
+        );
+        delete_query.request.query = Some("x=1".to_owned());
+        for request in [
+            envelope(
+                LogicalMethod::Delete,
+                "/protected/kv/key",
+                json_header(),
+                None,
+                None,
+            ),
+            envelope(
+                LogicalMethod::Delete,
+                "/protected/kv/key",
+                Vec::new(),
+                Some(b""),
+                None,
+            ),
+            delete_query,
+            envelope(
+                LogicalMethod::Delete,
+                "/protected/kv",
+                Vec::new(),
+                None,
+                Some(Credential::ApiKey {
+                    value_base64: EncodedBytes::from_bytes(b"key".to_vec()),
+                }),
+            ),
+        ] {
+            assert!(matches!(
+                prepare_user_operation(request, bound_user_authority()),
+                OperationPreparation::Rejected(_)
+            ));
+        }
+
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Delete,
+                    "/protected/kv/%2f",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Rejected(_)
+        ));
     }
 
     #[test]

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -5,7 +5,6 @@
 //! functions, and returns plaintext logical results for the gateway to encrypt
 //! through the request's original session lease.
 
-use std::io::{self, Write};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -17,6 +16,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use zeroize::{Zeroize, Zeroizing};
 
+use crate::bounded_json::BoundedJsonBuffer;
 use crate::jwt::{
     issue_transport_v2_user_tokens, validate_transport_v2_user_resumption, AuthContext,
 };
@@ -114,53 +114,6 @@ pub(crate) struct BoundUserAuthority {
     auth_context: AuthContext,
 }
 
-struct BoundedJsonBuffer {
-    bytes: Vec<u8>,
-    limit: usize,
-    exceeded: bool,
-}
-
-impl BoundedJsonBuffer {
-    fn new(limit: usize) -> Self {
-        Self {
-            bytes: Vec::new(),
-            limit,
-            exceeded: false,
-        }
-    }
-
-    fn into_bytes(mut self) -> Vec<u8> {
-        std::mem::take(&mut self.bytes)
-    }
-}
-
-impl Write for BoundedJsonBuffer {
-    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
-        let Some(next) = self.bytes.len().checked_add(buffer.len()) else {
-            self.exceeded = true;
-            return Err(io::Error::other("serialized JSON length overflow"));
-        };
-        if next > self.limit {
-            self.exceeded = true;
-            return Err(io::Error::other(
-                "serialized JSON exceeds logical response limit",
-            ));
-        }
-        self.bytes.extend_from_slice(buffer);
-        Ok(buffer.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
-impl Drop for BoundedJsonBuffer {
-    fn drop(&mut self) {
-        self.bytes.zeroize();
-    }
-}
-
 impl UserOperation {
     pub(crate) const fn requires_authentication_transition(&self) -> bool {
         matches!(
@@ -188,7 +141,7 @@ impl LogicalUnaryResponse {
     ) -> Result<Self, ApiError> {
         let mut buffer = BoundedJsonBuffer::new(logical_body_bytes);
         if let Err(error) = serde_json::to_writer(&mut buffer, value) {
-            if buffer.exceeded {
+            if buffer.exceeded() {
                 return Err(ApiError::PayloadTooLarge);
             }
             tracing::error!(
@@ -204,7 +157,7 @@ impl LogicalUnaryResponse {
                 name: "content-type".to_owned(),
                 value_base64: EncodedBytes::from_bytes(JSON_CONTENT_TYPE.to_vec()),
             }],
-            body: Some(Zeroizing::new(body)),
+            body: Some(body),
         })
     }
 
@@ -1546,8 +1499,8 @@ mod tests {
 
         let mut buffer = BoundedJsonBuffer::new(7);
         assert!(serde_json::to_writer(&mut buffer, &escaped).is_err());
-        assert!(buffer.exceeded);
-        assert!(buffer.bytes.len() <= 7);
+        assert!(buffer.exceeded());
+        assert!(buffer.len() <= 7);
     }
 
     #[test]

--- a/src/transport_v2/envelope.rs
+++ b/src/transport_v2/envelope.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 const MIB: usize = 1024 * 1024;
 const KIB: usize = 1024;
@@ -357,7 +357,7 @@ impl RequestEnvelope {
 
 impl LogicalRequest {
     pub(crate) fn validate(&self, limits: &EnvelopeLimits) -> Result<(), EnvelopeError> {
-        validate_path(&self.path, limits)?;
+        validate_logical_path(self.method, &self.path, limits)?;
         if let Some(query) = self.query.as_deref() {
             validate_query(query, limits)?;
         }
@@ -366,6 +366,97 @@ impl LogicalRequest {
             check_limit(body.len(), limits.logical_body_bytes, "logical body")?;
         }
         Ok(())
+    }
+}
+
+const KV_ITEM_PATH_PREFIX: &str = "/protected/kv/";
+
+fn validate_logical_path(
+    method: LogicalMethod,
+    path: &str,
+    limits: &EnvelopeLimits,
+) -> Result<(), EnvelopeError> {
+    check_limit(path.len(), limits.path_bytes, "path")?;
+    if decode_canonical_kv_item_path(method, path)?.is_some() {
+        return Ok(());
+    }
+    validate_path(path, limits)
+}
+
+/// Decodes the one opaque UTF-8 segment admitted by the released KV item API.
+///
+/// Literal separators select the route before this function runs. Every
+/// non-alphanumeric key byte must use one uppercase `%HH` triplet, matching the
+/// Rust SDK's `NON_ALPHANUMERIC` encoder. The result is decoded exactly once.
+pub(crate) fn decode_canonical_kv_item_path(
+    method: LogicalMethod,
+    path: &str,
+) -> Result<Option<Zeroizing<String>>, EnvelopeError> {
+    if !matches!(
+        method,
+        LogicalMethod::Get | LogicalMethod::Put | LogicalMethod::Delete
+    ) {
+        return Ok(None);
+    }
+    let Some(segment) = path.strip_prefix(KV_ITEM_PATH_PREFIX) else {
+        return Ok(None);
+    };
+    if segment.is_empty() {
+        return Err(EnvelopeError::InvalidPath(
+            "opaque path segment must not be empty",
+        ));
+    }
+
+    let encoded = segment.as_bytes();
+    let mut decoded = Zeroizing::new(Vec::with_capacity(encoded.len()));
+    let mut index = 0;
+    while index < encoded.len() {
+        let byte = encoded[index];
+        if byte.is_ascii_alphanumeric() {
+            decoded.push(byte);
+            index += 1;
+            continue;
+        }
+        if byte != b'%' {
+            return Err(EnvelopeError::InvalidPath(
+                "opaque path segment is not canonically encoded",
+            ));
+        }
+        let high = *encoded
+            .get(index + 1)
+            .ok_or(EnvelopeError::InvalidPath("invalid percent encoding"))?;
+        let low = *encoded
+            .get(index + 2)
+            .ok_or(EnvelopeError::InvalidPath("invalid percent encoding"))?;
+        let decoded_byte = (canonical_uri_hex_nibble(high)? << 4) | canonical_uri_hex_nibble(low)?;
+        if decoded_byte.is_ascii_alphanumeric() {
+            return Err(EnvelopeError::InvalidPath(
+                "opaque path segment over-encodes an alphanumeric byte",
+            ));
+        }
+        decoded.push(decoded_byte);
+        index += 3;
+    }
+
+    match String::from_utf8(std::mem::take(&mut *decoded)) {
+        Ok(value) => Ok(Some(Zeroizing::new(value))),
+        Err(error) => {
+            let mut bytes = error.into_bytes();
+            bytes.zeroize();
+            Err(EnvelopeError::InvalidPath(
+                "opaque path segment is not valid UTF-8",
+            ))
+        }
+    }
+}
+
+fn canonical_uri_hex_nibble(byte: u8) -> Result<u8, EnvelopeError> {
+    match byte {
+        b'0'..=b'9' => Ok(byte - b'0'),
+        b'A'..=b'F' => Ok(byte - b'A' + 10),
+        _ => Err(EnvelopeError::InvalidPath(
+            "opaque path segment requires uppercase percent encoding",
+        )),
     }
 }
 
@@ -913,6 +1004,88 @@ mod tests {
             &EnvelopeLimits::default(),
         )
         .unwrap();
+    }
+
+    #[test]
+    fn kv_item_paths_use_one_route_scoped_canonical_utf8_segment() {
+        for (encoded, decoded) in [
+            ("simple123", "simple123"),
+            ("key%2Fwith%2Fslashes", "key/with/slashes"),
+            ("key%3Fwith%3Dquery%26params", "key?with=query&params"),
+            ("key%23with%23hash", "key#with#hash"),
+            ("key%20with%20spaces", "key with spaces"),
+            ("key%25with%25percents", "key%with%percents"),
+            ("key%40with%21special%24chars", "key@with!special$chars"),
+            ("%2D%5F%2E%21%7E%2A%27%28%29", "-_.!~*'()"),
+            ("%2E", "."),
+            ("%2E%2E", ".."),
+            ("%2F", "/"),
+            ("%5C", "\\"),
+            ("%252F", "%2F"),
+            ("caf%C3%A9", "café"),
+            ("%F0%9F%94%90", "🔐"),
+        ] {
+            for method in [
+                LogicalMethod::Get,
+                LogicalMethod::Put,
+                LogicalMethod::Delete,
+            ] {
+                let path = format!("{KV_ITEM_PATH_PREFIX}{encoded}");
+                let value = decode_canonical_kv_item_path(method, &path)
+                    .unwrap()
+                    .expect("KV item route must decode");
+                assert_eq!(&*value, decoded, "{method:?} {encoded}");
+                validate_logical_path(method, &path, &EnvelopeLimits::default()).unwrap();
+            }
+        }
+
+        let json = request_json("null")
+            .replace("\"method\":\"POST\"", "\"method\":\"GET\"")
+            .replace("/v1/responses", "/protected/kv/key%2Fpart");
+        let envelope =
+            RequestEnvelope::from_json_slice(json.as_bytes(), &EnvelopeLimits::default()).unwrap();
+        assert_eq!(envelope.request.path, "/protected/kv/key%2Fpart");
+    }
+
+    #[test]
+    fn kv_item_paths_reject_noncanonical_or_ambiguous_segments() {
+        for invalid in [
+            "/protected/kv/",
+            "/protected/kv/a/b",
+            "/protected/kv/%2f",
+            "/protected/kv/%5c",
+            "/protected/kv/%2e",
+            "/protected/kv/%41",
+            "/protected/kv/%",
+            "/protected/kv/%0",
+            "/protected/kv/%GG",
+            "/protected/kv/raw_punctuation",
+            "/protected/kv/café",
+            "/protected/kv/%FF",
+        ] {
+            assert!(
+                validate_logical_path(LogicalMethod::Get, invalid, &EnvelopeLimits::default())
+                    .is_err(),
+                "{invalid}"
+            );
+        }
+
+        assert!(
+            decode_canonical_kv_item_path(LogicalMethod::Post, "/protected/kv/key%2Fpart")
+                .unwrap()
+                .is_none()
+        );
+        assert!(validate_logical_path(
+            LogicalMethod::Post,
+            "/protected/kv/key%2Fpart",
+            &EnvelopeLimits::default()
+        )
+        .is_err());
+        assert!(
+            decode_canonical_kv_item_path(LogicalMethod::Get, "/protected/kvx/key")
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/transport_v2/gateway.rs
+++ b/src/transport_v2/gateway.rs
@@ -26,6 +26,7 @@ use zeroize::Zeroize;
 
 use crate::encrypt::CustomRng;
 use crate::web::attestation_routes;
+use crate::web::encryption_middleware::hold_resource_through_response_body;
 use crate::{AppState, AsyncRngWrapper};
 
 use super::application::{
@@ -587,7 +588,7 @@ async fn key_exchange(
 async fn encrypted_request(
     State(app_state): State<Arc<AppState>>,
     request: Request<Body>,
-) -> Result<Json<EncryptedOuterResponse>, GatewayError> {
+) -> Result<Response, GatewayError> {
     let session_id = parse_request_session_id(request.uri(), request.headers())?;
     validate_json_content_type(request.headers())?;
     let working_set_permit = app_state
@@ -612,8 +613,15 @@ async fn encrypted_request(
         )
         .await?;
     drop(encrypted);
-    drop(working_set_permit);
-    Ok(Json(response))
+    Ok(encrypted_outer_http_response(response, working_set_permit))
+}
+
+fn encrypted_outer_http_response(
+    response: EncryptedOuterResponse,
+    working_set_permit: OwnedSemaphorePermit,
+) -> Response {
+    let response = Json(response).into_response();
+    hold_resource_through_response_body(response, working_set_permit)
 }
 
 #[derive(Deserialize)]
@@ -1292,6 +1300,29 @@ mod tests {
         assert!(Arc::clone(&state.request_working_set)
             .try_acquire_many_owned(maximum_units)
             .is_ok());
+    }
+
+    #[tokio::test]
+    async fn encrypted_outer_response_holds_working_set_through_body_lifetime() {
+        let working_set = Arc::new(Semaphore::new(1));
+        let response_value = || EncryptedOuterResponse {
+            encrypted: EncodedBytes::from_bytes(vec![1, 2, 3]),
+        };
+
+        let permit = Arc::clone(&working_set).try_acquire_owned().unwrap();
+        let response = encrypted_outer_http_response(response_value(), permit);
+        assert_eq!(working_set.available_permits(), 0);
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()[header::CONTENT_TYPE], "application/json");
+        let body = to_bytes(response.into_body(), 1024).await.unwrap();
+        assert_eq!(&body[..], br#"{"encrypted":"AQID"}"#);
+        assert_eq!(working_set.available_permits(), 1);
+
+        let permit = Arc::clone(&working_set).try_acquire_owned().unwrap();
+        let response = encrypted_outer_http_response(response_value(), permit);
+        assert_eq!(working_set.available_permits(), 0);
+        drop(response);
+        assert_eq!(working_set.available_permits(), 1);
     }
 
     #[test]

--- a/src/transport_v2/gateway.rs
+++ b/src/transport_v2/gateway.rs
@@ -724,7 +724,9 @@ fn encrypt_reserved_logical_response(
         request_id,
         status: response.status.as_u16(),
         headers: response.headers,
-        body_base64: response.body.map(EncodedBytes::from_bytes),
+        body_base64: response
+            .body
+            .map(|mut body| EncodedBytes::from_bytes(std::mem::take(&mut *body))),
     };
     if response.validate(&EnvelopeLimits::default()).is_err() {
         zeroize_response_body(&mut response);
@@ -1054,7 +1056,7 @@ mod tests {
             response: LogicalUnaryResponse {
                 status: StatusCode::OK,
                 headers: Vec::new(),
-                body: Some(br#"{"ok":true}"#.to_vec()),
+                body: Some(zeroize::Zeroizing::new(br#"{"ok":true}"#.to_vec())),
             },
             bound_session: false,
         }

--- a/src/transport_v2/gateway.rs
+++ b/src/transport_v2/gateway.rs
@@ -55,6 +55,9 @@ const REQUEST_WORKING_SET_UNIT_BYTES: usize = 64 * 1024;
 const REQUEST_WORKING_SET_MULTIPLIER: usize = 4;
 const REQUEST_WORKING_SET_UNITS: usize =
     REQUEST_WORKING_SET_BUDGET_BYTES / REQUEST_WORKING_SET_UNIT_BYTES;
+const STORED_OUTPUT_WORKING_SET_BYTES: usize = 200 * 1024 * 1024;
+const STORED_OUTPUT_WORKING_SET_UNITS: usize =
+    STORED_OUTPUT_WORKING_SET_BYTES / REQUEST_WORKING_SET_UNIT_BYTES;
 const SESSION_ID_HEADER: &str = "x-session-id";
 
 type PendingAttestationKey = [u8; 32];
@@ -333,6 +336,25 @@ impl TransportV2State {
             .map_err(|_| GatewayError::Unavailable)
     }
 
+    fn promote_stored_output_working_set(
+        &self,
+        permit: &mut OwnedSemaphorePermit,
+    ) -> Result<(), GatewayError> {
+        let additional_units = STORED_OUTPUT_WORKING_SET_UNITS
+            .checked_sub(permit.num_permits())
+            .unwrap_or_default();
+        if additional_units == 0 {
+            return Ok(());
+        }
+        let additional_units =
+            u32::try_from(additional_units).map_err(|_| GatewayError::Internal)?;
+        let additional = Arc::clone(&self.request_working_set)
+            .try_acquire_many_owned(additional_units)
+            .map_err(|_| GatewayError::Unavailable)?;
+        permit.merge(additional);
+        Ok(())
+    }
+
     /// Removes expired v2 pending handshakes and terminal v2 sessions.
     ///
     /// Both retirement collections outlive their respective lock guards. The
@@ -361,6 +383,7 @@ impl TransportV2State {
         app_state: Arc<AppState>,
         session_id: Uuid,
         encrypted: &[u8],
+        working_set_permit: &mut OwnedSemaphorePermit,
         now: Instant,
     ) -> Result<EncryptedOuterResponse, GatewayError> {
         let (lease, envelope) = self
@@ -390,6 +413,7 @@ impl TransportV2State {
             &lease,
             request_id,
             operation,
+            working_set_permit,
             now,
             move |dispatch_lease, operation, authentication, admitted_at| {
                 execute_user_operation(
@@ -409,6 +433,7 @@ impl TransportV2State {
         lease: &V2SessionLease,
         request_id: super::envelope::RequestId,
         operation: super::application::UserOperation,
+        working_set_permit: &mut OwnedSemaphorePermit,
         now: Instant,
         dispatch: Dispatch,
     ) -> Result<EncryptedOuterResponse, GatewayError>
@@ -428,6 +453,22 @@ impl TransportV2State {
             .state()
             .begin_unary_response()
             .map_err(GatewayError::from_session_record)?;
+        if operation.requires_stored_output_reservation()
+            && self
+                .promote_stored_output_working_set(working_set_permit)
+                .is_err()
+        {
+            return encrypt_reserved_logical_response(
+                lease,
+                request_id,
+                reservation,
+                LogicalUnaryResponse::protocol_error(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "stored_output_unavailable",
+                    "Stored response capacity is unavailable",
+                ),
+            );
+        }
         match lease.state().claim_request_id(request_id) {
             ReplayClaim::Claimed => {}
             ReplayClaim::Duplicate => {
@@ -591,7 +632,7 @@ async fn encrypted_request(
 ) -> Result<Response, GatewayError> {
     let session_id = parse_request_session_id(request.uri(), request.headers())?;
     validate_json_content_type(request.headers())?;
-    let working_set_permit = app_state
+    let mut working_set_permit = app_state
         .transport_v2_state
         .reserve_request_working_set(request.headers())?;
 
@@ -609,6 +650,7 @@ async fn encrypted_request(
             Arc::clone(&app_state),
             session_id,
             &encrypted,
+            &mut working_set_permit,
             Instant::now(),
         )
         .await?;
@@ -1304,6 +1346,27 @@ mod tests {
             .is_ok());
     }
 
+    #[test]
+    fn stored_output_promotion_reaches_the_conservative_response_reservation() {
+        let state = TransportV2State::new();
+        let mut permit = Arc::clone(&state.request_working_set)
+            .try_acquire_owned()
+            .unwrap();
+        state
+            .promote_stored_output_working_set(&mut permit)
+            .unwrap();
+        assert_eq!(permit.num_permits(), STORED_OUTPUT_WORKING_SET_UNITS);
+        assert_eq!(
+            state.request_working_set.available_permits(),
+            REQUEST_WORKING_SET_UNITS - STORED_OUTPUT_WORKING_SET_UNITS
+        );
+
+        state
+            .promote_stored_output_working_set(&mut permit)
+            .unwrap();
+        assert_eq!(permit.num_permits(), STORED_OUTPUT_WORKING_SET_UNITS);
+    }
+
     #[tokio::test]
     async fn encrypted_outer_response_holds_working_set_through_body_lifetime() {
         let working_set = Arc::new(Semaphore::new(1));
@@ -1473,11 +1536,15 @@ mod tests {
             panic!("valid login operation must be ready");
         };
         let first_dispatches = Arc::clone(&dispatches);
+        let mut working_set_permit = Arc::clone(&state.request_working_set)
+            .try_acquire_owned()
+            .unwrap();
         let first = state
             .process_ready_operation(
                 &lease,
                 request_id,
                 operation,
+                &mut working_set_permit,
                 now,
                 move |_lease, _operation, authentication, _| async move {
                     first_dispatches.fetch_add(1, Ordering::SeqCst);
@@ -1507,6 +1574,7 @@ mod tests {
                 &lease,
                 request_id,
                 operation,
+                &mut working_set_permit,
                 now,
                 move |_lease, _operation, authentication, _| async move {
                     second_dispatches.fetch_add(1, Ordering::SeqCst);
@@ -1593,11 +1661,15 @@ mod tests {
         else {
             panic!("a null body is a valid bodyless protected request");
         };
+        let mut working_set_permit = Arc::clone(&state.request_working_set)
+            .try_acquire_owned()
+            .unwrap();
         let response = state
             .process_ready_operation(
                 &lease,
                 request_id,
                 operation,
+                &mut working_set_permit,
                 now,
                 |_lease, _operation, authentication, _| async move {
                     assert!(authentication.is_none());
@@ -1611,6 +1683,75 @@ mod tests {
             200
         );
         assert_eq!(lease.state().replay_id_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn stored_output_contention_is_authenticated_before_replay_or_dispatch() {
+        let mut state = TransportV2State::new();
+        state.request_working_set = Arc::new(Semaphore::new(1));
+        let now = Instant::now();
+        let session_id = Uuid::new_v4();
+        let master_bytes = [0x71; 32];
+        let session = test_session(
+            session_id,
+            master_bytes,
+            now + Duration::from_secs(60),
+            Arc::clone(&state.global_replay_budget),
+        );
+        let auth_context = AuthContext::new(AuthMethod::Password, 7, [0x72; 32]);
+        session
+            .begin_authentication(RequestId::from_bytes([0x73; 16]))
+            .unwrap()
+            .commit_at(
+                BoundAuthority::user(
+                    Uuid::from_bytes([0x74; 16]),
+                    7,
+                    &auth_context,
+                    now + Duration::from_secs(30),
+                ),
+                now,
+            )
+            .unwrap();
+        state.insert_session(session).await.unwrap();
+
+        let request_id = RequestId::from_bytes([0x75; 16]);
+        let mut envelope = get_user_envelope(request_id, None);
+        envelope.request.path = "/protected/kv".to_owned();
+        let lease = state.acquire_session(&session_id, now).await.unwrap();
+        let OperationPreparation::Ready(operation) =
+            prepare_user_operation(envelope, lease.state().authority())
+        else {
+            panic!("valid KV list operation must be ready");
+        };
+        let mut working_set_permit = Arc::clone(&state.request_working_set)
+            .try_acquire_owned()
+            .unwrap();
+        let dispatches = Arc::new(AtomicUsize::new(0));
+        let observed_dispatches = Arc::clone(&dispatches);
+        let response = state
+            .process_ready_operation(
+                &lease,
+                request_id,
+                operation,
+                &mut working_set_permit,
+                now,
+                move |_lease, _operation, _authentication, _| async move {
+                    observed_dispatches.fetch_add(1, Ordering::SeqCst);
+                    successful_test_outcome()
+                },
+            )
+            .await
+            .unwrap();
+
+        let master = SessionMaster::from_bytes(master_bytes);
+        let client_keys = DirectionalKeys::derive(&master).unwrap();
+        assert_eq!(
+            response_status(&client_keys, &session_id, &request_id, &response),
+            503
+        );
+        assert_eq!(dispatches.load(Ordering::SeqCst), 0);
+        assert_eq!(lease.state().replay_id_count(), 0);
+        assert_eq!(working_set_permit.num_permits(), 1);
     }
 
     #[tokio::test]

--- a/src/web/encryption_middleware.rs
+++ b/src/web/encryption_middleware.rs
@@ -173,7 +173,10 @@ where
     Ok(hold_resource_through_response_body(response, session_lease))
 }
 
-fn hold_resource_through_response_body<T>(mut response: Response, resource: T) -> Response
+pub(crate) fn hold_resource_through_response_body<T>(
+    mut response: Response,
+    resource: T,
+) -> Response
 where
     T: Send + Unpin + 'static,
 {

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -376,6 +376,16 @@ pub struct DecryptDataRequest {
     pub key_options: KeyOptions,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
+#[serde(transparent)]
+pub(crate) struct KvValue(String);
+
+impl KvValue {
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 // API Key Management Types
 
 // Validation function for API key names
@@ -452,7 +462,7 @@ pub fn router(app_state: Arc<AppState>) -> Router<()> {
             "/protected/kv/:key",
             put(put_kv).layer(from_fn_with_state(
                 app_state.clone(),
-                decrypt_request::<String>,
+                decrypt_request::<KvValue>,
             )),
         )
         .route(
@@ -637,7 +647,8 @@ pub async fn get_kv(
     Extension(session_id): Extension<TransportSession>,
     Path(key): Path<String>,
 ) -> Result<Json<EncryptedResponse<Option<String>>>, ApiError> {
-    let value = match data.get(&user, &auth_context, key).await {
+    let key = Zeroizing::new(key);
+    let value = match data.get(&user, &auth_context, &key).await {
         Ok(kv) => kv,
         Err(e) => {
             tracing::error!("Error getting key-value pair: {:?}", e);
@@ -653,16 +664,24 @@ pub async fn put_kv(
     Extension(auth_context): Extension<AuthContext>,
     Extension(session_id): Extension<TransportSession>,
     Path(key): Path<String>,
-    Extension(value): Extension<String>,
-) -> Result<Json<EncryptedResponse<String>>, ApiError> {
-    match data.put(&user, &auth_context, key, value.clone()).await {
-        Ok(kv) => kv,
-        Err(e) => {
-            tracing::error!("Error putting key-value pair: {:?}", e);
-            return Err(ApiError::InternalServerError);
-        }
-    };
+    Extension(value): Extension<KvValue>,
+) -> Result<Json<EncryptedResponse<KvValue>>, ApiError> {
+    let key = Zeroizing::new(key);
+    put_kv_value(&data, &user, &auth_context, &key, value.as_str()).await?;
     encrypt_response(&data, &session_id, &value).await
+}
+
+pub(crate) async fn put_kv_value(
+    data: &AppState,
+    user: &User,
+    auth_context: &AuthContext,
+    key: &str,
+    value: &str,
+) -> Result<(), ApiError> {
+    data.put(user, auth_context, key, value).await.map_err(|_| {
+        tracing::error!("Error putting key-value pair");
+        ApiError::InternalServerError
+    })
 }
 
 pub async fn delete_kv(
@@ -672,16 +691,22 @@ pub async fn delete_kv(
     Extension(session_id): Extension<TransportSession>,
     Path(key): Path<String>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    match data.delete(&user, &auth_context, key).await {
-        Ok(_) => {
-            let response = json!({ "message": "Resource deleted successfully" });
-            encrypt_response(&data, &session_id, &response).await
-        }
-        Err(e) => {
-            tracing::error!("Error deleting key-value pair: {:?}", e);
-            Err(ApiError::InternalServerError)
-        }
-    }
+    let key = Zeroizing::new(key);
+    delete_kv_value(&data, &user, &auth_context, &key).await?;
+    let response = json!({ "message": "Resource deleted successfully" });
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn delete_kv_value(
+    data: &AppState,
+    user: &User,
+    auth_context: &AuthContext,
+    key: &str,
+) -> Result<(), ApiError> {
+    data.delete(user, auth_context, key).await.map_err(|_| {
+        tracing::error!("Error deleting key-value pair");
+        ApiError::InternalServerError
+    })
 }
 
 pub async fn delete_all_kv(
@@ -689,18 +714,18 @@ pub async fn delete_all_kv(
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
-    match data.delete_all(user.uuid).await {
-        Ok(_) => {
-            let response = json!({
-                "message": "All key-value pairs deleted successfully"
-            });
-            encrypt_response(&data, &session_id, &response).await
-        }
-        Err(e) => {
-            tracing::error!("Error deleting all key-value pairs: {:?}", e);
-            Err(ApiError::InternalServerError)
-        }
-    }
+    delete_all_kv_values(&data, user.uuid).await?;
+    let response = json!({
+        "message": "All key-value pairs deleted successfully"
+    });
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn delete_all_kv_values(data: &AppState, user_id: Uuid) -> Result<(), ApiError> {
+    data.delete_all(user_id).await.map_err(|_| {
+        tracing::error!("Error deleting all key-value pairs");
+        ApiError::InternalServerError
+    })
 }
 
 pub async fn list_kv(
@@ -1491,6 +1516,7 @@ mod tests {
         assert_zeroize_on_drop::<EncryptDataRequest>();
         assert_zeroize_on_drop::<EncryptDataResponse>();
         assert_zeroize_on_drop::<DecryptDataRequest>();
+        assert_zeroize_on_drop::<KvValue>();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- define canonical v2 KV paths matching released SDK encoding
- retain request and response working-set reservations through final body consumption
- project PUT, item DELETE, delete-all, item GET, and list through transport-neutral helpers
- add the shared bounded zeroizing JSON writer
- use v2-only repeatable-read preflight/fetch paths for stored output
- preserve exact v1 KV values, timestamps, ordering, missing-item, error, and encryption behavior

This consolidated PR contains the original commits from #314 through #318.

## Security properties

- validates bound authority and the complete encrypted route before dispatch
- reserves stored-output capacity before replay claim or storage access
- claims replay before every mutation
- bounds rows, ciphertext, aggregate plaintext, and final serialized output
- scopes every query and mutation to the bound user
- prevents size-preflight races with one read-only repeatable-read snapshot
- zeroizes keys, values, ciphertext projections, decoded data, and response buffers

## Compatibility

Every v1 route, handler, query, session, ciphertext, and response shape is unchanged. Existing SDKs continue to use v1.

## Validation

- strict formatting, Clippy, and full Rust suite
- disposable PostgreSQL bounded-read and tamper tests
- managed OpenSecret/Postgres/Continuum smoke
- released v1 client compatibility proofs
- raw encrypted v2 mutation/read/list/replay/isolation matrix
- independent security, compatibility, and working-set reviews

The original per-commit discussion and validation records remain available in #314–#317.