### PR TITLE
Transport v2: project API-key mutations

### DIFF
--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -289,6 +289,13 @@ and distinct Unicode byte strings remain application data rather than routing
 syntax. The future TypeScript v2 SDK must implement the same UTF-8 byte codec;
 generic URI encoders that leave punctuation unescaped are insufficient.
 
+`DELETE /protected/api-keys/<name>` reuses that exact opaque-segment codec and
+then applies the existing API-key name contract after decoding: 1–50 ASCII
+alphanumeric, space, hyphen, or underscore characters, with no edge spaces.
+For example, `Production Key-1_test` has the single v2 spelling
+`Production%20Key%2D1%5Ftest`. Other encodings of the same name are rejected;
+transport-v1 path handling is unchanged.
+
 The gateway never hands an arbitrary URI to the full transport-v1 router.
 Application operations are projected deliberately onto shared application
 services/handlers.
@@ -681,8 +688,14 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    consumption. Preserve `null`, string, bare-array, timestamp, ordering, and
    whole-list failure behavior from v1 while leaving every v1 query untouched.
 11. **Remaining protected user operations**: project account-lifecycle and user
-   API-key-management families in reviewable sub-stacks. Password/account
-   deletion must explicitly close the now-invalid bound session.
+   API-key-management families in reviewable sub-stacks. Start API-key
+   administration with bounded create/delete mutations: retain the existing
+   raw UUID key format without rotation, return it only through the original
+   bound-session response, wipe its plaintext response value on drop, and use
+   the canonical validated name segment for deletion. Keep list unsupported
+   until a following slice adds stored-output admission and a bounded narrow
+   database projection. Password/account deletion must explicitly close the
+   now-invalid bound session.
 12. **Stored user unary operations**: project conversations, conversation
    projects, instructions, response control, and web-provider unary routes in
    ownership-preserving families before the client cutover.

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -26,16 +26,17 @@ use crate::web::login_routes::{
     RegisterCredentials,
 };
 use crate::web::protected_routes::{
-    decrypt_data_value, delete_all_kv_values, delete_kv_value, encrypt_data_value,
-    private_key_bytes_data, private_key_data, protected_user_data, public_key_data, put_kv_value,
-    sign_message_data, third_party_token_data, DecryptDataRequest, DerivationPathQuery,
-    EncryptDataRequest, KvValue, PublicKeyQuery, SignMessageRequest, ThirdPartyTokenRequest,
+    create_api_key_data, decrypt_data_value, delete_all_kv_values, delete_api_key_by_name,
+    delete_kv_value, encrypt_data_value, private_key_bytes_data, private_key_data,
+    protected_user_data, public_key_data, put_kv_value, sign_message_data, third_party_token_data,
+    CreateApiKeyRequest, DecryptDataRequest, DerivationPathQuery, EncryptDataRequest, KvValue,
+    PublicKeyQuery, SignMessageRequest, ThirdPartyTokenRequest,
 };
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
 use super::envelope::{
-    decode_canonical_kv_item_path, Credential, EncodedBytes, EnvelopeLimits, HeaderField,
-    LogicalMethod, RequestEnvelope, RequestId, ResponseMode,
+    decode_canonical_api_key_name_path, decode_canonical_kv_item_path, Credential, EncodedBytes,
+    EnvelopeLimits, HeaderField, LogicalMethod, RequestEnvelope, RequestId, ResponseMode,
 };
 use super::session::{
     AuthenticationReservation, AuthenticationStartError, AuthorityState, BoundAuthority,
@@ -111,6 +112,12 @@ pub(crate) enum ProtectedUserOperation {
         key: Zeroizing<String>,
     },
     DeleteAllKv,
+    CreateApiKey {
+        body: SensitiveBytes,
+    },
+    DeleteApiKey {
+        name: Zeroizing<String>,
+    },
 }
 
 #[derive(Clone)]
