### PR TITLE
feat: project user logout over v2

### DIFF
--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -716,6 +716,14 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    explicitly close the now-invalid bound session only after that commit.
    Invalid codes, secrets, requests, expiry, and database failures return their
    existing encrypted errors without closing an otherwise valid session.
+   Project user logout as an exact bound-user JSON operation with the existing
+   refresh-token request and success body, then close the admitted session only
+   after the response is prepared. This remains session-local logout: matching
+   transport-v1 behavior, the submitted resumption credential is not revoked
+   server-side. The v2 SDK must treat the request as terminal, never
+   transparently retry or resume the logout attempt, and use generation-safe
+   local cleanup after the final response attempt. Exact cleanup behavior for
+   an ambiguous outcome is fixed in the SDK cutover PR.
 12. **Stored user unary operations**: project conversations, conversation
    projects, instructions, response control, and web-provider unary routes in
    ownership-preserving families before the client cutover.

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -22,8 +22,8 @@ use crate::jwt::{
 };
 use crate::kv::StoreError;
 use crate::web::login_routes::{
-    authenticate_login, register_and_authenticate, verify_email_data, AuthResponse, Credentials,
-    RefreshResponse, RegisterCredentials,
+    authenticate_login, logout_data, register_and_authenticate, verify_email_data, AuthResponse,
+    Credentials, LogoutRequest, RefreshResponse, RegisterCredentials,
 };
 use crate::web::protected_routes::{
     confirm_account_deletion_data, create_api_key_data, decrypt_data_value, delete_all_kv_values,
@@ -77,6 +77,9 @@ pub(crate) enum UserOperation {
     },
     VerifyEmail {
         code: uuid::Uuid,
+    },
+    Logout {
+        body: SensitiveBytes,
     },
     Protected {
         authority: BoundUserAuthority,
@@ -170,6 +173,14 @@ impl UserOperation {
                 ..
             }
         )
+    }
+
+    const fn session_effect_on_success(&self) -> SessionEffect {
+        match self {
+            Self::Logout { .. } => SessionEffect::Close,
+            Self::Protected { operation, .. } => operation.session_effect_on_success(),
+            _ => SessionEffect::Retain,
+        }
     }
 }
 
@@ -320,6 +331,7 @@ pub(crate) fn prepare_user_operation(
         DeleteApiKey,
         RequestAccountDeletion,
         ConfirmAccountDeletion,
+        Logout,
     }
 
     let kv_key = match decode_canonical_kv_item_path(request.method, &request.path) {
@@ -370,6 +382,7 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Post, "/protected/delete-account/confirm") => {
             Some(Route::ConfirmAccountDeletion)
         }
+        (LogicalMethod::Post, "/logout") => Some(Route::Logout),
         (LogicalMethod::Get, _) if kv_key.is_some() => Some(Route::GetKv),
         (LogicalMethod::Put, _) if kv_key.is_some() => Some(Route::PutKv),
         (LogicalMethod::Delete, _) if kv_key.is_some() => Some(Route::DeleteKv),
