### PR TITLE
feat: project account deletion confirmation over v2

### DIFF
--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -712,7 +712,10 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    an exact bound-user JSON mutation, preserving the generic success response,
    independent fresh attempts, and background email behavior while claiming
    replay state before request creation. Account-deletion confirmation must
-   explicitly close the now-invalid bound session.
+   pre-serialize its fixed success response before committing deletion, then
+   explicitly close the now-invalid bound session only after that commit.
+   Invalid codes, secrets, requests, expiry, and database failures return their
+   existing encrypted errors without closing an otherwise valid session.
 12. **Stored user unary operations**: project conversations, conversation
    projects, instructions, response control, and web-provider unary routes in
    ownership-preserving families before the client cutover.

--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -1,9 +1,10 @@
 use crate::{
     db::{setup_db, DBError},
-    encrypt::encrypt_with_key,
+    encrypt::{encrypt_key_deterministic, encrypt_with_key},
     generate_reset_hash,
     login_routes::RegisterCredentials,
     models::{
+        account_deletion::NewAccountDeletionRequest,
         email_verification::NewEmailVerification,
         oauth::NewUserOAuthConnection,
         org_projects::OrgProject,
@@ -818,6 +819,124 @@ async fn db_account_deletion_request_preserves_generic_response_and_distinct_att
     .execute(conn)
     .expect("test account deletion requests should delete");
     let _ = app_state.db.delete_user(&user);
+}
+
+#[tokio::test]
+#[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+async fn db_account_deletion_confirmation_preserves_failures_and_completed_audit_row() {
+    let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+        eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+        return;
+    };
+
+    let app_state = build_local_test_app_state(database_url).await;
+    let project = first_active_project(&app_state);
+    let user = app_state
+        .db
+        .create_user(NewUser::new(None, None, project.id))
+        .expect("guest deletion-confirmation test user should insert");
+    let confirmation_code = Uuid::new_v4();
+    let sibling_code = Uuid::new_v4();
+    let plaintext_secret = format!("deletion-secret-{}", Uuid::new_v4());
+    let enclave_key = SecretKey::from_slice(&app_state.enclave_key)
+        .expect("test enclave key must be a valid secp256k1 secret");
+    let selected = app_state
+        .db
+        .create_account_deletion_request(NewAccountDeletionRequest::new(
+            user.uuid,
+            project.id,
+            generate_reset_hash(plaintext_secret.clone()),
+            encrypt_key_deterministic(&enclave_key, confirmation_code.as_bytes()),
+            24,
+        ))
+        .expect("selected deletion request should insert");
+    let sibling = app_state
+        .db
+        .create_account_deletion_request(NewAccountDeletionRequest::new(
+            user.uuid,
+            project.id,
+            generate_reset_hash("sibling-secret".to_owned()),
+            encrypt_key_deterministic(&enclave_key, sibling_code.as_bytes()),
+            24,
+        ))
+        .expect("sibling deletion request should insert");
+
+    let invalid_code = crate::web::protected_routes::confirm_account_deletion_data(
+        &app_state,
+        &user,
+        crate::web::protected_routes::ConfirmAccountDeletionRequest {
+            confirmation_code: "not-a-uuid".to_owned(),
+            plaintext_secret: plaintext_secret.clone(),
+        },
+    )
+    .await;
+    assert!(matches!(invalid_code, Err(crate::ApiError::BadRequest)));
+
+    let invalid_secret = crate::web::protected_routes::confirm_account_deletion_data(
+        &app_state,
+        &user,
+        crate::web::protected_routes::ConfirmAccountDeletionRequest {
+            confirmation_code: confirmation_code.to_string(),
+            plaintext_secret: "wrong-secret".to_owned(),
+        },
+    )
+    .await;
+    assert!(matches!(invalid_secret, Err(crate::ApiError::BadRequest)));
+    app_state
+        .db
+        .get_user_by_uuid(user.uuid)
+        .expect("failed confirmation must preserve the user");
+
+    crate::web::protected_routes::confirm_account_deletion_data(
+        &app_state,
+        &user,
+        crate::web::protected_routes::ConfirmAccountDeletionRequest {
+            confirmation_code: confirmation_code.to_string(),
+            plaintext_secret,
+        },
+    )
+    .await
+    .expect("valid account deletion confirmation should succeed");
+    assert!(matches!(
+        app_state.db.get_user_by_uuid(user.uuid),
+        Err(DBError::UserNotFound)
+    ));
+
+    let conn = &mut app_state
+        .db
+        .get_pool()
+        .get()
+        .expect("test database connection should be available");
+    let rows = account_deletion_requests::table
+        .filter(account_deletion_requests::id.eq_any([selected.id, sibling.id]))
+        .order(account_deletion_requests::id.asc())
+        .select((
+            account_deletion_requests::id,
+            account_deletion_requests::is_deleted,
+            account_deletion_requests::completed_at,
+        ))
+        .load::<(i32, bool, Option<chrono::DateTime<Utc>>)>(conn)
+        .expect("orphan-preserving deletion audit rows should remain readable");
+    assert_eq!(rows.len(), 2);
+    let selected_row = rows
+        .iter()
+        .find(|(id, _, _)| *id == selected.id)
+        .expect("selected deletion audit row should remain");
+    assert!(selected_row.1);
+    assert!(selected_row.2.is_some());
+    let sibling_row = rows
+        .iter()
+        .find(|(id, _, _)| *id == sibling.id)
+        .expect("sibling deletion audit row should remain");
+    assert!(!sibling_row.1);
+    assert!(sibling_row.2.is_none());
+
+    diesel::delete(
+        account_deletion_requests::table
+            .filter(account_deletion_requests::id.eq_any([selected.id, sibling.id])),
+    )
+    .execute(conn)
+    .expect("test account deletion audit rows should delete");
 }
 
 #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,7 @@ use uuid::Uuid;
 use vsock::{VsockAddr, VsockStream};
 use web::attestation_routes;
 use x25519_dalek::{EphemeralSecret, PublicKey};
