### PR TITLE
Project user credentials and account lifecycle over transport v2

### DIFF
--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -716,6 +716,14 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    explicitly close the now-invalid bound session only after that commit.
    Invalid codes, secrets, requests, expiry, and database failures return their
    existing encrypted errors without closing an otherwise valid session.
+   Project user logout as an exact bound-user JSON operation with the existing
+   refresh-token request and success body, then close the admitted session only
+   after the response is prepared. This remains session-local logout: matching
+   transport-v1 behavior, the submitted resumption credential is not revoked
+   server-side. The v2 SDK must treat the request as terminal, never
+   transparently retry or resume the logout attempt, and use generation-safe
+   local cleanup after the final response attempt. Exact cleanup behavior for
+   an ambiguous outcome is fixed in the SDK cutover PR.
 12. **Stored user unary operations**: project conversations, conversation
    projects, instructions, response control, and web-provider unary routes in
    ownership-preserving families before the client cutover.

--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -705,7 +705,10 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    that accepts either an anonymous or already-bound session without changing
    its authority. Require one lowercase hyphenated UUID path spelling, reject
    all logical metadata, and preserve the existing invalid/expired 400 plus
-   success/already-verified 200 outcomes. Password/account deletion must
+   success/already-verified 200 outcomes. Project account-deletion request as
+   an exact bound-user JSON mutation, preserving the generic success response,
+   independent fresh attempts, and background email behavior while claiming
+   replay state before request creation. Account-deletion confirmation must
    explicitly close the now-invalid bound session.
 12. **Stored user unary operations**: project conversations, conversation
    projects, instructions, response control, and web-provider unary routes in

--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -289,6 +289,13 @@ and distinct Unicode byte strings remain application data rather than routing
 syntax. The future TypeScript v2 SDK must implement the same UTF-8 byte codec;
 generic URI encoders that leave punctuation unescaped are insufficient.
 
+`DELETE /protected/api-keys/<name>` reuses that exact opaque-segment codec and
+then applies the existing API-key name contract after decoding: 1–50 ASCII
+alphanumeric, space, hyphen, or underscore characters, with no edge spaces.
+For example, `Production Key-1_test` has the single v2 spelling
+`Production%20Key%2D1%5Ftest`. Other encodings of the same name are rejected;
+transport-v1 path handling is unchanged.
+
 The gateway never hands an arbitrary URI to the full transport-v1 router.
 Application operations are projected deliberately onto shared application
 services/handlers.
@@ -681,8 +688,14 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    consumption. Preserve `null`, string, bare-array, timestamp, ordering, and
    whole-list failure behavior from v1 while leaving every v1 query untouched.
 11. **Remaining protected user operations**: project account-lifecycle and user
-   API-key-management families in reviewable sub-stacks. Password/account
-   deletion must explicitly close the now-invalid bound session.
+   API-key-management families in reviewable sub-stacks. Start API-key
+   administration with bounded create/delete mutations: retain the existing
+   raw UUID key format without rotation, return it only through the original
+   bound-session response, wipe its plaintext response value on drop, and use
+   the canonical validated name segment for deletion. Keep list unsupported
+   until a following slice adds stored-output admission and a bounded narrow
+   database projection. Password/account deletion must explicitly close the
+   now-invalid bound session.
 12. **Stored user unary operations**: project conversations, conversation
    projects, instructions, response control, and web-provider unary routes in
    ownership-preserving families before the client cutover.

--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -712,7 +712,10 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    an exact bound-user JSON mutation, preserving the generic success response,
    independent fresh attempts, and background email behavior while claiming
    replay state before request creation. Account-deletion confirmation must
-   explicitly close the now-invalid bound session.
+   pre-serialize its fixed success response before committing deletion, then
+   explicitly close the now-invalid bound session only after that commit.
+   Invalid codes, secrets, requests, expiry, and database failures return their
+   existing encrypted errors without closing an otherwise valid session.
 12. **Stored user unary operations**: project conversations, conversation
    projects, instructions, response control, and web-provider unary routes in
    ownership-preserving families before the client cutover.

--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -701,8 +701,12 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    remains untouched. Project verification-email resend as a bound-user unary
    mutation with no logical body or metadata; preserve its existing 200 JSON
    outcomes while claiming replay state before any database or email side
-   effect. Password/account deletion must explicitly close the now-invalid
-   bound session.
+   effect. Project `GET /verify-email/{code}` as a code-authorized operation
+   that accepts either an anonymous or already-bound session without changing
+   its authority. Require one lowercase hyphenated UUID path spelling, reject
+   all logical metadata, and preserve the existing invalid/expired 400 plus
+   success/already-verified 200 outcomes. Password/account deletion must
+   explicitly close the now-invalid bound session.
 12. **Stored user unary operations**: project conversations, conversation
    projects, instructions, response control, and web-provider unary routes in
    ownership-preserving families before the client cutover.

--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -692,9 +692,13 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    administration with bounded create/delete mutations: retain the existing
    raw UUID key format without rotation, return it only through the original
    bound-session response, wipe its plaintext response value on drop, and use
-   the canonical validated name segment for deletion. Keep list unsupported
-   until a following slice adds stored-output admission and a bounded narrow
-   database projection. Password/account deletion must explicitly close the
+   the canonical validated name segment for deletion. Add list in a following
+   slice using the same conservative stored-output admission as KV reads and a
+   v2-only read-only repeatable-read database path. Preflight the user-scoped
+   row count and aggregate name bytes, cap the list at 65,536 rows, fetch only
+   `name` and `created_at`, recheck the snapshot totals, retain unspecified
+   server ordering, and bound final JSON serialization. The v1 full-row query
+   remains untouched. Password/account deletion must explicitly close the
    now-invalid bound session.
 12. **Stored user unary operations**: project conversations, conversation
    projects, instructions, response control, and web-provider unary routes in

--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -698,8 +698,11 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    row count and aggregate name bytes, cap the list at 65,536 rows, fetch only
    `name` and `created_at`, recheck the snapshot totals, retain unspecified
    server ordering, and bound final JSON serialization. The v1 full-row query
-   remains untouched. Password/account deletion must explicitly close the
-   now-invalid bound session.
+   remains untouched. Project verification-email resend as a bound-user unary
+   mutation with no logical body or metadata; preserve its existing 200 JSON
+   outcomes while claiming replay state before any database or email side
+   effect. Password/account deletion must explicitly close the now-invalid
+   bound session.
 12. **Stored user unary operations**: project conversations, conversation
    projects, instructions, response control, and web-provider unary routes in
    ownership-preserving families before the client cutover.

--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -391,8 +391,11 @@ Once bound:
 - login, registration, resumption, and API-key rebinding are rejected;
 - protected authorization comes from the bound session, never an outer bearer;
   and
-- logout encrypts its response with the admitting lease before closing and
-  zeroizing the session.
+- a successful terminal operation moves the exact session to `Closing` before
+  encrypting its final response through the already-admitted lease. Closing
+  fences new work but does not invalidate the held response key or reservation;
+  secret state is retired after active leases drop and cache cleanup detaches
+  it.
 
 The SDK owns each v2 session within exactly one authentication/client context;
 it never reuses the current origin-and-PCR-only global cache across users,

--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -404,8 +404,11 @@ platform users, API keys, or anonymous clients. User/account changes and
 a fresh one. Distinct API keys can have concurrent sessions against one origin
 without sharing authority.
 
-A password change may replace the same user's credential-bound `AuthContext`.
-That is credential-context evolution for one principal, not principal rebinding.
+A password change never replaces a bound session's credential-derived
+`AuthContext` in place. It prepares a fresh access descriptor and resumption
+credential for the replacement `AuthContext`, commits the password and seed
+wrap atomically, and terminally closes the old session. The client establishes
+a fresh attested session before using the replacement credentials.
 
 ### 8.1 User sessions
 
@@ -723,7 +726,16 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
    server-side. The v2 SDK must treat the request as terminal, never
    transparently retry or resume the logout attempt, and use generation-safe
    local cleanup after the final response attempt. Exact cleanup behavior for
-   an ambiguous outcome is fixed in the SDK cutover PR.
+   an ambiguous outcome is fixed in the SDK cutover PR. Project password change
+   as an exact bound-user JSON mutation with its existing logical request and
+   response fields. Prepare and locally verify the replacement password wrap,
+   issue both replacement v2 credentials, and bound-serialize the success
+   response before attempting the existing password-ciphertext CAS transaction.
+   A successful commit or any failure after the commit attempt terminally
+   closes the old session; definite parse, current-password, preparation, and
+   serialization failures retain a still-valid session. A lost final response
+   is never retried: the client recovers through a fresh login with the
+   submitted new password.
 12. **Stored user unary operations**: project conversations, conversation
    projects, instructions, response control, and web-provider unary routes in
    ownership-preserving families before the client cutover.

--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -2,6 +2,7 @@ use crate::{
     db::{setup_db, DBError},
     encrypt::{encrypt_key_deterministic, encrypt_with_key},
     generate_reset_hash,
+    jwt::{issue_transport_v2_user_tokens, validate_transport_v2_user_resumption},
     login_routes::RegisterCredentials,
     models::{
         account_deletion::NewAccountDeletionRequest,
@@ -1038,6 +1039,81 @@ async fn db_password_change_invalidates_old_auth_context_and_preserves_seed() {
 
 #[tokio::test]
 #[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+async fn db_password_change_activates_only_new_v2_resumption_after_commit() {
+    let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+        eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+        return;
+    };
+
+    let app_state = build_local_test_app_state(database_url).await;
+    let project = first_active_project(&app_state);
+    let marker = Uuid::new_v4();
+    let email = format!("aead-v2-password-change-{marker}@example.com");
+    let old_password = test_credential("old-before-v2-change");
+    let new_password = test_credential("new-after-v2-change");
+
+    let user =
+        create_password_wrapped_user(&app_state, project.id, email.clone(), old_password).await;
+    let old_login = app_state
+        .authenticate_user(
+            Some(email.clone()),
+            None,
+            old_password.to_string(),
+            project.id,
+        )
+        .await
+        .expect("old password login should not error")
+        .expect("old password login should verify and unwrap");
+    let old_tokens =
+        issue_transport_v2_user_tokens(&old_login.user, &old_login.auth_context, &app_state)
+            .expect("old v2 credentials should issue");
+
+    let prepared = app_state
+        .prepare_user_password_and_seed_wrap(
+            &old_login.user,
+            &old_login.auth_context,
+            new_password.to_string(),
+        )
+        .await
+        .expect("replacement password state should prepare");
+    let replacement_tokens =
+        issue_transport_v2_user_tokens(&old_login.user, prepared.new_auth_context(), &app_state)
+            .expect("replacement v2 credentials should issue before commit");
+    assert!(
+        validate_transport_v2_user_resumption(&replacement_tokens.resumption_token, &app_state)
+            .is_err(),
+        "a preissued replacement resumption credential must remain dormant before commit"
+    );
+
+    let new_auth_context = app_state
+        .commit_prepared_user_password_and_seed_wrap(&old_login.user, prepared)
+        .expect("replacement password state should commit");
+    app_state
+        .verify_seed_wrap_for_auth_context(&old_login.user, &new_auth_context)
+        .expect("committed replacement auth context should unwrap");
+
+    assert!(
+        validate_transport_v2_user_resumption(&old_tokens.resumption_token, &app_state).is_err(),
+        "the prior resumption credential must stop validating after commit"
+    );
+    let resumed =
+        validate_transport_v2_user_resumption(&replacement_tokens.resumption_token, &app_state)
+            .expect("the replacement resumption credential should validate after commit");
+    assert_eq!(resumed.user.uuid, old_login.user.uuid);
+    assert_eq!(resumed.auth_context, new_auth_context);
+
+    let new_login = app_state
+        .authenticate_user(Some(email), None, new_password.to_string(), project.id)
+        .await
+        .expect("new password login should not error")
+        .expect("new password should authenticate after commit");
+    assert_eq!(new_login.auth_context, new_auth_context);
+
+    let _ = app_state.db.delete_user(&user);
+}
+
+#[tokio::test]
+#[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
 async fn db_password_change_deletes_tampered_stale_password_wraps() {
     let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
         eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
@@ -1148,7 +1224,7 @@ async fn db_password_change_cannot_commit_after_destructive_reset_rotates_seed()
         .clone()
         .expect("password user should have old password verifier ciphertext");
     let (racing_password_hash, racing_password_enc) = app_state
-        .encrypt_user_password_verifier(racing_password.to_string())
+        .encrypt_user_password_verifier(zeroize::Zeroizing::new(racing_password.to_string()))
         .await
         .expect("racing password verifier should encrypt");
     let stale_racing_wrapping = app_state

--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -4,6 +4,7 @@ use crate::{
     generate_reset_hash,
     login_routes::RegisterCredentials,
     models::{
+        email_verification::NewEmailVerification,
         oauth::NewUserOAuthConnection,
         org_projects::OrgProject,
         password_reset::NewPasswordResetRequest,
@@ -658,6 +659,91 @@ async fn db_bounded_api_key_list_preserves_metadata_and_enforces_limits() {
 
     let _ = app_state.db.delete_user(&owner);
     let _ = app_state.db.delete_user(&other);
+}
+
+#[tokio::test]
+#[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+async fn db_email_verification_preserves_success_idempotency_and_expiry_contracts() {
+    let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+        eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+        return;
+    };
+
+    let app_state = build_local_test_app_state(database_url).await;
+    let project = first_active_project(&app_state);
+    let marker = Uuid::new_v4();
+    let user = create_password_wrapped_user(
+        &app_state,
+        project.id,
+        format!("aead-email-verification-{marker}@example.com"),
+        test_credential("email-verification"),
+    )
+    .await;
+
+    let verification = app_state
+        .db
+        .create_email_verification(NewEmailVerification::new(user.uuid, 24, false))
+        .expect("unverified email code should insert");
+    let first =
+        crate::web::login_routes::verify_email_data(&app_state, verification.verification_code)
+            .expect("fresh email code should verify");
+    assert_eq!(
+        first,
+        serde_json::json!({ "message": "Email verified successfully" })
+    );
+    assert!(
+        app_state
+            .db
+            .get_email_verification_by_code(verification.verification_code)
+            .expect("verified email row should remain readable")
+            .is_verified
+    );
+
+    let repeated =
+        crate::web::login_routes::verify_email_data(&app_state, verification.verification_code)
+            .expect("verified code should be application-idempotent");
+    assert_eq!(
+        repeated,
+        serde_json::json!({ "message": "Email already verified" })
+    );
+
+    let expired = app_state
+        .db
+        .create_email_verification(NewEmailVerification::new(user.uuid, -1, false))
+        .expect("expired email code should insert for the contract test");
+    assert!(matches!(
+        crate::web::login_routes::verify_email_data(&app_state, expired.verification_code),
+        Err(crate::ApiError::BadRequest)
+    ));
+    assert!(
+        !app_state
+            .db
+            .get_email_verification_by_code(expired.verification_code)
+            .expect("expired email row should remain readable")
+            .is_verified
+    );
+
+    let expired_verified = app_state
+        .db
+        .create_email_verification(NewEmailVerification::new(user.uuid, -1, true))
+        .expect("expired verified email code should insert for the contract test");
+    assert!(matches!(
+        crate::web::login_routes::verify_email_data(&app_state, expired_verified.verification_code,),
+        Err(crate::ApiError::BadRequest)
+    ));
+    assert!(
+        app_state
+            .db
+            .get_email_verification_by_code(expired_verified.verification_code)
+            .expect("expired verified email row should remain readable")
+            .is_verified
+    );
+    assert!(matches!(
+        crate::web::login_routes::verify_email_data(&app_state, Uuid::new_v4()),
+        Err(crate::ApiError::BadRequest)
+    ));
+
+    let _ = app_state.db.delete_user(&user);
 }
 
 #[tokio::test]

--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -1,9 +1,10 @@
 use crate::{
     db::{setup_db, DBError},
-    encrypt::encrypt_with_key,
+    encrypt::{encrypt_key_deterministic, encrypt_with_key},
     generate_reset_hash,
     login_routes::RegisterCredentials,
     models::{
+        account_deletion::NewAccountDeletionRequest,
         email_verification::NewEmailVerification,
         oauth::NewUserOAuthConnection,
         org_projects::OrgProject,
@@ -818,6 +819,124 @@ async fn db_account_deletion_request_preserves_generic_response_and_distinct_att
     .execute(conn)
     .expect("test account deletion requests should delete");
     let _ = app_state.db.delete_user(&user);
+}
+
+#[tokio::test]
+#[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+async fn db_account_deletion_confirmation_preserves_failures_and_completed_audit_row() {
+    let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+        eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+        return;
+    };
+
+    let app_state = build_local_test_app_state(database_url).await;
+    let project = first_active_project(&app_state);
+    let user = app_state
+        .db
+        .create_user(NewUser::new(None, None, project.id))
+        .expect("guest deletion-confirmation test user should insert");
+    let confirmation_code = Uuid::new_v4();
+    let sibling_code = Uuid::new_v4();
+    let plaintext_secret = format!("deletion-secret-{}", Uuid::new_v4());
+    let enclave_key = SecretKey::from_slice(&app_state.enclave_key)
+        .expect("test enclave key must be a valid secp256k1 secret");
+    let selected = app_state
+        .db
+        .create_account_deletion_request(NewAccountDeletionRequest::new(
+            user.uuid,
+            project.id,
+            generate_reset_hash(plaintext_secret.clone()),
+            encrypt_key_deterministic(&enclave_key, confirmation_code.as_bytes()),
+            24,
+        ))
+        .expect("selected deletion request should insert");
+    let sibling = app_state
+        .db
+        .create_account_deletion_request(NewAccountDeletionRequest::new(
+            user.uuid,
+            project.id,
+            generate_reset_hash("sibling-secret".to_owned()),
+            encrypt_key_deterministic(&enclave_key, sibling_code.as_bytes()),
+            24,
+        ))
+        .expect("sibling deletion request should insert");
+
+    let invalid_code = crate::web::protected_routes::confirm_account_deletion_data(
+        &app_state,
+        &user,
+        crate::web::protected_routes::ConfirmAccountDeletionRequest {
+            confirmation_code: "not-a-uuid".to_owned(),
+            plaintext_secret: plaintext_secret.clone(),
+        },
+    )
+    .await;
+    assert!(matches!(invalid_code, Err(crate::ApiError::BadRequest)));
+
+    let invalid_secret = crate::web::protected_routes::confirm_account_deletion_data(
+        &app_state,
+        &user,
+        crate::web::protected_routes::ConfirmAccountDeletionRequest {
+            confirmation_code: confirmation_code.to_string(),
+            plaintext_secret: "wrong-secret".to_owned(),
+        },
+    )
+    .await;
+    assert!(matches!(invalid_secret, Err(crate::ApiError::BadRequest)));
+    app_state
+        .db
+        .get_user_by_uuid(user.uuid)
+        .expect("failed confirmation must preserve the user");
+
+    crate::web::protected_routes::confirm_account_deletion_data(
+        &app_state,
+        &user,
+        crate::web::protected_routes::ConfirmAccountDeletionRequest {
+            confirmation_code: confirmation_code.to_string(),
+            plaintext_secret,
+        },
+    )
+    .await
+    .expect("valid account deletion confirmation should succeed");
+    assert!(matches!(
+        app_state.db.get_user_by_uuid(user.uuid),
+        Err(DBError::UserNotFound)
+    ));
+
+    let conn = &mut app_state
+        .db
+        .get_pool()
+        .get()
+        .expect("test database connection should be available");
+    let rows = account_deletion_requests::table
+        .filter(account_deletion_requests::id.eq_any([selected.id, sibling.id]))
+        .order(account_deletion_requests::id.asc())
+        .select((
+            account_deletion_requests::id,
+            account_deletion_requests::is_deleted,
+            account_deletion_requests::completed_at,
+        ))
+        .load::<(i32, bool, Option<chrono::DateTime<Utc>>)>(conn)
+        .expect("orphan-preserving deletion audit rows should remain readable");
+    assert_eq!(rows.len(), 2);
+    let selected_row = rows
+        .iter()
+        .find(|(id, _, _)| *id == selected.id)
+        .expect("selected deletion audit row should remain");
+    assert!(selected_row.1);
+    assert!(selected_row.2.is_some());
+    let sibling_row = rows
+        .iter()
+        .find(|(id, _, _)| *id == sibling.id)
+        .expect("sibling deletion audit row should remain");
+    assert!(!sibling_row.1);
+    assert!(sibling_row.2.is_none());
+
+    diesel::delete(
+        account_deletion_requests::table
+            .filter(account_deletion_requests::id.eq_any([selected.id, sibling.id])),
+    )
+    .execute(conn)
+    .expect("test account deletion audit rows should delete");
 }
 
 #[tokio::test]

--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -14,9 +14,10 @@ use crate::{
             ResponsesError,
         },
         schema::{
-            assistant_messages, conversation_projects, conversation_summaries, conversations,
-            org_projects, password_reset_requests, reasoning_items, responses, tool_calls,
-            tool_outputs, user_messages, user_oauth_connections, user_seed_wrappings,
+            account_deletion_requests, assistant_messages, conversation_projects,
+            conversation_summaries, conversations, org_projects, password_reset_requests,
+            reasoning_items, responses, tool_calls, tool_outputs, user_messages,
+            user_oauth_connections, user_seed_wrappings,
         },
         user_api_keys::{NewUserApiKey, UserApiKey, UserApiKeyError},
         user_kv::{NewUserKV, UserKV},
@@ -743,6 +744,79 @@ async fn db_email_verification_preserves_success_idempotency_and_expiry_contract
         Err(crate::ApiError::BadRequest)
     ));
 