@@ -265,10 +272,19 @@ pub(crate) fn prepare_user_operation(
         PutKv,
         DeleteKv,
         DeleteAllKv,
+        CreateApiKey,
+        DeleteApiKey,
     }
 
     let kv_key = match decode_canonical_kv_item_path(request.method, &request.path) {
         Ok(key) => key,
+        Err(_) => {
+            request.path.zeroize();
+            return rejected_bad_request();
+        }
+    };
+    let api_key_name = match decode_canonical_api_key_name_path(request.method, &request.path) {
+        Ok(name) => name,
         Err(_) => {
             request.path.zeroize();
             return rejected_bad_request();
@@ -288,12 +304,14 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Post, "/protected/decrypt") => Some(Route::DecryptData),
         (LogicalMethod::Get, "/protected/kv") => Some(Route::ListKv),
         (LogicalMethod::Delete, "/protected/kv") => Some(Route::DeleteAllKv),
+        (LogicalMethod::Post, "/protected/api-keys") => Some(Route::CreateApiKey),
         (LogicalMethod::Get, _) if kv_key.is_some() => Some(Route::GetKv),
         (LogicalMethod::Put, _) if kv_key.is_some() => Some(Route::PutKv),
         (LogicalMethod::Delete, _) if kv_key.is_some() => Some(Route::DeleteKv),
+        (LogicalMethod::Delete, _) if api_key_name.is_some() => Some(Route::DeleteApiKey),
         _ => None,
     };
-    if kv_key.is_some() {
+    if kv_key.is_some() || api_key_name.is_some() {
         request.path.zeroize();
     }
     let Some(route) = route else {
@@ -500,6 +518,52 @@ pub(crate) fn prepare_user_operation(
             OperationPreparation::Ready(UserOperation::Protected {
                 authority,
                 operation,
+            })
+        }
+        Route::CreateApiKey => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            let body = request
+                .body_base64
+                .expect("validated API-key creation body presence")
+                .into_bytes();
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation: ProtectedUserOperation::CreateApiKey {
+                    body: Zeroizing::new(body),
+                },
+            })
+        }
+        Route::DeleteApiKey => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation: ProtectedUserOperation::DeleteApiKey {
+                    name: api_key_name
+                        .expect("classified API-key item route must have a decoded name"),
+                },
             })
         }
     }
@@ -768,6 +832,19 @@ async fn execute_protected_user_operation(
                 }),
             )?;
             delete_all_kv_values(app_state, user.uuid).await?;
+            Ok(response)
+        }
+        ProtectedUserOperation::CreateApiKey { body } => {
+            let request = parse_json_body::<CreateApiKeyRequest>(body)?;
+            let value = create_api_key_data(app_state, user, request).await?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::DeleteApiKey { name } => {
+            let response = LogicalUnaryResponse::json(
+                StatusCode::OK,
+                &serde_json::json!({ "success": true }),
+            )?;
+            delete_api_key_by_name(app_state, user, &name)?;
             Ok(response)
         }
     }
@@ -1224,6 +1301,134 @@ mod tests {
                 operation: ProtectedUserOperation::DeleteAllKv,
                 ..
             })
