### PR TITLE
feat: project verification resend over v2

### DIFF
--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -698,8 +698,11 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    row count and aggregate name bytes, cap the list at 65,536 rows, fetch only
    `name` and `created_at`, recheck the snapshot totals, retain unspecified
    server ordering, and bound final JSON serialization. The v1 full-row query
-   remains untouched. Password/account deletion must explicitly close the
-   now-invalid bound session.
+   remains untouched. Project verification-email resend as a bound-user unary
+   mutation with no logical body or metadata; preserve its existing 200 JSON
+   outcomes while claiming replay state before any database or email side
+   effect. Password/account deletion must explicitly close the now-invalid
+   bound session.
 12. **Stored user unary operations**: project conversations, conversation
    projects, instructions, response control, and web-provider unary routes in
    ownership-preserving families before the client cutover.

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -28,9 +28,10 @@ use crate::web::login_routes::{
 use crate::web::protected_routes::{
     create_api_key_data, decrypt_data_value, delete_all_kv_values, delete_api_key_by_name,
     delete_kv_value, encrypt_data_value, list_bounded_api_keys_data, private_key_bytes_data,
-    private_key_data, protected_user_data, public_key_data, put_kv_value, sign_message_data,
-    third_party_token_data, CreateApiKeyRequest, DecryptDataRequest, DerivationPathQuery,
-    EncryptDataRequest, KvValue, PublicKeyQuery, SignMessageRequest, ThirdPartyTokenRequest,
+    private_key_data, protected_user_data, public_key_data, put_kv_value,
+    request_new_verification_code_data, sign_message_data, third_party_token_data,
+    CreateApiKeyRequest, DecryptDataRequest, DerivationPathQuery, EncryptDataRequest, KvValue,
+    PublicKeyQuery, SignMessageRequest, ThirdPartyTokenRequest,
 };
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
@@ -80,6 +81,7 @@ pub(crate) enum UserOperation {
 
 pub(crate) enum ProtectedUserOperation {
     GetUser,
+    RequestVerification,
     GetPrivateKey {
         query: Option<String>,
     },
@@ -264,6 +266,7 @@ pub(crate) fn prepare_user_operation(
         Register,
         Resume,
         GetUser,
+        RequestVerification,
         GetPrivateKey,
         GetPrivateKeyBytes,
         GetPublicKey,
@@ -300,6 +303,9 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Post, "/register") => Some(Route::Register),
         (LogicalMethod::Post, "/refresh") => Some(Route::Resume),
         (LogicalMethod::Get, "/protected/user") => Some(Route::GetUser),
+        (LogicalMethod::Post, "/protected/request_verification") => {
+            Some(Route::RequestVerification)
+        }
         (LogicalMethod::Get, "/protected/private_key") => Some(Route::GetPrivateKey),
         (LogicalMethod::Get, "/protected/private_key_bytes") => Some(Route::GetPrivateKeyBytes),
         (LogicalMethod::Get, "/protected/public_key") => Some(Route::GetPublicKey),
@@ -411,6 +417,23 @@ pub(crate) fn prepare_user_operation(
             OperationPreparation::Ready(UserOperation::Protected {
                 authority,
                 operation,
+            })
+        }
+        Route::RequestVerification => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation: ProtectedUserOperation::RequestVerification,
             })
         }
         Route::SignMessage