+    let _ = app_state.db.delete_user(&user);
+}
+
+#[tokio::test]
+#[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+async fn db_account_deletion_request_preserves_generic_response_and_distinct_attempts() {
+    let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+        eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+        return;
+    };
+
+    let app_state = build_local_test_app_state(database_url).await;
+    let project = first_active_project(&app_state);
+    let user = app_state
+        .db
+        .create_user(NewUser::new(None, None, project.id))
+        .expect("guest deletion-request test user should insert");
+
+    for hashed_secret in ["first-client-hash", "second-client-hash"] {
+        let value = crate::web::protected_routes::initiate_account_deletion_data(
+            &app_state,
+            &user,
+            crate::web::protected_routes::InitiateAccountDeletionRequest {
+                hashed_secret: hashed_secret.to_owned(),
+            },
+        )
+        .await
+        .expect("account deletion request should preserve its generic success response");
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "message": "We have sent a confirmation code to your email."
+            })
+        );
+    }
+
+    let conn = &mut app_state
+        .db
+        .get_pool()
+        .get()
+        .expect("test database connection should be available");
+    let stored = account_deletion_requests::table
+        .filter(account_deletion_requests::user_id.eq(user.uuid))
+        .order(account_deletion_requests::id.asc())
+        .select((
+            account_deletion_requests::project_id,
+            account_deletion_requests::hashed_secret,
+            account_deletion_requests::encrypted_code,
+            account_deletion_requests::expiration_time,
+            account_deletion_requests::is_deleted,
+        ))
+        .load::<(i32, String, Vec<u8>, chrono::DateTime<Utc>, bool)>(conn)
+        .expect("account deletion requests should remain readable");
+    assert_eq!(stored.len(), 2);
+    assert_eq!(stored[0].0, project.id);
+    assert_eq!(stored[0].1, "first-client-hash");
+    assert!(!stored[0].4);
+    assert_eq!(stored[1].0, project.id);
+    assert_eq!(stored[1].1, "second-client-hash");
+    assert!(!stored[1].4);
+    assert_ne!(stored[0].2, stored[1].2);
+    let now = Utc::now();
+    for (_, _, _, expiration_time, _) in &stored {
+        let remaining = expiration_time.signed_duration_since(now);
+        assert!(remaining > chrono::Duration::hours(23));
+        assert!(remaining <= chrono::Duration::hours(24));
+    }
+
+    diesel::delete(
+        account_deletion_requests::table.filter(account_deletion_requests::user_id.eq(user.uuid)),
+    )
+    .execute(conn)
+    .expect("test account deletion requests should delete");
     let _ = app_state.db.delete_user(&user);
 }
 

--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -839,6 +839,8 @@ async fn db_account_deletion_confirmation_preserves_failures_and_completed_audit
     let confirmation_code = Uuid::new_v4();
     let sibling_code = Uuid::new_v4();
     let plaintext_secret = format!("deletion-secret-{}", Uuid::new_v4());
+    let sibling_secret = format!("sibling-deletion-secret-{}", Uuid::new_v4());
+    let invalid_secret = format!("invalid-deletion-secret-{}", Uuid::new_v4());
     let enclave_key = SecretKey::from_slice(&app_state.enclave_key)
         .expect("test enclave key must be a valid secp256k1 secret");
     let selected = app_state
@@ -856,7 +858,7 @@ async fn db_account_deletion_confirmation_preserves_failures_and_completed_audit
         .create_account_deletion_request(NewAccountDeletionRequest::new(
             user.uuid,
             project.id,
-            generate_reset_hash("sibling-secret".to_owned()),
+            generate_reset_hash(sibling_secret),
             encrypt_key_deterministic(&enclave_key, sibling_code.as_bytes()),
             24,
         ))
@@ -878,7 +880,7 @@ async fn db_account_deletion_confirmation_preserves_failures_and_completed_audit
         &user,
         crate::web::protected_routes::ConfirmAccountDeletionRequest {
             confirmation_code: confirmation_code.to_string(),
-            plaintext_secret: "wrong-secret".to_owned(),
+            plaintext_secret: invalid_secret,
         },
     )
     .await;

--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -17,7 +17,7 @@ use crate::{
             org_projects, password_reset_requests, reasoning_items, responses, tool_calls,
             tool_outputs, user_messages, user_oauth_connections, user_seed_wrappings,
         },
-        user_api_keys::NewUserApiKey,
+        user_api_keys::{NewUserApiKey, UserApiKey, UserApiKeyError},
         user_kv::{NewUserKV, UserKV},
         user_seed_wrappings::NewUserSeedWrapping,
         users::{NewUser, User},
@@ -547,6 +547,114 @@ async fn db_bounded_kv_reads_preserve_wire_data_and_enforce_limits() {
         other_list.is_empty(),
         "bounded LIST must remain scoped to its user"
     );
+
+    let _ = app_state.db.delete_user(&owner);
+    let _ = app_state.db.delete_user(&other);
+}
+
+#[tokio::test]
+#[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+async fn db_bounded_api_key_list_preserves_metadata_and_enforces_limits() {
+    let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+        eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+        return;
+    };
+
+    let app_state = build_local_test_app_state(database_url).await;
+    let project = first_active_project(&app_state);
+    let marker = Uuid::new_v4();
+    let owner_email = format!("aead-bounded-api-keys-owner-{marker}@example.com");
+    let other_email = format!("aead-bounded-api-keys-other-{marker}@example.com");
+    let owner = create_password_wrapped_user(
+        &app_state,
+        project.id,
+        owner_email,
+        test_credential("bounded-api-keys-owner"),
+    )
+    .await;
+    let other = create_password_wrapped_user(
+        &app_state,
+        project.id,
+        other_email,
+        test_credential("bounded-api-keys-other"),
+    )
+    .await;
+
+    let names = ["bounded API key-1", "bounded API key_2"];
+    for (index, name) in names.iter().enumerate() {
+        app_state
+            .db
+            .create_user_api_key(NewUserApiKey::new(
+                owner.uuid,
+                format!("{:064x}", marker.as_u128().wrapping_add(index as u128)),
+                (*name).to_owned(),
+            ))
+            .expect("API-key metadata insert should succeed");
+    }
+
+    let aggregate_name_bytes = names.iter().map(|name| name.len()).sum();
+    let mut conn = app_state
+        .db
+        .get_pool()
+        .get()
+        .expect("bounded API-key test connection should open");
+    let mut bounded = UserApiKey::get_bounded_list_for_user(
+        &mut conn,
+        owner.uuid,
+        aggregate_name_bytes,
+        names.len(),
+    )
+    .expect("bounded API-key list should succeed at its exact limits");
+    let mut legacy = app_state
+        .db
+        .get_all_user_api_keys_for_user(owner.uuid)
+        .expect("legacy API-key list comparison should succeed");
+    bounded.sort_by(|left, right| left.name.cmp(&right.name));
+    legacy.sort_by(|left, right| left.name.cmp(&right.name));
+    assert_eq!(bounded.len(), names.len());
+    for (actual, expected) in bounded.iter().zip(&legacy) {
+        assert_eq!(actual.name, expected.name);
+        assert_eq!(actual.created_at, expected.created_at);
+    }
+
+    assert!(matches!(
+        UserApiKey::get_bounded_list_for_user(
+            &mut conn,
+            owner.uuid,
+            aggregate_name_bytes - 1,
+            names.len(),
+        ),
+        Err(UserApiKeyError::OutputTooLarge)
+    ));
+    assert!(matches!(
+        UserApiKey::get_bounded_list_for_user(
+            &mut conn,
+            owner.uuid,
+            aggregate_name_bytes,
+            names.len() - 1,
+        ),
+        Err(UserApiKeyError::OutputTooLarge)
+    ));
+    let other_rows = UserApiKey::get_bounded_list_for_user(&mut conn, other.uuid, 0, 0)
+        .expect("empty other-user API-key list should succeed");
+    assert!(
+        other_rows.is_empty(),
+        "API-key list must remain user-scoped"
+    );
+    drop(conn);
+
+    let response = crate::web::protected_routes::list_bounded_api_keys_data(
+        &app_state,
+        &owner,
+        aggregate_name_bytes,
+        names.len(),
+    )
+    .expect("bounded API-key response data should succeed");
+    assert_eq!(response.keys.len(), names.len());
+    for key in &response.keys {
+        assert!(names.contains(&key.name.as_str()));
+        assert!(key.created_at.timestamp() > 0);
+    }
 
     let _ = app_state.db.delete_user(&owner);
     let _ = app_state.db.delete_user(&other);

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,7 @@ use uuid::Uuid;
 use vsock::{VsockAddr, VsockStream};
 use web::attestation_routes;
 use x25519_dalek::{EphemeralSecret, PublicKey};
+use zeroize::Zeroizing;
 
 mod apple_signin;
 mod aws_credentials;