@@ -557,6 +570,29 @@ pub(crate) fn prepare_user_operation(
             OperationPreparation::Ready(UserOperation::Protected {
                 authority,
                 operation,
+            })
+        }
+        Route::Logout => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            if let Err(rejection) = bound_user_authority(authority) {
+                return rejection;
+            }
+            OperationPreparation::Ready(UserOperation::Logout {
+                body: Zeroizing::new(
+                    request
+                        .body_base64
+                        .expect("validated logout body presence")
+                        .into_bytes(),
+                ),
             })
         }
         Route::PutKv => {
@@ -759,6 +795,7 @@ pub(crate) async fn execute_user_operation(
     authentication: Option<AuthenticationReservation>,
     monotonic_now: Instant,
 ) -> ApplicationOutcome {
+    let session_effect_on_success = operation.session_effect_on_success();
     match operation {
         UserOperation::Login { body } => {
             let parsed =
@@ -834,12 +871,23 @@ pub(crate) async fn execute_user_operation(
             };
             ApplicationOutcome::success(response, SessionEffect::Retain)
         }
+        UserOperation::Logout { body } => {
+            debug_assert!(authentication.is_none());
+            let request = match parse_json_body::<LogoutRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            let response = match LogicalUnaryResponse::json(StatusCode::OK, &logout_data(request)) {
+                Ok(response) => response,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            ApplicationOutcome::success(response, session_effect_on_success)
+        }
         UserOperation::Protected {
             authority,
             operation,
         } => {
             debug_assert!(authentication.is_none());
-            let session_effect = operation.session_effect_on_success();
             let user = match app_state.verify_bound_user(
                 authority.user_id,
                 authority.project_id,
@@ -869,7 +917,7 @@ pub(crate) async fn execute_user_operation(
                     return ApplicationOutcome::error(error);
                 }
             };
-            ApplicationOutcome::success(response, session_effect)
+            ApplicationOutcome::success(response, session_effect_on_success)
         }
     }
 }
@@ -1469,6 +1517,116 @@ mod tests {
 
         assert!(matches!(
             prepare_user_operation(request(), AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::UNAUTHORIZED
+        ));
+
+        let mut with_query = request();
+        with_query.request.query = Some("transplanted=true".to_owned());
+        assert!(matches!(
+            prepare_user_operation(with_query, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_extra_header = request();
+        with_extra_header.request.headers.push(HeaderField {
+            name: "accept".to_owned(),
+            value_base64: EncodedBytes::from_bytes(b"application/json".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(with_extra_header, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut without_body = request();
+        without_body.request.body_base64 = None;
+        assert!(matches!(
+            prepare_user_operation(without_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_empty_body = request();
+        with_empty_body.request.body_base64 = Some(EncodedBytes::from_bytes(Vec::new()));
+        assert!(matches!(
+            prepare_user_operation(with_empty_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_credential = request();
+        with_credential.credential = Some(Credential::Resumption {
+            value_base64: EncodedBytes::from_bytes(b"transplanted".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(with_credential, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut streaming = request();
+        streaming.response_mode = ResponseMode::Stream;
+        assert!(matches!(
+            prepare_user_operation(streaming, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+    }
+
+    #[test]
+    fn logout_is_exact_bound_and_terminal_only_on_success() {
+        let request = || {
+            envelope(
+                LogicalMethod::Post,
+                "/logout",
+                json_header(),
+                Some(br#"{"refresh_token":"resumption-token"}"#),
+                None,
+            )
+        };
+        let OperationPreparation::Ready(operation) =
+            prepare_user_operation(request(), bound_user_authority())
+        else {
+            panic!("exact user logout must be admitted");
+        };
+        assert!(matches!(&operation, UserOperation::Logout { .. }));
+        assert_eq!(operation.session_effect_on_success(), SessionEffect::Close);
+        let parsed = parse_json_body::<LogoutRequest>(Zeroizing::new(
+            br#"{"refresh_token":"resumption-token","push_device_id":"123e4567-e89b-12d3-a456-426614174000"}"#
+                .to_vec(),
+        ))
+        .expect("the released Rust SDK logout extension must remain accepted");
+        assert_eq!(
+            logout_data(parsed),
+            serde_json::json!({ "message": "Logged out successfully" })
+        );
+
+        assert!(matches!(
+            prepare_user_operation(request(), AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::UNAUTHORIZED
+        ));
+        assert!(matches!(
+            prepare_user_operation(
+                request(),
+                AuthorityState::Bound(BoundAuthority::platform(
+                    uuid::Uuid::from_bytes([0x42; 16]),
+                    Instant::now() + std::time::Duration::from_secs(60),
+                )),
+            ),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::UNAUTHORIZED
+        ));
+        assert!(matches!(
+            prepare_user_operation(
+                request(),
+                AuthorityState::Bound(BoundAuthority::api_key(
+                    17,
+                    uuid::Uuid::from_bytes([0x43; 16]),
+                )),
+            ),
             OperationPreparation::Rejected(response)
                 if response.status == StatusCode::UNAUTHORIZED
         ));

--- a/src/web/login_routes.rs
+++ b/src/web/login_routes.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 use tokio::spawn;
 use tracing::{error, info};
 use uuid::Uuid;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 #[derive(Deserialize, Clone)]
 pub struct PasswordResetRequestPayload {
@@ -129,8 +130,8 @@ pub struct RefreshResponse {
     pub(crate) refresh_token: String,
 }
 
-#[derive(Deserialize, Clone)]
-pub struct LogoutRequest {
+#[derive(Deserialize, Clone, Zeroize, ZeroizeOnDrop)]
+pub(crate) struct LogoutRequest {
     refresh_token: String,
 }
 
@@ -260,12 +261,15 @@ pub async fn logout(
     Extension(logout_request): Extension<LogoutRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+    let response = logout_data(logout_request);
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) fn logout_data(mut logout_request: LogoutRequest) -> serde_json::Value {
     info!("Logout request received");
     // TODO actually delete the refresh token
-    drop(logout_request.refresh_token);
-    let response = json!({ "message": "Logged out successfully" });
-    let result = encrypt_response(&data, &session_id, &response).await;
-    result
+    logout_request.refresh_token.zeroize();
+    json!({ "message": "Logged out successfully" })
 }
 
 pub async fn register(


### PR DESCRIPTION
## Summary

- project the existing `POST /logout` logical operation through an exact user-bound v2 unary envelope
- preserve the encrypted `{refresh_token}` request, optional released-Rust-SDK `push_device_id`, fixed 200 response, and intentionally session-local behavior
- close the exact admitted v2 session only after successful body parsing and response preparation
- keep malformed logout attempts on an otherwise-valid session encrypted and non-terminal
- zeroize the raw logical body and parsed refresh-token value

## Compatibility and security boundary

- additive v2 projection only; `/v1` routing, middleware, request tolerance, log event, response, and encryption behavior are unchanged
- logout checks that the session is already bound to a user but intentionally does not add a database or seed-wrap dependency absent from v1
- logout does not revoke the stateless resumption credential or close other sessions; the protocol and future SDK contract describe it honestly as session-local
- no migration, release, deployment, SDK cutover, or credential-rotation change

## Validation

- `cargo fmt --all`
- strict all-target/all-feature Clippy with warnings denied
- full suite: 543 passed, 25 ignored, 0 failed
- managed workspace smoke, including the existing v1 compatibility path
- raw encrypted v2 lifecycle: malformed logout 400; same-session protected read 200; valid logout 200 with exact message; subsequent admission plaintext 400; fresh-session resumption with the same credential 200
- independent final security and v1-compatibility reviews: no credible P0/P1/P2 findings

## Stack

- stacked on #325 (`codex-session-v2-account-deletion-confirmation`)