+use zeroize::Zeroizing;
 
 mod apple_signin;
 mod aws_credentials;
@@ -2642,13 +2643,13 @@ impl AppState {
     pub async fn confirm_account_deletion(
         &self,
         user_id: Uuid,
-        confirmation_code: String,
-        plaintext_secret: String,
+        confirmation_code: Zeroizing<String>,
+        plaintext_secret: Zeroizing<String>,
     ) -> Result<(), Error> {
         let user = self.db.get_user_by_uuid(user_id)?;
 
         // Parse the confirmation code UUID from string
-        let confirmation_code_uuid = match Uuid::parse_str(&confirmation_code) {
+        let confirmation_code_uuid = match Uuid::parse_str(confirmation_code.as_str()) {
             Ok(uuid) => uuid,
             Err(_) => return Err(Error::InvalidAccountDeletionRequest),
         };
@@ -2673,7 +2674,8 @@ impl AppState {
             }
 
             // Hash the plaintext secret again for comparison
-            let hashed_plaintext = generate_reset_hash(plaintext_secret.clone());
+            let hashed_plaintext =
+                Zeroizing::new(generate_reset_hash_bytes(plaintext_secret.as_bytes()));
 
             // Compare the hashed values using constant-time comparison
             if hashed_plaintext
@@ -3403,10 +3405,14 @@ impl RngCore for AsyncRngWrapper {
 // Implement CryptoRng for AsyncRngWrapper
 impl CryptoRng for AsyncRngWrapper {}
 
-pub fn generate_reset_hash(password: String) -> String {
+fn generate_reset_hash_bytes(password: &[u8]) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(password.as_bytes());
+    hasher.update(password);
     format!("{:x}", hasher.finalize())
+}
+
+pub fn generate_reset_hash(password: String) -> String {
+    generate_reset_hash_bytes(password.as_bytes())
 }
 
 async fn retrieve_billing_api_key(

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -26,13 +26,13 @@ use crate::web::login_routes::{
     RefreshResponse, RegisterCredentials,
 };
 use crate::web::protected_routes::{
-    create_api_key_data, decrypt_data_value, delete_all_kv_values, delete_api_key_by_name,
-    delete_kv_value, encrypt_data_value, initiate_account_deletion_data,
+    confirm_account_deletion_data, create_api_key_data, decrypt_data_value, delete_all_kv_values,
+    delete_api_key_by_name, delete_kv_value, encrypt_data_value, initiate_account_deletion_data,
     list_bounded_api_keys_data, private_key_bytes_data, private_key_data, protected_user_data,
     public_key_data, put_kv_value, request_new_verification_code_data, sign_message_data,
-    third_party_token_data, CreateApiKeyRequest, DecryptDataRequest, DerivationPathQuery,
-    EncryptDataRequest, InitiateAccountDeletionRequest, KvValue, PublicKeyQuery,
-    SignMessageRequest, ThirdPartyTokenRequest,
+    third_party_token_data, ConfirmAccountDeletionRequest, CreateApiKeyRequest, DecryptDataRequest,
+    DerivationPathQuery, EncryptDataRequest, InitiateAccountDeletionRequest, KvValue,
+    PublicKeyQuery, SignMessageRequest, ThirdPartyTokenRequest,
 };
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
@@ -130,6 +130,19 @@ pub(crate) enum ProtectedUserOperation {
     RequestAccountDeletion {
         body: SensitiveBytes,
     },
+    ConfirmAccountDeletion {
+        body: SensitiveBytes,
+    },
+}
+
+impl ProtectedUserOperation {
+    const fn session_effect_on_success(&self) -> SessionEffect {
+        if matches!(self, Self::ConfirmAccountDeletion { .. }) {
+            SessionEffect::Close
+        } else {
+            SessionEffect::Retain
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -306,6 +319,7 @@ pub(crate) fn prepare_user_operation(
         ListApiKeys,
         DeleteApiKey,
         RequestAccountDeletion,
+        ConfirmAccountDeletion,
     }
 
     let kv_key = match decode_canonical_kv_item_path(request.method, &request.path) {
@@ -352,6 +366,9 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Get, "/protected/api-keys") => Some(Route::ListApiKeys),
         (LogicalMethod::Post, "/protected/delete-account/request") => {
             Some(Route::RequestAccountDeletion)
+        }
+        (LogicalMethod::Post, "/protected/delete-account/confirm") => {
+            Some(Route::ConfirmAccountDeletion)
         }
         (LogicalMethod::Get, _) if kv_key.is_some() => Some(Route::GetKv),
         (LogicalMethod::Put, _) if kv_key.is_some() => Some(Route::PutKv),
@@ -501,7 +518,8 @@ pub(crate) fn prepare_user_operation(
         | Route::IssueThirdPartyToken
         | Route::EncryptData
         | Route::DecryptData
-        | Route::RequestAccountDeletion => {
+        | Route::RequestAccountDeletion
+        | Route::ConfirmAccountDeletion => {
             if credential.is_some()
                 || request.query.is_some()
                 || !has_exact_json_content_type(&request.headers)
@@ -530,6 +548,9 @@ pub(crate) fn prepare_user_operation(
                 Route::DecryptData => ProtectedUserOperation::DecryptData { body },
                 Route::RequestAccountDeletion => {
                     ProtectedUserOperation::RequestAccountDeletion { body }
+                }
+                Route::ConfirmAccountDeletion => {
+                    ProtectedUserOperation::ConfirmAccountDeletion { body }
                 }
                 _ => unreachable!("fixed protected POST classifier is exhaustive"),
             };
@@ -818,6 +839,7 @@ pub(crate) async fn execute_user_operation(
             operation,
         } => {
             debug_assert!(authentication.is_none());
+            let session_effect = operation.session_effect_on_success();
             let user = match app_state.verify_bound_user(
                 authority.user_id,
                 authority.project_id,
@@ -847,7 +869,7 @@ pub(crate) async fn execute_user_operation(
                     return ApplicationOutcome::error(error);
                 }
             };
-            ApplicationOutcome::success(response, SessionEffect::Retain)
+            ApplicationOutcome::success(response, session_effect)
         }
     }
 }
@@ -985,6 +1007,17 @@ async fn execute_protected_user_operation(
             let request = parse_json_body::<InitiateAccountDeletionRequest>(body)?;
             let value = initiate_account_deletion_data(app_state, user, request).await?;
             LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::ConfirmAccountDeletion { body } => {
+            let request = parse_json_body::<ConfirmAccountDeletionRequest>(body)?;
+            let response = LogicalUnaryResponse::json(
+                StatusCode::OK,
+                &serde_json::json!({
+                    "message": "Your account has been successfully deleted."
+                }),
+            )?;
+            confirm_account_deletion_data(app_state, user, request).await?;
+            Ok(response)
         }
     }
 }
@@ -1356,13 +1389,16 @@ mod tests {
                 None,
             )
         };
+        let OperationPreparation::Ready(UserOperation::Protected { operation, .. }) =
+            prepare_user_operation(request(), bound_user_authority())
+        else {
+            panic!("exact account deletion request must be admitted");
+        };
         assert!(matches!(
-            prepare_user_operation(request(), bound_user_authority()),
-            OperationPreparation::Ready(UserOperation::Protected {
-                operation: ProtectedUserOperation::RequestAccountDeletion { .. },
-                ..
-            })
+            &operation,
+            ProtectedUserOperation::RequestAccountDeletion { .. }
         ));
+        assert_eq!(operation.session_effect_on_success(), SessionEffect::Retain);
         assert!(matches!(
             prepare_user_operation(request(), AuthorityState::Anonymous),
             OperationPreparation::Rejected(response)
@@ -1402,6 +1438,90 @@ mod tests {
         });
         assert!(matches!(
             prepare_user_operation(with_credential, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+    }
+
+    #[test]
+    fn account_deletion_confirmation_is_exact_and_terminal_only_on_success() {
+        let request = || {
+            envelope(
+                LogicalMethod::Post,
+                "/protected/delete-account/confirm",
+                json_header(),
+                Some(
+                    br#"{"confirmation_code":"123e4567-e89b-12d3-a456-426614174000","plaintext_secret":"client-secret"}"#,
+                ),
+                None,
+            )
+        };
+        let OperationPreparation::Ready(UserOperation::Protected { operation, .. }) =
+            prepare_user_operation(request(), bound_user_authority())
+        else {
+            panic!("exact account deletion confirmation must be admitted");
+        };
+        assert!(matches!(
+            &operation,
+            ProtectedUserOperation::ConfirmAccountDeletion { .. }
+        ));
+        assert_eq!(operation.session_effect_on_success(), SessionEffect::Close);
+
+        assert!(matches!(
+            prepare_user_operation(request(), AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::UNAUTHORIZED
+        ));
+
+        let mut with_query = request();
+        with_query.request.query = Some("transplanted=true".to_owned());
+        assert!(matches!(
+            prepare_user_operation(with_query, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_extra_header = request();
+        with_extra_header.request.headers.push(HeaderField {
+            name: "accept".to_owned(),
+            value_base64: EncodedBytes::from_bytes(b"application/json".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(with_extra_header, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut without_body = request();
+        without_body.request.body_base64 = None;
+        assert!(matches!(
+            prepare_user_operation(without_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_empty_body = request();
+        with_empty_body.request.body_base64 = Some(EncodedBytes::from_bytes(Vec::new()));
+        assert!(matches!(
+            prepare_user_operation(with_empty_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_credential = request();
+        with_credential.credential = Some(Credential::Resumption {
+            value_base64: EncodedBytes::from_bytes(b"transplanted".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(with_credential, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut streaming = request();
+        streaming.response_mode = ResponseMode::Stream;
+        assert!(matches!(
+            prepare_user_operation(streaming, bound_user_authority()),
             OperationPreparation::Rejected(response)
                 if response.status == StatusCode::BAD_REQUEST
         ));

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -95,7 +95,7 @@ pub struct InitiateAccountDeletionRequest {
     pub hashed_secret: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct ConfirmAccountDeletionRequest {
     pub confirmation_code: String,
     pub plaintext_secret: String,
@@ -1352,25 +1352,29 @@ pub async fn confirm_account_deletion(
     Extension(confirm_request): Extension<ConfirmAccountDeletionRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+    confirm_account_deletion_data(&data, &user, confirm_request).await?;
+
+    let response = json!({
+        "message": "Your account has been successfully deleted."
+    });
+
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn confirm_account_deletion_data(
+    data: &AppState,
+    user: &User,
+    mut confirm_request: ConfirmAccountDeletionRequest,
+) -> Result<(), ApiError> {
     info!("User {} is confirming account deletion", user.uuid);
 
-    // Confirm the account deletion
+    let confirmation_code = Zeroizing::new(std::mem::take(&mut confirm_request.confirmation_code));
+    let plaintext_secret = Zeroizing::new(std::mem::take(&mut confirm_request.plaintext_secret));
     match data
-        .confirm_account_deletion(
-            user.uuid,
-            confirm_request.confirmation_code.clone(),
-            confirm_request.plaintext_secret.clone(),
-        )
+        .confirm_account_deletion(user.uuid, confirmation_code, plaintext_secret)
         .await
     {
-        Ok(_) => {
-            let response = json!({
-                "message": "Your account has been successfully deleted."
-            });
-
-            let result = encrypt_response(&data, &session_id, &response).await;
-            result
-        }
+        Ok(()) => Ok(()),
         Err(e) => match e {
             Error::AccountDeletionExpired => {
                 warn!("Account deletion confirmation has expired: {:?}", e);


### PR DESCRIPTION
## Summary

- project the existing `POST /protected/delete-account/confirm` application operation through the exact, bound-user v2 unary envelope
- pre-serialize the fixed success response before the destructive commit, then close new admission for the now-invalid session only after confirmation succeeds
- retain an otherwise-valid session for invalid code, secret, request, expiry, or database errors
- share the account-deletion application helper with v1 while preserving its route, authentication, body, error, response, database, audit, and email behavior
- move confirmation secrets without cloning and zeroize their owned request values and derived comparison hash

## Compatibility and scope

- additive v2 projection only; `/v1` behavior is unchanged
- preserves the existing deletion transaction and audit-row behavior, including its pre-existing concurrent-confirmation semantics
- no migration, release, deployment, client cutover, or account-lifecycle policy change

## Validation

- `cargo fmt --all`
- strict all-target/all-feature Clippy with warnings denied
- full suite: 542 passed, 25 ignored, 0 failed
- disposable migrated-Postgres test covering invalid confirmation preservation, successful deletion, and completed audit-row retention
- managed session-v2 smoke, including released-v1 compatibility
- raw encrypted v2 lifecycle proof: invalid confirmation 400; replay 409; same-session protected read 200; successful confirmation 200; subsequent admission 400; user removed and audit row completed
- independent final security and v1-compatibility reviews: no credible P0/P1/P2 findings

## Stack

- stacked on #324 (`codex-session-v2-terminal-session-outcome`)