@@ -2594,13 +2595,13 @@ impl AppState {
     pub async fn confirm_account_deletion(
         &self,
         user_id: Uuid,
-        confirmation_code: String,
-        plaintext_secret: String,
+        confirmation_code: Zeroizing<String>,
+        plaintext_secret: Zeroizing<String>,
     ) -> Result<(), Error> {
         let user = self.db.get_user_by_uuid(user_id)?;
 
         // Parse the confirmation code UUID from string
-        let confirmation_code_uuid = match Uuid::parse_str(&confirmation_code) {
+        let confirmation_code_uuid = match Uuid::parse_str(confirmation_code.as_str()) {
             Ok(uuid) => uuid,
             Err(_) => return Err(Error::InvalidAccountDeletionRequest),
         };
@@ -2625,7 +2626,8 @@ impl AppState {
             }
 
             // Hash the plaintext secret again for comparison
-            let hashed_plaintext = generate_reset_hash(plaintext_secret.clone());
+            let hashed_plaintext =
+                Zeroizing::new(generate_reset_hash_bytes(plaintext_secret.as_bytes()));
 
             // Compare the hashed values using constant-time comparison
             if hashed_plaintext
@@ -3355,10 +3357,14 @@ impl RngCore for AsyncRngWrapper {
 // Implement CryptoRng for AsyncRngWrapper
 impl CryptoRng for AsyncRngWrapper {}
 
-pub fn generate_reset_hash(password: String) -> String {
+fn generate_reset_hash_bytes(password: &[u8]) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(password.as_bytes());
+    hasher.update(password);
     format!("{:x}", hasher.finalize())
+}
+
+pub fn generate_reset_hash(password: String) -> String {
+    generate_reset_hash_bytes(password.as_bytes())
 }
 
 async fn retrieve_billing_api_key(

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,7 @@ use uuid::Uuid;
 use vsock::{VsockAddr, VsockStream};
 use web::attestation_routes;
 use x25519_dalek::{EphemeralSecret, PublicKey};
-use zeroize::Zeroizing;
+use zeroize::{Zeroize, Zeroizing};
 
 mod apple_signin;
 mod aws_credentials;
@@ -812,6 +812,19 @@ pub(crate) struct VerifiedUserAuthentication {
     pub(crate) auth_context: AuthContext,
 }
 
+pub(crate) struct PreparedUserPasswordChange {
+    expected_password_enc: Vec<u8>,
+    new_password_enc: Vec<u8>,
+    new_wrapping: NewUserSeedWrapping,
+    new_auth_context: AuthContext,
+}
+
+impl PreparedUserPasswordChange {
+    pub(crate) fn new_auth_context(&self) -> &AuthContext {
+        &self.new_auth_context
+    }
+}
+
 #[derive(Default)]
 pub struct AppStateBuilder {
     app_mode: Option<AppMode>,
@@ -1347,7 +1360,7 @@ impl AppState {
         &self,
         user: &User,
         auth_context: &AuthContext,
-    ) -> Result<Vec<u8>, Error> {
+    ) -> Result<Zeroizing<Vec<u8>>, Error> {
         if user.project_id != auth_context.project_id {
             return Err(Error::AuthenticationError);
         }
@@ -1374,7 +1387,7 @@ impl AppState {
                 credential_kind,
                 &auth_binding,
             ) {
-                Ok(seed) => return Ok(seed),
+                Ok(seed) => return Ok(Zeroizing::new(seed)),
                 Err(_) => continue,
             }
         }
@@ -1382,7 +1395,7 @@ impl AppState {
         Err(Error::AuthenticationError)
     }
 
-    fn verify_seed_wrap_for_auth_context(
+    pub(crate) fn verify_seed_wrap_for_auth_context(
         &self,
         user: &User,
         auth_context: &AuthContext,
@@ -1441,17 +1454,19 @@ impl AppState {
     ) -> Result<(), Error> {
         let auth_binding =
             self.password_auth_binding_for_user(user, decrypted_password_verifier)?;
-        let decrypted_seed = decrypt_seed_v1(
-            &self.enclave_key,
-            &new_wrapping.seed_enc,
-            user.uuid,
-            user.project_id,
-            CredentialKind::Password,
-            &auth_binding,
-        )
-        .map_err(|e| Error::EncryptionError(e.to_string()))?;
+        let decrypted_seed = Zeroizing::new(
+            decrypt_seed_v1(
+                &self.enclave_key,
+                &new_wrapping.seed_enc,
+                user.uuid,
+                user.project_id,
+                CredentialKind::Password,
+                &auth_binding,
+            )
+            .map_err(|e| Error::EncryptionError(e.to_string()))?,
+        );
 
-        if decrypted_seed != plaintext_seed {
+        if decrypted_seed.as_slice() != plaintext_seed {
             return Err(Error::EncryptionError(
                 "New password seed wrap verification failed".to_string(),
             ));
@@ -1709,6 +1724,8 @@ impl AppState {
         user_password: String,
         user_project_id: i32,
     ) -> Result<Option<VerifiedUserAuthentication>, Error> {
+        let user_password = Zeroizing::new(user_password);
+
         // Ensure at least one identifier is provided
         if user_email.is_none() && user_id.is_none() {
             return Err(Error::AuthenticationError);
@@ -1737,19 +1754,29 @@ impl AppState {
         let secret_key = SecretKey::from_slice(&self.enclave_key.clone())
             .map_err(|e| Error::EncryptionError(e.to_string()))?;
 
-        let decrypted_password_bytes =
+        let mut decrypted_password_bytes = Zeroizing::new(
             decrypt_with_key(&secret_key, user.password_enc.as_ref().unwrap())
-                .map_err(|e| Error::EncryptionError(e.to_string()))?;
+                .map_err(|e| Error::EncryptionError(e.to_string()))?,
+        );
 
-        let decrypted_password_hash = String::from_utf8(decrypted_password_bytes)
-            .map_err(|e| Error::EncryptionError(format!("Failed to decode UTF-8: {}", e)))?;
+        let decrypted_password_hash =
+            match String::from_utf8(std::mem::take(&mut *decrypted_password_bytes)) {
+                Ok(password_hash) => Zeroizing::new(password_hash),
+                Err(error) => {
+                    let message = format!("Failed to decode UTF-8: {}", error);
+                    let mut bytes = error.into_bytes();
+                    bytes.zeroize();
+                    return Err(Error::EncryptionError(message));
+                }
+            };
         let verifier_for_binding = decrypted_password_hash.clone();
 
         // Verifying the password is blocking and potentially slow, so we'll do so via
         // `spawn_blocking`.
-        let res =
-            task::spawn_blocking(move || verify_password(user_password, &decrypted_password_hash))
-                .await?;
+        let res = task::spawn_blocking(move || {
+            verify_password(user_password.as_bytes(), decrypted_password_hash.as_str())
+        })
+        .await?;
 
         match res {
             Ok(_) => {
@@ -2192,6 +2219,7 @@ impl AppState {
         new_password: String,
         project_id: i32,
     ) -> Result<(), Error> {
+        let new_password = Zeroizing::new(new_password);
         let user = self.db.get_user_by_email(email.clone(), project_id)?;
 
         // Verify user has an email
@@ -2452,16 +2480,18 @@ impl AppState {
         }
     }
 
-    async fn update_user_password_and_seed_wrap(
+    pub(crate) async fn prepare_user_password_and_seed_wrap(
         &self,
         user: &User,
         auth_context: &AuthContext,
         new_password: String,
-    ) -> Result<AuthContext, Error> {
+    ) -> Result<PreparedUserPasswordChange, Error> {
+        let new_password = Zeroizing::new(new_password);
         let expected_password_enc = user
             .password_enc
             .as_deref()
-            .ok_or(Error::AuthenticationError)?;
+            .ok_or(Error::AuthenticationError)?
+            .to_vec();
         let plaintext_seed = self.decrypt_seed_for_auth_context(user, auth_context)?;
         let (password_hash, encrypted_password) =
             self.encrypt_user_password_verifier(new_password).await?;
@@ -2469,27 +2499,53 @@ impl AppState {
             self.new_password_seed_wrapping_for_user(user, &password_hash, &plaintext_seed)?;
         let new_auth_context = self.password_auth_context_for_user(user, &password_hash)?;
 
+        Ok(PreparedUserPasswordChange {
+            expected_password_enc,
+            new_password_enc: encrypted_password,
+            new_wrapping,
+            new_auth_context,
+        })
+    }
+
+    pub(crate) fn commit_prepared_user_password_and_seed_wrap(
+        &self,
+        user: &User,
+        prepared: PreparedUserPasswordChange,
+    ) -> Result<AuthContext, Error> {
         self.db
             .update_user_password_and_seed_wrap(
                 user,
-                expected_password_enc,
-                encrypted_password,
-                new_wrapping,
+                &prepared.expected_password_enc,
+                prepared.new_password_enc,
+                prepared.new_wrapping,
             )
             .map_err(|err| match err {
                 DBError::StaleCredentialState => Error::AuthenticationError,
                 err => Error::from(err),
             })?;
-        self.verify_seed_wrap_for_auth_context(user, &new_auth_context)?;
 
+        Ok(prepared.new_auth_context)
+    }
+
+    async fn update_user_password_and_seed_wrap(
+        &self,
+        user: &User,
+        auth_context: &AuthContext,
+        new_password: String,
+    ) -> Result<AuthContext, Error> {
+        let prepared = self
+            .prepare_user_password_and_seed_wrap(user, auth_context, new_password)
+            .await?;
+        let new_auth_context = self.commit_prepared_user_password_and_seed_wrap(user, prepared)?;
+        self.verify_seed_wrap_for_auth_context(user, &new_auth_context)?;
         Ok(new_auth_context)
     }
 
     async fn encrypt_user_password_verifier(
         &self,
-        new_password: String,
-    ) -> Result<(String, Vec<u8>), Error> {
-        let password_hash = password_auth::generate_hash(new_password);
+        new_password: Zeroizing<String>,
+    ) -> Result<(Zeroizing<String>, Vec<u8>), Error> {
+        let password_hash = Zeroizing::new(password_auth::generate_hash(new_password.as_bytes()));
         let secret_key = SecretKey::from_slice(&self.enclave_key)
             .map_err(|e| Error::EncryptionError(e.to_string()))?;
         let encrypted_password = encrypt_with_key(&secret_key, password_hash.as_bytes()).await;

--- a/src/models/user_api_keys.rs
+++ b/src/models/user_api_keys.rs
@@ -1,9 +1,12 @@
 use crate::models::schema::user_api_keys;
 use chrono::{DateTime, Utc};
+use diesel::dsl::{count_star, sql};
 use diesel::prelude::*;
+use diesel::sql_types::{BigInt, Nullable};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
+use zeroize::{Zeroize, Zeroizing};
 
 #[derive(Error, Debug)]
 pub enum UserApiKeyError {
@@ -13,6 +16,10 @@ pub enum UserApiKeyError {
     DuplicateName,
     #[error("API key not found")]
     NotFound,
+    #[error("API key list output is too large")]
+    OutputTooLarge,
+    #[error("API key list changed during its bounded read")]
+    InconsistentSnapshot,
 }
 
 #[derive(Queryable, Serialize, Deserialize, Clone)]
@@ -26,6 +33,26 @@ pub struct UserApiKey {
     pub name: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+/// Narrow metadata projection used only by bounded transport-v2 list reads.
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = user_api_keys)]
+pub struct UserApiKeyListItem {
+    pub name: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl Zeroize for UserApiKeyListItem {
+    fn zeroize(&mut self) {
+        self.name.zeroize();
+    }
+}
+
+impl Drop for UserApiKeyListItem {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
 }
 
 impl std::fmt::Debug for UserApiKey {
@@ -114,6 +141,57 @@ impl UserApiKey {
             .map_err(UserApiKeyError::DatabaseError)
     }
 
+    /// Load only bounded API-key metadata for transport v2.
+    ///
+    /// The row count and total name bytes are measured before the narrow
+    /// projection is loaded in the same read-only, repeatable-read snapshot.
+    pub fn get_bounded_list_for_user(
+        conn: &mut PgConnection,
+        lookup_user_id: Uuid,
+        logical_body_limit: usize,
+        row_limit: usize,
+    ) -> Result<Zeroizing<Vec<UserApiKeyListItem>>, UserApiKeyError> {
+        conn.build_transaction()
+            .read_only()
+            .repeatable_read()
+            .run::<_, UserApiKeyError, _>(|conn| {
+                let (row_count, aggregate_name_bytes) = user_api_keys::table
+                    .filter(user_api_keys::user_id.eq(lookup_user_id))
+                    .select((
+                        count_star(),
+                        sql::<Nullable<BigInt>>("SUM(octet_length(name)::bigint)::bigint"),
+                    ))
+                    .first::<(i64, Option<i64>)>(conn)
+                    .map_err(UserApiKeyError::DatabaseError)?;
+                let (expected_rows, expected_name_bytes) = validate_bounded_list_aggregate(
+                    row_count,
+                    aggregate_name_bytes,
+                    logical_body_limit,
+                    row_limit,
+                )?;
+
+                let rows = Zeroizing::new(
+                    user_api_keys::table
+                        .filter(user_api_keys::user_id.eq(lookup_user_id))
+                        .select(UserApiKeyListItem::as_select())
+                        .load::<UserApiKeyListItem>(conn)
+                        .map_err(UserApiKeyError::DatabaseError)?,
+                );
+                if rows.len() != expected_rows {
+                    return Err(UserApiKeyError::InconsistentSnapshot);
+                }
+                let actual_name_bytes = rows.iter().try_fold(0_usize, |total, row| {
+                    total
+                        .checked_add(row.name.len())
+                        .ok_or(UserApiKeyError::OutputTooLarge)
+                })?;
+                if actual_name_bytes != expected_name_bytes {
+                    return Err(UserApiKeyError::InconsistentSnapshot);
+                }
+                Ok(rows)
+            })
+    }
+
     pub fn delete(self, conn: &mut PgConnection) -> Result<(), UserApiKeyError> {
         diesel::delete(user_api_keys::table.filter(user_api_keys::id.eq(self.id)))
             .execute(conn)
@@ -145,6 +223,68 @@ impl UserApiKey {
             Err(UserApiKeyError::NotFound)
         } else {
             Ok(())
+        }
+    }
+}
+
+fn validate_bounded_list_aggregate(
+    row_count: i64,
+    aggregate_name_bytes: Option<i64>,
+    logical_body_limit: usize,
+    row_limit: usize,
+) -> Result<(usize, usize), UserApiKeyError> {
+    let row_count =
+        usize::try_from(row_count).map_err(|_| UserApiKeyError::InconsistentSnapshot)?;
+    if row_count > row_limit {
+        return Err(UserApiKeyError::OutputTooLarge);
+    }
+
+    let aggregate_name_bytes = match (row_count, aggregate_name_bytes) {
+        (0, None) => 0,
+        (0, Some(_)) | (_, None) => return Err(UserApiKeyError::InconsistentSnapshot),
+        (_, Some(bytes)) => {
+            usize::try_from(bytes).map_err(|_| UserApiKeyError::InconsistentSnapshot)?
+        }
+    };
+    if aggregate_name_bytes > logical_body_limit {
+        return Err(UserApiKeyError::OutputTooLarge);
+    }
+    Ok((row_count, aggregate_name_bytes))
+}
+
+#[cfg(test)]
+mod bounded_list_tests {
+    use super::*;
+
+    #[test]
+    fn aggregate_preflight_bounds_rows_and_name_bytes() {
+        assert_eq!(
+            validate_bounded_list_aggregate(0, None, 0, 0).unwrap(),
+            (0, 0)
+        );
+        assert_eq!(
+            validate_bounded_list_aggregate(2, Some(9), 9, 2).unwrap(),
+            (2, 9)
+        );
+        assert!(matches!(
+            validate_bounded_list_aggregate(2, Some(9), 8, 2),
+            Err(UserApiKeyError::OutputTooLarge)
+        ));
+        assert!(matches!(
+            validate_bounded_list_aggregate(2, Some(9), 9, 1),
+            Err(UserApiKeyError::OutputTooLarge)
+        ));
+        for inconsistent in [
+            validate_bounded_list_aggregate(-1, None, 9, 2),
+            validate_bounded_list_aggregate(1, None, 9, 2),
+            validate_bounded_list_aggregate(0, Some(0), 9, 2),
+            validate_bounded_list_aggregate(0, Some(1), 9, 2),
+            validate_bounded_list_aggregate(1, Some(-1), 9, 2),
+        ] {
+            assert!(matches!(
+                inconsistent,
+                Err(UserApiKeyError::InconsistentSnapshot)
+            ));
         }
     }
 }

--- a/src/security_invariants.rs
+++ b/src/security_invariants.rs
@@ -761,9 +761,9 @@ fn password_credential_lifecycle_rewraps_seed_and_reissues_tokens() {
         "password change must unwrap with the current signed AuthContext, not a DB-recomputed password auth context"
     );
 
-    let password_update_helper = extract_function_body(
+    let password_prepare_helper = extract_function_body(
         &main_contents,
-        "async fn update_user_password_and_seed_wrap",
+        "pub(crate) async fn prepare_user_password_and_seed_wrap",
     );
     for required_pattern in [
         "let expected_password_enc = user",
@@ -771,10 +771,40 @@ fn password_credential_lifecycle_rewraps_seed_and_reissues_tokens() {
         "encrypt_user_password_verifier(new_password)",
         "new_password_seed_wrapping_for_user(user, &password_hash, &plaintext_seed)",
         "password_auth_context_for_user(user, &password_hash)",
-        "expected_password_enc",
         "encrypted_password",
         "new_wrapping",
+        "PreparedUserPasswordChange",
+    ] {
+        assert!(
+            password_prepare_helper.contains(required_pattern),
+            "password-change preparation must contain `{required_pattern}`"
+        );
+    }
+
+    let password_commit_helper = extract_function_body(
+        &main_contents,
+        "pub(crate) fn commit_prepared_user_password_and_seed_wrap",
+    );
+    for required_pattern in [
+        ".update_user_password_and_seed_wrap(",
+        "&prepared.expected_password_enc",
+        "prepared.new_password_enc",
+        "prepared.new_wrapping",
         "DBError::StaleCredentialState => Error::AuthenticationError",
+    ] {
+        assert!(
+            password_commit_helper.contains(required_pattern),
+            "password-change commit must contain `{required_pattern}`"
+        );
+    }
+
+    let password_update_helper = extract_function_body(
+        &main_contents,
+        "async fn update_user_password_and_seed_wrap",
+    );
+    for required_pattern in [
+        "prepare_user_password_and_seed_wrap(user, auth_context, new_password)",
+        "commit_prepared_user_password_and_seed_wrap(user, prepared)",
         "verify_seed_wrap_for_auth_context(user, &new_auth_context)",
     ] {
         assert!(
@@ -942,8 +972,9 @@ fn password_registration_and_login_issue_tokens_only_after_seed_wrap_verificatio
 
     let authenticate_body = extract_function_body(&main_contents, "async fn authenticate_user");
     for required_pattern in [
+        "let user_password = Zeroizing::new(user_password)",
         "decrypt_with_key(&secret_key, user.password_enc.as_ref().unwrap())",
-        "verify_password(user_password, &decrypted_password_hash)",
+        "verify_password(user_password.as_bytes(), decrypted_password_hash.as_str())",
         "password_auth_context_for_user(&user, &verifier_for_binding)",
         "verify_seed_wrap_for_auth_context(&user, &auth_context)",
         "VerifiedUserAuthentication { user, auth_context }",

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -28,11 +28,13 @@ use crate::web::login_routes::{
 use crate::web::protected_routes::{
     confirm_account_deletion_data, create_api_key_data, decrypt_data_value, delete_all_kv_values,
     delete_api_key_by_name, delete_kv_value, encrypt_data_value, initiate_account_deletion_data,
-    list_bounded_api_keys_data, private_key_bytes_data, private_key_data, protected_user_data,
-    public_key_data, put_kv_value, request_new_verification_code_data, sign_message_data,
-    third_party_token_data, ConfirmAccountDeletionRequest, CreateApiKeyRequest, DecryptDataRequest,
-    DerivationPathQuery, EncryptDataRequest, InitiateAccountDeletionRequest, KvValue,
-    PublicKeyQuery, SignMessageRequest, ThirdPartyTokenRequest,
+    list_bounded_api_keys_data, map_password_change_error, private_key_bytes_data,
+    private_key_data, protected_user_data, public_key_data, put_kv_value,
+    request_new_verification_code_data, sign_message_data, third_party_token_data,
+    verify_password_change_request, ChangePasswordRequest, ConfirmAccountDeletionRequest,
+    CreateApiKeyRequest, DecryptDataRequest, DerivationPathQuery, EncryptDataRequest,
+    InitiateAccountDeletionRequest, KvValue, PublicKeyQuery, SignMessageRequest,
+    ThirdPartyTokenRequest,
 };
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
@@ -79,6 +81,10 @@ pub(crate) enum UserOperation {
         code: uuid::Uuid,
     },
     Logout {
+        body: SensitiveBytes,
+    },
+    ChangePassword {
+        authority: BoundUserAuthority,
         body: SensitiveBytes,
     },
     Protected {
@@ -177,7 +183,7 @@ impl UserOperation {
 
     const fn session_effect_on_success(&self) -> SessionEffect {
         match self {
-            Self::Logout { .. } => SessionEffect::Close,
+            Self::Logout { .. } | Self::ChangePassword { .. } => SessionEffect::Close,
             Self::Protected { operation, .. } => operation.session_effect_on_success(),
             _ => SessionEffect::Retain,
         }
@@ -332,6 +338,7 @@ pub(crate) fn prepare_user_operation(
         RequestAccountDeletion,
         ConfirmAccountDeletion,
         Logout,
+        ChangePassword,
     }
 
     let kv_key = match decode_canonical_kv_item_path(request.method, &request.path) {
@@ -382,6 +389,7 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Post, "/protected/delete-account/confirm") => {
             Some(Route::ConfirmAccountDeletion)
         }
+        (LogicalMethod::Post, "/protected/change_password") => Some(Route::ChangePassword),
         (LogicalMethod::Post, "/logout") => Some(Route::Logout),
         (LogicalMethod::Get, _) if kv_key.is_some() => Some(Route::GetKv),
         (LogicalMethod::Put, _) if kv_key.is_some() => Some(Route::PutKv),
@@ -532,7 +540,8 @@ pub(crate) fn prepare_user_operation(
         | Route::EncryptData
         | Route::DecryptData
         | Route::RequestAccountDeletion
-        | Route::ConfirmAccountDeletion => {
+        | Route::ConfirmAccountDeletion
+        | Route::ChangePassword => {
             if credential.is_some()
                 || request.query.is_some()
                 || !has_exact_json_content_type(&request.headers)
@@ -552,6 +561,12 @@ pub(crate) fn prepare_user_operation(
                 .expect("validated protected JSON body presence")
                 .into_bytes();
             let body = Zeroizing::new(body);
+            if matches!(route, Route::ChangePassword) {
+                return OperationPreparation::Ready(UserOperation::ChangePassword {
+                    authority,
+                    body,
+                });
+            }
             let operation = match route {
                 Route::SignMessage => ProtectedUserOperation::SignMessage { body },
                 Route::IssueThirdPartyToken => {
@@ -883,6 +898,89 @@ pub(crate) async fn execute_user_operation(
             };
             ApplicationOutcome::success(response, session_effect_on_success)
         }
+        UserOperation::ChangePassword { authority, body } => {
+            debug_assert!(authentication.is_none());
+            let user = match app_state.verify_bound_user(
+                authority.user_id,
+                authority.project_id,
+                &authority.auth_context,
+            ) {
+                Ok(user) => user,
+                Err(error) => {
+                    if matches!(error, ApiError::Unauthorized | ApiError::InvalidJwt) {
+                        return ApplicationOutcome::closing_error(error);
+                    }
+                    return ApplicationOutcome::error(error);
+                }
+            };
+            let mut request = match parse_json_body::<ChangePasswordRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            if let Err(error) =
+                verify_password_change_request(&app_state, &user, &mut request).await
+            {
+                return bound_user_error_outcome(&app_state, &authority, error);
+            }
+
+            let new_password = std::mem::take(&mut request.new_password);
+            let prepared = match app_state
+                .prepare_user_password_and_seed_wrap(&user, &authority.auth_context, new_password)
+                .await
+            {
+                Ok(prepared) => prepared,
+                Err(error) => {
+                    let error = map_password_change_error(error);
+                    return bound_user_error_outcome(&app_state, &authority, error);
+                }
+            };
+
+            let issued = match issue_transport_v2_user_tokens(
+                &user,
+                prepared.new_auth_context(),
+                &app_state,
+            ) {
+                Ok(issued) => issued,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            let mut access_token = issued.access_token;
+            let mut resumption_token = issued.resumption_token;
+            #[derive(Serialize)]
+            struct ChangePasswordResponse<'a> {
+                message: &'static str,
+                access_token: &'a str,
+                refresh_token: &'a str,
+            }
+            let response = LogicalUnaryResponse::json(
+                StatusCode::OK,
+                &ChangePasswordResponse {
+                    message: "Password changed successfully",
+                    access_token: &access_token,
+                    refresh_token: &resumption_token,
+                },
+            );
+            access_token.zeroize();
+            resumption_token.zeroize();
+            let response = match response {
+                Ok(response) => response,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+
+            let new_auth_context =
+                match app_state.commit_prepared_user_password_and_seed_wrap(&user, prepared) {
+                    Ok(auth_context) => auth_context,
+                    Err(error) => {
+                        return ApplicationOutcome::closing_error(map_password_change_error(error));
+                    }
+                };
+            if let Err(error) =
+                app_state.verify_seed_wrap_for_auth_context(&user, &new_auth_context)
+            {
+                return ApplicationOutcome::closing_error(map_password_change_error(error));
+            }
+
+            ApplicationOutcome::success(response, session_effect_on_success)
+        }
         UserOperation::Protected {
             authority,
             operation,
@@ -919,6 +1017,25 @@ pub(crate) async fn execute_user_operation(
             };
             ApplicationOutcome::success(response, session_effect_on_success)
         }
+    }
+}
+
+fn bound_user_error_outcome(
+    app_state: &AppState,
+    authority: &BoundUserAuthority,
+    error: ApiError,
+) -> ApplicationOutcome {
+    if matches!(
+        app_state.verify_bound_user(
+            authority.user_id,
+            authority.project_id,
+            &authority.auth_context,
+        ),
+        Err(ApiError::Unauthorized | ApiError::InvalidJwt)
+    ) {
+        ApplicationOutcome::closing_error(error)
+    } else {
+        ApplicationOutcome::error(error)
     }
 }
 
@@ -1627,6 +1744,85 @@ mod tests {
                     uuid::Uuid::from_bytes([0x43; 16]),
                 )),
             ),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::UNAUTHORIZED
+        ));
+
+        let mut with_query = request();
+        with_query.request.query = Some("transplanted=true".to_owned());
+        assert!(matches!(
+            prepare_user_operation(with_query, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_extra_header = request();
+        with_extra_header.request.headers.push(HeaderField {
+            name: "accept".to_owned(),
+            value_base64: EncodedBytes::from_bytes(b"application/json".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(with_extra_header, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut without_body = request();
+        without_body.request.body_base64 = None;
+        assert!(matches!(
+            prepare_user_operation(without_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_empty_body = request();
+        with_empty_body.request.body_base64 = Some(EncodedBytes::from_bytes(Vec::new()));
+        assert!(matches!(
+            prepare_user_operation(with_empty_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_credential = request();
+        with_credential.credential = Some(Credential::Resumption {
+            value_base64: EncodedBytes::from_bytes(b"transplanted".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(with_credential, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut streaming = request();
+        streaming.response_mode = ResponseMode::Stream;
+        assert!(matches!(
+            prepare_user_operation(streaming, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+    }
+
+    #[test]
+    fn password_change_is_exact_bound_and_terminal_only_on_success() {
+        let request = || {
+            envelope(
+                LogicalMethod::Post,
+                "/protected/change_password",
+                json_header(),
+                Some(br#"{"current_password":"old","new_password":"new"}"#),
+                None,
+            )
+        };
+        let OperationPreparation::Ready(operation) =
+            prepare_user_operation(request(), bound_user_authority())
+        else {
+            panic!("exact password change must be admitted");
+        };
+        assert!(matches!(&operation, UserOperation::ChangePassword { .. }));
+        assert_eq!(operation.session_effect_on_success(), SessionEffect::Close);
+
+        assert!(matches!(
+            prepare_user_operation(request(), AuthorityState::Anonymous),
             OperationPreparation::Rejected(response)
                 if response.status == StatusCode::UNAUTHORIZED
         ));

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -26,13 +26,13 @@ use crate::web::login_routes::{
     RefreshResponse, RegisterCredentials,
 };
 use crate::web::protected_routes::{
-    create_api_key_data, decrypt_data_value, delete_all_kv_values, delete_api_key_by_name,
-    delete_kv_value, encrypt_data_value, initiate_account_deletion_data,
+    confirm_account_deletion_data, create_api_key_data, decrypt_data_value, delete_all_kv_values,
+    delete_api_key_by_name, delete_kv_value, encrypt_data_value, initiate_account_deletion_data,
     list_bounded_api_keys_data, private_key_bytes_data, private_key_data, protected_user_data,
     public_key_data, put_kv_value, request_new_verification_code_data, sign_message_data,
-    third_party_token_data, CreateApiKeyRequest, DecryptDataRequest, DerivationPathQuery,
-    EncryptDataRequest, InitiateAccountDeletionRequest, KvValue, PublicKeyQuery,
-    SignMessageRequest, ThirdPartyTokenRequest,
+    third_party_token_data, ConfirmAccountDeletionRequest, CreateApiKeyRequest, DecryptDataRequest,
+    DerivationPathQuery, EncryptDataRequest, InitiateAccountDeletionRequest, KvValue,
+    PublicKeyQuery, SignMessageRequest, ThirdPartyTokenRequest,
 };
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
@@ -130,6 +130,19 @@ pub(crate) enum ProtectedUserOperation {
     RequestAccountDeletion {
         body: SensitiveBytes,
     },
+    ConfirmAccountDeletion {
+        body: SensitiveBytes,
+    },
+}
+
+impl ProtectedUserOperation {
+    const fn session_effect_on_success(&self) -> SessionEffect {
+        if matches!(self, Self::ConfirmAccountDeletion { .. }) {
+            SessionEffect::Close
+        } else {
+            SessionEffect::Retain
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -306,6 +319,7 @@ pub(crate) fn prepare_user_operation(
         ListApiKeys,
         DeleteApiKey,
         RequestAccountDeletion,
+        ConfirmAccountDeletion,
     }
 
     let kv_key = match decode_canonical_kv_item_path(request.method, &request.path) {
@@ -352,6 +366,9 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Get, "/protected/api-keys") => Some(Route::ListApiKeys),
         (LogicalMethod::Post, "/protected/delete-account/request") => {
             Some(Route::RequestAccountDeletion)
+        }
+        (LogicalMethod::Post, "/protected/delete-account/confirm") => {
+            Some(Route::ConfirmAccountDeletion)
         }
         (LogicalMethod::Get, _) if kv_key.is_some() => Some(Route::GetKv),
         (LogicalMethod::Put, _) if kv_key.is_some() => Some(Route::PutKv),
@@ -501,7 +518,8 @@ pub(crate) fn prepare_user_operation(
         | Route::IssueThirdPartyToken
         | Route::EncryptData
         | Route::DecryptData
-        | Route::RequestAccountDeletion => {
+        | Route::RequestAccountDeletion
+        | Route::ConfirmAccountDeletion => {
             if credential.is_some()
                 || request.query.is_some()
                 || !has_exact_json_content_type(&request.headers)
@@ -530,6 +548,9 @@ pub(crate) fn prepare_user_operation(
                 Route::DecryptData => ProtectedUserOperation::DecryptData { body },
                 Route::RequestAccountDeletion => {
                     ProtectedUserOperation::RequestAccountDeletion { body }
+                }
+                Route::ConfirmAccountDeletion => {
+                    ProtectedUserOperation::ConfirmAccountDeletion { body }
                 }
                 _ => unreachable!("fixed protected POST classifier is exhaustive"),
             };
@@ -818,6 +839,7 @@ pub(crate) async fn execute_user_operation(
             operation,
         } => {
             debug_assert!(authentication.is_none());
+            let session_effect = operation.session_effect_on_success();
             let user = match app_state.verify_bound_user(
                 authority.user_id,
                 authority.project_id,
@@ -847,7 +869,7 @@ pub(crate) async fn execute_user_operation(
                     return ApplicationOutcome::error(error);
                 }
             };
-            ApplicationOutcome::success(response, SessionEffect::Retain)
+            ApplicationOutcome::success(response, session_effect)
         }
     }
 }
@@ -985,6 +1007,17 @@ async fn execute_protected_user_operation(
             let request = parse_json_body::<InitiateAccountDeletionRequest>(body)?;
             let value = initiate_account_deletion_data(app_state, user, request).await?;
             LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::ConfirmAccountDeletion { body } => {
+            let request = parse_json_body::<ConfirmAccountDeletionRequest>(body)?;
+            let response = LogicalUnaryResponse::json(
+                StatusCode::OK,
+                &serde_json::json!({
+                    "message": "Your account has been successfully deleted."
+                }),
+            )?;
+            confirm_account_deletion_data(app_state, user, request).await?;
+            Ok(response)
         }
     }
 }
@@ -1356,13 +1389,16 @@ mod tests {
                 None,
             )
         };
+        let OperationPreparation::Ready(UserOperation::Protected { operation, .. }) =
+            prepare_user_operation(request(), bound_user_authority())
+        else {
+            panic!("exact account deletion request must be admitted");
+        };
         assert!(matches!(
-            prepare_user_operation(request(), bound_user_authority()),
-            OperationPreparation::Ready(UserOperation::Protected {
-                operation: ProtectedUserOperation::RequestAccountDeletion { .. },
-                ..
-            })
+            &operation,
+            ProtectedUserOperation::RequestAccountDeletion { .. }
         ));
+        assert_eq!(operation.session_effect_on_success(), SessionEffect::Retain);
         assert!(matches!(
             prepare_user_operation(request(), AuthorityState::Anonymous),
             OperationPreparation::Rejected(response)
@@ -1402,6 +1438,90 @@ mod tests {
         });
         assert!(matches!(
             prepare_user_operation(with_credential, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+    }
+
+    #[test]
+    fn account_deletion_confirmation_is_exact_and_terminal_only_on_success() {
+        let request = || {
+            envelope(
+                LogicalMethod::Post,
+                "/protected/delete-account/confirm",
+                json_header(),
+                Some(
+                    br#"{"confirmation_code":"123e4567-e89b-12d3-a456-426614174000","plaintext_secret":"client-secret"}"#,
+                ),
+                None,
+            )
+        };
+        let OperationPreparation::Ready(UserOperation::Protected { operation, .. }) =
+            prepare_user_operation(request(), bound_user_authority())
+        else {
+            panic!("exact account deletion confirmation must be admitted");
+        };
+        assert!(matches!(
+            &operation,
+            ProtectedUserOperation::ConfirmAccountDeletion { .. }
+        ));
+        assert_eq!(operation.session_effect_on_success(), SessionEffect::Close);
+
+        assert!(matches!(
+            prepare_user_operation(request(), AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::UNAUTHORIZED
+        ));
+
+        let mut with_query = request();
+        with_query.request.query = Some("transplanted=true".to_owned());
+        assert!(matches!(
+            prepare_user_operation(with_query, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_extra_header = request();
+        with_extra_header.request.headers.push(HeaderField {
+            name: "accept".to_owned(),
+            value_base64: EncodedBytes::from_bytes(b"application/json".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(with_extra_header, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut without_body = request();
+        without_body.request.body_base64 = None;
+        assert!(matches!(
+            prepare_user_operation(without_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_empty_body = request();
+        with_empty_body.request.body_base64 = Some(EncodedBytes::from_bytes(Vec::new()));
+        assert!(matches!(
+            prepare_user_operation(with_empty_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_credential = request();
+        with_credential.credential = Some(Credential::Resumption {
+            value_base64: EncodedBytes::from_bytes(b"transplanted".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(with_credential, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut streaming = request();
+        streaming.response_mode = ResponseMode::Stream;
+        assert!(matches!(
+            prepare_user_operation(streaming, bound_user_authority()),
             OperationPreparation::Rejected(response)
                 if response.status == StatusCode::BAD_REQUEST
         ));

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -22,8 +22,8 @@ use crate::jwt::{
 };
 use crate::kv::StoreError;
 use crate::web::login_routes::{
-    authenticate_login, register_and_authenticate, AuthResponse, Credentials, RefreshResponse,
-    RegisterCredentials,
+    authenticate_login, register_and_authenticate, verify_email_data, AuthResponse, Credentials,
+    RefreshResponse, RegisterCredentials,
 };
 use crate::web::protected_routes::{
     create_api_key_data, decrypt_data_value, delete_all_kv_values, delete_api_key_by_name,
@@ -36,8 +36,9 @@ use crate::web::protected_routes::{
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
 use super::envelope::{
-    decode_canonical_api_key_name_path, decode_canonical_kv_item_path, Credential, EncodedBytes,
-    EnvelopeLimits, HeaderField, LogicalMethod, RequestEnvelope, RequestId, ResponseMode,
+    decode_canonical_api_key_name_path, decode_canonical_kv_item_path,
+    decode_canonical_verify_email_path, Credential, EncodedBytes, EnvelopeLimits, HeaderField,
+    LogicalMethod, RequestEnvelope, RequestId, ResponseMode,
 };
 use super::session::{
     AuthenticationReservation, AuthenticationStartError, AuthorityState, BoundAuthority,
@@ -72,6 +73,9 @@ pub(crate) enum UserOperation {
     },
     Resume {
         credential: SensitiveBytes,
+    },
+    VerifyEmail {
+        code: uuid::Uuid,
     },
     Protected {
         authority: BoundUserAuthority,
@@ -265,6 +269,7 @@ pub(crate) fn prepare_user_operation(
         Login,
         Register,
         Resume,
+        VerifyEmail,
         GetUser,
         RequestVerification,
         GetPrivateKey,
@@ -298,10 +303,19 @@ pub(crate) fn prepare_user_operation(
             return rejected_bad_request();
         }
     };
+    let verification_code = match decode_canonical_verify_email_path(request.method, &request.path)
+    {
+        Ok(code) => code,
+        Err(_) => {
+            request.path.zeroize();
+            return rejected_bad_request();
+        }
+    };
     let route = match (request.method, request.path.as_str()) {
         (LogicalMethod::Post, "/login") => Some(Route::Login),
         (LogicalMethod::Post, "/register") => Some(Route::Register),
         (LogicalMethod::Post, "/refresh") => Some(Route::Resume),
+        (LogicalMethod::Get, _) if verification_code.is_some() => Some(Route::VerifyEmail),
         (LogicalMethod::Get, "/protected/user") => Some(Route::GetUser),
         (LogicalMethod::Post, "/protected/request_verification") => {
             Some(Route::RequestVerification)
@@ -323,7 +337,7 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Delete, _) if api_key_name.is_some() => Some(Route::DeleteApiKey),
         _ => None,
     };
-    if kv_key.is_some() || api_key_name.is_some() {
+    if kv_key.is_some() || api_key_name.is_some() || verification_code.is_some() {
         request.path.zeroize();
     }
     let Some(route) = route else {
@@ -387,6 +401,31 @@ pub(crate) fn prepare_user_operation(
             }
             OperationPreparation::Ready(UserOperation::Resume {
                 credential: Zeroizing::new(value_base64.into_bytes()),
+            })
+        }
+        Route::VerifyEmail => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            match authority {
+                AuthorityState::Anonymous | AuthorityState::Bound(_) => {}
+                AuthorityState::Authenticating(_) => {
+                    return OperationPreparation::Rejected(authentication_start_error(
+                        AuthenticationStartError::AuthenticationInProgress,
+                    ));
+                }
+                AuthorityState::Closing => {
+                    return OperationPreparation::Rejected(authentication_start_error(
+                        AuthenticationStartError::Closing,
+                    ));
+                }
+            }
+            OperationPreparation::Ready(UserOperation::VerifyEmail {
+                code: verification_code.expect("classified verification route must have a code"),
             })
         }
         Route::GetUser | Route::GetPrivateKey | Route::GetPrivateKeyBytes | Route::GetPublicKey => {
@@ -737,6 +776,16 @@ pub(crate) async fn execute_user_operation(
                 monotonic_now,
                 UserAuthResponseKind::Refresh,
             )
+        }
+        UserOperation::VerifyEmail { code } => {
+            debug_assert!(authentication.is_none());
+            let response = match verify_email_data(&app_state, code)
+                .and_then(|value| LogicalUnaryResponse::json(StatusCode::OK, &value))
+            {
+                Ok(response) => response,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            ApplicationOutcome::success(response, false)
         }
         UserOperation::Protected {
             authority,
@@ -1260,6 +1309,80 @@ mod tests {
         });
         assert!(matches!(
             prepare_user_operation(with_credential, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+    }
+
+    #[test]
+    fn email_verification_is_a_canonical_code_operation_without_rebinding() {
+        let path = "/verify-email/123e4567-e89b-12d3-a456-426614174000";
+        let request = || envelope(LogicalMethod::Get, path, Vec::new(), None, None);
+        for authority in [AuthorityState::Anonymous, bound_user_authority()] {
+            assert!(matches!(
+                prepare_user_operation(request(), authority),
+                OperationPreparation::Ready(UserOperation::VerifyEmail { code })
+                    if code == uuid::Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").unwrap()
+            ));
+        }
+
+        assert!(matches!(
+            prepare_user_operation(
+                request(),
+                AuthorityState::Authenticating(RequestId::from_bytes([0x41; 16])),
+            ),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::CONFLICT
+        ));
+        assert!(matches!(
+            prepare_user_operation(request(), AuthorityState::Closing),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::CONFLICT
+        ));
+
+        let mut with_query = request();
+        with_query.request.query = Some("transplanted=true".to_owned());
+        assert!(matches!(
+            prepare_user_operation(with_query, AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_header = request();
+        with_header.request.headers = json_header();
+        assert!(matches!(
+            prepare_user_operation(with_header, AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_body = request();
+        with_body.request.body_base64 = Some(EncodedBytes::from_bytes(b"{}".to_vec()));
+        assert!(matches!(
+            prepare_user_operation(with_body, AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_credential = request();
+        with_credential.credential = Some(Credential::Resumption {
+            value_base64: EncodedBytes::from_bytes(b"transplanted".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(with_credential, AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let uppercase = envelope(
+            LogicalMethod::Get,
+            "/verify-email/123E4567-E89B-12D3-A456-426614174000",
+            Vec::new(),
+            None,
+            None,
+        );
+        assert!(matches!(
+            prepare_user_operation(uppercase, AuthorityState::Anonymous),
             OperationPreparation::Rejected(response)
                 if response.status == StatusCode::BAD_REQUEST
         ));

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -238,21 +238,35 @@ impl LogicalUnaryResponse {
 
 pub(crate) struct ApplicationOutcome {
     pub(crate) response: LogicalUnaryResponse,
-    pub(crate) bound_session: bool,
+    pub(crate) session_effect: SessionEffect,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SessionEffect {
+    Retain,
+    NewlyBound,
+    Close,
 }
 
 impl ApplicationOutcome {
-    fn success(response: LogicalUnaryResponse, bound_session: bool) -> Self {
+    fn success(response: LogicalUnaryResponse, session_effect: SessionEffect) -> Self {
         Self {
             response,
-            bound_session,
+            session_effect,
         }
     }
 
     fn error(error: ApiError) -> Self {
         Self {
             response: LogicalUnaryResponse::api_error(&error),
-            bound_session: false,
+            session_effect: SessionEffect::Retain,
+        }
+    }
+
+    fn closing_error(error: ApiError) -> Self {
+        Self {
+            response: LogicalUnaryResponse::api_error(&error),
+            session_effect: SessionEffect::Close,
         }
     }
 }
@@ -797,7 +811,7 @@ pub(crate) async fn execute_user_operation(
                 Ok(response) => response,
                 Err(error) => return ApplicationOutcome::error(error),
             };
-            ApplicationOutcome::success(response, false)
+            ApplicationOutcome::success(response, SessionEffect::Retain)
         }
         UserOperation::Protected {
             authority,
@@ -812,7 +826,7 @@ pub(crate) async fn execute_user_operation(
                 Ok(user) => user,
                 Err(error) => {
                     if matches!(error, ApiError::Unauthorized | ApiError::InvalidJwt) {
-                        lease.state().close();
+                        return ApplicationOutcome::closing_error(error);
                     }
                     return ApplicationOutcome::error(error);
                 }
@@ -828,12 +842,12 @@ pub(crate) async fn execute_user_operation(
                 Ok(response) => response,
                 Err(error) => {
                     if matches!(error, ApiError::Unauthorized | ApiError::InvalidJwt) {
-                        lease.state().close();
+                        return ApplicationOutcome::closing_error(error);
                     }
                     return ApplicationOutcome::error(error);
                 }
             };
-            ApplicationOutcome::success(response, false)
+            ApplicationOutcome::success(response, SessionEffect::Retain)
         }
     }
 }
@@ -1082,7 +1096,7 @@ fn finish_user_binding(
         return ApplicationOutcome::error(ApiError::InternalServerError);
     }
 
-    ApplicationOutcome::success(response, true)
+    ApplicationOutcome::success(response, SessionEffect::NewlyBound)
 }
 
 fn monotonic_authentication_expiry(

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -22,8 +22,8 @@ use crate::jwt::{
 };
 use crate::kv::StoreError;
 use crate::web::login_routes::{
-    authenticate_login, register_and_authenticate, verify_email_data, AuthResponse, Credentials,
-    RefreshResponse, RegisterCredentials,
+    authenticate_login, logout_data, register_and_authenticate, verify_email_data, AuthResponse,
+    Credentials, LogoutRequest, RefreshResponse, RegisterCredentials,
 };
 use crate::web::protected_routes::{
     confirm_account_deletion_data, create_api_key_data, decrypt_data_value, delete_all_kv_values,
@@ -77,6 +77,9 @@ pub(crate) enum UserOperation {
     },
     VerifyEmail {
         code: uuid::Uuid,
+    },
+    Logout {
+        body: SensitiveBytes,
     },
     Protected {
         authority: BoundUserAuthority,
@@ -170,6 +173,14 @@ impl UserOperation {
                 ..
             }
         )
+    }
+
+    const fn session_effect_on_success(&self) -> SessionEffect {
+        match self {
+            Self::Logout { .. } => SessionEffect::Close,
+            Self::Protected { operation, .. } => operation.session_effect_on_success(),
+            _ => SessionEffect::Retain,
+        }
     }
 }
 
@@ -320,6 +331,7 @@ pub(crate) fn prepare_user_operation(
         DeleteApiKey,
         RequestAccountDeletion,
         ConfirmAccountDeletion,
+        Logout,
     }
 
     let kv_key = match decode_canonical_kv_item_path(request.method, &request.path) {
@@ -370,6 +382,7 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Post, "/protected/delete-account/confirm") => {
             Some(Route::ConfirmAccountDeletion)
         }
+        (LogicalMethod::Post, "/logout") => Some(Route::Logout),
         (LogicalMethod::Get, _) if kv_key.is_some() => Some(Route::GetKv),
         (LogicalMethod::Put, _) if kv_key.is_some() => Some(Route::PutKv),
         (LogicalMethod::Delete, _) if kv_key.is_some() => Some(Route::DeleteKv),
@@ -557,6 +570,29 @@ pub(crate) fn prepare_user_operation(
             OperationPreparation::Ready(UserOperation::Protected {
                 authority,
                 operation,
+            })
+        }
+        Route::Logout => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            if let Err(rejection) = bound_user_authority(authority) {
+                return rejection;
+            }
+            OperationPreparation::Ready(UserOperation::Logout {
+                body: Zeroizing::new(
+                    request
+                        .body_base64
+                        .expect("validated logout body presence")
+                        .into_bytes(),
+                ),
             })
         }
         Route::PutKv => {
@@ -759,6 +795,7 @@ pub(crate) async fn execute_user_operation(
     authentication: Option<AuthenticationReservation>,
     monotonic_now: Instant,
 ) -> ApplicationOutcome {
+    let session_effect_on_success = operation.session_effect_on_success();
     match operation {
         UserOperation::Login { body } => {
             let parsed =
@@ -834,12 +871,23 @@ pub(crate) async fn execute_user_operation(
             };
             ApplicationOutcome::success(response, SessionEffect::Retain)
         }
+        UserOperation::Logout { body } => {
+            debug_assert!(authentication.is_none());
+            let request = match parse_json_body::<LogoutRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            let response = match LogicalUnaryResponse::json(StatusCode::OK, &logout_data(request)) {
+                Ok(response) => response,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            ApplicationOutcome::success(response, session_effect_on_success)
+        }
         UserOperation::Protected {
             authority,
             operation,
         } => {
             debug_assert!(authentication.is_none());
-            let session_effect = operation.session_effect_on_success();
             let user = match app_state.verify_bound_user(
                 authority.user_id,
                 authority.project_id,
@@ -869,7 +917,7 @@ pub(crate) async fn execute_user_operation(
                     return ApplicationOutcome::error(error);
                 }
             };
-            ApplicationOutcome::success(response, session_effect)
+            ApplicationOutcome::success(response, session_effect_on_success)
         }
     }
 }
@@ -1469,6 +1517,116 @@ mod tests {
 
         assert!(matches!(
             prepare_user_operation(request(), AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::UNAUTHORIZED
+        ));
+
+        let mut with_query = request();
+        with_query.request.query = Some("transplanted=true".to_owned());
+        assert!(matches!(
+            prepare_user_operation(with_query, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_extra_header = request();
+        with_extra_header.request.headers.push(HeaderField {
+            name: "accept".to_owned(),
+            value_base64: EncodedBytes::from_bytes(b"application/json".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(with_extra_header, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut without_body = request();
+        without_body.request.body_base64 = None;
+        assert!(matches!(
+            prepare_user_operation(without_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_empty_body = request();
+        with_empty_body.request.body_base64 = Some(EncodedBytes::from_bytes(Vec::new()));
+        assert!(matches!(
+            prepare_user_operation(with_empty_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_credential = request();
+        with_credential.credential = Some(Credential::Resumption {
+            value_base64: EncodedBytes::from_bytes(b"transplanted".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(with_credential, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut streaming = request();
+        streaming.response_mode = ResponseMode::Stream;
+        assert!(matches!(
+            prepare_user_operation(streaming, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+    }
+
+    #[test]
+    fn logout_is_exact_bound_and_terminal_only_on_success() {
+        let request = || {
+            envelope(
+                LogicalMethod::Post,
+                "/logout",
+                json_header(),
+                Some(br#"{"refresh_token":"resumption-token"}"#),
+                None,
+            )
+        };
+        let OperationPreparation::Ready(operation) =
+            prepare_user_operation(request(), bound_user_authority())
+        else {
+            panic!("exact user logout must be admitted");
+        };
+        assert!(matches!(&operation, UserOperation::Logout { .. }));
+        assert_eq!(operation.session_effect_on_success(), SessionEffect::Close);
+        let parsed = parse_json_body::<LogoutRequest>(Zeroizing::new(
+            br#"{"refresh_token":"resumption-token","push_device_id":"123e4567-e89b-12d3-a456-426614174000"}"#
+                .to_vec(),
+        ))
+        .expect("the released Rust SDK logout extension must remain accepted");
+        assert_eq!(
+            logout_data(parsed),
+            serde_json::json!({ "message": "Logged out successfully" })
+        );
+
+        assert!(matches!(
+            prepare_user_operation(request(), AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::UNAUTHORIZED
+        ));
+        assert!(matches!(
+            prepare_user_operation(
+                request(),
+                AuthorityState::Bound(BoundAuthority::platform(
+                    uuid::Uuid::from_bytes([0x42; 16]),
+                    Instant::now() + std::time::Duration::from_secs(60),
+                )),
+            ),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::UNAUTHORIZED
+        ));
+        assert!(matches!(
+            prepare_user_operation(
+                request(),
+                AuthorityState::Bound(BoundAuthority::api_key(
+                    17,
+                    uuid::Uuid::from_bytes([0x43; 16]),
+                )),
+            ),
             OperationPreparation::Rejected(response)
                 if response.status == StatusCode::UNAUTHORIZED
         ));

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -27,11 +27,12 @@ use crate::web::login_routes::{
 };
 use crate::web::protected_routes::{
     create_api_key_data, decrypt_data_value, delete_all_kv_values, delete_api_key_by_name,
-    delete_kv_value, encrypt_data_value, list_bounded_api_keys_data, private_key_bytes_data,
-    private_key_data, protected_user_data, public_key_data, put_kv_value,
-    request_new_verification_code_data, sign_message_data, third_party_token_data,
-    CreateApiKeyRequest, DecryptDataRequest, DerivationPathQuery, EncryptDataRequest, KvValue,
-    PublicKeyQuery, SignMessageRequest, ThirdPartyTokenRequest,
+    delete_kv_value, encrypt_data_value, initiate_account_deletion_data,
+    list_bounded_api_keys_data, private_key_bytes_data, private_key_data, protected_user_data,
+    public_key_data, put_kv_value, request_new_verification_code_data, sign_message_data,
+    third_party_token_data, CreateApiKeyRequest, DecryptDataRequest, DerivationPathQuery,
+    EncryptDataRequest, InitiateAccountDeletionRequest, KvValue, PublicKeyQuery,
+    SignMessageRequest, ThirdPartyTokenRequest,
 };
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
@@ -125,6 +126,9 @@ pub(crate) enum ProtectedUserOperation {
     ListApiKeys,
     DeleteApiKey {
         name: Zeroizing<String>,
+    },
+    RequestAccountDeletion {
+        body: SensitiveBytes,
     },
 }
 
@@ -287,6 +291,7 @@ pub(crate) fn prepare_user_operation(
         CreateApiKey,
         ListApiKeys,
         DeleteApiKey,
+        RequestAccountDeletion,
     }
 
     let kv_key = match decode_canonical_kv_item_path(request.method, &request.path) {
@@ -331,6 +336,9 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Delete, "/protected/kv") => Some(Route::DeleteAllKv),
         (LogicalMethod::Post, "/protected/api-keys") => Some(Route::CreateApiKey),
         (LogicalMethod::Get, "/protected/api-keys") => Some(Route::ListApiKeys),
+        (LogicalMethod::Post, "/protected/delete-account/request") => {
+            Some(Route::RequestAccountDeletion)
+        }
         (LogicalMethod::Get, _) if kv_key.is_some() => Some(Route::GetKv),
         (LogicalMethod::Put, _) if kv_key.is_some() => Some(Route::PutKv),
         (LogicalMethod::Delete, _) if kv_key.is_some() => Some(Route::DeleteKv),
@@ -478,7 +486,8 @@ pub(crate) fn prepare_user_operation(
         Route::SignMessage
         | Route::IssueThirdPartyToken
         | Route::EncryptData
-        | Route::DecryptData => {
+        | Route::DecryptData
+        | Route::RequestAccountDeletion => {
             if credential.is_some()
                 || request.query.is_some()
                 || !has_exact_json_content_type(&request.headers)
@@ -505,6 +514,9 @@ pub(crate) fn prepare_user_operation(
                 }
                 Route::EncryptData => ProtectedUserOperation::EncryptData { body },
                 Route::DecryptData => ProtectedUserOperation::DecryptData { body },
+                Route::RequestAccountDeletion => {
+                    ProtectedUserOperation::RequestAccountDeletion { body }
+                }
                 _ => unreachable!("fixed protected POST classifier is exhaustive"),
             };
             OperationPreparation::Ready(UserOperation::Protected {
@@ -955,6 +967,11 @@ async fn execute_protected_user_operation(
             delete_api_key_by_name(app_state, user, &name)?;
             Ok(response)
         }
+        ProtectedUserOperation::RequestAccountDeletion { body } => {
+            let request = parse_json_body::<InitiateAccountDeletionRequest>(body)?;
+            let value = initiate_account_deletion_data(app_state, user, request).await?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
     }
 }
 
@@ -1299,6 +1316,68 @@ mod tests {
         with_body.request.body_base64 = Some(EncodedBytes::from_bytes(b"{}".to_vec()));
         assert!(matches!(
             prepare_user_operation(with_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_credential = request();
+        with_credential.credential = Some(Credential::Resumption {
+            value_base64: EncodedBytes::from_bytes(b"transplanted".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(with_credential, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+    }
+
+    #[test]
+    fn account_deletion_request_requires_a_bound_user_and_exact_json_request() {
+        let request = || {
+            envelope(
+                LogicalMethod::Post,
+                "/protected/delete-account/request",
+                json_header(),
+                Some(br#"{"hashed_secret":"client-hash"}"#),
+                None,
+            )
+        };
+        assert!(matches!(
+            prepare_user_operation(request(), bound_user_authority()),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::RequestAccountDeletion { .. },
+                ..
+            })
+        ));
+        assert!(matches!(
+            prepare_user_operation(request(), AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::UNAUTHORIZED
+        ));
+
+        let mut with_query = request();
+        with_query.request.query = Some("transplanted=true".to_owned());
+        assert!(matches!(
+            prepare_user_operation(with_query, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_extra_header = request();
+        with_extra_header.request.headers.push(HeaderField {
+            name: "accept".to_owned(),
+            value_base64: EncodedBytes::from_bytes(b"application/json".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(with_extra_header, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut without_body = request();
+        without_body.request.body_base64 = None;
+        assert!(matches!(
+            prepare_user_operation(without_body, bound_user_authority()),
             OperationPreparation::Rejected(response)
                 if response.status == StatusCode::BAD_REQUEST
         ));

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -28,9 +28,10 @@ use crate::web::login_routes::{
 use crate::web::protected_routes::{
     create_api_key_data, decrypt_data_value, delete_all_kv_values, delete_api_key_by_name,
     delete_kv_value, encrypt_data_value, list_bounded_api_keys_data, private_key_bytes_data,
-    private_key_data, protected_user_data, public_key_data, put_kv_value, sign_message_data,
-    third_party_token_data, CreateApiKeyRequest, DecryptDataRequest, DerivationPathQuery,
-    EncryptDataRequest, KvValue, PublicKeyQuery, SignMessageRequest, ThirdPartyTokenRequest,
+    private_key_data, protected_user_data, public_key_data, put_kv_value,
+    request_new_verification_code_data, sign_message_data, third_party_token_data,
+    CreateApiKeyRequest, DecryptDataRequest, DerivationPathQuery, EncryptDataRequest, KvValue,
+    PublicKeyQuery, SignMessageRequest, ThirdPartyTokenRequest,
 };
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
@@ -80,6 +81,7 @@ pub(crate) enum UserOperation {
 
 pub(crate) enum ProtectedUserOperation {
     GetUser,
+    RequestVerification,
     GetPrivateKey {
         query: Option<String>,
     },
@@ -264,6 +266,7 @@ pub(crate) fn prepare_user_operation(
         Register,
         Resume,
         GetUser,
+        RequestVerification,
         GetPrivateKey,
         GetPrivateKeyBytes,
         GetPublicKey,
@@ -300,6 +303,9 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Post, "/register") => Some(Route::Register),
         (LogicalMethod::Post, "/refresh") => Some(Route::Resume),
         (LogicalMethod::Get, "/protected/user") => Some(Route::GetUser),
+        (LogicalMethod::Post, "/protected/request_verification") => {
+            Some(Route::RequestVerification)
+        }
         (LogicalMethod::Get, "/protected/private_key") => Some(Route::GetPrivateKey),
         (LogicalMethod::Get, "/protected/private_key_bytes") => Some(Route::GetPrivateKeyBytes),
         (LogicalMethod::Get, "/protected/public_key") => Some(Route::GetPublicKey),
@@ -411,6 +417,23 @@ pub(crate) fn prepare_user_operation(
             OperationPreparation::Ready(UserOperation::Protected {
                 authority,
                 operation,
+            })
+        }
+        Route::RequestVerification => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation: ProtectedUserOperation::RequestVerification,
             })
         }
         Route::SignMessage
@@ -763,6 +786,10 @@ async fn execute_protected_user_operation(
     match operation {
         ProtectedUserOperation::GetUser => {
             let value = protected_user_data(app_state, user)?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::RequestVerification => {
+            let value = request_new_verification_code_data(app_state, user).await?;
             LogicalUnaryResponse::json(StatusCode::OK, &value)
         }
         ProtectedUserOperation::GetPrivateKey { query } => {
@@ -1167,6 +1194,74 @@ mod tests {
                 operation: ProtectedUserOperation::GetUser,
                 ..
             })
+        ));
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Post,
+                    "/protected/request_verification",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::RequestVerification,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn verification_resend_rejects_unbound_and_transplanted_metadata() {
+        let request = || {
+            envelope(
+                LogicalMethod::Post,
+                "/protected/request_verification",
+                Vec::new(),
+                None,
+                None,
+            )
+        };
+        assert!(matches!(
+            prepare_user_operation(request(), AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::UNAUTHORIZED
+        ));
+
+        let mut with_query = request();
+        with_query.request.query = Some("transplanted=true".to_owned());
+        assert!(matches!(
+            prepare_user_operation(with_query, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_header = request();
+        with_header.request.headers = json_header();
+        assert!(matches!(
+            prepare_user_operation(with_header, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_body = request();
+        with_body.request.body_base64 = Some(EncodedBytes::from_bytes(b"{}".to_vec()));
+        assert!(matches!(
+            prepare_user_operation(with_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut with_credential = request();
+        with_credential.credential = Some(Credential::Resumption {
+            value_base64: EncodedBytes::from_bytes(b"transplanted".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(with_credential, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
         ));
     }
 

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -27,10 +27,10 @@ use crate::web::login_routes::{
 };
 use crate::web::protected_routes::{
     create_api_key_data, decrypt_data_value, delete_all_kv_values, delete_api_key_by_name,
-    delete_kv_value, encrypt_data_value, private_key_bytes_data, private_key_data,
-    protected_user_data, public_key_data, put_kv_value, sign_message_data, third_party_token_data,
-    CreateApiKeyRequest, DecryptDataRequest, DerivationPathQuery, EncryptDataRequest, KvValue,
-    PublicKeyQuery, SignMessageRequest, ThirdPartyTokenRequest,
+    delete_kv_value, encrypt_data_value, list_bounded_api_keys_data, private_key_bytes_data,
+    private_key_data, protected_user_data, public_key_data, put_kv_value, sign_message_data,
+    third_party_token_data, CreateApiKeyRequest, DecryptDataRequest, DerivationPathQuery,
+    EncryptDataRequest, KvValue, PublicKeyQuery, SignMessageRequest, ThirdPartyTokenRequest,
 };
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
@@ -52,6 +52,7 @@ const MAX_ENCRYPTED_DATA_BASE64_BYTES: usize =
 const MAX_ENCRYPTION_PLAINTEXT_BYTES: usize =
     (MAX_ENCRYPTED_DATA_BASE64_BYTES / 4) * 3 - AES_GCM_NONCE_AND_TAG_BYTES;
 const MAX_V2_KV_LIST_ROWS: usize = 65_536;
+const MAX_V2_API_KEY_LIST_ROWS: usize = 65_536;
 
 type SensitiveBytes = Zeroizing<Vec<u8>>;
 
@@ -115,6 +116,7 @@ pub(crate) enum ProtectedUserOperation {
     CreateApiKey {
         body: SensitiveBytes,
     },
+    ListApiKeys,
     DeleteApiKey {
         name: Zeroizing<String>,
     },
@@ -139,7 +141,9 @@ impl UserOperation {
         matches!(
             self,
             Self::Protected {
-                operation: ProtectedUserOperation::GetKv { .. } | ProtectedUserOperation::ListKv,
+                operation: ProtectedUserOperation::GetKv { .. }
+                    | ProtectedUserOperation::ListKv
+                    | ProtectedUserOperation::ListApiKeys,
                 ..
             }
         )
@@ -273,6 +277,7 @@ pub(crate) fn prepare_user_operation(
         DeleteKv,
         DeleteAllKv,
         CreateApiKey,
+        ListApiKeys,
         DeleteApiKey,
     }
 
@@ -305,6 +310,7 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Get, "/protected/kv") => Some(Route::ListKv),
         (LogicalMethod::Delete, "/protected/kv") => Some(Route::DeleteAllKv),
         (LogicalMethod::Post, "/protected/api-keys") => Some(Route::CreateApiKey),
+        (LogicalMethod::Get, "/protected/api-keys") => Some(Route::ListApiKeys),
         (LogicalMethod::Get, _) if kv_key.is_some() => Some(Route::GetKv),
         (LogicalMethod::Put, _) if kv_key.is_some() => Some(Route::PutKv),
         (LogicalMethod::Delete, _) if kv_key.is_some() => Some(Route::DeleteKv),
@@ -544,6 +550,23 @@ pub(crate) fn prepare_user_operation(
                 operation: ProtectedUserOperation::CreateApiKey {
                     body: Zeroizing::new(body),
                 },
+            })
+        }
+        Route::ListApiKeys => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation: ProtectedUserOperation::ListApiKeys,
             })
         }
         Route::DeleteApiKey => {
@@ -837,6 +860,15 @@ async fn execute_protected_user_operation(
         ProtectedUserOperation::CreateApiKey { body } => {
             let request = parse_json_body::<CreateApiKeyRequest>(body)?;
             let value = create_api_key_data(app_state, user, request).await?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::ListApiKeys => {
+            let value = list_bounded_api_keys_data(
+                app_state,
+                user,
+                EnvelopeLimits::default().logical_body_bytes,
+                MAX_V2_API_KEY_LIST_ROWS,
+            )?;
             LogicalUnaryResponse::json(StatusCode::OK, &value)
         }
         ProtectedUserOperation::DeleteApiKey { name } => {
@@ -1340,23 +1372,31 @@ mod tests {
             }) if &*name == "Production Key-1_test"
         ));
 
-        assert!(matches!(
-            prepare_user_operation(
-                envelope(
-                    LogicalMethod::Get,
-                    "/protected/api-keys",
-                    Vec::new(),
-                    None,
-                    None,
-                ),
-                bound_user_authority(),
+        let list = prepare_user_operation(
+            envelope(
+                LogicalMethod::Get,
+                "/protected/api-keys",
+                Vec::new(),
+                None,
+                None,
             ),
-            OperationPreparation::Unsupported
+            bound_user_authority(),
+        );
+        assert!(matches!(
+            &list,
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::ListApiKeys,
+                ..
+            })
         ));
+        let OperationPreparation::Ready(list) = list else {
+            unreachable!("matched ready API-key list operation")
+        };
+        assert!(list.requires_stored_output_reservation());
     }
 
     #[test]
-    fn api_key_mutations_reject_anonymous_and_transplanted_metadata() {
+    fn api_key_administration_rejects_anonymous_and_transplanted_metadata() {
         let create = || {
             envelope(
                 LogicalMethod::Post,
@@ -1427,6 +1467,55 @@ mod tests {
         delete_with_query.request.query = Some("transplanted=true".to_owned());
         assert!(matches!(
             prepare_user_operation(delete_with_query, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let list = || {
+            envelope(
+                LogicalMethod::Get,
+                "/protected/api-keys",
+                Vec::new(),
+                None,
+                None,
+            )
+        };
+        assert!(matches!(
+            prepare_user_operation(list(), AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::UNAUTHORIZED
+        ));
+
+        let mut list_with_query = list();
+        list_with_query.request.query = Some("transplanted=true".to_owned());
+        assert!(matches!(
+            prepare_user_operation(list_with_query, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut list_with_header = list();
+        list_with_header.request.headers = json_header();
+        assert!(matches!(
+            prepare_user_operation(list_with_header, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut list_with_body = list();
+        list_with_body.request.body_base64 = Some(EncodedBytes::from_bytes(b"{}".to_vec()));
+        assert!(matches!(
+            prepare_user_operation(list_with_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut list_with_credential = list();
+        list_with_credential.credential = Some(Credential::Resumption {
+            value_base64: EncodedBytes::from_bytes(b"transplanted".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(list_with_credential, bound_user_authority()),
             OperationPreparation::Rejected(response)
                 if response.status == StatusCode::BAD_REQUEST
         ));
@@ -1503,6 +1592,31 @@ mod tests {
         assert_eq!(
             &*list.body.unwrap(),
             br#"[{"key":"key","value":"value","created_at":1,"updated_at":2}]"#
+        );
+    }
+
+    #[test]
+    fn api_key_list_keeps_existing_json_wire_shape() {
+        use crate::web::protected_routes::{ApiKeyInfo, ListApiKeysResponse};
+
+        let empty =
+            LogicalUnaryResponse::json(StatusCode::OK, &ListApiKeysResponse { keys: Vec::new() })
+                .unwrap();
+        assert_eq!(&*empty.body.unwrap(), br#"{"keys":[]}"#);
+
+        let populated = LogicalUnaryResponse::json(
+            StatusCode::OK,
+            &ListApiKeysResponse {
+                keys: vec![ApiKeyInfo {
+                    name: "Production Key".to_owned(),
+                    created_at: "2026-08-29T12:34:56Z".parse().unwrap(),
+                }],
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            &*populated.body.unwrap(),
+            br#"{"keys":[{"name":"Production Key","created_at":"2026-08-29T12:34:56Z"}]}"#
         );
     }
 

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -26,16 +26,17 @@ use crate::web::login_routes::{
     RegisterCredentials,
 };
 use crate::web::protected_routes::{
-    decrypt_data_value, delete_all_kv_values, delete_kv_value, encrypt_data_value,
-    private_key_bytes_data, private_key_data, protected_user_data, public_key_data, put_kv_value,
-    sign_message_data, third_party_token_data, DecryptDataRequest, DerivationPathQuery,
-    EncryptDataRequest, KvValue, PublicKeyQuery, SignMessageRequest, ThirdPartyTokenRequest,
+    create_api_key_data, decrypt_data_value, delete_all_kv_values, delete_api_key_by_name,
+    delete_kv_value, encrypt_data_value, private_key_bytes_data, private_key_data,
+    protected_user_data, public_key_data, put_kv_value, sign_message_data, third_party_token_data,
+    CreateApiKeyRequest, DecryptDataRequest, DerivationPathQuery, EncryptDataRequest, KvValue,
+    PublicKeyQuery, SignMessageRequest, ThirdPartyTokenRequest,
 };
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
 use super::envelope::{
-    decode_canonical_kv_item_path, Credential, EncodedBytes, EnvelopeLimits, HeaderField,
-    LogicalMethod, RequestEnvelope, RequestId, ResponseMode,
+    decode_canonical_api_key_name_path, decode_canonical_kv_item_path, Credential, EncodedBytes,
+    EnvelopeLimits, HeaderField, LogicalMethod, RequestEnvelope, RequestId, ResponseMode,
 };
 use super::session::{
     AuthenticationReservation, AuthenticationStartError, AuthorityState, BoundAuthority,
@@ -111,6 +112,12 @@ pub(crate) enum ProtectedUserOperation {
         key: Zeroizing<String>,
     },
     DeleteAllKv,
+    CreateApiKey {
+        body: SensitiveBytes,
+    },
+    DeleteApiKey {
+        name: Zeroizing<String>,
+    },
 }
 
 #[derive(Clone)]
@@ -265,10 +272,19 @@ pub(crate) fn prepare_user_operation(
         PutKv,
         DeleteKv,
         DeleteAllKv,
+        CreateApiKey,
+        DeleteApiKey,
     }
 
     let kv_key = match decode_canonical_kv_item_path(request.method, &request.path) {
         Ok(key) => key,
+        Err(_) => {
+            request.path.zeroize();
+            return rejected_bad_request();
+        }
+    };
+    let api_key_name = match decode_canonical_api_key_name_path(request.method, &request.path) {
+        Ok(name) => name,
         Err(_) => {
             request.path.zeroize();
             return rejected_bad_request();
@@ -288,12 +304,14 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Post, "/protected/decrypt") => Some(Route::DecryptData),
         (LogicalMethod::Get, "/protected/kv") => Some(Route::ListKv),
         (LogicalMethod::Delete, "/protected/kv") => Some(Route::DeleteAllKv),
+        (LogicalMethod::Post, "/protected/api-keys") => Some(Route::CreateApiKey),
         (LogicalMethod::Get, _) if kv_key.is_some() => Some(Route::GetKv),
         (LogicalMethod::Put, _) if kv_key.is_some() => Some(Route::PutKv),
         (LogicalMethod::Delete, _) if kv_key.is_some() => Some(Route::DeleteKv),
+        (LogicalMethod::Delete, _) if api_key_name.is_some() => Some(Route::DeleteApiKey),
         _ => None,
     };
-    if kv_key.is_some() {
+    if kv_key.is_some() || api_key_name.is_some() {
         request.path.zeroize();
     }
     let Some(route) = route else {
@@ -500,6 +518,52 @@ pub(crate) fn prepare_user_operation(
             OperationPreparation::Ready(UserOperation::Protected {
                 authority,
                 operation,
+            })
+        }
+        Route::CreateApiKey => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            let body = request
+                .body_base64
+                .expect("validated API-key creation body presence")
+                .into_bytes();
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation: ProtectedUserOperation::CreateApiKey {
+                    body: Zeroizing::new(body),
+                },
+            })
+        }
+        Route::DeleteApiKey => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation: ProtectedUserOperation::DeleteApiKey {
+                    name: api_key_name
+                        .expect("classified API-key item route must have a decoded name"),
+                },
             })
         }
     }
@@ -768,6 +832,19 @@ async fn execute_protected_user_operation(
                 }),
             )?;
             delete_all_kv_values(app_state, user.uuid).await?;
+            Ok(response)
+        }
+        ProtectedUserOperation::CreateApiKey { body } => {
+            let request = parse_json_body::<CreateApiKeyRequest>(body)?;
+            let value = create_api_key_data(app_state, user, request).await?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::DeleteApiKey { name } => {
+            let response = LogicalUnaryResponse::json(
+                StatusCode::OK,
+                &serde_json::json!({ "success": true }),
+            )?;
+            delete_api_key_by_name(app_state, user, &name)?;
             Ok(response)
         }
     }
@@ -1224,6 +1301,134 @@ mod tests {
                 operation: ProtectedUserOperation::DeleteAllKv,
                 ..
             })
+        ));
+    }
+
+    #[test]
+    fn exact_api_key_mutation_contracts_are_admitted() {
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Post,
+                    "/protected/api-keys",
+                    json_header(),
+                    Some(br#"{"name":"Production Key-1_test"}"#),
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::CreateApiKey { .. },
+                ..
+            })
+        ));
+
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Delete,
+                    "/protected/api-keys/Production%20Key%2D1%5Ftest",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::DeleteApiKey { name },
+                ..
+            }) if &*name == "Production Key-1_test"
+        ));
+
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Get,
+                    "/protected/api-keys",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                bound_user_authority(),
+            ),
+            OperationPreparation::Unsupported
+        ));
+    }
+
+    #[test]
+    fn api_key_mutations_reject_anonymous_and_transplanted_metadata() {
+        let create = || {
+            envelope(
+                LogicalMethod::Post,
+                "/protected/api-keys",
+                json_header(),
+                Some(br#"{"name":"Production Key"}"#),
+                None,
+            )
+        };
+        assert!(matches!(
+            prepare_user_operation(create(), AuthorityState::Anonymous),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::UNAUTHORIZED
+        ));
+
+        let mut create_with_query = create();
+        create_with_query.request.query = Some("transplanted=true".to_owned());
+        assert!(matches!(
+            prepare_user_operation(create_with_query, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut create_with_credential = create();
+        create_with_credential.credential = Some(Credential::Resumption {
+            value_base64: EncodedBytes::from_bytes(b"transplanted".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(create_with_credential, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut create_stream = create();
+        create_stream.response_mode = ResponseMode::Stream;
+        assert!(matches!(
+            prepare_user_operation(create_stream, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let delete = || {
+            envelope(
+                LogicalMethod::Delete,
+                "/protected/api-keys/Production%20Key",
+                Vec::new(),
+                None,
+                None,
+            )
+        };
+        let mut delete_with_body = delete();
+        delete_with_body.request.body_base64 = Some(EncodedBytes::from_bytes(b"{}".to_vec()));
+        assert!(matches!(
+            prepare_user_operation(delete_with_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut delete_with_header = delete();
+        delete_with_header.request.headers = json_header();
+        assert!(matches!(
+            prepare_user_operation(delete_with_header, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut delete_with_query = delete();
+        delete_with_query.request.query = Some("transplanted=true".to_owned());
+        assert!(matches!(
+            prepare_user_operation(delete_with_query, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
         ));
     }
 

--- a/src/transport_v2/envelope.rs
+++ b/src/transport_v2/envelope.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use uuid::Uuid;
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 const MIB: usize = 1024 * 1024;
@@ -371,6 +372,7 @@ impl LogicalRequest {
 
 const KV_ITEM_PATH_PREFIX: &str = "/protected/kv/";
 const API_KEY_ITEM_PATH_PREFIX: &str = "/protected/api-keys/";
+const VERIFY_EMAIL_PATH_PREFIX: &str = "/verify-email/";
 
 fn validate_logical_path(
     method: LogicalMethod,
@@ -382,6 +384,9 @@ fn validate_logical_path(
         return Ok(());
     }
     if decode_canonical_api_key_name_path(method, path)?.is_some() {
+        return Ok(());
+    }
+    if decode_canonical_verify_email_path(method, path)?.is_some() {
         return Ok(());
     }
     validate_path(path, limits)
@@ -438,6 +443,32 @@ pub(crate) fn decode_canonical_api_key_name_path(
         ));
     }
     Ok(Some(decoded))
+}
+
+/// Decodes the one canonical UUID credential admitted by email verification.
+///
+/// Axum's v1 `Path<Uuid>` parser remains untouched. Transport v2 deliberately
+/// accepts only the lowercase hyphenated UUID spelling so one verification
+/// action has one authenticated logical path.
+pub(crate) fn decode_canonical_verify_email_path(
+    method: LogicalMethod,
+    path: &str,
+) -> Result<Option<Uuid>, EnvelopeError> {
+    if method != LogicalMethod::Get {
+        return Ok(None);
+    }
+    let Some(segment) = path.strip_prefix(VERIFY_EMAIL_PATH_PREFIX) else {
+        return Ok(None);
+    };
+    let code = Uuid::parse_str(segment).map_err(|_| {
+        EnvelopeError::InvalidPath("email verification code must be a canonical UUID")
+    })?;
+    if code.hyphenated().to_string() != segment {
+        return Err(EnvelopeError::InvalidPath(
+            "email verification code must use lowercase hyphenated UUID spelling",
+        ));
+    }
+    Ok(Some(code))
 }
 
 fn decode_canonical_opaque_segment(segment: &str) -> Result<Zeroizing<String>, EnvelopeError> {
@@ -1192,6 +1223,49 @@ mod tests {
         ] {
             assert!(
                 validate_logical_path(LogicalMethod::Delete, invalid, &EnvelopeLimits::default())
+                    .is_err(),
+                "{invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn email_verification_path_uses_one_canonical_uuid_spelling() {
+        let encoded = "123e4567-e89b-12d3-a456-426614174000";
+        let path = format!("{VERIFY_EMAIL_PATH_PREFIX}{encoded}");
+        assert_eq!(
+            decode_canonical_verify_email_path(LogicalMethod::Get, &path).unwrap(),
+            Some(Uuid::parse_str(encoded).unwrap())
+        );
+        validate_logical_path(LogicalMethod::Get, &path, &EnvelopeLimits::default()).unwrap();
+
+        assert!(
+            decode_canonical_verify_email_path(LogicalMethod::Post, &path)
+                .unwrap()
+                .is_none()
+        );
+        assert!(decode_canonical_verify_email_path(
+            LogicalMethod::Get,
+            "/verify-emails/123e4567-e89b-12d3-a456-426614174000",
+        )
+        .unwrap()
+        .is_none());
+    }
+
+    #[test]
+    fn email_verification_path_rejects_uuid_aliases_and_malformed_codes() {
+        for invalid in [
+            "/verify-email/",
+            "/verify-email/123E4567-E89B-12D3-A456-426614174000",
+            "/verify-email/123e4567e89b12d3a456426614174000",
+            "/verify-email/{123e4567-e89b-12d3-a456-426614174000}",
+            "/verify-email/urn:uuid:123e4567-e89b-12d3-a456-426614174000",
+            "/verify-email/123e4567%2De89b%2D12d3%2Da456%2D426614174000",
+            "/verify-email/123e4567-e89b-12d3-a456-426614174000/extra",
+            "/verify-email/not-a-uuid",
+        ] {
+            assert!(
+                validate_logical_path(LogicalMethod::Get, invalid, &EnvelopeLimits::default())
                     .is_err(),
                 "{invalid}"
             );

--- a/src/transport_v2/envelope.rs
+++ b/src/transport_v2/envelope.rs
@@ -370,6 +370,7 @@ impl LogicalRequest {
 }
 
 const KV_ITEM_PATH_PREFIX: &str = "/protected/kv/";
+const API_KEY_ITEM_PATH_PREFIX: &str = "/protected/api-keys/";
 
 fn validate_logical_path(
     method: LogicalMethod,
@@ -378,6 +379,9 @@ fn validate_logical_path(
 ) -> Result<(), EnvelopeError> {
     check_limit(path.len(), limits.path_bytes, "path")?;
     if decode_canonical_kv_item_path(method, path)?.is_some() {
+        return Ok(());
+    }
+    if decode_canonical_api_key_name_path(method, path)?.is_some() {
         return Ok(());
     }
     validate_path(path, limits)
@@ -401,6 +405,42 @@ pub(crate) fn decode_canonical_kv_item_path(
     let Some(segment) = path.strip_prefix(KV_ITEM_PATH_PREFIX) else {
         return Ok(None);
     };
+    decode_canonical_opaque_segment(segment).map(Some)
+}
+
+/// Decodes the validated API-key name carried by the DELETE item route.
+///
+/// API-key names are ASCII alphanumeric characters, spaces, hyphens, and
+/// underscores. V2 uses the same route-scoped opaque-segment spelling as KV:
+/// alphanumeric bytes remain literal and every other byte is one uppercase
+/// `%HH` triplet. Rejecting equivalent aliases gives the operation one path
+/// spelling across clients before the name reaches the database lookup.
+pub(crate) fn decode_canonical_api_key_name_path(
+    method: LogicalMethod,
+    path: &str,
+) -> Result<Option<Zeroizing<String>>, EnvelopeError> {
+    if method != LogicalMethod::Delete {
+        return Ok(None);
+    }
+    let Some(segment) = path.strip_prefix(API_KEY_ITEM_PATH_PREFIX) else {
+        return Ok(None);
+    };
+    let decoded = decode_canonical_opaque_segment(segment)?;
+    if decoded.len() > 50
+        || decoded.starts_with(' ')
+        || decoded.ends_with(' ')
+        || !decoded
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b' ' | b'-' | b'_'))
+    {
+        return Err(EnvelopeError::InvalidPath(
+            "API-key name segment violates the name contract",
+        ));
+    }
+    Ok(Some(decoded))
+}
+
+fn decode_canonical_opaque_segment(segment: &str) -> Result<Zeroizing<String>, EnvelopeError> {
     if segment.is_empty() {
         return Err(EnvelopeError::InvalidPath(
             "opaque path segment must not be empty",
@@ -439,7 +479,7 @@ pub(crate) fn decode_canonical_kv_item_path(
     }
 
     match String::from_utf8(std::mem::take(&mut *decoded)) {
-        Ok(value) => Ok(Some(Zeroizing::new(value))),
+        Ok(value) => Ok(Zeroizing::new(value)),
         Err(error) => {
             let mut bytes = error.into_bytes();
             bytes.zeroize();
@@ -1086,6 +1126,76 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    #[test]
+    fn api_key_delete_paths_use_one_restricted_canonical_name_segment() {
+        for (encoded, decoded) in [
+            ("Production%20Key", "Production Key"),
+            ("agent%2Dproxy%5F42", "agent-proxy_42"),
+            ("a%20%20b", "a  b"),
+            ("%2D", "-"),
+            ("%5F", "_"),
+            (
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ),
+        ] {
+            let path = format!("{API_KEY_ITEM_PATH_PREFIX}{encoded}");
+            let value = decode_canonical_api_key_name_path(LogicalMethod::Delete, &path)
+                .unwrap()
+                .expect("API-key item route must decode");
+            assert_eq!(&*value, decoded, "{encoded}");
+            validate_logical_path(LogicalMethod::Delete, &path, &EnvelopeLimits::default())
+                .unwrap();
+        }
+
+        assert!(decode_canonical_api_key_name_path(
+            LogicalMethod::Get,
+            "/protected/api-keys/Production%20Key",
+        )
+        .unwrap()
+        .is_none());
+        assert!(decode_canonical_api_key_name_path(
+            LogicalMethod::Delete,
+            "/protected/api-keysx/Production%20Key",
+        )
+        .unwrap()
+        .is_none());
+    }
+
+    #[test]
+    fn api_key_delete_paths_reject_aliases_and_invalid_names() {
+        let overlong = format!("{API_KEY_ITEM_PATH_PREFIX}{}", "a".repeat(51));
+        for invalid in [
+            "/protected/api-keys/",
+            "/protected/api-keys/%20leading",
+            "/protected/api-keys/trailing%20",
+            "/protected/api-keys/literal-hyphen",
+            "/protected/api-keys/literal_underscore",
+            "/protected/api-keys/%2d",
+            "/protected/api-keys/%5f",
+            "/protected/api-keys/%41",
+            "/protected/api-keys/plus+alias",
+            "/protected/api-keys/literal space",
+            "/protected/api-keys/%252D",
+            "/protected/api-keys/%2F",
+            "/protected/api-keys/%5C",
+            "/protected/api-keys/%2E",
+            "/protected/api-keys/%FF",
+            "/protected/api-keys/%",
+            "/protected/api-keys/%2",
+            "/protected/api-keys/%GG",
+            "/protected/api-keys/name/part",
+            "/protected/api-keys/caf%C3%A9",
+            overlong.as_str(),
+        ] {
+            assert!(
+                validate_logical_path(LogicalMethod::Delete, invalid, &EnvelopeLimits::default())
+                    .is_err(),
+                "{invalid}"
+            );
+        }
     }
 
     #[test]

--- a/src/transport_v2/gateway.rs
+++ b/src/transport_v2/gateway.rs
@@ -31,7 +31,7 @@ use crate::{AppState, AsyncRngWrapper};
 
 use super::application::{
     begin_authentication_transition, execute_user_operation, prepare_user_operation,
-    LogicalUnaryResponse, OperationPreparation,
+    LogicalUnaryResponse, OperationPreparation, SessionEffect,
 };
 use super::crypto::{
     encrypt_key_exchange_record, CryptoError, DirectionalKeys, HandshakePayload, SessionMaster,
@@ -519,10 +519,16 @@ impl TransportV2State {
         }
 
         let outcome = dispatch(lease.clone(), operation, authentication, now).await;
-        let bound_session = outcome.bound_session;
+        let session_effect = outcome.session_effect;
+        if session_effect == SessionEffect::Close {
+            // Stop new admission before producing the terminal response. The
+            // exact held lease and pre-dispatch reservation intentionally stay
+            // usable while Closing so this admitted response can still finish.
+            lease.state().close();
+        }
         let encrypted =
             encrypt_reserved_logical_response(lease, request_id, reservation, outcome.response);
-        if encrypted.is_err() && bound_session {
+        if encrypted.is_err() && session_effect == SessionEffect::NewlyBound {
             // Never leave a newly authenticated session reachable when its
             // only binding response could not be authenticated to the client.
             lease.state().close();
@@ -1100,7 +1106,7 @@ mod tests {
                 headers: Vec::new(),
                 body: Some(zeroize::Zeroizing::new(br#"{"ok":true}"#.to_vec())),
             },
-            bound_session: false,
+            session_effect: SessionEffect::Retain,
         }
     }
 
@@ -1683,6 +1689,276 @@ mod tests {
             200
         );
         assert_eq!(lease.state().replay_id_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn terminal_effect_closes_before_encrypting_the_admitted_response() {
+        let state = TransportV2State::new();
+        let now = Instant::now();
+        let session_id = Uuid::new_v4();
+        let master_bytes = [0x81; 32];
+        let session = test_session(
+            session_id,
+            master_bytes,
+            now + Duration::from_secs(60),
+            Arc::clone(&state.global_replay_budget),
+        );
+        session
+            .begin_authentication(RequestId::from_bytes([0x82; 16]))
+            .unwrap()
+            .commit_at(
+                BoundAuthority::user(
+                    Uuid::from_bytes([0x83; 16]),
+                    7,
+                    &AuthContext::new(AuthMethod::Password, 7, [0x84; 32]),
+                    now + Duration::from_secs(30),
+                ),
+                now,
+            )
+            .unwrap();
+        state.insert_session(session).await.unwrap();
+
+        let request_id = RequestId::from_bytes([0x85; 16]);
+        let lease = state.acquire_session(&session_id, now).await.unwrap();
+        let OperationPreparation::Ready(operation) = prepare_user_operation(
+            get_user_envelope(request_id, None),
+            lease.state().authority(),
+        ) else {
+            panic!("bound user operation must be ready");
+        };
+        let mut working_set_permit = Arc::clone(&state.request_working_set)
+            .try_acquire_owned()
+            .unwrap();
+        let response = state
+            .process_ready_operation(
+                &lease,
+                request_id,
+                operation,
+                &mut working_set_permit,
+                now,
+                |_lease, _operation, authentication, _| async move {
+                    assert!(authentication.is_none());
+                    let mut outcome = successful_test_outcome();
+                    outcome.session_effect = SessionEffect::Close;
+                    outcome
+                },
+            )
+            .await
+            .expect("held terminal response must still encrypt");
+
+        let client_keys =
+            DirectionalKeys::derive(&SessionMaster::from_bytes(master_bytes)).unwrap();
+        assert_eq!(
+            response_status(&client_keys, &session_id, &request_id, &response),
+            200
+        );
+        assert!(lease.state().is_closing());
+        assert!(state.acquire_session(&session_id, now).await.is_err());
+        assert_eq!(state.cleanup_expired_at(now).await, 0);
+        drop(lease);
+        assert_eq!(state.cleanup_expired_at(now).await, 1);
+    }
+
+    #[tokio::test]
+    async fn terminal_effect_stays_closed_when_response_encryption_fails() {
+        let state = TransportV2State::new();
+        let now = Instant::now();
+        let session_id = Uuid::new_v4();
+        let session = test_session(
+            session_id,
+            [0x91; 32],
+            now + Duration::from_secs(60),
+            Arc::clone(&state.global_replay_budget),
+        );
+        session
+            .begin_authentication(RequestId::from_bytes([0x92; 16]))
+            .unwrap()
+            .commit_at(
+                BoundAuthority::user(
+                    Uuid::from_bytes([0x93; 16]),
+                    7,
+                    &AuthContext::new(AuthMethod::Password, 7, [0x94; 32]),
+                    now + Duration::from_secs(30),
+                ),
+                now,
+            )
+            .unwrap();
+        state.insert_session(session).await.unwrap();
+
+        let request_id = RequestId::from_bytes([0x95; 16]);
+        let lease = state.acquire_session(&session_id, now).await.unwrap();
+        let OperationPreparation::Ready(operation) = prepare_user_operation(
+            get_user_envelope(request_id, None),
+            lease.state().authority(),
+        ) else {
+            panic!("bound user operation must be ready");
+        };
+        let mut working_set_permit = Arc::clone(&state.request_working_set)
+            .try_acquire_owned()
+            .unwrap();
+        let result = state
+            .process_ready_operation(
+                &lease,
+                request_id,
+                operation,
+                &mut working_set_permit,
+                now,
+                |_lease, _operation, authentication, _| async move {
+                    assert!(authentication.is_none());
+                    super::super::application::ApplicationOutcome {
+                        response: LogicalUnaryResponse {
+                            status: StatusCode::OK,
+                            headers: vec![HeaderField {
+                                name: "invalid header name".to_owned(),
+                                value_base64: EncodedBytes::from_bytes(b"x".to_vec()),
+                            }],
+                            body: None,
+                        },
+                        session_effect: SessionEffect::Close,
+                    }
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(GatewayError::Internal)));
+        assert!(lease.state().is_closing());
+        assert!(state.acquire_session(&session_id, now).await.is_err());
+        assert_eq!(state.cleanup_expired_at(now).await, 0);
+        drop(lease);
+        assert_eq!(state.cleanup_expired_at(now).await, 1);
+    }
+
+    #[tokio::test]
+    async fn newly_bound_effect_keeps_a_successfully_delivered_session_open() {
+        let state = TransportV2State::new();
+        let now = Instant::now();
+        let session_id = Uuid::new_v4();
+        let master_bytes = [0xa1; 32];
+        state
+            .insert_session(test_session(
+                session_id,
+                master_bytes,
+                now + Duration::from_secs(60),
+                Arc::clone(&state.global_replay_budget),
+            ))
+            .await
+            .unwrap();
+
+        let request_id = RequestId::from_bytes([0xa2; 16]);
+        let lease = state.acquire_session(&session_id, now).await.unwrap();
+        let OperationPreparation::Ready(operation) =
+            prepare_user_operation(login_envelope(request_id), lease.state().authority())
+        else {
+            panic!("anonymous login operation must be ready");
+        };
+        let mut working_set_permit = Arc::clone(&state.request_working_set)
+            .try_acquire_owned()
+            .unwrap();
+        let response = state
+            .process_ready_operation(
+                &lease,
+                request_id,
+                operation,
+                &mut working_set_permit,
+                now,
+                |_lease, _operation, authentication, _| async move {
+                    authentication
+                        .expect("login must reserve authentication")
+                        .commit_at(
+                            BoundAuthority::user(
+                                Uuid::from_bytes([0xa3; 16]),
+                                7,
+                                &AuthContext::new(AuthMethod::Password, 7, [0xa4; 32]),
+                                now + Duration::from_secs(30),
+                            ),
+                            now,
+                        )
+                        .unwrap();
+                    let mut outcome = successful_test_outcome();
+                    outcome.session_effect = SessionEffect::NewlyBound;
+                    outcome
+                },
+            )
+            .await
+            .expect("binding response must encrypt");
+
+        let client_keys =
+            DirectionalKeys::derive(&SessionMaster::from_bytes(master_bytes)).unwrap();
+        assert_eq!(
+            response_status(&client_keys, &session_id, &request_id, &response),
+            200
+        );
+        assert!(matches!(
+            lease.state().authority(),
+            AuthorityState::Bound(_)
+        ));
+        assert!(!lease.state().is_closing());
+        assert!(state.acquire_session(&session_id, now).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn newly_bound_effect_closes_when_its_binding_response_cannot_encrypt() {
+        let state = TransportV2State::new();
+        let now = Instant::now();
+        let session_id = Uuid::new_v4();
+        state
+            .insert_session(test_session(
+                session_id,
+                [0xb1; 32],
+                now + Duration::from_secs(60),
+                Arc::clone(&state.global_replay_budget),
+            ))
+            .await
+            .unwrap();
+
+        let request_id = RequestId::from_bytes([0xb2; 16]);
+        let lease = state.acquire_session(&session_id, now).await.unwrap();
+        let OperationPreparation::Ready(operation) =
+            prepare_user_operation(login_envelope(request_id), lease.state().authority())
+        else {
+            panic!("anonymous login operation must be ready");
+        };
+        let mut working_set_permit = Arc::clone(&state.request_working_set)
+            .try_acquire_owned()
+            .unwrap();
+        let result = state
+            .process_ready_operation(
+                &lease,
+                request_id,
+                operation,
+                &mut working_set_permit,
+                now,
+                |_lease, _operation, authentication, _| async move {
+                    authentication
+                        .expect("login must reserve authentication")
+                        .commit_at(
+                            BoundAuthority::user(
+                                Uuid::from_bytes([0xb3; 16]),
+                                7,
+                                &AuthContext::new(AuthMethod::Password, 7, [0xb4; 32]),
+                                now + Duration::from_secs(30),
+                            ),
+                            now,
+                        )
+                        .unwrap();
+                    super::super::application::ApplicationOutcome {
+                        response: LogicalUnaryResponse {
+                            status: StatusCode::OK,
+                            headers: vec![HeaderField {
+                                name: "invalid header name".to_owned(),
+                                value_base64: EncodedBytes::from_bytes(b"x".to_vec()),
+                            }],
+                            body: None,
+                        },
+                        session_effect: SessionEffect::NewlyBound,
+                    }
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(GatewayError::Internal)));
+        assert!(lease.state().is_closing());
+        assert!(state.acquire_session(&session_id, now).await.is_err());
     }
 
     #[tokio::test]

--- a/src/web/login_routes.rs
+++ b/src/web/login_routes.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 use tokio::spawn;
 use tracing::{error, info};
 use uuid::Uuid;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 #[derive(Deserialize, Clone)]
 pub struct PasswordResetRequestPayload {
@@ -129,8 +130,8 @@ pub struct RefreshResponse {
     pub(crate) refresh_token: String,
 }
 
-#[derive(Deserialize, Clone)]
-pub struct LogoutRequest {
+#[derive(Deserialize, Clone, Zeroize, ZeroizeOnDrop)]
+pub(crate) struct LogoutRequest {
     refresh_token: String,
 }
 
@@ -260,12 +261,15 @@ pub async fn logout(
     Extension(logout_request): Extension<LogoutRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+    let response = logout_data(logout_request);
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) fn logout_data(mut logout_request: LogoutRequest) -> serde_json::Value {
     info!("Logout request received");
     // TODO actually delete the refresh token
-    drop(logout_request.refresh_token);
-    let response = json!({ "message": "Logged out successfully" });
-    let result = encrypt_response(&data, &session_id, &response).await;
-    result
+    logout_request.refresh_token.zeroize();
+    json!({ "message": "Logged out successfully" })
 }
 
 pub async fn register(

--- a/src/web/login_routes.rs
+++ b/src/web/login_routes.rs
@@ -401,6 +401,14 @@ pub async fn verify_email(
     Path(code): Path<Uuid>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+    let response = verify_email_data(&data, code)?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) fn verify_email_data(
+    data: &AppState,
+    code: Uuid,
+) -> Result<serde_json::Value, ApiError> {
     let verification = match data.db.get_email_verification_by_code(code) {
         Ok(v) => v,
         Err(DBError::EmailVerificationNotFound) => return Err(ApiError::BadRequest),
@@ -412,10 +420,9 @@ pub async fn verify_email(
     }
 
     if verification.is_verified {
-        let response = json!({
+        return Ok(json!({
             "message": "Email already verified"
-        });
-        return encrypt_response(&data, &session_id, &response).await;
+        }));
     }
 
     let mut verification = verification;
@@ -423,11 +430,9 @@ pub async fn verify_email(
         return Err(ApiError::InternalServerError);
     }
 
-    let response = json!({
+    Ok(json!({
         "message": "Email verified successfully"
-    });
-    let result = encrypt_response(&data, &session_id, &response).await;
-    result
+    }))
 }
 
 pub async fn password_reset_request(

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -95,7 +95,7 @@ pub struct InitiateAccountDeletionRequest {
     pub hashed_secret: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct ConfirmAccountDeletionRequest {
     pub confirmation_code: String,
     pub plaintext_secret: String,
@@ -1352,25 +1352,29 @@ pub async fn confirm_account_deletion(
     Extension(confirm_request): Extension<ConfirmAccountDeletionRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+    confirm_account_deletion_data(&data, &user, confirm_request).await?;
+
+    let response = json!({
+        "message": "Your account has been successfully deleted."
+    });
+
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn confirm_account_deletion_data(
+    data: &AppState,
+    user: &User,
+    mut confirm_request: ConfirmAccountDeletionRequest,
+) -> Result<(), ApiError> {
     info!("User {} is confirming account deletion", user.uuid);
 
-    // Confirm the account deletion
+    let confirmation_code = Zeroizing::new(std::mem::take(&mut confirm_request.confirmation_code));
+    let plaintext_secret = Zeroizing::new(std::mem::take(&mut confirm_request.plaintext_secret));
     match data
-        .confirm_account_deletion(
-            user.uuid,
-            confirm_request.confirmation_code.clone(),
-            confirm_request.plaintext_secret.clone(),
-        )
+        .confirm_account_deletion(user.uuid, confirmation_code, plaintext_secret)
         .await
     {
-        Ok(_) => {
-            let response = json!({
-                "message": "Your account has been successfully deleted."
-            });
-
-            let result = encrypt_response(&data, &session_id, &response).await;
-            result
-        }
+        Ok(()) => Ok(()),
         Err(e) => match e {
             Error::AccountDeletionExpired => {
                 warn!("Account deletion confirmation has expired: {:?}", e);

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -430,10 +430,11 @@ pub struct CreateApiKeyRequest {
     pub name: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct CreateApiKeyResponse {
     pub key: String, // UUID format with dashes - only returned on creation
     pub name: String,
+    #[zeroize(skip)]
     pub created_at: DateTime<Utc>,
 }
 
@@ -1395,6 +1396,15 @@ pub async fn create_api_key(
     Extension(request): Extension<CreateApiKeyRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<CreateApiKeyResponse>>, ApiError> {
+    let response = create_api_key_data(&data, &user, request).await?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn create_api_key_data(
+    data: &AppState,
+    user: &User,
+    request: CreateApiKeyRequest,
+) -> Result<CreateApiKeyResponse, ApiError> {
     debug!("Creating new API key for user: {}", user.uuid);
 
     // Validate the request
@@ -1410,11 +1420,12 @@ pub async fn create_api_key(
     let random_bytes: [u8; 16] =
         crate::encrypt::generate_random_enclave::<16>(data.aws_credential_manager.clone()).await;
     let api_key_uuid = Uuid::from_bytes(random_bytes);
+    let mut api_key = Zeroizing::new(api_key_uuid.to_string());
 
     // Hash the UUID string (with dashes) using SHA-256
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
-    hasher.update(api_key_uuid.to_string().as_bytes());
+    hasher.update(api_key.as_bytes());
     let key_hash = format!("{:x}", hasher.finalize());
 
     // Create the database record
@@ -1437,13 +1448,13 @@ pub async fn create_api_key(
     })?;
 
     let response = CreateApiKeyResponse {
-        key: api_key_uuid.to_string(), // Return the actual UUID to the user (only time it's shown)
+        key: std::mem::take(&mut *api_key), // Return the actual UUID to the user only once
         name: api_key_record.name,
         created_at: api_key_record.created_at,
     };
 
     info!("Created API key '{}' for user {}", response.name, user.uuid);
-    encrypt_response(&data, &session_id, &response).await
+    Ok(response)
 }
 
 pub async fn list_api_keys(
@@ -1480,10 +1491,21 @@ pub async fn delete_api_key(
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+    delete_api_key_by_name(&data, &user, &name)?;
+
+    let response = json!({ "success": true });
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) fn delete_api_key_by_name(
+    data: &AppState,
+    user: &User,
+    name: &str,
+) -> Result<(), ApiError> {
     debug!("Deleting API key '{}' for user: {}", name, user.uuid);
 
     data.db
-        .delete_user_api_key_by_name(&name, user.uuid)
+        .delete_user_api_key_by_name(name, user.uuid)
         .map_err(|e| {
             error!("Failed to delete API key: {:?}", e);
             match e {
@@ -1495,9 +1517,7 @@ pub async fn delete_api_key(
         })?;
 
     info!("Deleted API key '{}' for user {}", name, user.uuid);
-
-    let response = json!({ "success": true });
-    encrypt_response(&data, &session_id, &response).await
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1513,6 +1533,7 @@ mod tests {
         assert_zeroize_on_drop::<PrivateKeyResponse>();
         assert_zeroize_on_drop::<PrivateKeyBytesResponse>();
         assert_zeroize_on_drop::<ThirdPartyTokenResponse>();
+        assert_zeroize_on_drop::<CreateApiKeyResponse>();
         assert_zeroize_on_drop::<EncryptDataRequest>();
         assert_zeroize_on_drop::<EncryptDataResponse>();
         assert_zeroize_on_drop::<DecryptDataRequest>();

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -751,12 +751,19 @@ pub async fn request_new_verification_code(
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+    let response = request_new_verification_code_data(&data, &user).await?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn request_new_verification_code_data(
+    data: &AppState,
+    user: &User,
+) -> Result<serde_json::Value, ApiError> {
     // First check if user has an email
     let email = match user.get_email() {
         Some(email) => email.to_string(),
         None => {
-            let response = json!({ "error": "No email associated with account" });
-            return encrypt_response(&data, &session_id, &response).await;
+            return Ok(json!({ "error": "No email associated with account" }));
         }
     };
 
@@ -764,8 +771,7 @@ pub async fn request_new_verification_code(
     match data.db.get_email_verification_by_user_id(user.uuid) {
         Ok(verification) => {
             if verification.is_verified {
-                let response = json!({ "error": "User is already verified" });
-                return encrypt_response(&data, &session_id, &response).await;
+                return Ok(json!({ "error": "User is already verified" }));
             }
             // Delete the old verification
             if let Err(e) = data.db.delete_email_verification(&verification) {
@@ -793,20 +799,14 @@ pub async fn request_new_verification_code(
     };
 
     // Send the new verification email
-    if let Err(e) = send_verification_email(
-        &data,
-        user.project_id,
-        email,
-        verification.verification_code,
-    )
-    .await
+    if let Err(e) =
+        send_verification_email(data, user.project_id, email, verification.verification_code).await
     {
         tracing::error!("Error sending verification email: {:?}", e);
         return Err(ApiError::InternalServerError);
     }
 
-    let response = json!({ "message": "New verification code sent successfully" });
-    encrypt_response(&data, &session_id, &response).await
+    Ok(json!({ "message": "New verification code sent successfully" }))
 }
 
 pub async fn change_password(

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -84,7 +84,7 @@ pub struct ProtectedUserData {
     pub user: AppUser,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct ChangePasswordRequest {
     pub current_password: String,
     pub new_password: String,
@@ -813,7 +813,7 @@ pub async fn change_password(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(change_request): Extension<ChangePasswordRequest>,
+    Extension(mut change_request): Extension<ChangePasswordRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     // Check if user is an OAuth-only user
@@ -829,7 +829,7 @@ pub async fn change_password(
         .authenticate_user(
             email,
             Some(user.uuid),
-            change_request.current_password,
+            std::mem::take(&mut change_request.current_password),
             user.project_id,
         )
         .await
@@ -840,7 +840,7 @@ pub async fn change_password(
                 .update_user_password_and_seed_wrap(
                     &user,
                     &auth_context,
-                    change_request.new_password,
+                    std::mem::take(&mut change_request.new_password),
                 )
                 .await
             {
@@ -877,6 +877,39 @@ pub async fn change_password(
             // Current password is incorrect
             Err(ApiError::InvalidUsernameOrPassword)
         }
+    }
+}
+
+pub(crate) async fn verify_password_change_request(
+    data: &AppState,
+    user: &User,
+    change_request: &mut ChangePasswordRequest,
+) -> Result<(), ApiError> {
+    if user.password_enc.is_none() {
+        error!("OAuth-only user attempted to change password");
+        return Err(ApiError::InvalidUsernameOrPassword);
+    }
+
+    let email = user.get_email().map(str::to_owned);
+    match data
+        .authenticate_user(
+            email,
+            Some(user.uuid),
+            std::mem::take(&mut change_request.current_password),
+            user.project_id,
+        )
+        .await
+    {
+        Ok(Some(authenticated_user)) if authenticated_user.user.uuid == user.uuid => Ok(()),
+        _ => Err(ApiError::InvalidUsernameOrPassword),
+    }
+}
+
+pub(crate) fn map_password_change_error(error: Error) -> ApiError {
+    error!("Error changing password: {:?}", error);
+    match error {
+        Error::AuthenticationError => ApiError::InvalidUsernameOrPassword,
+        _ => ApiError::InternalServerError,
     }
 }
 
@@ -1580,6 +1613,7 @@ mod tests {
 
         assert_zeroize_on_drop::<PrivateKeyResponse>();
         assert_zeroize_on_drop::<PrivateKeyBytesResponse>();
+        assert_zeroize_on_drop::<ChangePasswordRequest>();
         assert_zeroize_on_drop::<ThirdPartyTokenResponse>();
         assert_zeroize_on_drop::<CreateApiKeyResponse>();
         assert_zeroize_on_drop::<ApiKeyInfo>();

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -438,13 +438,14 @@ pub struct CreateApiKeyResponse {
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct ApiKeyInfo {
     pub name: String,
+    #[zeroize(skip)]
     pub created_at: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct ListApiKeysResponse {
     pub keys: Vec<ApiKeyInfo>,
 }
@@ -1485,6 +1486,46 @@ pub async fn list_api_keys(
     encrypt_response(&data, &session_id, &response).await
 }
 
+pub(crate) fn list_bounded_api_keys_data(
+    data: &AppState,
+    user: &User,
+    logical_body_limit: usize,
+    row_limit: usize,
+) -> Result<ListApiKeysResponse, ApiError> {
+    debug!("Listing bounded API keys for user: {}", user.uuid);
+
+    let mut conn = data.db.get_pool().get().map_err(|error| {
+        error!("Failed to get a database connection for bounded API-key listing: {error:?}");
+        ApiError::InternalServerError
+    })?;
+    let mut rows = crate::models::user_api_keys::UserApiKey::get_bounded_list_for_user(
+        &mut conn,
+        user.uuid,
+        logical_body_limit,
+        row_limit,
+    )
+    .map_err(|error| {
+        if matches!(
+            error,
+            crate::models::user_api_keys::UserApiKeyError::OutputTooLarge
+        ) {
+            ApiError::PayloadTooLarge
+        } else {
+            error!("Failed to read bounded API-key metadata");
+            ApiError::InternalServerError
+        }
+    })?;
+
+    let keys = rows
+        .iter_mut()
+        .map(|row| ApiKeyInfo {
+            name: std::mem::take(&mut row.name),
+            created_at: row.created_at,
+        })
+        .collect();
+    Ok(ListApiKeysResponse { keys })
+}
+
 pub async fn delete_api_key(
     State(data): State<Arc<AppState>>,
     Path(name): Path<String>,
@@ -1534,6 +1575,8 @@ mod tests {
         assert_zeroize_on_drop::<PrivateKeyBytesResponse>();
         assert_zeroize_on_drop::<ThirdPartyTokenResponse>();
         assert_zeroize_on_drop::<CreateApiKeyResponse>();
+        assert_zeroize_on_drop::<ApiKeyInfo>();
+        assert_zeroize_on_drop::<ListApiKeysResponse>();
         assert_zeroize_on_drop::<EncryptDataRequest>();
         assert_zeroize_on_drop::<EncryptDataResponse>();
         assert_zeroize_on_drop::<DecryptDataRequest>();

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -90,7 +90,7 @@ pub struct ChangePasswordRequest {
     pub new_password: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct InitiateAccountDeletionRequest {
     pub hashed_secret: String,
 }
@@ -1315,26 +1315,29 @@ pub async fn initiate_account_deletion(
     Extension(delete_request): Extension<InitiateAccountDeletionRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+    let response = initiate_account_deletion_data(&data, &user, delete_request).await?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn initiate_account_deletion_data(
+    data: &AppState,
+    user: &User,
+    mut delete_request: InitiateAccountDeletionRequest,
+) -> Result<serde_json::Value, ApiError> {
     info!("User {} is initiating account deletion request", user.uuid);
 
     // Create the account deletion request
+    let hashed_secret = std::mem::take(&mut delete_request.hashed_secret);
     match data
-        .create_account_deletion_request(
-            user.uuid,
-            delete_request.hashed_secret.clone(),
-            user.project_id,
-        )
+        .create_account_deletion_request(user.uuid, hashed_secret, user.project_id)
         .await
     {
-        Ok(_) => {
+        Ok(()) => {
             // Success - we return a generic message regardless of whether the
             // request was actually created and email sent
-            let response = json!({
+            Ok(json!({
                 "message": "We have sent a confirmation code to your email."
-            });
-
-            let result = encrypt_response(&data, &session_id, &response).await;
-            result
+            }))
         }
         Err(e) => {
             error!("Error in initiating account deletion: {:?}", e);


### PR DESCRIPTION
## Summary

- project complete user API-key administration: create, list, and delete
- project verification resend and email confirmation
- project account-deletion request and confirmation
- model terminal session outcomes for account deletion, logout, and password change
- project logout and password change while preserving their existing application contracts
- bound stored-output reads, preflight terminal responses before mutation, and zeroize credentials and password material

This consolidated PR contains the original commits from #319 through #327. Password-reset request and confirmation will be added to this same capability PR before final review.

## Security properties

- immutable bound-user authority is revalidated before every operation
- replay is claimed before database, email, or credential side effects
- API-key plaintext is returned only through the originating encrypted response and is not rotated
- stored API-key lists are bounded before loading
- account deletion and committed password changes terminally close stale sessions
- terminal responses still use the exact admitted session lease
- uncertain outcomes are never transparently replayed

## Compatibility

All v1 routes, middleware, status mappings, response shapes, JWT/token persistence, API-key formats, and existing SDK behavior remain unchanged.

## Validation

- strict formatting, Clippy, and full Rust suite
- disposable PostgreSQL credential, lifecycle, tamper, and race tests
- managed local stack smoke
- released TypeScript v1 SDK live proofs
- raw encrypted v2 API-key, verification, deletion, logout, password-change, replay, and session-lifecycle matrices
- independent security, replay/concurrency, memory, and compatibility reviews

The original per-commit discussion and validation records remain available in #319–#326.