@@ -763,6 +786,10 @@ async fn execute_protected_user_operation(
     match operation {
         ProtectedUserOperation::GetUser => {
             let value = protected_user_data(app_state, user)?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::RequestVerification => {
+            let value = request_new_verification_code_data(app_state, user).await?;
             LogicalUnaryResponse::json(StatusCode::OK, &value)
         }
         ProtectedUserOperation::GetPrivateKey { query } => {
@@ -1167,6 +1194,74 @@ mod tests {
                 operation: ProtectedUserOperation::GetUser,
                 ..
             })
+        ));
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Post,
+                    "/protected/request_verification",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::RequestVerification,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn verification_resend_rejects_unbound_and_transplanted_metadata() {
+        let request = || {
+            envelope(
+                LogicalMethod::Post,
+                "/protected/request_verification",
+                Vec::new(),
+                None,
+                None,
+            )
+        };
+        assert!(matches!(
+            prepare_user_operation(request(), AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::UNAUTHORIZED
+        ));
+
+        let mut with_query = request();
+        with_query.request.query = Some("transplanted=true".to_owned());
+        assert!(matches!(
+            prepare_user_operation(with_query, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_header = request();
+        with_header.request.headers = json_header();
+        assert!(matches!(
+            prepare_user_operation(with_header, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_body = request();
+        with_body.request.body_base64 = Some(EncodedBytes::from_bytes(b"{}".to_vec()));
+        assert!(matches!(
+            prepare_user_operation(with_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_credential = request();
+        with_credential.credential = Some(Credential::Resumption {
+            value_base64: EncodedBytes::from_bytes(b"transplanted".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(with_credential, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
         ));
     }
 

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -751,12 +751,19 @@ pub async fn request_new_verification_code(
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+    let response = request_new_verification_code_data(&data, &user).await?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn request_new_verification_code_data(
+    data: &AppState,
+    user: &User,
+) -> Result<serde_json::Value, ApiError> {
     // First check if user has an email
     let email = match user.get_email() {
         Some(email) => email.to_string(),
         None => {
-            let response = json!({ "error": "No email associated with account" });
-            return encrypt_response(&data, &session_id, &response).await;
+            return Ok(json!({ "error": "No email associated with account" }));
         }
     };
 
@@ -764,8 +771,7 @@ pub async fn request_new_verification_code(
     match data.db.get_email_verification_by_user_id(user.uuid) {
         Ok(verification) => {
             if verification.is_verified {
-                let response = json!({ "error": "User is already verified" });
-                return encrypt_response(&data, &session_id, &response).await;
+                return Ok(json!({ "error": "User is already verified" }));
             }
             // Delete the old verification
             if let Err(e) = data.db.delete_email_verification(&verification) {
@@ -793,20 +799,14 @@ pub async fn request_new_verification_code(
     };
 
     // Send the new verification email
-    if let Err(e) = send_verification_email(
-        &data,
-        user.project_id,
-        email,
-        verification.verification_code,
-    )
-    .await
+    if let Err(e) =
+        send_verification_email(data, user.project_id, email, verification.verification_code).await
     {
         tracing::error!("Error sending verification email: {:?}", e);
         return Err(ApiError::InternalServerError);
     }
 
-    let response = json!({ "message": "New verification code sent successfully" });
-    encrypt_response(&data, &session_id, &response).await
+    Ok(json!({ "message": "New verification code sent successfully" }))
 }
 
 pub async fn change_password(


### PR DESCRIPTION
Stacked on #320. Review only commit `ed5711e` above that PR.

## What

- extracts the existing verification-resend application behavior behind a transport-neutral helper reused by v1
- projects exact bound-user `POST /protected/request_verification` through transport v2
- requires unary mode with no credential, query, logical headers, or logical body
- preserves the existing 200 JSON outcomes for guests, already-verified users, and successful resend
- relies on the existing gateway replay claim before any database or email side effect
- leaves all existing v1 quirks and SDK behavior unchanged

## Validation

- `cargo fmt --all`
- strict all-target/all-feature Clippy with warnings denied
- full Rust suite: 533 passed, 22 ignored
- managed workspace smoke passed
- encrypted v2 live guest flow: exact 200 body, same-ID replay 409, query transplant 400
- released-style v1 guest resend returned the identical existing 200 body
- all temporary users were removed and verified absent; temporary harnesses removed
- focused design, security, and compatibility reviews found no P0/P1/P2 issues

No email-delivery semantics, SDK code, or v1 behavior change is included.