### PR TITLE
feat: project email verification over v2

### DIFF
--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -701,8 +701,12 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    remains untouched. Project verification-email resend as a bound-user unary
    mutation with no logical body or metadata; preserve its existing 200 JSON
    outcomes while claiming replay state before any database or email side
-   effect. Password/account deletion must explicitly close the now-invalid
-   bound session.
+   effect. Project `GET /verify-email/{code}` as a code-authorized operation
+   that accepts either an anonymous or already-bound session without changing
+   its authority. Require one lowercase hyphenated UUID path spelling, reject
+   all logical metadata, and preserve the existing invalid/expired 400 plus
+   success/already-verified 200 outcomes. Password/account deletion must
+   explicitly close the now-invalid bound session.
 12. **Stored user unary operations**: project conversations, conversation
    projects, instructions, response control, and web-provider unary routes in
    ownership-preserving families before the client cutover.

--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -4,6 +4,7 @@ use crate::{
     generate_reset_hash,
     login_routes::RegisterCredentials,
     models::{
+        email_verification::NewEmailVerification,
         oauth::NewUserOAuthConnection,
         org_projects::OrgProject,
         password_reset::NewPasswordResetRequest,
@@ -658,6 +659,91 @@ async fn db_bounded_api_key_list_preserves_metadata_and_enforces_limits() {
 
     let _ = app_state.db.delete_user(&owner);
     let _ = app_state.db.delete_user(&other);
+}
+
+#[tokio::test]
+#[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+async fn db_email_verification_preserves_success_idempotency_and_expiry_contracts() {
+    let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+        eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+        return;
+    };
+
+    let app_state = build_local_test_app_state(database_url).await;
+    let project = first_active_project(&app_state);
+    let marker = Uuid::new_v4();
+    let user = create_password_wrapped_user(
+        &app_state,
+        project.id,
+        format!("aead-email-verification-{marker}@example.com"),
+        test_credential("email-verification"),
+    )
+    .await;
+
+    let verification = app_state
+        .db
+        .create_email_verification(NewEmailVerification::new(user.uuid, 24, false))
+        .expect("unverified email code should insert");
+    let first =
+        crate::web::login_routes::verify_email_data(&app_state, verification.verification_code)
+            .expect("fresh email code should verify");
+    assert_eq!(
+        first,
+        serde_json::json!({ "message": "Email verified successfully" })
+    );
+    assert!(
+        app_state
+            .db
+            .get_email_verification_by_code(verification.verification_code)
+            .expect("verified email row should remain readable")
+            .is_verified
+    );
+
+    let repeated =
+        crate::web::login_routes::verify_email_data(&app_state, verification.verification_code)
+            .expect("verified code should be application-idempotent");
+    assert_eq!(
+        repeated,
+        serde_json::json!({ "message": "Email already verified" })
+    );
+
+    let expired = app_state
+        .db
+        .create_email_verification(NewEmailVerification::new(user.uuid, -1, false))
+        .expect("expired email code should insert for the contract test");
+    assert!(matches!(
+        crate::web::login_routes::verify_email_data(&app_state, expired.verification_code),
+        Err(crate::ApiError::BadRequest)
+    ));
+    assert!(
+        !app_state
+            .db
+            .get_email_verification_by_code(expired.verification_code)
+            .expect("expired email row should remain readable")
+            .is_verified
+    );
+
+    let expired_verified = app_state
+        .db
+        .create_email_verification(NewEmailVerification::new(user.uuid, -1, true))
+        .expect("expired verified email code should insert for the contract test");
+    assert!(matches!(
+        crate::web::login_routes::verify_email_data(&app_state, expired_verified.verification_code,),
+        Err(crate::ApiError::BadRequest)
+    ));
+    assert!(
+        app_state
+            .db
+            .get_email_verification_by_code(expired_verified.verification_code)
+            .expect("expired verified email row should remain readable")
+            .is_verified
+    );
+    assert!(matches!(
+        crate::web::login_routes::verify_email_data(&app_state, Uuid::new_v4()),
+        Err(crate::ApiError::BadRequest)
+    ));
+
+    let _ = app_state.db.delete_user(&user);
 }
 
 #[tokio::test]

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -22,8 +22,8 @@ use crate::jwt::{
 };
 use crate::kv::StoreError;
 use crate::web::login_routes::{
-    authenticate_login, register_and_authenticate, AuthResponse, Credentials, RefreshResponse,
-    RegisterCredentials,
+    authenticate_login, register_and_authenticate, verify_email_data, AuthResponse, Credentials,
+    RefreshResponse, RegisterCredentials,
 };
 use crate::web::protected_routes::{
     create_api_key_data, decrypt_data_value, delete_all_kv_values, delete_api_key_by_name,
@@ -36,8 +36,9 @@ use crate::web::protected_routes::{
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
 use super::envelope::{
-    decode_canonical_api_key_name_path, decode_canonical_kv_item_path, Credential, EncodedBytes,
-    EnvelopeLimits, HeaderField, LogicalMethod, RequestEnvelope, RequestId, ResponseMode,
+    decode_canonical_api_key_name_path, decode_canonical_kv_item_path,
+    decode_canonical_verify_email_path, Credential, EncodedBytes, EnvelopeLimits, HeaderField,
+    LogicalMethod, RequestEnvelope, RequestId, ResponseMode,
 };
 use super::session::{
     AuthenticationReservation, AuthenticationStartError, AuthorityState, BoundAuthority,
@@ -72,6 +73,9 @@ pub(crate) enum UserOperation {
     },
     Resume {
         credential: SensitiveBytes,
+    },
+    VerifyEmail {
+        code: uuid::Uuid,
     },
     Protected {
         authority: BoundUserAuthority,
@@ -265,6 +269,7 @@ pub(crate) fn prepare_user_operation(
         Login,
         Register,
         Resume,
+        VerifyEmail,
         GetUser,
         RequestVerification,
         GetPrivateKey,
@@ -298,10 +303,19 @@ pub(crate) fn prepare_user_operation(
             return rejected_bad_request();
         }
     };
+    let verification_code = match decode_canonical_verify_email_path(request.method, &request.path)
+    {
+        Ok(code) => code,
+        Err(_) => {
+            request.path.zeroize();
+            return rejected_bad_request();
+        }
+    };
     let route = match (request.method, request.path.as_str()) {
         (LogicalMethod::Post, "/login") => Some(Route::Login),
         (LogicalMethod::Post, "/register") => Some(Route::Register),
         (LogicalMethod::Post, "/refresh") => Some(Route::Resume),
+        (LogicalMethod::Get, _) if verification_code.is_some() => Some(Route::VerifyEmail),
         (LogicalMethod::Get, "/protected/user") => Some(Route::GetUser),
         (LogicalMethod::Post, "/protected/request_verification") => {
             Some(Route::RequestVerification)
@@ -323,7 +337,7 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Delete, _) if api_key_name.is_some() => Some(Route::DeleteApiKey),
         _ => None,
     };
-    if kv_key.is_some() || api_key_name.is_some() {
+    if kv_key.is_some() || api_key_name.is_some() || verification_code.is_some() {
         request.path.zeroize();
     }
     let Some(route) = route else {
@@ -387,6 +401,31 @@ pub(crate) fn prepare_user_operation(
             }
             OperationPreparation::Ready(UserOperation::Resume {
                 credential: Zeroizing::new(value_base64.into_bytes()),
+            })
+        }
+        Route::VerifyEmail => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            match authority {
+                AuthorityState::Anonymous | AuthorityState::Bound(_) => {}
+                AuthorityState::Authenticating(_) => {
+                    return OperationPreparation::Rejected(authentication_start_error(
+                        AuthenticationStartError::AuthenticationInProgress,
+                    ));
+                }
+                AuthorityState::Closing => {
+                    return OperationPreparation::Rejected(authentication_start_error(
+                        AuthenticationStartError::Closing,
+                    ));
+                }
+            }
+            OperationPreparation::Ready(UserOperation::VerifyEmail {
+                code: verification_code.expect("classified verification route must have a code"),
             })
         }
         Route::GetUser | Route::GetPrivateKey | Route::GetPrivateKeyBytes | Route::GetPublicKey => {
@@ -737,6 +776,16 @@ pub(crate) async fn execute_user_operation(
                 monotonic_now,
                 UserAuthResponseKind::Refresh,
             )
+        }
+        UserOperation::VerifyEmail { code } => {
+            debug_assert!(authentication.is_none());
+            let response = match verify_email_data(&app_state, code)
+                .and_then(|value| LogicalUnaryResponse::json(StatusCode::OK, &value))
+            {
+                Ok(response) => response,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            ApplicationOutcome::success(response, false)
         }
         UserOperation::Protected {
             authority,
@@ -1260,6 +1309,80 @@ mod tests {
         });
         assert!(matches!(
             prepare_user_operation(with_credential, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+    }
+
+    #[test]
+    fn email_verification_is_a_canonical_code_operation_without_rebinding() {
+        let path = "/verify-email/123e4567-e89b-12d3-a456-426614174000";
+        let request = || envelope(LogicalMethod::Get, path, Vec::new(), None, None);
+        for authority in [AuthorityState::Anonymous, bound_user_authority()] {
+            assert!(matches!(
+                prepare_user_operation(request(), authority),
+                OperationPreparation::Ready(UserOperation::VerifyEmail { code })
+                    if code == uuid::Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").unwrap()
+            ));
+        }
+
+        assert!(matches!(
+            prepare_user_operation(
+                request(),
+                AuthorityState::Authenticating(RequestId::from_bytes([0x41; 16])),
+            ),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::CONFLICT
+        ));
+        assert!(matches!(
+            prepare_user_operation(request(), AuthorityState::Closing),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::CONFLICT
+        ));
+
+        let mut with_query = request();
+        with_query.request.query = Some("transplanted=true".to_owned());
+        assert!(matches!(
+            prepare_user_operation(with_query, AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_header = request();
+        with_header.request.headers = json_header();
+        assert!(matches!(
+            prepare_user_operation(with_header, AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_body = request();
+        with_body.request.body_base64 = Some(EncodedBytes::from_bytes(b"{}".to_vec()));
+        assert!(matches!(
+            prepare_user_operation(with_body, AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_credential = request();
+        with_credential.credential = Some(Credential::Resumption {
+            value_base64: EncodedBytes::from_bytes(b"transplanted".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(with_credential, AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let uppercase = envelope(
+            LogicalMethod::Get,
+            "/verify-email/123E4567-E89B-12D3-A456-426614174000",
+            Vec::new(),
+            None,
+            None,
+        );
+        assert!(matches!(
+            prepare_user_operation(uppercase, AuthorityState::Anonymous),
             OperationPreparation::Rejected(response)
                 if response.status == StatusCode::BAD_REQUEST
         ));

--- a/src/transport_v2/envelope.rs
+++ b/src/transport_v2/envelope.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use uuid::Uuid;
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 const MIB: usize = 1024 * 1024;
@@ -371,6 +372,7 @@ impl LogicalRequest {
 
 const KV_ITEM_PATH_PREFIX: &str = "/protected/kv/";
 const API_KEY_ITEM_PATH_PREFIX: &str = "/protected/api-keys/";
+const VERIFY_EMAIL_PATH_PREFIX: &str = "/verify-email/";
 
 fn validate_logical_path(
     method: LogicalMethod,
@@ -382,6 +384,9 @@ fn validate_logical_path(
         return Ok(());
     }
     if decode_canonical_api_key_name_path(method, path)?.is_some() {
+        return Ok(());
+    }
+    if decode_canonical_verify_email_path(method, path)?.is_some() {
         return Ok(());
     }
     validate_path(path, limits)
@@ -438,6 +443,32 @@ pub(crate) fn decode_canonical_api_key_name_path(
         ));
     }
     Ok(Some(decoded))
+}
+
+/// Decodes the one canonical UUID credential admitted by email verification.
+///
+/// Axum's v1 `Path<Uuid>` parser remains untouched. Transport v2 deliberately
+/// accepts only the lowercase hyphenated UUID spelling so one verification
+/// action has one authenticated logical path.
+pub(crate) fn decode_canonical_verify_email_path(
+    method: LogicalMethod,
+    path: &str,
+) -> Result<Option<Uuid>, EnvelopeError> {
+    if method != LogicalMethod::Get {
+        return Ok(None);
+    }
+    let Some(segment) = path.strip_prefix(VERIFY_EMAIL_PATH_PREFIX) else {
+        return Ok(None);
+    };
+    let code = Uuid::parse_str(segment).map_err(|_| {
+        EnvelopeError::InvalidPath("email verification code must be a canonical UUID")
+    })?;
+    if code.hyphenated().to_string() != segment {
+        return Err(EnvelopeError::InvalidPath(
+            "email verification code must use lowercase hyphenated UUID spelling",
+        ));
+    }
+    Ok(Some(code))
 }
 
 fn decode_canonical_opaque_segment(segment: &str) -> Result<Zeroizing<String>, EnvelopeError> {
@@ -1192,6 +1223,49 @@ mod tests {
         ] {
             assert!(
                 validate_logical_path(LogicalMethod::Delete, invalid, &EnvelopeLimits::default())
+                    .is_err(),
+                "{invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn email_verification_path_uses_one_canonical_uuid_spelling() {
+        let encoded = "123e4567-e89b-12d3-a456-426614174000";
+        let path = format!("{VERIFY_EMAIL_PATH_PREFIX}{encoded}");
+        assert_eq!(
+            decode_canonical_verify_email_path(LogicalMethod::Get, &path).unwrap(),
+            Some(Uuid::parse_str(encoded).unwrap())
+        );
+        validate_logical_path(LogicalMethod::Get, &path, &EnvelopeLimits::default()).unwrap();
+
+        assert!(
+            decode_canonical_verify_email_path(LogicalMethod::Post, &path)
+                .unwrap()
+                .is_none()
+        );
+        assert!(decode_canonical_verify_email_path(
+            LogicalMethod::Get,
+            "/verify-emails/123e4567-e89b-12d3-a456-426614174000",
+        )
+        .unwrap()
+        .is_none());
+    }
+
+    #[test]
+    fn email_verification_path_rejects_uuid_aliases_and_malformed_codes() {
+        for invalid in [
+            "/verify-email/",
+            "/verify-email/123E4567-E89B-12D3-A456-426614174000",
+            "/verify-email/123e4567e89b12d3a456426614174000",
+            "/verify-email/{123e4567-e89b-12d3-a456-426614174000}",
+            "/verify-email/urn:uuid:123e4567-e89b-12d3-a456-426614174000",
+            "/verify-email/123e4567%2De89b%2D12d3%2Da456%2D426614174000",
+            "/verify-email/123e4567-e89b-12d3-a456-426614174000/extra",
+            "/verify-email/not-a-uuid",
+        ] {
+            assert!(
+                validate_logical_path(LogicalMethod::Get, invalid, &EnvelopeLimits::default())
                     .is_err(),
                 "{invalid}"
             );

--- a/src/web/login_routes.rs
+++ b/src/web/login_routes.rs
@@ -401,6 +401,14 @@ pub async fn verify_email(
     Path(code): Path<Uuid>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+    let response = verify_email_data(&data, code)?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) fn verify_email_data(
+    data: &AppState,
+    code: Uuid,
+) -> Result<serde_json::Value, ApiError> {
     let verification = match data.db.get_email_verification_by_code(code) {
         Ok(v) => v,
         Err(DBError::EmailVerificationNotFound) => return Err(ApiError::BadRequest),
@@ -412,10 +420,9 @@ pub async fn verify_email(
     }
 
     if verification.is_verified {
-        let response = json!({
+        return Ok(json!({
             "message": "Email already verified"
-        });
-        return encrypt_response(&data, &session_id, &response).await;
+        }));
     }
 
     let mut verification = verification;
@@ -423,11 +430,9 @@ pub async fn verify_email(
         return Err(ApiError::InternalServerError);
     }
 
-    let response = json!({
+    Ok(json!({
         "message": "Email verified successfully"
-    });
-    let result = encrypt_response(&data, &session_id, &response).await;
-    result
+    }))
 }
 
 pub async fn password_reset_request(


### PR DESCRIPTION
## Summary

- project `GET /verify-email/{code}` through the isolated transport-v2 request gateway
- treat the email verification code as the narrow bearer capability, admitting either an anonymous or already-bound session without changing session authority
- require one lowercase hyphenated UUID spelling and reject logical credentials, query, headers, and body
- extract a transport-neutral verification helper while leaving the existing v1 route, middleware, UUID aliases, response encryption, and response/error ordering unchanged

## Security and compatibility

- exact request IDs are claimed by the existing gateway before the database mutation
- responses are encrypted through the exact session lease that decrypted the request
- a fresh request ID preserves the existing application-idempotent `Email already verified` result
- expired verification rows are still rejected before the already-verified check, matching v1
- this PR is stacked on `codex-session-v2-verification-resend`

## Validation

- `cargo fmt --all`
- strict all-target/all-feature Clippy with warnings denied
- full all-feature Rust suite: 536 passed, 23 ignored, 0 failed
- disposable migrated PostgreSQL contract test: fresh success, repeat, expired-unverified, expired-verified, and unknown code
- managed local stack smoke passed
- raw encrypted v2 proof: anonymous success, same-ID encrypted 409 replay rejection, fresh-ID repeat, query transplant rejection, bound cross-user code verification without authority rebinding, and wrong-session response decryption rejection
- released v1 TypeScript SDK proof: canonical and uppercase UUID-alias verification both passed
- exact temporary users were deleted and verified absent
- independent security and v1-compatibility reviews found no credible P0/P1/P2 issue
