### PR TITLE
feat: project account deletion requests over v2

### DIFF
--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -705,7 +705,10 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    that accepts either an anonymous or already-bound session without changing
    its authority. Require one lowercase hyphenated UUID path spelling, reject
    all logical metadata, and preserve the existing invalid/expired 400 plus
-   success/already-verified 200 outcomes. Password/account deletion must
+   success/already-verified 200 outcomes. Project account-deletion request as
+   an exact bound-user JSON mutation, preserving the generic success response,
+   independent fresh attempts, and background email behavior while claiming
+   replay state before request creation. Account-deletion confirmation must
    explicitly close the now-invalid bound session.
 12. **Stored user unary operations**: project conversations, conversation
    projects, instructions, response control, and web-provider unary routes in

--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -14,9 +14,10 @@ use crate::{
             ResponsesError,
         },
         schema::{
-            assistant_messages, conversation_projects, conversation_summaries, conversations,
-            org_projects, password_reset_requests, reasoning_items, responses, tool_calls,
-            tool_outputs, user_messages, user_oauth_connections, user_seed_wrappings,
+            account_deletion_requests, assistant_messages, conversation_projects,
+            conversation_summaries, conversations, org_projects, password_reset_requests,
+            reasoning_items, responses, tool_calls, tool_outputs, user_messages,
+            user_oauth_connections, user_seed_wrappings,
         },
         user_api_keys::{NewUserApiKey, UserApiKey, UserApiKeyError},
         user_kv::{NewUserKV, UserKV},
@@ -743,6 +744,79 @@ async fn db_email_verification_preserves_success_idempotency_and_expiry_contract
         Err(crate::ApiError::BadRequest)
     ));
 
+    let _ = app_state.db.delete_user(&user);
+}
+
+#[tokio::test]
+#[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+async fn db_account_deletion_request_preserves_generic_response_and_distinct_attempts() {
+    let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+        eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+        return;
+    };
+
+    let app_state = build_local_test_app_state(database_url).await;
+    let project = first_active_project(&app_state);
+    let user = app_state
+        .db
+        .create_user(NewUser::new(None, None, project.id))
+        .expect("guest deletion-request test user should insert");
+
+    for hashed_secret in ["first-client-hash", "second-client-hash"] {
+        let value = crate::web::protected_routes::initiate_account_deletion_data(
+            &app_state,
+            &user,
+            crate::web::protected_routes::InitiateAccountDeletionRequest {
+                hashed_secret: hashed_secret.to_owned(),
+            },
+        )
+        .await
+        .expect("account deletion request should preserve its generic success response");
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "message": "We have sent a confirmation code to your email."
+            })
+        );
+    }
+
+    let conn = &mut app_state
+        .db
+        .get_pool()
+        .get()
+        .expect("test database connection should be available");
+    let stored = account_deletion_requests::table
+        .filter(account_deletion_requests::user_id.eq(user.uuid))
+        .order(account_deletion_requests::id.asc())
+        .select((
+            account_deletion_requests::project_id,
+            account_deletion_requests::hashed_secret,
+            account_deletion_requests::encrypted_code,
+            account_deletion_requests::expiration_time,
+            account_deletion_requests::is_deleted,
+        ))
+        .load::<(i32, String, Vec<u8>, chrono::DateTime<Utc>, bool)>(conn)
+        .expect("account deletion requests should remain readable");
+    assert_eq!(stored.len(), 2);
+    assert_eq!(stored[0].0, project.id);
+    assert_eq!(stored[0].1, "first-client-hash");
+    assert!(!stored[0].4);
+    assert_eq!(stored[1].0, project.id);
+    assert_eq!(stored[1].1, "second-client-hash");
+    assert!(!stored[1].4);
+    assert_ne!(stored[0].2, stored[1].2);
+    let now = Utc::now();
+    for (_, _, _, expiration_time, _) in &stored {
+        let remaining = expiration_time.signed_duration_since(now);
+        assert!(remaining > chrono::Duration::hours(23));
+        assert!(remaining <= chrono::Duration::hours(24));
+    }
+
+    diesel::delete(
+        account_deletion_requests::table.filter(account_deletion_requests::user_id.eq(user.uuid)),
+    )
+    .execute(conn)
+    .expect("test account deletion requests should delete");
     let _ = app_state.db.delete_user(&user);
 }
 

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -27,11 +27,12 @@ use crate::web::login_routes::{
 };
 use crate::web::protected_routes::{
     create_api_key_data, decrypt_data_value, delete_all_kv_values, delete_api_key_by_name,
-    delete_kv_value, encrypt_data_value, list_bounded_api_keys_data, private_key_bytes_data,
-    private_key_data, protected_user_data, public_key_data, put_kv_value,
-    request_new_verification_code_data, sign_message_data, third_party_token_data,
-    CreateApiKeyRequest, DecryptDataRequest, DerivationPathQuery, EncryptDataRequest, KvValue,
-    PublicKeyQuery, SignMessageRequest, ThirdPartyTokenRequest,
+    delete_kv_value, encrypt_data_value, initiate_account_deletion_data,
+    list_bounded_api_keys_data, private_key_bytes_data, private_key_data, protected_user_data,
+    public_key_data, put_kv_value, request_new_verification_code_data, sign_message_data,
+    third_party_token_data, CreateApiKeyRequest, DecryptDataRequest, DerivationPathQuery,
+    EncryptDataRequest, InitiateAccountDeletionRequest, KvValue, PublicKeyQuery,
+    SignMessageRequest, ThirdPartyTokenRequest,
 };
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
@@ -125,6 +126,9 @@ pub(crate) enum ProtectedUserOperation {
     ListApiKeys,
     DeleteApiKey {
         name: Zeroizing<String>,
+    },
+    RequestAccountDeletion {
+        body: SensitiveBytes,
     },
 }
 