+        ));
+    }
+
+    #[test]
+    fn exact_api_key_mutation_contracts_are_admitted() {
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Post,
+                    "/protected/api-keys",
+                    json_header(),
+                    Some(br#"{"name":"Production Key-1_test"}"#),
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::CreateApiKey { .. },
+                ..
+            })
+        ));
+
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Delete,
+                    "/protected/api-keys/Production%20Key%2D1%5Ftest",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::DeleteApiKey { name },
+                ..
+            }) if &*name == "Production Key-1_test"
+        ));
+
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Get,
+                    "/protected/api-keys",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Unsupported
+        ));
+    }
+
+    #[test]
+    fn api_key_mutations_reject_anonymous_and_transplanted_metadata() {
+        let create = || {
+            envelope(
+                LogicalMethod::Post,
+                "/protected/api-keys",
+                json_header(),
+                Some(br#"{"name":"Production Key"}"#),
+                None,
+            )
+        };
+        assert!(matches!(
+            prepare_user_operation(create(), AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::UNAUTHORIZED
+        ));
+
+        let mut create_with_query = create();
+        create_with_query.request.query = Some("transplanted=true".to_owned());
+        assert!(matches!(
+            prepare_user_operation(create_with_query, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut create_with_credential = create();
+        create_with_credential.credential = Some(Credential::Resumption {
+            value_base64: EncodedBytes::from_bytes(b"transplanted".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(create_with_credential, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut create_stream = create();
+        create_stream.response_mode = ResponseMode::Stream;
+        assert!(matches!(
+            prepare_user_operation(create_stream, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let delete = || {
+            envelope(
+                LogicalMethod::Delete,
+                "/protected/api-keys/Production%20Key",
+                Vec::new(),
+                None,
+                None,
+            )
+        };
+        let mut delete_with_body = delete();
+        delete_with_body.request.body_base64 = Some(EncodedBytes::from_bytes(b"{}".to_vec()));
+        assert!(matches!(
+            prepare_user_operation(delete_with_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut delete_with_header = delete();
+        delete_with_header.request.headers = json_header();
+        assert!(matches!(
+            prepare_user_operation(delete_with_header, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut delete_with_query = delete();
+        delete_with_query.request.query = Some("transplanted=true".to_owned());
+        assert!(matches!(
+            prepare_user_operation(delete_with_query, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
         ));
     }
 

--- a/src/transport_v2/envelope.rs
+++ b/src/transport_v2/envelope.rs
@@ -370,6 +370,7 @@ impl LogicalRequest {
 }
 
 const KV_ITEM_PATH_PREFIX: &str = "/protected/kv/";
+const API_KEY_ITEM_PATH_PREFIX: &str = "/protected/api-keys/";
 
 fn validate_logical_path(
     method: LogicalMethod,
@@ -378,6 +379,9 @@ fn validate_logical_path(
 ) -> Result<(), EnvelopeError> {
     check_limit(path.len(), limits.path_bytes, "path")?;
     if decode_canonical_kv_item_path(method, path)?.is_some() {
+        return Ok(());
+    }
+    if decode_canonical_api_key_name_path(method, path)?.is_some() {
         return Ok(());
     }
     validate_path(path, limits)
@@ -401,6 +405,42 @@ pub(crate) fn decode_canonical_kv_item_path(
     let Some(segment) = path.strip_prefix(KV_ITEM_PATH_PREFIX) else {
         return Ok(None);
     };
+    decode_canonical_opaque_segment(segment).map(Some)
+}
+
+/// Decodes the validated API-key name carried by the DELETE item route.
+///
+/// API-key names are ASCII alphanumeric characters, spaces, hyphens, and
+/// underscores. V2 uses the same route-scoped opaque-segment spelling as KV:
+/// alphanumeric bytes remain literal and every other byte is one uppercase
+/// `%HH` triplet. Rejecting equivalent aliases gives the operation one path
+/// spelling across clients before the name reaches the database lookup.
+pub(crate) fn decode_canonical_api_key_name_path(
+    method: LogicalMethod,
+    path: &str,
+) -> Result<Option<Zeroizing<String>>, EnvelopeError> {
+    if method != LogicalMethod::Delete {
+        return Ok(None);
+    }
+    let Some(segment) = path.strip_prefix(API_KEY_ITEM_PATH_PREFIX) else {
+        return Ok(None);
+    };
+    let decoded = decode_canonical_opaque_segment(segment)?;
+    if decoded.len() > 50
+        || decoded.starts_with(' ')
+        || decoded.ends_with(' ')
+        || !decoded
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b' ' | b'-' | b'_'))
+    {
+        return Err(EnvelopeError::InvalidPath(
+            "API-key name segment violates the name contract",
+        ));
+    }
+    Ok(Some(decoded))
+}
+
+fn decode_canonical_opaque_segment(segment: &str) -> Result<Zeroizing<String>, EnvelopeError> {
     if segment.is_empty() {
         return Err(EnvelopeError::InvalidPath(
             "opaque path segment must not be empty",
@@ -439,7 +479,7 @@ pub(crate) fn decode_canonical_kv_item_path(
     }
 
     match String::from_utf8(std::mem::take(&mut *decoded)) {
-        Ok(value) => Ok(Some(Zeroizing::new(value))),
+        Ok(value) => Ok(Zeroizing::new(value)),
         Err(error) => {
             let mut bytes = error.into_bytes();
             bytes.zeroize();
@@ -1086,6 +1126,76 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    #[test]
+    fn api_key_delete_paths_use_one_restricted_canonical_name_segment() {
+        for (encoded, decoded) in [
+            ("Production%20Key", "Production Key"),
+            ("agent%2Dproxy%5F42", "agent-proxy_42"),
+            ("a%20%20b", "a  b"),
+            ("%2D", "-"),
+            ("%5F", "_"),
+            (
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ),
+        ] {
+            let path = format!("{API_KEY_ITEM_PATH_PREFIX}{encoded}");
+            let value = decode_canonical_api_key_name_path(LogicalMethod::Delete, &path)
+                .unwrap()
+                .expect("API-key item route must decode");
+            assert_eq!(&*value, decoded, "{encoded}");
+            validate_logical_path(LogicalMethod::Delete, &path, &EnvelopeLimits::default())
+                .unwrap();
+        }
+
+        assert!(decode_canonical_api_key_name_path(
+            LogicalMethod::Get,
+            "/protected/api-keys/Production%20Key",
+        )
+        .unwrap()
+        .is_none());
+        assert!(decode_canonical_api_key_name_path(
+            LogicalMethod::Delete,
+            "/protected/api-keysx/Production%20Key",
+        )
+        .unwrap()
+        .is_none());
+    }
+
+    #[test]
+    fn api_key_delete_paths_reject_aliases_and_invalid_names() {
+        let overlong = format!("{API_KEY_ITEM_PATH_PREFIX}{}", "a".repeat(51));
+        for invalid in [
+            "/protected/api-keys/",
+            "/protected/api-keys/%20leading",
+            "/protected/api-keys/trailing%20",
+            "/protected/api-keys/literal-hyphen",
+            "/protected/api-keys/literal_underscore",
+            "/protected/api-keys/%2d",
+            "/protected/api-keys/%5f",
+            "/protected/api-keys/%41",
+            "/protected/api-keys/plus+alias",
+            "/protected/api-keys/literal space",
+            "/protected/api-keys/%252D",
+            "/protected/api-keys/%2F",
+            "/protected/api-keys/%5C",
+            "/protected/api-keys/%2E",
+            "/protected/api-keys/%FF",
+            "/protected/api-keys/%",
+            "/protected/api-keys/%2",
+            "/protected/api-keys/%GG",
+            "/protected/api-keys/name/part",
+            "/protected/api-keys/caf%C3%A9",
+            overlong.as_str(),
+        ] {
+            assert!(
+                validate_logical_path(LogicalMethod::Delete, invalid, &EnvelopeLimits::default())
+                    .is_err(),
+                "{invalid}"
+            );
+        }
     }
 
     #[test]

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -430,10 +430,11 @@ pub struct CreateApiKeyRequest {
     pub name: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct CreateApiKeyResponse {
     pub key: String, // UUID format with dashes - only returned on creation
     pub name: String,
+    #[zeroize(skip)]
     pub created_at: DateTime<Utc>,
 }
 
@@ -1395,6 +1396,15 @@ pub async fn create_api_key(
     Extension(request): Extension<CreateApiKeyRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<CreateApiKeyResponse>>, ApiError> {
+    let response = create_api_key_data(&data, &user, request).await?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn create_api_key_data(
+    data: &AppState,
+    user: &User,
+    request: CreateApiKeyRequest,
+) -> Result<CreateApiKeyResponse, ApiError> {
     debug!("Creating new API key for user: {}", user.uuid);
 
     // Validate the request
@@ -1410,11 +1420,12 @@ pub async fn create_api_key(
     let random_bytes: [u8; 16] =
         crate::encrypt::generate_random_enclave::<16>(data.aws_credential_manager.clone()).await;
     let api_key_uuid = Uuid::from_bytes(random_bytes);
+    let mut api_key = Zeroizing::new(api_key_uuid.to_string());
 
     // Hash the UUID string (with dashes) using SHA-256
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
-    hasher.update(api_key_uuid.to_string().as_bytes());
+    hasher.update(api_key.as_bytes());
     let key_hash = format!("{:x}", hasher.finalize());
 
     // Create the database record
@@ -1437,13 +1448,13 @@ pub async fn create_api_key(
     })?;
 
     let response = CreateApiKeyResponse {
-        key: api_key_uuid.to_string(), // Return the actual UUID to the user (only time it's shown)
+        key: std::mem::take(&mut *api_key), // Return the actual UUID to the user only once
         name: api_key_record.name,
         created_at: api_key_record.created_at,
     };
 
     info!("Created API key '{}' for user {}", response.name, user.uuid);
-    encrypt_response(&data, &session_id, &response).await
+    Ok(response)
 }
 
 pub async fn list_api_keys(
@@ -1480,10 +1491,21 @@ pub async fn delete_api_key(
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+    delete_api_key_by_name(&data, &user, &name)?;
+
+    let response = json!({ "success": true });
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) fn delete_api_key_by_name(
+    data: &AppState,
+    user: &User,
+    name: &str,
+) -> Result<(), ApiError> {
     debug!("Deleting API key '{}' for user: {}", name, user.uuid);
 
     data.db
-        .delete_user_api_key_by_name(&name, user.uuid)
+        .delete_user_api_key_by_name(name, user.uuid)
         .map_err(|e| {
             error!("Failed to delete API key: {:?}", e);
             match e {
@@ -1495,9 +1517,7 @@ pub async fn delete_api_key(
         })?;
 
     info!("Deleted API key '{}' for user {}", name, user.uuid);
-
-    let response = json!({ "success": true });
-    encrypt_response(&data, &session_id, &response).await
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1513,6 +1533,7 @@ mod tests {
         assert_zeroize_on_drop::<PrivateKeyResponse>();
         assert_zeroize_on_drop::<PrivateKeyBytesResponse>();
         assert_zeroize_on_drop::<ThirdPartyTokenResponse>();
+        assert_zeroize_on_drop::<CreateApiKeyResponse>();
         assert_zeroize_on_drop::<EncryptDataRequest>();
         assert_zeroize_on_drop::<EncryptDataResponse>();
         assert_zeroize_on_drop::<DecryptDataRequest>();


### PR DESCRIPTION
## Summary

- project bound-user API-key creation and deletion through the isolated transport-v2 gateway
- preserve the existing raw dashed-UUID key format, validation, status codes, response shapes, and user-scoped database behavior without rotating existing keys
- share transport-neutral create/delete helpers with v1 while leaving every v1 route and middleware contract unchanged
- generalize the existing canonical opaque-segment decoder and require one v2 spelling for validated API-key names
- wipe the one-time plaintext API-key response value on drop; keep API-key listing unsupported until its bounded stored-output slice

## Security properties

- the gateway claims the exact unordered replay ID before randomness generation or either database mutation
- immutable bound-user authority is revalidated before dispatch, and database operations remain scoped to that user UUID
- create/delete responses are encrypted with the exact leased session that authenticated the request
- method, path, query, headers, credential presence, body presence, and response mode are validated inside the encrypted envelope
- canonical decoding rejects aliases, encoded separators, invalid UTF-8, invalid characters, edge whitespace, and overlong names
- the raw generated key and serialized v2 logical response use zeroizing storage and are never logged

## Compatibility

- `/v1` handlers retain their routes, middleware, logical results, status/error mapping, key generation, hashing, and deletion behavior
- a released-style TypeScript v1 live flow created, listed, and deleted a name containing spaces, hyphen, and underscore successfully
- future TypeScript v2 uses the same dedicated opaque-segment codec already required for KV; old TypeScript and Rust SDKs remain on v1
- `GET /protected/api-keys` remains an authenticated v2 404 until the next bounded-read PR

## Validation

- `cargo fmt --all -- --check`
- strict all-target/all-feature Clippy with warnings denied
- full Rust suite: 530 passed, 21 ignored, 0 failed
- focused API-key tests: 13 passed
- managed OpenSecret/Postgres/Continuum/Tinfoil smoke passed
- released-style v1 API-key create/list/delete live compatibility passed
- raw encrypted v2 live matrix passed: bound create/delete, exact response shapes, response-key isolation, duplicate name 409, cross-user 404, create/delete replay 409, metadata transplant 400, canonical-alias rejection, and missing delete 404
- independent focused security review: no P0-P2 findings
- independent focused compatibility review: no P0-P2 findings
