### PR TITLE
feat: project bounded API key lists over v2

### DIFF
--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -692,9 +692,13 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    administration with bounded create/delete mutations: retain the existing
    raw UUID key format without rotation, return it only through the original
    bound-session response, wipe its plaintext response value on drop, and use
-   the canonical validated name segment for deletion. Keep list unsupported
-   until a following slice adds stored-output admission and a bounded narrow
-   database projection. Password/account deletion must explicitly close the
+   the canonical validated name segment for deletion. Add list in a following
+   slice using the same conservative stored-output admission as KV reads and a
+   v2-only read-only repeatable-read database path. Preflight the user-scoped
+   row count and aggregate name bytes, cap the list at 65,536 rows, fetch only
+   `name` and `created_at`, recheck the snapshot totals, retain unspecified
+   server ordering, and bound final JSON serialization. The v1 full-row query
+   remains untouched. Password/account deletion must explicitly close the
    now-invalid bound session.
 12. **Stored user unary operations**: project conversations, conversation
    projects, instructions, response control, and web-provider unary routes in

--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -17,7 +17,7 @@ use crate::{
             org_projects, password_reset_requests, reasoning_items, responses, tool_calls,
             tool_outputs, user_messages, user_oauth_connections, user_seed_wrappings,
         },
-        user_api_keys::NewUserApiKey,
+        user_api_keys::{NewUserApiKey, UserApiKey, UserApiKeyError},
         user_kv::{NewUserKV, UserKV},
         user_seed_wrappings::NewUserSeedWrapping,
         users::{NewUser, User},
@@ -547,6 +547,114 @@ async fn db_bounded_kv_reads_preserve_wire_data_and_enforce_limits() {
         other_list.is_empty(),
         "bounded LIST must remain scoped to its user"
     );
+
+    let _ = app_state.db.delete_user(&owner);
+    let _ = app_state.db.delete_user(&other);
+}
+
+#[tokio::test]
+#[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+async fn db_bounded_api_key_list_preserves_metadata_and_enforces_limits() {
+    let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+        eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+        return;
+    };
+
+    let app_state = build_local_test_app_state(database_url).await;
+    let project = first_active_project(&app_state);
+    let marker = Uuid::new_v4();
+    let owner_email = format!("aead-bounded-api-keys-owner-{marker}@example.com");
+    let other_email = format!("aead-bounded-api-keys-other-{marker}@example.com");
+    let owner = create_password_wrapped_user(
+        &app_state,
+        project.id,
+        owner_email,
+        test_credential("bounded-api-keys-owner"),
+    )
+    .await;
+    let other = create_password_wrapped_user(
+        &app_state,
+        project.id,
+        other_email,
+        test_credential("bounded-api-keys-other"),
+    )
+    .await;
+
+    let names = ["bounded API key-1", "bounded API key_2"];
+    for (index, name) in names.iter().enumerate() {
+        app_state
+            .db
+            .create_user_api_key(NewUserApiKey::new(
+                owner.uuid,
+                format!("{:064x}", marker.as_u128().wrapping_add(index as u128)),
+                (*name).to_owned(),
+            ))
+            .expect("API-key metadata insert should succeed");
+    }
+
+    let aggregate_name_bytes = names.iter().map(|name| name.len()).sum();
+    let mut conn = app_state
+        .db
+        .get_pool()
+        .get()
+        .expect("bounded API-key test connection should open");
+    let mut bounded = UserApiKey::get_bounded_list_for_user(
+        &mut conn,
+        owner.uuid,
+        aggregate_name_bytes,
+        names.len(),
+    )
+    .expect("bounded API-key list should succeed at its exact limits");
+    let mut legacy = app_state
+        .db
+        .get_all_user_api_keys_for_user(owner.uuid)
+        .expect("legacy API-key list comparison should succeed");
+    bounded.sort_by(|left, right| left.name.cmp(&right.name));
+    legacy.sort_by(|left, right| left.name.cmp(&right.name));
+    assert_eq!(bounded.len(), names.len());
+    for (actual, expected) in bounded.iter().zip(&legacy) {
+        assert_eq!(actual.name, expected.name);
+        assert_eq!(actual.created_at, expected.created_at);
+    }
+
+    assert!(matches!(
+        UserApiKey::get_bounded_list_for_user(
+            &mut conn,
+            owner.uuid,
+            aggregate_name_bytes - 1,
+            names.len(),
+        ),
+        Err(UserApiKeyError::OutputTooLarge)
+    ));
+    assert!(matches!(
+        UserApiKey::get_bounded_list_for_user(
+            &mut conn,
+            owner.uuid,
+            aggregate_name_bytes,
+            names.len() - 1,
+        ),
+        Err(UserApiKeyError::OutputTooLarge)
+    ));
+    let other_rows = UserApiKey::get_bounded_list_for_user(&mut conn, other.uuid, 0, 0)
+        .expect("empty other-user API-key list should succeed");
+    assert!(
+        other_rows.is_empty(),
+        "API-key list must remain user-scoped"
+    );
+    drop(conn);
+
+    let response = crate::web::protected_routes::list_bounded_api_keys_data(
+        &app_state,
+        &owner,
+        aggregate_name_bytes,
+        names.len(),
+    )
+    .expect("bounded API-key response data should succeed");
+    assert_eq!(response.keys.len(), names.len());
+    for key in &response.keys {
+        assert!(names.contains(&key.name.as_str()));
+        assert!(key.created_at.timestamp() > 0);
+    }
 
     let _ = app_state.db.delete_user(&owner);
     let _ = app_state.db.delete_user(&other);