@@ -287,6 +291,7 @@ pub(crate) fn prepare_user_operation(
         CreateApiKey,
         ListApiKeys,
         DeleteApiKey,
+        RequestAccountDeletion,
     }
 
     let kv_key = match decode_canonical_kv_item_path(request.method, &request.path) {
@@ -331,6 +336,9 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Delete, "/protected/kv") => Some(Route::DeleteAllKv),
         (LogicalMethod::Post, "/protected/api-keys") => Some(Route::CreateApiKey),
         (LogicalMethod::Get, "/protected/api-keys") => Some(Route::ListApiKeys),
+        (LogicalMethod::Post, "/protected/delete-account/request") => {
+            Some(Route::RequestAccountDeletion)
+        }
         (LogicalMethod::Get, _) if kv_key.is_some() => Some(Route::GetKv),
         (LogicalMethod::Put, _) if kv_key.is_some() => Some(Route::PutKv),
         (LogicalMethod::Delete, _) if kv_key.is_some() => Some(Route::DeleteKv),
@@ -478,7 +486,8 @@ pub(crate) fn prepare_user_operation(
         Route::SignMessage
         | Route::IssueThirdPartyToken
         | Route::EncryptData
-        | Route::DecryptData => {
+        | Route::DecryptData
+        | Route::RequestAccountDeletion => {
             if credential.is_some()
                 || request.query.is_some()
                 || !has_exact_json_content_type(&request.headers)
@@ -505,6 +514,9 @@ pub(crate) fn prepare_user_operation(
                 }
                 Route::EncryptData => ProtectedUserOperation::EncryptData { body },
                 Route::DecryptData => ProtectedUserOperation::DecryptData { body },
+                Route::RequestAccountDeletion => {
+                    ProtectedUserOperation::RequestAccountDeletion { body }
+                }
                 _ => unreachable!("fixed protected POST classifier is exhaustive"),
             };
             OperationPreparation::Ready(UserOperation::Protected {
@@ -955,6 +967,11 @@ async fn execute_protected_user_operation(
             delete_api_key_by_name(app_state, user, &name)?;
             Ok(response)
         }
+        ProtectedUserOperation::RequestAccountDeletion { body } => {
+            let request = parse_json_body::<InitiateAccountDeletionRequest>(body)?;
+            let value = initiate_account_deletion_data(app_state, user, request).await?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
     }
 }
 
@@ -1299,6 +1316,68 @@ mod tests {
         with_body.request.body_base64 = Some(EncodedBytes::from_bytes(b"{}".to_vec()));
         assert!(matches!(
             prepare_user_operation(with_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_credential = request();
+        with_credential.credential = Some(Credential::Resumption {
+            value_base64: EncodedBytes::from_bytes(b"transplanted".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(with_credential, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+    }
+
+    #[test]
+    fn account_deletion_request_requires_a_bound_user_and_exact_json_request() {
+        let request = || {
+            envelope(
+                LogicalMethod::Post,
+                "/protected/delete-account/request",
+                json_header(),
+                Some(br#"{"hashed_secret":"client-hash"}"#),
+                None,
+            )
+        };
+        assert!(matches!(
+            prepare_user_operation(request(), bound_user_authority()),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::RequestAccountDeletion { .. },
+                ..
+            })
+        ));
+        assert!(matches!(
+            prepare_user_operation(request(), AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::UNAUTHORIZED
+        ));
+
+        let mut with_query = request();
+        with_query.request.query = Some("transplanted=true".to_owned());
+        assert!(matches!(
+            prepare_user_operation(with_query, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_extra_header = request();
+        with_extra_header.request.headers.push(HeaderField {
+            name: "accept".to_owned(),
+            value_base64: EncodedBytes::from_bytes(b"application/json".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(with_extra_header, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut without_body = request();
+        without_body.request.body_base64 = None;
+        assert!(matches!(
+            prepare_user_operation(without_body, bound_user_authority()),
             OperationPreparation::Rejected(response)
                 if response.status == StatusCode::BAD_REQUEST
         ));

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -90,7 +90,7 @@ pub struct ChangePasswordRequest {
     pub new_password: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct InitiateAccountDeletionRequest {
     pub hashed_secret: String,
 }
@@ -1315,26 +1315,29 @@ pub async fn initiate_account_deletion(
     Extension(delete_request): Extension<InitiateAccountDeletionRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+    let response = initiate_account_deletion_data(&data, &user, delete_request).await?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn initiate_account_deletion_data(
+    data: &AppState,
+    user: &User,
+    mut delete_request: InitiateAccountDeletionRequest,
+) -> Result<serde_json::Value, ApiError> {
     info!("User {} is initiating account deletion request", user.uuid);
 
     // Create the account deletion request
+    let hashed_secret = std::mem::take(&mut delete_request.hashed_secret);
     match data
-        .create_account_deletion_request(
-            user.uuid,
-            delete_request.hashed_secret.clone(),
-            user.project_id,
-        )
+        .create_account_deletion_request(user.uuid, hashed_secret, user.project_id)
         .await
     {
-        Ok(_) => {
+        Ok(()) => {
             // Success - we return a generic message regardless of whether the
             // request was actually created and email sent
-            let response = json!({
+            Ok(json!({
                 "message": "We have sent a confirmation code to your email."
-            });
-
-            let result = encrypt_response(&data, &session_id, &response).await;
-            result
+            }))
         }
         Err(e) => {
             error!("Error in initiating account deletion: {:?}", e);


### PR DESCRIPTION
## Summary

- project `POST /protected/delete-account/request` through transport v2 as an exact bound-user JSON mutation
- extract a transport-neutral helper while preserving the existing v1 route, authentication, body, generic response, database behavior, and detached email delivery
- move and zeroize the client-provided hash instead of cloning transient request material
- keep account-deletion confirmation and terminal session closure in a later dedicated slice

## Security and compatibility

- the bound user/project/auth context is live-revalidated immediately before dispatch
- credentials, query, extra headers, and absent/empty bodies are rejected before application work
- the existing gateway claims the exact unordered request ID before database insertion or email scheduling
- exact replay returns an encrypted 409 without another row; a fresh request ID intentionally preserves independent-attempt behavior
- the response is encrypted through the exact session lease that admitted the request, and the session remains bound
- this PR is stacked on `codex-session-v2-email-verification`

## Validation

- `cargo fmt --all`
- strict all-target/all-feature Clippy with warnings denied
- full all-feature Rust suite: 537 passed, 24 ignored, 0 failed
- disposable migrated PostgreSQL contract test: exact generic response, two distinct active rows/ciphertexts, project/hash persistence, and 24-hour expiry; exact database dropped and verified absent
- managed local stack smoke passed
- raw encrypted v2 proof: anonymous 401/no row, bound exact 200/one row, same-ID encrypted 409/count unchanged, fresh-ID second row, query transplant 400/count unchanged, and session remains bound
- released v1 TypeScript SDK request preserved its normal row creation
- exact temporary guest and orphan-preserving deletion rows were removed and verified absent
- independent design, side-effect, security, and v1-compatibility reviews found no credible P0/P1/P2 issue