--- a/src/models/user_api_keys.rs
+++ b/src/models/user_api_keys.rs
@@ -1,9 +1,12 @@
 use crate::models::schema::user_api_keys;
 use chrono::{DateTime, Utc};
+use diesel::dsl::{count_star, sql};
 use diesel::prelude::*;
+use diesel::sql_types::{BigInt, Nullable};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
+use zeroize::{Zeroize, Zeroizing};
 
 #[derive(Error, Debug)]
 pub enum UserApiKeyError {
@@ -13,6 +16,10 @@ pub enum UserApiKeyError {
     DuplicateName,
     #[error("API key not found")]
     NotFound,
+    #[error("API key list output is too large")]
+    OutputTooLarge,
+    #[error("API key list changed during its bounded read")]
+    InconsistentSnapshot,
 }
 
 #[derive(Queryable, Serialize, Deserialize, Clone)]
@@ -26,6 +33,26 @@ pub struct UserApiKey {
     pub name: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+/// Narrow metadata projection used only by bounded transport-v2 list reads.
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = user_api_keys)]
+pub struct UserApiKeyListItem {
+    pub name: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl Zeroize for UserApiKeyListItem {
+    fn zeroize(&mut self) {
+        self.name.zeroize();
+    }
+}
+
+impl Drop for UserApiKeyListItem {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
 }
 
 impl std::fmt::Debug for UserApiKey {
@@ -114,6 +141,57 @@ impl UserApiKey {
             .map_err(UserApiKeyError::DatabaseError)
     }
 
+    /// Load only bounded API-key metadata for transport v2.
+    ///
+    /// The row count and total name bytes are measured before the narrow
+    /// projection is loaded in the same read-only, repeatable-read snapshot.
+    pub fn get_bounded_list_for_user(
+        conn: &mut PgConnection,
+        lookup_user_id: Uuid,
+        logical_body_limit: usize,
+        row_limit: usize,
+    ) -> Result<Zeroizing<Vec<UserApiKeyListItem>>, UserApiKeyError> {
+        conn.build_transaction()
+            .read_only()
+            .repeatable_read()
+            .run::<_, UserApiKeyError, _>(|conn| {
+                let (row_count, aggregate_name_bytes) = user_api_keys::table
+                    .filter(user_api_keys::user_id.eq(lookup_user_id))
+                    .select((
+                        count_star(),
+                        sql::<Nullable<BigInt>>("SUM(octet_length(name)::bigint)::bigint"),
+                    ))
+                    .first::<(i64, Option<i64>)>(conn)
+                    .map_err(UserApiKeyError::DatabaseError)?;
+                let (expected_rows, expected_name_bytes) = validate_bounded_list_aggregate(
+                    row_count,
+                    aggregate_name_bytes,
+                    logical_body_limit,
+                    row_limit,
+                )?;
+
+                let rows = Zeroizing::new(
+                    user_api_keys::table
+                        .filter(user_api_keys::user_id.eq(lookup_user_id))
+                        .select(UserApiKeyListItem::as_select())
+                        .load::<UserApiKeyListItem>(conn)
+                        .map_err(UserApiKeyError::DatabaseError)?,
+                );
+                if rows.len() != expected_rows {
+                    return Err(UserApiKeyError::InconsistentSnapshot);
+                }
+                let actual_name_bytes = rows.iter().try_fold(0_usize, |total, row| {
+                    total
+                        .checked_add(row.name.len())
+                        .ok_or(UserApiKeyError::OutputTooLarge)
+                })?;
+                if actual_name_bytes != expected_name_bytes {
+                    return Err(UserApiKeyError::InconsistentSnapshot);
+                }
+                Ok(rows)
+            })
+    }
+
     pub fn delete(self, conn: &mut PgConnection) -> Result<(), UserApiKeyError> {
         diesel::delete(user_api_keys::table.filter(user_api_keys::id.eq(self.id)))
             .execute(conn)
@@ -145,6 +223,68 @@ impl UserApiKey {
             Err(UserApiKeyError::NotFound)
         } else {
             Ok(())
+        }
+    }
+}
+
+fn validate_bounded_list_aggregate(
+    row_count: i64,
+    aggregate_name_bytes: Option<i64>,
+    logical_body_limit: usize,
+    row_limit: usize,
+) -> Result<(usize, usize), UserApiKeyError> {
+    let row_count =
+        usize::try_from(row_count).map_err(|_| UserApiKeyError::InconsistentSnapshot)?;
+    if row_count > row_limit {
+        return Err(UserApiKeyError::OutputTooLarge);
+    }
+
+    let aggregate_name_bytes = match (row_count, aggregate_name_bytes) {
+        (0, None) => 0,
+        (0, Some(_)) | (_, None) => return Err(UserApiKeyError::InconsistentSnapshot),
+        (_, Some(bytes)) => {
+            usize::try_from(bytes).map_err(|_| UserApiKeyError::InconsistentSnapshot)?
+        }
+    };
+    if aggregate_name_bytes > logical_body_limit {
+        return Err(UserApiKeyError::OutputTooLarge);
+    }
+    Ok((row_count, aggregate_name_bytes))
+}
+
+#[cfg(test)]
+mod bounded_list_tests {
+    use super::*;
+
+    #[test]
+    fn aggregate_preflight_bounds_rows_and_name_bytes() {
+        assert_eq!(
+            validate_bounded_list_aggregate(0, None, 0, 0).unwrap(),
+            (0, 0)
+        );
+        assert_eq!(
+            validate_bounded_list_aggregate(2, Some(9), 9, 2).unwrap(),
+            (2, 9)
+        );
+        assert!(matches!(
+            validate_bounded_list_aggregate(2, Some(9), 8, 2),
+            Err(UserApiKeyError::OutputTooLarge)
+        ));
+        assert!(matches!(
+            validate_bounded_list_aggregate(2, Some(9), 9, 1),
+            Err(UserApiKeyError::OutputTooLarge)
+        ));
+        for inconsistent in [
+            validate_bounded_list_aggregate(-1, None, 9, 2),
+            validate_bounded_list_aggregate(1, None, 9, 2),
+            validate_bounded_list_aggregate(0, Some(0), 9, 2),
+            validate_bounded_list_aggregate(0, Some(1), 9, 2),
+            validate_bounded_list_aggregate(1, Some(-1), 9, 2),
+        ] {
+            assert!(matches!(
+                inconsistent,
+                Err(UserApiKeyError::InconsistentSnapshot)
+            ));
         }
     }
 }

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -27,10 +27,10 @@ use crate::web::login_routes::{
 };
 use crate::web::protected_routes::{
     create_api_key_data, decrypt_data_value, delete_all_kv_values, delete_api_key_by_name,
-    delete_kv_value, encrypt_data_value, private_key_bytes_data, private_key_data,
-    protected_user_data, public_key_data, put_kv_value, sign_message_data, third_party_token_data,
-    CreateApiKeyRequest, DecryptDataRequest, DerivationPathQuery, EncryptDataRequest, KvValue,
-    PublicKeyQuery, SignMessageRequest, ThirdPartyTokenRequest,
+    delete_kv_value, encrypt_data_value, list_bounded_api_keys_data, private_key_bytes_data,
+    private_key_data, protected_user_data, public_key_data, put_kv_value, sign_message_data,
+    third_party_token_data, CreateApiKeyRequest, DecryptDataRequest, DerivationPathQuery,
+    EncryptDataRequest, KvValue, PublicKeyQuery, SignMessageRequest, ThirdPartyTokenRequest,
 };
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
@@ -52,6 +52,7 @@ const MAX_ENCRYPTED_DATA_BASE64_BYTES: usize =
 const MAX_ENCRYPTION_PLAINTEXT_BYTES: usize =
     (MAX_ENCRYPTED_DATA_BASE64_BYTES / 4) * 3 - AES_GCM_NONCE_AND_TAG_BYTES;
 const MAX_V2_KV_LIST_ROWS: usize = 65_536;
+const MAX_V2_API_KEY_LIST_ROWS: usize = 65_536;
 
 type SensitiveBytes = Zeroizing<Vec<u8>>;
 
@@ -115,6 +116,7 @@ pub(crate) enum ProtectedUserOperation {
     CreateApiKey {
         body: SensitiveBytes,
     },
+    ListApiKeys,
     DeleteApiKey {
         name: Zeroizing<String>,
     },
@@ -139,7 +141,9 @@ impl UserOperation {
         matches!(
             self,
             Self::Protected {
-                operation: ProtectedUserOperation::GetKv { .. } | ProtectedUserOperation::ListKv,
+                operation: ProtectedUserOperation::GetKv { .. }
+                    | ProtectedUserOperation::ListKv
+                    | ProtectedUserOperation::ListApiKeys,
                 ..
             }
         )
@@ -273,6 +277,7 @@ pub(crate) fn prepare_user_operation(
         DeleteKv,
         DeleteAllKv,
         CreateApiKey,
+        ListApiKeys,
         DeleteApiKey,
     }
 
@@ -305,6 +310,7 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Get, "/protected/kv") => Some(Route::ListKv),
         (LogicalMethod::Delete, "/protected/kv") => Some(Route::DeleteAllKv),
         (LogicalMethod::Post, "/protected/api-keys") => Some(Route::CreateApiKey),
+        (LogicalMethod::Get, "/protected/api-keys") => Some(Route::ListApiKeys),
         (LogicalMethod::Get, _) if kv_key.is_some() => Some(Route::GetKv),
         (LogicalMethod::Put, _) if kv_key.is_some() => Some(Route::PutKv),
         (LogicalMethod::Delete, _) if kv_key.is_some() => Some(Route::DeleteKv),
@@ -544,6 +550,23 @@ pub(crate) fn prepare_user_operation(
                 operation: ProtectedUserOperation::CreateApiKey {
                     body: Zeroizing::new(body),
                 },
+            })
+        }
+        Route::ListApiKeys => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation: ProtectedUserOperation::ListApiKeys,
             })
         }
         Route::DeleteApiKey => {
@@ -837,6 +860,15 @@ async fn execute_protected_user_operation(
         ProtectedUserOperation::CreateApiKey { body } => {
             let request = parse_json_body::<CreateApiKeyRequest>(body)?;
             let value = create_api_key_data(app_state, user, request).await?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::ListApiKeys => {
+            let value = list_bounded_api_keys_data(
+                app_state,
+                user,
+                EnvelopeLimits::default().logical_body_bytes,
+                MAX_V2_API_KEY_LIST_ROWS,
+            )?;
             LogicalUnaryResponse::json(StatusCode::OK, &value)
         }
         ProtectedUserOperation::DeleteApiKey { name } => {
@@ -1340,23 +1372,31 @@ mod tests {
             }) if &*name == "Production Key-1_test"
         ));
 
-        assert!(matches!(
-            prepare_user_operation(
-                envelope(
-                    LogicalMethod::Get,
-                    "/protected/api-keys",
-                    Vec::new(),
-                    None,
-                    None,
-                ),
-                bound_user_authority(),
+        let list = prepare_user_operation(
+            envelope(
+                LogicalMethod::Get,
+                "/protected/api-keys",
+                Vec::new(),
+                None,
+                None,
             ),
-            OperationPreparation::Unsupported
+            bound_user_authority(),
+        );
+        assert!(matches!(
+            &list,
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::ListApiKeys,
+                ..
+            })
         ));
+        let OperationPreparation::Ready(list) = list else {
+            unreachable!("matched ready API-key list operation")
+        };
+        assert!(list.requires_stored_output_reservation());
     }
 
     #[test]
-    fn api_key_mutations_reject_anonymous_and_transplanted_metadata() {
+    fn api_key_administration_rejects_anonymous_and_transplanted_metadata() {
         let create = || {
             envelope(
                 LogicalMethod::Post,
@@ -1427,6 +1467,55 @@ mod tests {
         delete_with_query.request.query = Some("transplanted=true".to_owned());
         assert!(matches!(
             prepare_user_operation(delete_with_query, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let list = || {
+            envelope(
+                LogicalMethod::Get,
+                "/protected/api-keys",
+                Vec::new(),
+                None,
+                None,
+            )
+        };
+        assert!(matches!(
+            prepare_user_operation(list(), AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::UNAUTHORIZED
+        ));
+
+        let mut list_with_query = list();
+        list_with_query.request.query = Some("transplanted=true".to_owned());
+        assert!(matches!(
+            prepare_user_operation(list_with_query, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut list_with_header = list();
+        list_with_header.request.headers = json_header();
+        assert!(matches!(
+            prepare_user_operation(list_with_header, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut list_with_body = list();
+        list_with_body.request.body_base64 = Some(EncodedBytes::from_bytes(b"{}".to_vec()));
+        assert!(matches!(
+            prepare_user_operation(list_with_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut list_with_credential = list();
+        list_with_credential.credential = Some(Credential::Resumption {
+            value_base64: EncodedBytes::from_bytes(b"transplanted".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(list_with_credential, bound_user_authority()),
             OperationPreparation::Rejected(response)
                 if response.status == StatusCode::BAD_REQUEST
         ));
@@ -1503,6 +1592,31 @@ mod tests {
         assert_eq!(
             &*list.body.unwrap(),
             br#"[{"key":"key","value":"value","created_at":1,"updated_at":2}]"#
+        );
+    }
+
+    #[test]
+    fn api_key_list_keeps_existing_json_wire_shape() {
+        use crate::web::protected_routes::{ApiKeyInfo, ListApiKeysResponse};
+
+        let empty =
+            LogicalUnaryResponse::json(StatusCode::OK, &ListApiKeysResponse { keys: Vec::new() })
+                .unwrap();
+        assert_eq!(&*empty.body.unwrap(), br#"{"keys":[]}"#);
+
+        let populated = LogicalUnaryResponse::json(
+            StatusCode::OK,
+            &ListApiKeysResponse {
+                keys: vec![ApiKeyInfo {
+                    name: "Production Key".to_owned(),
+                    created_at: "2026-08-29T12:34:56Z".parse().unwrap(),
+                }],
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            &*populated.body.unwrap(),
+            br#"{"keys":[{"name":"Production Key","created_at":"2026-08-29T12:34:56Z"}]}"#
         );
     }
 

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -438,13 +438,14 @@ pub struct CreateApiKeyResponse {
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct ApiKeyInfo {
     pub name: String,
+    #[zeroize(skip)]
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct ListApiKeysResponse {
     pub keys: Vec<ApiKeyInfo>,
 }
@@ -1485,6 +1486,46 @@ pub async fn list_api_keys(
     encrypt_response(&data, &session_id, &response).await
 }
 
+pub(crate) fn list_bounded_api_keys_data(
+    data: &AppState,
+    user: &User,
+    logical_body_limit: usize,
+    row_limit: usize,
+) -> Result<ListApiKeysResponse, ApiError> {
+    debug!("Listing bounded API keys for user: {}", user.uuid);
+
+    let mut conn = data.db.get_pool().get().map_err(|error| {
+        error!("Failed to get a database connection for bounded API-key listing: {error:?}");
+        ApiError::InternalServerError
+    })?;
+    let mut rows = crate::models::user_api_keys::UserApiKey::get_bounded_list_for_user(
+        &mut conn,
+        user.uuid,
+        logical_body_limit,
+        row_limit,
+    )
+    .map_err(|error| {
+        if matches!(
+            error,
+            crate::models::user_api_keys::UserApiKeyError::OutputTooLarge
+        ) {
+            ApiError::PayloadTooLarge
+        } else {
+            error!("Failed to read bounded API-key metadata");
+            ApiError::InternalServerError
+        }
+    })?;
+
+    let keys = rows
+        .iter_mut()
+        .map(|row| ApiKeyInfo {
+            name: std::mem::take(&mut row.name),
+            created_at: row.created_at,
+        })
+        .collect();
+    Ok(ListApiKeysResponse { keys })
+}
+
 pub async fn delete_api_key(
     State(data): State<Arc<AppState>>,
     Path(name): Path<String>,
@@ -1534,6 +1575,8 @@ mod tests {
         assert_zeroize_on_drop::<PrivateKeyBytesResponse>();
         assert_zeroize_on_drop::<ThirdPartyTokenResponse>();
         assert_zeroize_on_drop::<CreateApiKeyResponse>();
+        assert_zeroize_on_drop::<ApiKeyInfo>();
+        assert_zeroize_on_drop::<ListApiKeysResponse>();
         assert_zeroize_on_drop::<EncryptDataRequest>();
         assert_zeroize_on_drop::<EncryptDataResponse>();
         assert_zeroize_on_drop::<DecryptDataRequest>();


### PR DESCRIPTION
Stacked on #319. Review only commit `556229c` above that PR.

## What

- projects bound-user `GET /protected/api-keys` through the isolated transport-v2 gateway
- preserves the existing `{"keys":[{"name","created_at"}]}` contract and unspecified server ordering
- adds a v2-only, read-only repeatable-read query that preflights row count and aggregate name bytes, fetches only `name` and `created_at`, and rechecks the snapshot
- requires the existing 200 MiB stored-output reservation and retains the 28 MiB bounded JSON writer as the exact wire ceiling
- rejects anonymous authority and transplanted credential/query/header/body metadata
- leaves the v1 handler and full-row query unchanged

## Validation

- `cargo fmt --all`
- strict all-target/all-feature Clippy with warnings denied
- full Rust suite: 532 passed, 22 ignored
- focused API-key suite: 15 passed, 1 ignored
- disposable migrated Postgres bounded-list test passed; database dropped and verified absent
- managed workspace smoke passed
- encrypted v2 live matrix: create/list/replay/transplant/tenant-isolation/delete passed
- released-style v1 create/list/delete compatibility flow passed
- focused security and compatibility reviews found no P0/P1/P2 issues

No SDK or v1 behavior changes are included.