### PR TITLE
Project conversation projects and instructions over transport v2

### DIFF
--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -1188,6 +1188,85 @@ async fn db_password_change_deletes_tampered_stale_password_wraps() {
 
 #[tokio::test]
 #[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+async fn db_conversation_project_uuid_delete_is_owner_scoped_and_cascades() {
+    let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+        eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+        return;
+    };
+
+    let app_state = build_local_test_app_state(database_url).await;
+    let org_project = first_active_project(&app_state);
+    let marker = Uuid::new_v4();
+    let owner =
+        create_response_transaction_test_user(&app_state, org_project.id, marker, "project-owner");
+    let attacker = create_response_transaction_test_user(
+        &app_state,
+        org_project.id,
+        marker,
+        "project-attacker",
+    );
+    let project_uuid = Uuid::new_v4();
+    let project = app_state
+        .db
+        .create_conversation_project(NewConversationProject {
+            uuid: project_uuid,
+            user_id: owner.uuid,
+            name_enc: vec![0x5a; 1024 * 1024],
+        })
+        .expect("owner conversation project should insert");
+    let conversation_uuid = Uuid::new_v4();
+    app_state
+        .db
+        .create_conversation(NewConversation {
+            uuid: conversation_uuid,
+            user_id: owner.uuid,
+            project_id: Some(project.id),
+            is_pinned: false,
+            metadata_enc: None,
+        })
+        .expect("assigned conversation should insert");
+
+    assert!(matches!(
+        app_state
+            .db
+            .delete_conversation_project_by_uuid_and_user(project_uuid, attacker.uuid),
+        Err(DBError::ResponsesError(
+            ResponsesError::ConversationProjectNotFound
+        ))
+    ));
+    app_state
+        .db
+        .get_conversation_project_by_uuid_and_user(project_uuid, owner.uuid)
+        .expect("foreign deletion must preserve the owner project");
+
+    let deleted = app_state
+        .db
+        .delete_conversation_project_by_uuid_and_user(project_uuid, owner.uuid)
+        .expect("owner-scoped UUID deletion should succeed");
+    assert_eq!(deleted, project_uuid);
+    assert!(matches!(
+        app_state
+            .db
+            .get_conversation_project_by_uuid_and_user(project_uuid, owner.uuid),
+        Err(DBError::ResponsesError(
+            ResponsesError::ConversationProjectNotFound
+        ))
+    ));
+    assert!(matches!(
+        app_state
+            .db
+            .get_conversation_by_uuid_and_user(conversation_uuid, owner.uuid),
+        Err(DBError::ResponsesError(
+            ResponsesError::ConversationNotFound
+        ))
+    ));
+
+    let _ = app_state.db.delete_user(&owner);
+    let _ = app_state.db.delete_user(&attacker);
+}
+
+#[tokio::test]
+#[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
 async fn db_password_change_cannot_commit_after_destructive_reset_rotates_seed() {
     let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
         eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");

--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -12,13 +12,13 @@ use crate::{
         password_reset::NewPasswordResetRequest,
         responses::{
             NewAssistantMessage, NewConversation, NewConversationProject, NewReasoningItem,
-            NewResponse, NewToolCall, NewToolOutput, NewUserMessage, ResponseStatus,
-            ResponsesError,
+            NewResponse, NewToolCall, NewToolOutput, NewUserInstruction, NewUserMessage,
+            ProjectInstructionUpdate, ResponseStatus, ResponsesError,
         },
         schema::{
             account_deletion_requests, assistant_messages, conversation_projects,
             conversation_summaries, conversations, org_projects, password_reset_requests,
-            reasoning_items, responses, tool_calls, tool_outputs, user_messages,
+            reasoning_items, responses, tool_calls, tool_outputs, user_instructions, user_messages,
             user_oauth_connections, user_seed_wrappings,
         },
         user_api_keys::{NewUserApiKey, UserApiKey, UserApiKeyError},
@@ -28,6 +28,7 @@ use crate::{
     },
     private_key::generate_twelve_word_seed,
     seed_wrapping::{password_reset_code_mac, CredentialKind},
+    transport_v2::stored_resources::{self, InstructionUpdateCiphertext, StoredResourceError},
     AppMode, AppState, AppStateBuilder, Error,
 };
 use chrono::Utc;
@@ -1263,6 +1264,387 @@ async fn db_conversation_project_uuid_delete_is_owner_scoped_and_cascades() {
 
     let _ = app_state.db.delete_user(&owner);
     let _ = app_state.db.delete_user(&attacker);
+}
+
+#[tokio::test]
+#[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+async fn db_v2_project_and_instruction_reads_are_bounded_scoped_and_sentinel_safe() {
+    let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+        eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+        return;
+    };
+
+    let app_state = build_local_test_app_state(database_url).await;
+    let org_project = first_active_project(&app_state);
+    let marker = Uuid::new_v4();
+    let owner =
+        create_response_transaction_test_user(&app_state, org_project.id, marker, "bounded-owner");
+    let other =
+        create_response_transaction_test_user(&app_state, org_project.id, marker, "bounded-other");
+
+    let safe_project = app_state
+        .db
+        .create_conversation_project(NewConversationProject {
+            uuid: Uuid::new_v4(),
+            user_id: owner.uuid,
+            name_enc: vec![0x11; 32],
+        })
+        .expect("safe project should insert");
+    app_state
+        .db
+        .create_user_instruction(NewUserInstruction {
+            uuid: Uuid::new_v4(),
+            user_id: owner.uuid,
+            project_id: Some(safe_project.id),
+            name_enc: None,
+            prompt_enc: vec![0x22; 33],
+            prompt_tokens: 1,
+            is_default: false,
+        })
+        .expect("safe project instruction should insert");
+    app_state
+        .db
+        .create_conversation_project(NewConversationProject {
+            uuid: Uuid::new_v4(),
+            user_id: owner.uuid,
+            name_enc: vec![0x33; 1024 * 1024],
+        })
+        .expect("oversized sentinel project should insert");
+
+    let project =
+        stored_resources::get_project(app_state.db.get_pool(), owner.uuid, safe_project.uuid, 9)
+            .expect("project should fit the exact aggregate plaintext limit");
+    assert_eq!(project.project.uuid, safe_project.uuid);
+    assert_eq!(project.prompt_enc.as_ref().map(Vec::len), Some(33));
+    assert!(matches!(
+        stored_resources::get_project(app_state.db.get_pool(), owner.uuid, safe_project.uuid, 8,),
+        Err(StoredResourceError::OutputTooLarge)
+    ));
+    assert!(matches!(
+        stored_resources::get_project(
+            app_state.db.get_pool(),
+            other.uuid,
+            safe_project.uuid,
+            usize::MAX,
+        ),
+        Err(StoredResourceError::ConversationProjectNotFound)
+    ));
+    let (project_page, project_has_more) =
+        stored_resources::list_projects(app_state.db.get_pool(), owner.uuid, 1, None, "asc", 4)
+            .expect("oversized lookahead project must not reject the safe returned page");
+    assert!(project_has_more);
+    assert_eq!(project_page.len(), 1);
+    assert_eq!(project_page[0].uuid, safe_project.uuid);
+
+    let safe_instruction = app_state
+        .db
+        .create_user_instruction(NewUserInstruction {
+            uuid: Uuid::new_v4(),
+            user_id: owner.uuid,
+            project_id: None,
+            name_enc: Some(vec![0x44; 32]),
+            prompt_enc: vec![0x55; 33],
+            prompt_tokens: 1,
+            is_default: false,
+        })
+        .expect("safe global instruction should insert");
+    let oversized_instruction = app_state
+        .db
+        .create_user_instruction(NewUserInstruction {
+            uuid: Uuid::new_v4(),
+            user_id: owner.uuid,
+            project_id: None,
+            name_enc: Some(vec![0x66; 1024 * 1024]),
+            prompt_enc: vec![0x77; 1024 * 1024],
+            prompt_tokens: 1,
+            is_default: false,
+        })
+        .expect("oversized sentinel instruction should insert");
+
+    let instruction = stored_resources::get_instruction(
+        app_state.db.get_pool(),
+        owner.uuid,
+        safe_instruction.uuid,
+        9,
+    )
+    .expect("instruction should fit the exact aggregate plaintext limit");
+    assert_eq!(instruction.uuid, safe_instruction.uuid);
+    assert!(matches!(
+        stored_resources::get_instruction(
+            app_state.db.get_pool(),
+            other.uuid,
+            safe_instruction.uuid,
+            usize::MAX,
+        ),
+        Err(StoredResourceError::InstructionNotFound)
+    ));
+    let (instruction_page, instruction_has_more) =
+        stored_resources::list_instructions(app_state.db.get_pool(), owner.uuid, 1, None, "asc", 9)
+            .expect("oversized lookahead instruction must not reject the safe returned page");
+    assert!(instruction_has_more);
+    assert_eq!(instruction_page.len(), 1);
+    assert_eq!(instruction_page[0].uuid, safe_instruction.uuid);
+
+    assert!(matches!(
+        stored_resources::delete_instruction(
+            app_state.db.get_pool(),
+            other.uuid,
+            oversized_instruction.uuid,
+        ),
+        Err(StoredResourceError::InstructionNotFound)
+    ));
+    assert_eq!(
+        stored_resources::delete_instruction(
+            app_state.db.get_pool(),
+            owner.uuid,
+            oversized_instruction.uuid,
+        )
+        .expect("owner narrow deletion should succeed"),
+        oversized_instruction.uuid
+    );
+    let remaining = user_instructions::table
+        .filter(user_instructions::uuid.eq(oversized_instruction.uuid))
+        .count()
+        .get_result::<i64>(
+            &mut app_state
+                .db
+                .get_pool()
+                .get()
+                .expect("verification connection should open"),
+        )
+        .expect("instruction deletion should be queryable");
+    assert_eq!(remaining, 0);
+
+    let _ = app_state.db.delete_user(&owner);
+    let _ = app_state.db.delete_user(&other);
+}
+
+#[tokio::test]
+#[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+async fn db_v2_project_and_instruction_mutations_are_atomic_and_reject_stale_state() {
+    let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+        eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+        return;
+    };
+
+    let app_state = build_local_test_app_state(database_url).await;
+    let org_project = first_active_project(&app_state);
+    let marker = Uuid::new_v4();
+    let owner =
+        create_response_transaction_test_user(&app_state, org_project.id, marker, "mutation-owner");
+
+    let project = app_state
+        .db
+        .create_conversation_project(NewConversationProject {
+            uuid: Uuid::new_v4(),
+            user_id: owner.uuid,
+            name_enc: vec![0x11; 32],
+        })
+        .expect("project should insert");
+    app_state
+        .db
+        .create_user_instruction(NewUserInstruction {
+            uuid: Uuid::new_v4(),
+            user_id: owner.uuid,
+            project_id: Some(project.id),
+            name_enc: None,
+            prompt_enc: vec![0x22; 33],
+            prompt_tokens: 1,
+            is_default: false,
+        })
+        .expect("project instruction should insert");
+
+    let updated_project = stored_resources::update_project(
+        app_state.db.get_pool(),
+        owner.uuid,
+        project.uuid,
+        project.updated_at,
+        Some(vec![0x31; 34]),
+        ProjectInstructionUpdate::Set {
+            prompt_enc: vec![0x32; 35],
+            prompt_tokens: 2,
+        },
+    )
+    .expect("current project snapshot should update atomically");
+    assert_eq!(updated_project.uuid, project.uuid);
+
+    let stored_project = stored_resources::get_project(
+        app_state.db.get_pool(),
+        owner.uuid,
+        project.uuid,
+        usize::MAX,
+    )
+    .expect("updated project should remain readable");
+    assert_eq!(stored_project.project.name_enc, vec![0x31; 34]);
+    assert_eq!(stored_project.prompt_enc, Some(vec![0x32; 35]));
+
+    assert!(matches!(
+        stored_resources::update_project(
+            app_state.db.get_pool(),
+            owner.uuid,
+            project.uuid,
+            project.updated_at - chrono::Duration::seconds(1),
+            Some(vec![0x41; 36]),
+            ProjectInstructionUpdate::Set {
+                prompt_enc: vec![0x42; 37],
+                prompt_tokens: 3,
+            },
+        ),
+        Err(StoredResourceError::StaleResource)
+    ));
+    let unchanged_project = stored_resources::get_project(
+        app_state.db.get_pool(),
+        owner.uuid,
+        project.uuid,
+        usize::MAX,
+    )
+    .expect("stale project update must leave both rows unchanged");
+    assert_eq!(unchanged_project.project.name_enc, vec![0x31; 34]);
+    assert_eq!(unchanged_project.prompt_enc, Some(vec![0x32; 35]));
+
+    let first_instruction = app_state
+        .db
+        .create_user_instruction(NewUserInstruction {
+            uuid: Uuid::new_v4(),
+            user_id: owner.uuid,
+            project_id: None,
+            name_enc: Some(vec![0x51; 32]),
+            prompt_enc: vec![0x52; 33],
+            prompt_tokens: 4,
+            is_default: true,
+        })
+        .expect("first general instruction should insert");
+    let second_instruction = app_state
+        .db
+        .create_user_instruction(NewUserInstruction {
+            uuid: Uuid::new_v4(),
+            user_id: owner.uuid,
+            project_id: None,
+            name_enc: Some(vec![0x61; 32]),
+            prompt_enc: vec![0x62; 33],
+            prompt_tokens: 5,
+            is_default: false,
+        })
+        .expect("second general instruction should insert");
+
+    let updated_instruction = stored_resources::update_instruction(
+        app_state.db.get_pool(),
+        owner.uuid,
+        second_instruction.uuid,
+        second_instruction.updated_at,
+        InstructionUpdateCiphertext {
+            name_enc: vec![0x71; 34],
+            prompt_enc: vec![0x72; 35],
+            prompt_tokens: 6,
+            is_default: true,
+        },
+    )
+    .expect("current instruction snapshot should update and become default atomically");
+    assert!(updated_instruction.is_default);
+
+    let mut conn = app_state
+        .db
+        .get_pool()
+        .get()
+        .expect("verification connection should open");
+    let instruction_state = user_instructions::table
+        .filter(user_instructions::uuid.eq_any([first_instruction.uuid, second_instruction.uuid]))
+        .select((
+            user_instructions::uuid,
+            user_instructions::name_enc,
+            user_instructions::prompt_enc,
+            user_instructions::prompt_tokens,
+            user_instructions::is_default,
+        ))
+        .load::<(Uuid, Option<Vec<u8>>, Vec<u8>, i32, bool)>(&mut conn)
+        .expect("instruction mutation should be queryable");
+    let first_state = instruction_state
+        .iter()
+        .find(|row| row.0 == first_instruction.uuid)
+        .expect("first instruction should remain");
+    let second_state = instruction_state
+        .iter()
+        .find(|row| row.0 == second_instruction.uuid)
+        .expect("second instruction should remain");
+    assert!(!first_state.4);
+    assert_eq!(second_state.1, Some(vec![0x71; 34]));
+    assert_eq!(second_state.2, vec![0x72; 35]);
+    assert_eq!(second_state.3, 6);
+    assert!(second_state.4);
+
+    assert!(matches!(
+        stored_resources::update_instruction(
+            app_state.db.get_pool(),
+            owner.uuid,
+            second_instruction.uuid,
+            second_instruction.updated_at - chrono::Duration::seconds(1),
+            InstructionUpdateCiphertext {
+                name_enc: vec![0x81; 36],
+                prompt_enc: vec![0x82; 37],
+                prompt_tokens: 7,
+                is_default: false,
+            },
+        ),
+        Err(StoredResourceError::StaleResource)
+    ));
+    let second_after_stale = stored_resources::get_instruction(
+        app_state.db.get_pool(),
+        owner.uuid,
+        second_instruction.uuid,
+        usize::MAX,
+    )
+    .expect("stale instruction update must leave the row unchanged");
+    assert_eq!(second_after_stale.name_enc, Some(vec![0x71; 34]));
+    assert_eq!(second_after_stale.prompt_enc, vec![0x72; 35]);
+    assert_eq!(second_after_stale.prompt_tokens, 6);
+    assert!(second_after_stale.is_default);
+
+    let first_after_clear = stored_resources::get_instruction(
+        app_state.db.get_pool(),
+        owner.uuid,
+        first_instruction.uuid,
+        usize::MAX,
+    )
+    .expect("cleared default instruction should remain readable");
+    let first_default = stored_resources::set_default_instruction(
+        app_state.db.get_pool(),
+        owner.uuid,
+        first_instruction.uuid,
+        first_after_clear.updated_at,
+    )
+    .expect("current instruction snapshot should become default atomically");
+    assert!(first_default.is_default);
+
+    assert!(matches!(
+        stored_resources::set_default_instruction(
+            app_state.db.get_pool(),
+            owner.uuid,
+            second_instruction.uuid,
+            second_instruction.updated_at - chrono::Duration::seconds(1),
+        ),
+        Err(StoredResourceError::StaleResource)
+    ));
+    let default_state = user_instructions::table
+        .filter(user_instructions::uuid.eq_any([first_instruction.uuid, second_instruction.uuid]))
+        .select((user_instructions::uuid, user_instructions::is_default))
+        .load::<(Uuid, bool)>(&mut conn)
+        .expect("default state should be queryable");
+    assert_eq!(
+        default_state
+            .iter()
+            .find(|row| row.0 == first_instruction.uuid)
+            .map(|row| row.1),
+        Some(true)
+    );
+    assert_eq!(
+        default_state
+            .iter()
+            .find(|row| row.0 == second_instruction.uuid)
+            .map(|row| row.1),
+        Some(false)
+    );
+
+    let _ = app_state.db.delete_user(&owner);
 }
 
 #[tokio::test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -589,6 +589,11 @@ pub trait DBConnection {
     fn delete_conversation(&self, conversation_id: i64, user_id: Uuid) -> Result<(), DBError>;
     fn delete_all_conversations(&self, user_id: Uuid) -> Result<(), DBError>;
     fn delete_conversation_project(&self, project_id: i64, user_id: Uuid) -> Result<(), DBError>;
+    fn delete_conversation_project_by_uuid_and_user(
+        &self,
+        project_uuid: Uuid,
+        user_id: Uuid,
+    ) -> Result<Uuid, DBError>;
 
     // Responses (job tracker)
     fn create_response(&self, new_response: NewResponse) -> Result<Response, DBError>;
@@ -2423,6 +2428,16 @@ impl DBConnection for PostgresConnection {
     fn delete_conversation_project(&self, project_id: i64, user_id: Uuid) -> Result<(), DBError> {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         ConversationProject::delete_by_id_and_user(conn, project_id, user_id).map_err(DBError::from)
+    }
+
+    fn delete_conversation_project_by_uuid_and_user(
+        &self,
+        project_uuid: Uuid,
+        user_id: Uuid,
+    ) -> Result<Uuid, DBError> {
+        let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
+        ConversationProject::delete_by_uuid_and_user(conn, project_uuid, user_id)
+            .map_err(DBError::from)
     }
 
     // Responses (job tracker) implementations

--- a/src/models/responses.rs
+++ b/src/models/responses.rs
@@ -390,6 +390,29 @@ impl ConversationProject {
         Ok(())
     }
 
+    /// Deletes one owner-scoped project without loading its encrypted name.
+    ///
+    /// Transport v2 uses this narrow statement so a bodyless deletion cannot
+    /// materialize attacker-sized stored ciphertext merely to resolve the
+    /// internal row ID. Existing v1 lookup/delete behavior remains unchanged.
+    pub fn delete_by_uuid_and_user(
+        conn: &mut PgConnection,
+        project_uuid: Uuid,
+        user_id: Uuid,
+    ) -> Result<Uuid, ResponsesError> {
+        diesel::delete(
+            conversation_projects::table
+                .filter(conversation_projects::uuid.eq(project_uuid))
+                .filter(conversation_projects::user_id.eq(user_id)),
+        )
+        .returning(conversation_projects::uuid)
+        .get_result::<Uuid>(conn)
+        .map_err(|error| match error {
+            diesel::result::Error::NotFound => ResponsesError::ConversationProjectNotFound,
+            error => ResponsesError::DatabaseError(error),
+        })
+    }
+
     pub fn count_for_user(conn: &mut PgConnection, user_id: Uuid) -> Result<i64, ResponsesError> {
         use diesel::dsl::count;
 

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -36,12 +36,20 @@ use crate::web::protected_routes::{
     InitiateAccountDeletionRequest, KvValue, PublicKeyQuery, SignMessageRequest,
     ThirdPartyTokenRequest,
 };
+use crate::web::responses::{
+    constants::OBJECT_TYPE_CONVERSATION_PROJECT,
+    conversation_projects::{
+        create_conversation_project_with_name_data, delete_conversation_project_by_uuid_data,
+        validate_project_name, CreateConversationProjectRequest,
+    },
+    DeletedObjectResponse,
+};
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
 use super::envelope::{
-    decode_canonical_api_key_name_path, decode_canonical_kv_item_path,
-    decode_canonical_verify_email_path, Credential, EncodedBytes, EnvelopeLimits, HeaderField,
-    LogicalMethod, RequestEnvelope, RequestId, ResponseMode,
+    decode_canonical_api_key_name_path, decode_canonical_conversation_project_path,
+    decode_canonical_kv_item_path, decode_canonical_verify_email_path, Credential, EncodedBytes,
+    EnvelopeLimits, HeaderField, LogicalMethod, RequestEnvelope, RequestId, ResponseMode,
 };
 use super::session::{
     AuthenticationReservation, AuthenticationStartError, AuthorityState, BoundAuthority,
@@ -136,6 +144,12 @@ pub(crate) enum ProtectedUserOperation {
     DeleteApiKey {
         name: Zeroizing<String>,
     },
+    CreateConversationProject {
+        body: SensitiveBytes,
+    },
+    DeleteConversationProject {
+        project_id: uuid::Uuid,
+    },
     RequestAccountDeletion {
         body: SensitiveBytes,
     },
@@ -194,6 +208,45 @@ pub(crate) struct LogicalUnaryResponse {
     pub(crate) status: StatusCode,
     pub(crate) headers: Vec<HeaderField>,
     pub(crate) body: Option<Zeroizing<Vec<u8>>>,
+}
+
+#[derive(Serialize)]
+struct ConversationProjectCreationResponsePreflight<'a> {
+    id: uuid::Uuid,
+    object: &'static str,
+    name: &'a str,
+    instructions: Option<&'a str>,
+    created_at: i64,
+    updated_at: i64,
+}
+
+fn preflight_conversation_project_creation_response(name: &str) -> Result<(), ApiError> {
+    preflight_conversation_project_creation_response_with_limit(
+        name,
+        EnvelopeLimits::default().logical_body_bytes,
+    )
+}
+
+fn preflight_conversation_project_creation_response_with_limit(
+    name: &str,
+    logical_body_bytes: usize,
+) -> Result<(), ApiError> {
+    let candidate = ConversationProjectCreationResponsePreflight {
+        id: uuid::Uuid::nil(),
+        object: OBJECT_TYPE_CONVERSATION_PROJECT,
+        name,
+        instructions: None,
+        created_at: i64::MIN,
+        updated_at: i64::MIN,
+    };
+    // Creation assigns the UUID and timestamps in PostgreSQL. Prove before
+    // insertion that the request-derived response fits; the actual UUID has
+    // the same width and real timestamps are shorter. Drop the bounded copy
+    // before entering storage so the preflight does not inflate the mutation.
+    let response =
+        LogicalUnaryResponse::json_with_limit(StatusCode::OK, &candidate, logical_body_bytes)?;
+    drop(response);
+    Ok(())
 }
 
 impl LogicalUnaryResponse {
@@ -335,6 +388,8 @@ pub(crate) fn prepare_user_operation(
         CreateApiKey,
         ListApiKeys,
         DeleteApiKey,
+        CreateConversationProject,
+        DeleteConversationProject,
         RequestAccountDeletion,
         ConfirmAccountDeletion,
         Logout,
@@ -363,6 +418,14 @@ pub(crate) fn prepare_user_operation(
             return rejected_bad_request();
         }
     };
+    let conversation_project_id =
+        match decode_canonical_conversation_project_path(request.method, &request.path) {
+            Ok(project_id) => project_id,
+            Err(_) => {
+                request.path.zeroize();
+                return rejected_bad_request();
+            }
+        };
     let route = match (request.method, request.path.as_str()) {
         (LogicalMethod::Post, "/login") => Some(Route::Login),
         (LogicalMethod::Post, "/register") => Some(Route::Register),
@@ -383,6 +446,9 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Delete, "/protected/kv") => Some(Route::DeleteAllKv),
         (LogicalMethod::Post, "/protected/api-keys") => Some(Route::CreateApiKey),
         (LogicalMethod::Get, "/protected/api-keys") => Some(Route::ListApiKeys),
+        (LogicalMethod::Post, "/v1/conversation-projects") => {
+            Some(Route::CreateConversationProject)
+        }
         (LogicalMethod::Post, "/protected/delete-account/request") => {
             Some(Route::RequestAccountDeletion)
         }
@@ -395,9 +461,16 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Put, _) if kv_key.is_some() => Some(Route::PutKv),
         (LogicalMethod::Delete, _) if kv_key.is_some() => Some(Route::DeleteKv),
         (LogicalMethod::Delete, _) if api_key_name.is_some() => Some(Route::DeleteApiKey),
+        (LogicalMethod::Delete, _) if conversation_project_id.is_some() => {
+            Some(Route::DeleteConversationProject)
+        }
         _ => None,
     };
-    if kv_key.is_some() || api_key_name.is_some() || verification_code.is_some() {
+    if kv_key.is_some()
+        || api_key_name.is_some()
+        || verification_code.is_some()
+        || conversation_project_id.is_some()
+    {
         request.path.zeroize();
     }
     let Some(route) = route else {
@@ -746,6 +819,52 @@ pub(crate) fn prepare_user_operation(
                 operation: ProtectedUserOperation::DeleteApiKey {
                     name: api_key_name
                         .expect("classified API-key item route must have a decoded name"),
+                },
+            })
+        }
+        Route::CreateConversationProject => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            let body = request
+                .body_base64
+                .expect("validated conversation-project creation body presence")
+                .into_bytes();
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation: ProtectedUserOperation::CreateConversationProject {
+                    body: Zeroizing::new(body),
+                },
+            })
+        }
+        Route::DeleteConversationProject => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation: ProtectedUserOperation::DeleteConversationProject {
+                    project_id: conversation_project_id
+                        .expect("classified conversation-project route must have an ID"),
                 },
             })
         }
@@ -1166,6 +1285,21 @@ async fn execute_protected_user_operation(
                 &serde_json::json!({ "success": true }),
             )?;
             delete_api_key_by_name(app_state, user, &name)?;
+            Ok(response)
+        }
+        ProtectedUserOperation::CreateConversationProject { body } => {
+            let request = parse_json_body::<CreateConversationProjectRequest>(body)?;
+            let name = Zeroizing::new(validate_project_name(&request.name)?);
+            preflight_conversation_project_creation_response(&name)?;
+            let value =
+                create_conversation_project_with_name_data(app_state, user, auth_context, name)
+                    .await?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::DeleteConversationProject { project_id } => {
+            let value = DeletedObjectResponse::conversation_project(project_id);
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value)?;
+            delete_conversation_project_by_uuid_data(app_state, user, project_id)?;
             Ok(response)
         }
         ProtectedUserOperation::RequestAccountDeletion { body } => {
@@ -2178,6 +2312,147 @@ mod tests {
             unreachable!("matched ready API-key list operation")
         };
         assert!(list.requires_stored_output_reservation());
+    }
+
+    #[test]
+    fn conversation_project_create_and_delete_are_exact_bound_mutations() {
+        let create = || {
+            envelope(
+                LogicalMethod::Post,
+                "/v1/conversation-projects",
+                json_header(),
+                Some(br#"{"name":"  Project name  "}"#),
+                None,
+            )
+        };
+        let create_operation = prepare_user_operation(create(), bound_user_authority());
+        assert!(matches!(
+            &create_operation,
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::CreateConversationProject { .. },
+                ..
+            })
+        ));
+        let OperationPreparation::Ready(create_operation) = create_operation else {
+            unreachable!("matched ready conversation-project creation")
+        };
+        assert!(!create_operation.requires_stored_output_reservation());
+
+        let project_id = "123e4567-e89b-12d3-a456-426614174000";
+        let delete = || {
+            envelope(
+                LogicalMethod::Delete,
+                &format!("/v1/conversation-projects/{project_id}"),
+                Vec::new(),
+                None,
+                None,
+            )
+        };
+        let delete_operation = prepare_user_operation(delete(), bound_user_authority());
+        assert!(matches!(
+            &delete_operation,
+            OperationPreparation::Ready(UserOperation::Protected {
+                operation: ProtectedUserOperation::DeleteConversationProject {
+                    project_id: decoded,
+                },
+                ..
+            }) if *decoded == uuid::Uuid::parse_str(project_id).unwrap()
+        ));
+        let OperationPreparation::Ready(delete_operation) = delete_operation else {
+            unreachable!("matched ready conversation-project deletion")
+        };
+        assert!(!delete_operation.requires_stored_output_reservation());
+
+        for request in [create(), delete()] {
+            assert!(matches!(
+                prepare_user_operation(request, AuthorityState::Anonymous),
+                OperationPreparation::Rejected(response)
+                    if response.status == StatusCode::UNAUTHORIZED
+            ));
+        }
+
+        let mut create_with_query = create();
+        create_with_query.request.query = Some("transplanted=true".to_owned());
+        assert!(matches!(
+            prepare_user_operation(create_with_query, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut create_with_credential = create();
+        create_with_credential.credential = Some(Credential::Resumption {
+            value_base64: EncodedBytes::from_bytes(b"transplanted".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(create_with_credential, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut delete_with_body = delete();
+        delete_with_body.request.body_base64 = Some(EncodedBytes::from_bytes(b"{}".to_vec()));
+        assert!(matches!(
+            prepare_user_operation(delete_with_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let mut streaming = create();
+        streaming.response_mode = ResponseMode::Stream;
+        assert!(matches!(
+            prepare_user_operation(streaming, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        for (method, path) in [
+            (LogicalMethod::Get, "/v1/conversation-projects"),
+            (
+                LogicalMethod::Get,
+                "/v1/conversation-projects/123e4567-e89b-12d3-a456-426614174000",
+            ),
+            (
+                LogicalMethod::Post,
+                "/v1/conversation-projects/123e4567-e89b-12d3-a456-426614174000",
+            ),
+        ] {
+            assert!(matches!(
+                prepare_user_operation(
+                    envelope(method, path, Vec::new(), None, None),
+                    bound_user_authority(),
+                ),
+                OperationPreparation::Unsupported
+            ));
+        }
+    }
+
+    #[test]
+    fn conversation_project_creation_preflight_matches_wire_shape_and_bounds_before_insert() {
+        let name = "quoted \\\" project ☃";
+        let candidate = ConversationProjectCreationResponsePreflight {
+            id: uuid::Uuid::nil(),
+            object: OBJECT_TYPE_CONVERSATION_PROJECT,
+            name,
+            instructions: None,
+            created_at: i64::MIN,
+            updated_at: i64::MIN,
+        };
+        let actual = crate::web::responses::conversation_projects::ConversationProjectResponse {
+            id: uuid::Uuid::nil(),
+            object: OBJECT_TYPE_CONVERSATION_PROJECT,
+            name: name.to_owned(),
+            instructions: None,
+            created_at: i64::MIN,
+            updated_at: i64::MIN,
+        };
+        assert_eq!(
+            serde_json::to_vec(&candidate).unwrap(),
+            serde_json::to_vec(&actual).unwrap(),
+        );
+        assert!(matches!(
+            preflight_conversation_project_creation_response_with_limit(name, 8),
+            Err(ApiError::PayloadTooLarge)
+        ));
     }
 
     #[test]

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -17,10 +17,12 @@ use serde::Serialize;
 use zeroize::{Zeroize, Zeroizing};
 
 use crate::bounded_json::BoundedJsonBuffer;
+use crate::encrypt::{decrypt_with_key, encrypt_with_key};
 use crate::jwt::{
     issue_transport_v2_user_tokens, validate_transport_v2_user_resumption, AuthContext,
 };
 use crate::kv::StoreError;
+use crate::tokens::count_tokens;
 use crate::web::login_routes::{
     authenticate_login, logout_data, register_and_authenticate, verify_email_data, AuthResponse,
     Credentials, LogoutRequest, RefreshResponse, RegisterCredentials,
@@ -37,25 +39,37 @@ use crate::web::protected_routes::{
     ThirdPartyTokenRequest,
 };
 use crate::web::responses::{
-    constants::OBJECT_TYPE_CONVERSATION_PROJECT,
+    constants::{
+        DEFAULT_PAGINATION_LIMIT, MAX_PAGINATION_LIMIT, OBJECT_TYPE_CONVERSATION_PROJECT,
+        OBJECT_TYPE_LIST,
+    },
     conversation_projects::{
         create_conversation_project_with_name_data, delete_conversation_project_by_uuid_data,
-        validate_project_name, CreateConversationProjectRequest,
+        validate_project_name, ConversationProjectListItem, ConversationProjectListResponse,
+        ConversationProjectResponse, CreateConversationProjectRequest,
+        ListConversationProjectsParams, UpdateConversationProjectRequest,
     },
-    DeletedObjectResponse,
+    instructions::{
+        create_instruction_with_content_data, validate_instruction_content,
+        CreateInstructionRequest, InstructionListResponse, InstructionResponse,
+        ListInstructionsParams, UpdateInstructionRequest,
+    },
+    DeletedObjectResponse, NullableField,
 };
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
 use super::envelope::{
     decode_canonical_api_key_name_path, decode_canonical_conversation_project_path,
-    decode_canonical_kv_item_path, decode_canonical_verify_email_path, Credential, EncodedBytes,
-    EnvelopeLimits, HeaderField, LogicalMethod, RequestEnvelope, RequestId, ResponseMode,
+    decode_canonical_instruction_path, decode_canonical_kv_item_path,
+    decode_canonical_verify_email_path, Credential, EncodedBytes, EnvelopeLimits, HeaderField,
+    InstructionItemPath, LogicalMethod, RequestEnvelope, RequestId, ResponseMode,
 };
 use super::session::{
     AuthenticationReservation, AuthenticationStartError, AuthorityState, BoundAuthority,
     BoundPrincipal,
 };
 use super::session_cache::V2SessionLease;
+use super::stored_resources::{self, StoredResourceError};
 
 const JSON_CONTENT_TYPE: &[u8] = b"application/json";
 const AES_GCM_NONCE_AND_TAG_BYTES: usize = 12 + 16;
@@ -147,8 +161,37 @@ pub(crate) enum ProtectedUserOperation {
     CreateConversationProject {
         body: SensitiveBytes,
     },
+    ListConversationProjects {
+        query: Option<String>,
+    },
+    GetConversationProject {
+        project_id: uuid::Uuid,
+    },
+    UpdateConversationProject {
+        project_id: uuid::Uuid,
+        body: SensitiveBytes,
+    },
     DeleteConversationProject {
         project_id: uuid::Uuid,
+    },
+    CreateInstruction {
+        body: SensitiveBytes,
+    },
+    ListInstructions {
+        query: Option<String>,
+    },
+    GetInstruction {
+        instruction_id: uuid::Uuid,
+    },
+    UpdateInstruction {
+        instruction_id: uuid::Uuid,
+        body: SensitiveBytes,
+    },
+    DeleteInstruction {
+        instruction_id: uuid::Uuid,
+    },
+    SetDefaultInstruction {
+        instruction_id: uuid::Uuid,
     },
     RequestAccountDeletion {
         body: SensitiveBytes,
@@ -189,7 +232,14 @@ impl UserOperation {
             Self::Protected {
                 operation: ProtectedUserOperation::GetKv { .. }
                     | ProtectedUserOperation::ListKv
-                    | ProtectedUserOperation::ListApiKeys,
+                    | ProtectedUserOperation::ListApiKeys
+                    | ProtectedUserOperation::ListConversationProjects { .. }
+                    | ProtectedUserOperation::GetConversationProject { .. }
+                    | ProtectedUserOperation::UpdateConversationProject { .. }
+                    | ProtectedUserOperation::ListInstructions { .. }
+                    | ProtectedUserOperation::GetInstruction { .. }
+                    | ProtectedUserOperation::UpdateInstruction { .. }
+                    | ProtectedUserOperation::SetDefaultInstruction { .. },
                 ..
             }
         )
@@ -220,22 +270,47 @@ struct ConversationProjectCreationResponsePreflight<'a> {
     updated_at: i64,
 }
 
+#[derive(Serialize)]
+struct InstructionResponsePreflight<'a> {
+    id: uuid::Uuid,
+    object: &'static str,
+    name: &'a str,
+    prompt: &'a str,
+    prompt_tokens: i32,
+    is_default: bool,
+    created_at: i64,
+    updated_at: i64,
+}
+
 fn preflight_conversation_project_creation_response(name: &str) -> Result<(), ApiError> {
-    preflight_conversation_project_creation_response_with_limit(
+    preflight_conversation_project_response_with_limit(
         name,
+        None,
         EnvelopeLimits::default().logical_body_bytes,
     )
 }
 
-fn preflight_conversation_project_creation_response_with_limit(
+fn preflight_conversation_project_response(
     name: &str,
+    instructions: Option<&str>,
+) -> Result<(), ApiError> {
+    preflight_conversation_project_response_with_limit(
+        name,
+        instructions,
+        EnvelopeLimits::default().logical_body_bytes,
+    )
+}
+
+fn preflight_conversation_project_response_with_limit(
+    name: &str,
+    instructions: Option<&str>,
     logical_body_bytes: usize,
 ) -> Result<(), ApiError> {
     let candidate = ConversationProjectCreationResponsePreflight {
         id: uuid::Uuid::nil(),
         object: OBJECT_TYPE_CONVERSATION_PROJECT,
         name,
-        instructions: None,
+        instructions,
         created_at: i64::MIN,
         updated_at: i64::MIN,
     };
@@ -243,6 +318,41 @@ fn preflight_conversation_project_creation_response_with_limit(
     // insertion that the request-derived response fits; the actual UUID has
     // the same width and real timestamps are shorter. Drop the bounded copy
     // before entering storage so the preflight does not inflate the mutation.
+    let response =
+        LogicalUnaryResponse::json_with_limit(StatusCode::OK, &candidate, logical_body_bytes)?;
+    drop(response);
+    Ok(())
+}
+
+fn preflight_instruction_response(
+    name: &str,
+    prompt: &str,
+    is_default: bool,
+) -> Result<(), ApiError> {
+    preflight_instruction_response_with_limit(
+        name,
+        prompt,
+        is_default,
+        EnvelopeLimits::default().logical_body_bytes,
+    )
+}
+
+fn preflight_instruction_response_with_limit(
+    name: &str,
+    prompt: &str,
+    is_default: bool,
+    logical_body_bytes: usize,
+) -> Result<(), ApiError> {
+    let candidate = InstructionResponsePreflight {
+        id: uuid::Uuid::nil(),
+        object: "instruction",
+        name,
+        prompt,
+        prompt_tokens: i32::MIN,
+        is_default,
+        created_at: i64::MIN,
+        updated_at: i64::MIN,
+    };
     let response =
         LogicalUnaryResponse::json_with_limit(StatusCode::OK, &candidate, logical_body_bytes)?;
     drop(response);
@@ -389,7 +499,16 @@ pub(crate) fn prepare_user_operation(
         ListApiKeys,
         DeleteApiKey,
         CreateConversationProject,
+        ListConversationProjects,
+        GetConversationProject,
+        UpdateConversationProject,
         DeleteConversationProject,
+        CreateInstruction,
+        ListInstructions,
+        GetInstruction,
+        UpdateInstruction,
+        DeleteInstruction,
+        SetDefaultInstruction,
         RequestAccountDeletion,
         ConfirmAccountDeletion,
         Logout,
@@ -426,6 +545,13 @@ pub(crate) fn prepare_user_operation(
                 return rejected_bad_request();
             }
         };
+    let instruction_path = match decode_canonical_instruction_path(request.method, &request.path) {
+        Ok(path) => path,
+        Err(_) => {
+            request.path.zeroize();
+            return rejected_bad_request();
+        }
+    };
     let route = match (request.method, request.path.as_str()) {
         (LogicalMethod::Post, "/login") => Some(Route::Login),
         (LogicalMethod::Post, "/register") => Some(Route::Register),
@@ -449,6 +575,9 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Post, "/v1/conversation-projects") => {
             Some(Route::CreateConversationProject)
         }
+        (LogicalMethod::Get, "/v1/conversation-projects") => Some(Route::ListConversationProjects),
+        (LogicalMethod::Post, "/v1/instructions") => Some(Route::CreateInstruction),
+        (LogicalMethod::Get, "/v1/instructions") => Some(Route::ListInstructions),
         (LogicalMethod::Post, "/protected/delete-account/request") => {
             Some(Route::RequestAccountDeletion)
         }
@@ -464,12 +593,39 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Delete, _) if conversation_project_id.is_some() => {
             Some(Route::DeleteConversationProject)
         }
+        (LogicalMethod::Get, _) if conversation_project_id.is_some() => {
+            Some(Route::GetConversationProject)
+        }
+        (LogicalMethod::Post, _) if conversation_project_id.is_some() => {
+            Some(Route::UpdateConversationProject)
+        }
+        (LogicalMethod::Get, _)
+            if matches!(instruction_path, Some(InstructionItemPath::Item(_))) =>
+        {
+            Some(Route::GetInstruction)
+        }
+        (LogicalMethod::Post, _)
+            if matches!(instruction_path, Some(InstructionItemPath::Item(_))) =>
+        {
+            Some(Route::UpdateInstruction)
+        }
+        (LogicalMethod::Delete, _)
+            if matches!(instruction_path, Some(InstructionItemPath::Item(_))) =>
+        {
+            Some(Route::DeleteInstruction)
+        }
+        (LogicalMethod::Post, _)
+            if matches!(instruction_path, Some(InstructionItemPath::SetDefault(_))) =>
+        {
+            Some(Route::SetDefaultInstruction)
+        }
         _ => None,
     };
     if kv_key.is_some()
         || api_key_name.is_some()
         || verification_code.is_some()
         || conversation_project_id.is_some()
+        || instruction_path.is_some()
     {
         request.path.zeroize();
     }
@@ -848,6 +1004,71 @@ pub(crate) fn prepare_user_operation(
                 },
             })
         }
+        Route::ListConversationProjects => {
+            if credential.is_some() || !request.headers.is_empty() || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation: ProtectedUserOperation::ListConversationProjects {
+                    query: request.query,
+                },
+            })
+        }
+        Route::GetConversationProject => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation: ProtectedUserOperation::GetConversationProject {
+                    project_id: conversation_project_id
+                        .expect("classified conversation-project route must have an ID"),
+                },
+            })
+        }
+        Route::UpdateConversationProject => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation: ProtectedUserOperation::UpdateConversationProject {
+                    project_id: conversation_project_id
+                        .expect("classified conversation-project route must have an ID"),
+                    body: Zeroizing::new(
+                        request
+                            .body_base64
+                            .expect("validated conversation-project update body")
+                            .into_bytes(),
+                    ),
+                },
+            })
+        }
         Route::DeleteConversationProject => {
             if credential.is_some()
                 || request.query.is_some()
@@ -865,6 +1086,112 @@ pub(crate) fn prepare_user_operation(
                 operation: ProtectedUserOperation::DeleteConversationProject {
                     project_id: conversation_project_id
                         .expect("classified conversation-project route must have an ID"),
+                },
+            })
+        }
+        Route::CreateInstruction => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation: ProtectedUserOperation::CreateInstruction {
+                    body: Zeroizing::new(
+                        request
+                            .body_base64
+                            .expect("validated instruction creation body")
+                            .into_bytes(),
+                    ),
+                },
+            })
+        }
+        Route::ListInstructions => {
+            if credential.is_some() || !request.headers.is_empty() || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation: ProtectedUserOperation::ListInstructions {
+                    query: request.query,
+                },
+            })
+        }
+        Route::GetInstruction | Route::DeleteInstruction | Route::SetDefaultInstruction => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            let instruction_id = match instruction_path
+                .expect("classified instruction route must have a decoded path")
+            {
+                InstructionItemPath::Item(id) | InstructionItemPath::SetDefault(id) => id,
+            };
+            let operation = match route {
+                Route::GetInstruction => ProtectedUserOperation::GetInstruction { instruction_id },
+                Route::DeleteInstruction => {
+                    ProtectedUserOperation::DeleteInstruction { instruction_id }
+                }
+                Route::SetDefaultInstruction => {
+                    ProtectedUserOperation::SetDefaultInstruction { instruction_id }
+                }
+                _ => unreachable!("instruction route group is exhaustive"),
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation,
+            })
+        }
+        Route::UpdateInstruction => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            let Some(InstructionItemPath::Item(instruction_id)) = instruction_path else {
+                unreachable!("classified instruction update must use an item path")
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation: ProtectedUserOperation::UpdateInstruction {
+                    instruction_id,
+                    body: Zeroizing::new(
+                        request
+                            .body_base64
+                            .expect("validated instruction update body")
+                            .into_bytes(),
+                    ),
                 },
             })
         }
@@ -1296,11 +1623,397 @@ async fn execute_protected_user_operation(
                     .await?;
             LogicalUnaryResponse::json(StatusCode::OK, &value)
         }
+        ProtectedUserOperation::ListConversationProjects { query } => {
+            let params = parse_logical_query::<ListConversationProjectsParams>(query)?;
+            let limit = if params.limit <= 0 {
+                DEFAULT_PAGINATION_LIMIT
+            } else {
+                params.limit.min(MAX_PAGINATION_LIMIT)
+            };
+            let (mut projects, has_more) = stored_resources::list_projects(
+                app_state.db.get_pool(),
+                user.uuid,
+                limit,
+                params.after,
+                &params.order,
+                EnvelopeLimits::default().logical_body_bytes,
+            )
+            .map_err(map_project_storage_error)?;
+            let user_key = app_state
+                .get_user_key(user, auth_context, None, None)
+                .await
+                .map_err(|_| crate::web::responses::error_mapping::map_key_retrieval_error())?;
+            let first_id = projects.first().map(|project| project.uuid);
+            let last_id = projects.last().map(|project| project.uuid);
+            let mut data = Vec::with_capacity(projects.len());
+            for project in &mut projects {
+                let mut name = decrypt_required_string(
+                    &user_key,
+                    &project.name_enc,
+                    "conversation project name",
+                )?;
+                data.push(ConversationProjectListItem {
+                    id: project.uuid,
+                    object: OBJECT_TYPE_CONVERSATION_PROJECT,
+                    name: std::mem::take(&mut *name),
+                    created_at: project.created_at.timestamp(),
+                    updated_at: project.updated_at.timestamp(),
+                });
+            }
+            let value = ConversationProjectListResponse {
+                object: OBJECT_TYPE_LIST,
+                data,
+                has_more,
+                first_id,
+                last_id,
+            };
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::GetConversationProject { project_id } => {
+            let mut stored = stored_resources::get_project(
+                app_state.db.get_pool(),
+                user.uuid,
+                project_id,
+                EnvelopeLimits::default().logical_body_bytes,
+            )
+            .map_err(map_project_storage_error)?;
+            let user_key = app_state
+                .get_user_key(user, auth_context, None, None)
+                .await
+                .map_err(|_| crate::web::responses::error_mapping::map_key_retrieval_error())?;
+            let mut name = decrypt_required_string(
+                &user_key,
+                &stored.project.name_enc,
+                "conversation project name",
+            )?;
+            let mut instructions = decrypt_optional_string(
+                &user_key,
+                stored.prompt_enc.as_ref(),
+                "conversation project instruction",
+            )?;
+            let value = ConversationProjectResponse {
+                id: stored.project.uuid,
+                object: OBJECT_TYPE_CONVERSATION_PROJECT,
+                name: std::mem::take(&mut *name),
+                instructions: instructions
+                    .as_mut()
+                    .map(|value| std::mem::take(&mut **value)),
+                created_at: stored.project.created_at.timestamp(),
+                updated_at: stored.project.updated_at.timestamp(),
+            };
+            stored.zeroize();
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::UpdateConversationProject { project_id, body } => {
+            let mut request = parse_json_body::<UpdateConversationProjectRequest>(body)?;
+            if request.name.is_none() && request.instructions.is_missing() {
+                return Err(ApiError::BadRequest);
+            }
+
+            let mut stored = stored_resources::get_project(
+                app_state.db.get_pool(),
+                user.uuid,
+                project_id,
+                EnvelopeLimits::default().logical_body_bytes,
+            )
+            .map_err(map_project_storage_error)?;
+            let user_key = app_state
+                .get_user_key(user, auth_context, None, None)
+                .await
+                .map_err(|_| crate::web::responses::error_mapping::map_key_retrieval_error())?;
+
+            let supplied_name = request.name.is_some();
+            let mut final_name = if let Some(name) = request.name.take() {
+                let name = Zeroizing::new(name);
+                Zeroizing::new(validate_project_name(&name)?)
+            } else {
+                decrypt_required_string(
+                    &user_key,
+                    &stored.project.name_enc,
+                    "conversation project name",
+                )?
+            };
+
+            enum InstructionMutation {
+                Unchanged,
+                Set,
+                Clear,
+            }
+            let (instruction_mutation, mut final_instructions) =
+                match std::mem::take(&mut request.instructions) {
+                    NullableField::Missing => (
+                        InstructionMutation::Unchanged,
+                        decrypt_optional_string(
+                            &user_key,
+                            stored.prompt_enc.as_ref(),
+                            "conversation project instruction",
+                        )?,
+                    ),
+                    NullableField::Null => (InstructionMutation::Clear, None),
+                    NullableField::Value(prompt) => {
+                        if prompt.trim().is_empty() {
+                            return Err(ApiError::BadRequest);
+                        }
+                        (InstructionMutation::Set, Some(Zeroizing::new(prompt)))
+                    }
+                };
+
+            preflight_conversation_project_response(
+                &final_name,
+                final_instructions.as_deref().map(String::as_str),
+            )?;
+
+            let name_enc = if supplied_name {
+                Some(encrypt_with_key(&user_key, final_name.as_bytes()).await)
+            } else {
+                None
+            };
+            let instruction_update = match instruction_mutation {
+                InstructionMutation::Unchanged => {
+                    crate::models::responses::ProjectInstructionUpdate::Unchanged
+                }
+                InstructionMutation::Clear => {
+                    crate::models::responses::ProjectInstructionUpdate::Clear
+                }
+                InstructionMutation::Set => {
+                    let prompt = final_instructions
+                        .as_ref()
+                        .expect("set instruction must retain its plaintext");
+                    crate::models::responses::ProjectInstructionUpdate::Set {
+                        prompt_enc: encrypt_with_key(&user_key, prompt.as_bytes()).await,
+                        prompt_tokens: count_tokens(prompt).min(i32::MAX as usize) as i32,
+                    }
+                }
+            };
+            let metadata = stored_resources::update_project(
+                app_state.db.get_pool(),
+                user.uuid,
+                project_id,
+                stored.project.updated_at,
+                name_enc,
+                instruction_update,
+            )
+            .map_err(map_project_storage_error)?;
+            stored.zeroize();
+
+            let value = ConversationProjectResponse {
+                id: metadata.uuid,
+                object: OBJECT_TYPE_CONVERSATION_PROJECT,
+                name: std::mem::take(&mut *final_name),
+                instructions: final_instructions
+                    .as_mut()
+                    .map(|value| std::mem::take(&mut **value)),
+                created_at: metadata.created_at.timestamp(),
+                updated_at: metadata.updated_at.timestamp(),
+            };
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
         ProtectedUserOperation::DeleteConversationProject { project_id } => {
             let value = DeletedObjectResponse::conversation_project(project_id);
             let response = LogicalUnaryResponse::json(StatusCode::OK, &value)?;
             delete_conversation_project_by_uuid_data(app_state, user, project_id)?;
             Ok(response)
+        }
+        ProtectedUserOperation::CreateInstruction { body } => {
+            let mut request = parse_json_body::<CreateInstructionRequest>(body)?;
+            validate_instruction_content(&request.name, &request.prompt)?;
+            preflight_instruction_response(&request.name, &request.prompt, request.is_default)?;
+            let name = Zeroizing::new(std::mem::take(&mut request.name));
+            let prompt = Zeroizing::new(std::mem::take(&mut request.prompt));
+            let value = create_instruction_with_content_data(
+                app_state,
+                user,
+                auth_context,
+                name,
+                prompt,
+                request.is_default,
+            )
+            .await?;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::ListInstructions { query } => {
+            let params = parse_logical_query::<ListInstructionsParams>(query)?;
+            let limit = if params.limit <= 0 {
+                DEFAULT_PAGINATION_LIMIT
+            } else {
+                params.limit.min(MAX_PAGINATION_LIMIT)
+            };
+            let (mut instructions, has_more) = stored_resources::list_instructions(
+                app_state.db.get_pool(),
+                user.uuid,
+                limit,
+                params.after,
+                &params.order,
+                EnvelopeLimits::default().logical_body_bytes,
+            )
+            .map_err(map_instruction_storage_error)?;
+            let user_key = app_state
+                .get_user_key(user, auth_context, None, None)
+                .await
+                .map_err(|_| crate::web::responses::error_mapping::map_key_retrieval_error())?;
+            let first_id = instructions.first().map(|instruction| instruction.uuid);
+            let last_id = instructions.last().map(|instruction| instruction.uuid);
+            let mut data = Vec::with_capacity(instructions.len());
+            for instruction in &mut instructions {
+                let (mut name, mut prompt) = decrypt_instruction_content(&user_key, instruction)?;
+                data.push(InstructionResponse {
+                    id: instruction.uuid,
+                    object: "instruction",
+                    name: std::mem::take(&mut *name),
+                    prompt: std::mem::take(&mut *prompt),
+                    prompt_tokens: instruction.prompt_tokens,
+                    is_default: instruction.is_default,
+                    created_at: instruction.created_at.timestamp(),
+                    updated_at: instruction.updated_at.timestamp(),
+                });
+            }
+            let value = InstructionListResponse {
+                object: OBJECT_TYPE_LIST,
+                data,
+                has_more,
+                first_id,
+                last_id,
+            };
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::GetInstruction { instruction_id } => {
+            let mut instruction = stored_resources::get_instruction(
+                app_state.db.get_pool(),
+                user.uuid,
+                instruction_id,
+                EnvelopeLimits::default().logical_body_bytes,
+            )
+            .map_err(map_instruction_storage_error)?;
+            let user_key = app_state
+                .get_user_key(user, auth_context, None, None)
+                .await
+                .map_err(|_| crate::web::responses::error_mapping::map_key_retrieval_error())?;
+            let (mut name, mut prompt) = decrypt_instruction_content(&user_key, &instruction)?;
+            let value = InstructionResponse {
+                id: instruction.uuid,
+                object: "instruction",
+                name: std::mem::take(&mut *name),
+                prompt: std::mem::take(&mut *prompt),
+                prompt_tokens: instruction.prompt_tokens,
+                is_default: instruction.is_default,
+                created_at: instruction.created_at.timestamp(),
+                updated_at: instruction.updated_at.timestamp(),
+            };
+            instruction.zeroize();
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::UpdateInstruction {
+            instruction_id,
+            body,
+        } => {
+            let mut request = parse_json_body::<UpdateInstructionRequest>(body)?;
+            if request.name.is_none() && request.prompt.is_none() && request.is_default.is_none() {
+                return Err(ApiError::BadRequest);
+            }
+            let mut instruction = stored_resources::get_instruction(
+                app_state.db.get_pool(),
+                user.uuid,
+                instruction_id,
+                EnvelopeLimits::default().logical_body_bytes,
+            )
+            .map_err(map_instruction_storage_error)?;
+            let user_key = app_state
+                .get_user_key(user, auth_context, None, None)
+                .await
+                .map_err(|_| crate::web::responses::error_mapping::map_key_retrieval_error())?;
+            let (mut current_name, mut current_prompt) =
+                decrypt_instruction_content(&user_key, &instruction)?;
+            let mut final_name = request
+                .name
+                .take()
+                .map(Zeroizing::new)
+                .unwrap_or_else(|| Zeroizing::new(std::mem::take(&mut *current_name)));
+            let mut final_prompt = request
+                .prompt
+                .take()
+                .map(Zeroizing::new)
+                .unwrap_or_else(|| Zeroizing::new(std::mem::take(&mut *current_prompt)));
+            validate_instruction_content(&final_name, &final_prompt)?;
+            let is_default = request.is_default.unwrap_or(instruction.is_default);
+            preflight_instruction_response(&final_name, &final_prompt, is_default)?;
+            let name_enc = encrypt_with_key(&user_key, final_name.as_bytes()).await;
+            let prompt_enc = encrypt_with_key(&user_key, final_prompt.as_bytes()).await;
+            let prompt_tokens = count_tokens(&final_prompt).min(i32::MAX as usize) as i32;
+            let metadata = stored_resources::update_instruction(
+                app_state.db.get_pool(),
+                user.uuid,
+                instruction_id,
+                instruction.updated_at,
+                stored_resources::InstructionUpdateCiphertext {
+                    name_enc,
+                    prompt_enc,
+                    prompt_tokens,
+                    is_default,
+                },
+            )
+            .map_err(map_instruction_storage_error)?;
+            instruction.zeroize();
+            let value = InstructionResponse {
+                id: metadata.uuid,
+                object: "instruction",
+                name: std::mem::take(&mut *final_name),
+                prompt: std::mem::take(&mut *final_prompt),
+                prompt_tokens: metadata.prompt_tokens,
+                is_default: metadata.is_default,
+                created_at: metadata.created_at.timestamp(),
+                updated_at: metadata.updated_at.timestamp(),
+            };
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        ProtectedUserOperation::DeleteInstruction { instruction_id } => {
+            let value = DeletedObjectResponse {
+                id: instruction_id,
+                object: "instruction.deleted",
+                deleted: true,
+            };
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value)?;
+            let deleted = stored_resources::delete_instruction(
+                app_state.db.get_pool(),
+                user.uuid,
+                instruction_id,
+            )
+            .map_err(map_instruction_storage_error)?;
+            debug_assert_eq!(deleted, instruction_id);
+            Ok(response)
+        }
+        ProtectedUserOperation::SetDefaultInstruction { instruction_id } => {
+            let mut instruction = stored_resources::get_instruction(
+                app_state.db.get_pool(),
+                user.uuid,
+                instruction_id,
+                EnvelopeLimits::default().logical_body_bytes,
+            )
+            .map_err(map_instruction_storage_error)?;
+            let user_key = app_state
+                .get_user_key(user, auth_context, None, None)
+                .await
+                .map_err(|_| crate::web::responses::error_mapping::map_key_retrieval_error())?;
+            let (mut name, mut prompt) = decrypt_instruction_content(&user_key, &instruction)?;
+            preflight_instruction_response(&name, &prompt, true)?;
+            let metadata = stored_resources::set_default_instruction(
+                app_state.db.get_pool(),
+                user.uuid,
+                instruction_id,
+                instruction.updated_at,
+            )
+            .map_err(map_instruction_storage_error)?;
+            instruction.zeroize();
+            let value = InstructionResponse {
+                id: metadata.uuid,
+                object: "instruction",
+                name: std::mem::take(&mut *name),
+                prompt: std::mem::take(&mut *prompt),
+                prompt_tokens: metadata.prompt_tokens,
+                is_default: metadata.is_default,
+                created_at: metadata.created_at.timestamp(),
+                updated_at: metadata.updated_at.timestamp(),
+            };
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
         }
         ProtectedUserOperation::RequestAccountDeletion { body } => {
             let request = parse_json_body::<InitiateAccountDeletionRequest>(body)?;
@@ -1328,6 +2041,79 @@ fn map_bounded_kv_read_error(error: StoreError) -> ApiError {
         tracing::error!("Error reading bounded key-value output");
         ApiError::InternalServerError
     }
+}
+
+fn map_project_storage_error(error: StoredResourceError) -> ApiError {
+    match error {
+        StoredResourceError::ConversationProjectNotFound => ApiError::NotFound,
+        StoredResourceError::OutputTooLarge => ApiError::PayloadTooLarge,
+        StoredResourceError::StaleResource => ApiError::Conflict,
+        error => {
+            tracing::error!(?error, "Failed to read bounded conversation-project state");
+            ApiError::InternalServerError
+        }
+    }
+}
+
+fn map_instruction_storage_error(error: StoredResourceError) -> ApiError {
+    match error {
+        StoredResourceError::InstructionNotFound => ApiError::NotFound,
+        StoredResourceError::OutputTooLarge => ApiError::PayloadTooLarge,
+        StoredResourceError::StaleResource => ApiError::Conflict,
+        error => {
+            tracing::error!(?error, "Failed to read bounded instruction state");
+            ApiError::InternalServerError
+        }
+    }
+}
+
+fn decrypt_instruction_content(
+    user_key: &secp256k1::SecretKey,
+    instruction: &stored_resources::InstructionCiphertextRow,
+) -> Result<(Zeroizing<String>, Zeroizing<String>), ApiError> {
+    let name = decrypt_required_string(
+        user_key,
+        instruction
+            .name_enc
+            .as_ref()
+            .ok_or(ApiError::InternalServerError)?,
+        "instruction name",
+    )?;
+    let prompt = decrypt_required_string(user_key, &instruction.prompt_enc, "instruction prompt")?;
+    Ok((name, prompt))
+}
+
+fn decrypt_required_string(
+    user_key: &secp256k1::SecretKey,
+    ciphertext: &Vec<u8>,
+    description: &'static str,
+) -> Result<Zeroizing<String>, ApiError> {
+    decrypt_optional_string(user_key, Some(ciphertext), description)?
+        .ok_or(ApiError::InternalServerError)
+}
+
+fn decrypt_optional_string(
+    user_key: &secp256k1::SecretKey,
+    ciphertext: Option<&Vec<u8>>,
+    description: &'static str,
+) -> Result<Option<Zeroizing<String>>, ApiError> {
+    let Some(ciphertext) = ciphertext else {
+        return Ok(None);
+    };
+    let mut plaintext = Zeroizing::new(decrypt_with_key(user_key, ciphertext).map_err(|_| {
+        tracing::error!(description, "Failed to decrypt bounded stored output");
+        ApiError::InternalServerError
+    })?);
+    let value = match String::from_utf8(std::mem::take(&mut *plaintext)) {
+        Ok(value) => value,
+        Err(error) => {
+            let mut invalid_bytes = error.into_bytes();
+            let value = String::from_utf8_lossy(&invalid_bytes).into_owned();
+            invalid_bytes.zeroize();
+            value
+        }
+    };
+    Ok(Some(Zeroizing::new(value)))
 }
 
 fn parse_json_body<T: DeserializeOwned>(body: SensitiveBytes) -> Result<T, ApiError> {
@@ -2315,7 +3101,7 @@ mod tests {
     }
 
     #[test]
-    fn conversation_project_create_and_delete_are_exact_bound_mutations() {
+    fn conversation_project_family_is_exact_bound_and_classified_by_storage_risk() {
         let create = || {
             envelope(
                 LogicalMethod::Post,
@@ -2405,25 +3191,133 @@ mod tests {
                 if response.status == StatusCode::BAD_REQUEST
         ));
 
-        for (method, path) in [
-            (LogicalMethod::Get, "/v1/conversation-projects"),
-            (
+        let list = prepare_user_operation(
+            envelope(
                 LogicalMethod::Get,
-                "/v1/conversation-projects/123e4567-e89b-12d3-a456-426614174000",
+                "/v1/conversation-projects",
+                Vec::new(),
+                None,
+                None,
             ),
-            (
+            bound_user_authority(),
+        );
+        let get = prepare_user_operation(
+            envelope(
+                LogicalMethod::Get,
+                &format!("/v1/conversation-projects/{project_id}"),
+                Vec::new(),
+                None,
+                None,
+            ),
+            bound_user_authority(),
+        );
+        let update = prepare_user_operation(
+            envelope(
                 LogicalMethod::Post,
-                "/v1/conversation-projects/123e4567-e89b-12d3-a456-426614174000",
+                &format!("/v1/conversation-projects/{project_id}"),
+                json_header(),
+                Some(br#"{"instructions":null}"#),
+                None,
             ),
-        ] {
-            assert!(matches!(
-                prepare_user_operation(
-                    envelope(method, path, Vec::new(), None, None),
-                    bound_user_authority(),
-                ),
-                OperationPreparation::Unsupported
-            ));
+            bound_user_authority(),
+        );
+        for operation in [list, get, update] {
+            let OperationPreparation::Ready(operation) = operation else {
+                panic!("bounded conversation-project operation must be admitted");
+            };
+            assert!(operation.requires_stored_output_reservation());
         }
+    }
+
+    #[test]
+    fn instruction_family_is_exact_bound_and_classified_by_storage_risk() {
+        let instruction_id = "123e4567-e89b-12d3-a456-426614174000";
+        let item_path = format!("/v1/instructions/{instruction_id}");
+        let create = prepare_user_operation(
+            envelope(
+                LogicalMethod::Post,
+                "/v1/instructions",
+                json_header(),
+                Some(br#"{"name":"n","prompt":"p"}"#),
+                None,
+            ),
+            bound_user_authority(),
+        );
+        let delete = prepare_user_operation(
+            envelope(LogicalMethod::Delete, &item_path, Vec::new(), None, None),
+            bound_user_authority(),
+        );
+        for operation in [create, delete] {
+            let OperationPreparation::Ready(operation) = operation else {
+                panic!("fixed-output instruction mutation must be admitted");
+            };
+            assert!(!operation.requires_stored_output_reservation());
+        }
+
+        let list = prepare_user_operation(
+            envelope(
+                LogicalMethod::Get,
+                "/v1/instructions",
+                Vec::new(),
+                None,
+                None,
+            ),
+            bound_user_authority(),
+        );
+        let get = prepare_user_operation(
+            envelope(LogicalMethod::Get, &item_path, Vec::new(), None, None),
+            bound_user_authority(),
+        );
+        let update = prepare_user_operation(
+            envelope(
+                LogicalMethod::Post,
+                &item_path,
+                json_header(),
+                Some(br#"{"is_default":false}"#),
+                None,
+            ),
+            bound_user_authority(),
+        );
+        let set_default = prepare_user_operation(
+            envelope(
+                LogicalMethod::Post,
+                &format!("{item_path}/set-default"),
+                Vec::new(),
+                None,
+                None,
+            ),
+            bound_user_authority(),
+        );
+        for operation in [list, get, update, set_default] {
+            let OperationPreparation::Ready(operation) = operation else {
+                panic!("stored instruction operation must be admitted");
+            };
+            assert!(operation.requires_stored_output_reservation());
+        }
+
+        let mut transplanted = envelope(
+            LogicalMethod::Post,
+            &item_path,
+            json_header(),
+            Some(br#"{"name":"n"}"#),
+            None,
+        );
+        transplanted.credential = Some(Credential::Resumption {
+            value_base64: EncodedBytes::from_bytes(b"stolen".to_vec()),
+        });
+        assert!(matches!(
+            prepare_user_operation(transplanted, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(LogicalMethod::Get, &item_path, Vec::new(), None, None),
+                AuthorityState::Anonymous,
+            ),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::UNAUTHORIZED
+        ));
     }
 
     #[test]
@@ -2450,7 +3344,41 @@ mod tests {
             serde_json::to_vec(&actual).unwrap(),
         );
         assert!(matches!(
-            preflight_conversation_project_creation_response_with_limit(name, 8),
+            preflight_conversation_project_response_with_limit(name, None, 8),
+            Err(ApiError::PayloadTooLarge)
+        ));
+    }
+
+    #[test]
+    fn instruction_preflight_matches_wire_shape_and_bounds_before_default_mutation() {
+        let name = "  quoted \" instruction  ";
+        let prompt = "  preserve prompt whitespace ☃  ";
+        let candidate = InstructionResponsePreflight {
+            id: uuid::Uuid::nil(),
+            object: "instruction",
+            name,
+            prompt,
+            prompt_tokens: i32::MIN,
+            is_default: true,
+            created_at: i64::MIN,
+            updated_at: i64::MIN,
+        };
+        let actual = InstructionResponse {
+            id: uuid::Uuid::nil(),
+            object: "instruction",
+            name: name.to_owned(),
+            prompt: prompt.to_owned(),
+            prompt_tokens: i32::MIN,
+            is_default: true,
+            created_at: i64::MIN,
+            updated_at: i64::MIN,
+        };
+        assert_eq!(
+            serde_json::to_vec(&candidate).unwrap(),
+            serde_json::to_vec(&actual).unwrap(),
+        );
+        assert!(matches!(
+            preflight_instruction_response_with_limit(name, prompt, true, 8),
             Err(ApiError::PayloadTooLarge)
         ));
     }

--- a/src/transport_v2/envelope.rs
+++ b/src/transport_v2/envelope.rs
@@ -374,6 +374,13 @@ const KV_ITEM_PATH_PREFIX: &str = "/protected/kv/";
 const API_KEY_ITEM_PATH_PREFIX: &str = "/protected/api-keys/";
 const VERIFY_EMAIL_PATH_PREFIX: &str = "/verify-email/";
 const CONVERSATION_PROJECT_ITEM_PATH_PREFIX: &str = "/v1/conversation-projects/";
+const INSTRUCTION_ITEM_PATH_PREFIX: &str = "/v1/instructions/";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum InstructionItemPath {
+    Item(Uuid),
+    SetDefault(Uuid),
+}
 
 fn validate_logical_path(
     method: LogicalMethod,
@@ -391,6 +398,9 @@ fn validate_logical_path(
         return Ok(());
     }
     if decode_canonical_conversation_project_path(method, path)?.is_some() {
+        return Ok(());
+    }
+    if decode_canonical_instruction_path(method, path)?.is_some() {
         return Ok(());
     }
     validate_path(path, limits)
@@ -502,6 +512,47 @@ pub(crate) fn decode_canonical_conversation_project_path(
         ));
     }
     Ok(Some(project_id))
+}
+
+/// Decodes canonical general-instruction item and set-default paths.
+///
+/// The fixed `/set-default` suffix is recognized before the ordinary item
+/// form, preventing the action route from being confused with an alternate
+/// UUID spelling. Project-linked instructions remain outside this route
+/// family and are filtered by the owner-scoped storage projection.
+pub(crate) fn decode_canonical_instruction_path(
+    method: LogicalMethod,
+    path: &str,
+) -> Result<Option<InstructionItemPath>, EnvelopeError> {
+    let Some(segment) = path.strip_prefix(INSTRUCTION_ITEM_PATH_PREFIX) else {
+        return Ok(None);
+    };
+    let (segment, set_default) = if let Some(segment) = segment.strip_suffix("/set-default") {
+        if method != LogicalMethod::Post {
+            return Ok(None);
+        }
+        (segment, true)
+    } else {
+        if !matches!(
+            method,
+            LogicalMethod::Get | LogicalMethod::Post | LogicalMethod::Delete
+        ) {
+            return Ok(None);
+        }
+        (segment, false)
+    };
+    let instruction_id = Uuid::parse_str(segment)
+        .map_err(|_| EnvelopeError::InvalidPath("instruction ID must be a canonical UUID"))?;
+    if instruction_id.hyphenated().to_string() != segment {
+        return Err(EnvelopeError::InvalidPath(
+            "instruction ID must use lowercase hyphenated UUID spelling",
+        ));
+    }
+    Ok(Some(if set_default {
+        InstructionItemPath::SetDefault(instruction_id)
+    } else {
+        InstructionItemPath::Item(instruction_id)
+    }))
 }
 
 fn decode_canonical_opaque_segment(segment: &str) -> Result<Zeroizing<String>, EnvelopeError> {
@@ -1355,6 +1406,60 @@ mod tests {
                     "{method:?} {invalid}"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn instruction_item_and_set_default_paths_are_canonical_and_distinct() {
+        let encoded = "123e4567-e89b-12d3-a456-426614174000";
+        let id = Uuid::parse_str(encoded).unwrap();
+        let item = format!("{INSTRUCTION_ITEM_PATH_PREFIX}{encoded}");
+        for method in [
+            LogicalMethod::Get,
+            LogicalMethod::Post,
+            LogicalMethod::Delete,
+        ] {
+            assert_eq!(
+                decode_canonical_instruction_path(method, &item).unwrap(),
+                Some(InstructionItemPath::Item(id))
+            );
+            validate_logical_path(method, &item, &EnvelopeLimits::default()).unwrap();
+        }
+
+        let set_default = format!("{item}/set-default");
+        assert_eq!(
+            decode_canonical_instruction_path(LogicalMethod::Post, &set_default).unwrap(),
+            Some(InstructionItemPath::SetDefault(id))
+        );
+        validate_logical_path(
+            LogicalMethod::Post,
+            &set_default,
+            &EnvelopeLimits::default(),
+        )
+        .unwrap();
+        assert!(
+            decode_canonical_instruction_path(LogicalMethod::Get, &set_default)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn instruction_paths_reject_uuid_aliases_and_suffix_ambiguity() {
+        for invalid in [
+            "/v1/instructions/",
+            "/v1/instructions/123E4567-E89B-12D3-A456-426614174000",
+            "/v1/instructions/123e4567e89b12d3a456426614174000",
+            "/v1/instructions/{123e4567-e89b-12d3-a456-426614174000}",
+            "/v1/instructions/123e4567-e89b-12d3-a456-426614174000/extra",
+            "/v1/instructions/123e4567-e89b-12d3-a456-426614174000/set-default/extra",
+            "/v1/instructions/not-a-uuid",
+        ] {
+            assert!(
+                validate_logical_path(LogicalMethod::Post, invalid, &EnvelopeLimits::default())
+                    .is_err(),
+                "{invalid}"
+            );
         }
     }
 

--- a/src/transport_v2/envelope.rs
+++ b/src/transport_v2/envelope.rs
@@ -373,6 +373,7 @@ impl LogicalRequest {
 const KV_ITEM_PATH_PREFIX: &str = "/protected/kv/";
 const API_KEY_ITEM_PATH_PREFIX: &str = "/protected/api-keys/";
 const VERIFY_EMAIL_PATH_PREFIX: &str = "/verify-email/";
+const CONVERSATION_PROJECT_ITEM_PATH_PREFIX: &str = "/v1/conversation-projects/";
 
 fn validate_logical_path(
     method: LogicalMethod,
@@ -387,6 +388,9 @@ fn validate_logical_path(
         return Ok(());
     }
     if decode_canonical_verify_email_path(method, path)?.is_some() {
+        return Ok(());
+    }
+    if decode_canonical_conversation_project_path(method, path)?.is_some() {
         return Ok(());
     }
     validate_path(path, limits)
@@ -469,6 +473,35 @@ pub(crate) fn decode_canonical_verify_email_path(
         ));
     }
     Ok(Some(code))
+}
+
+/// Decodes the canonical UUID segment used by one conversation-project item.
+///
+/// Axum's v1 UUID aliases remain untouched. Transport v2 accepts one lowercase
+/// hyphenated spelling for GET, POST, and DELETE so the authenticated logical
+/// path identifies exactly one project operation.
+pub(crate) fn decode_canonical_conversation_project_path(
+    method: LogicalMethod,
+    path: &str,
+) -> Result<Option<Uuid>, EnvelopeError> {
+    if !matches!(
+        method,
+        LogicalMethod::Get | LogicalMethod::Post | LogicalMethod::Delete
+    ) {
+        return Ok(None);
+    }
+    let Some(segment) = path.strip_prefix(CONVERSATION_PROJECT_ITEM_PATH_PREFIX) else {
+        return Ok(None);
+    };
+    let project_id = Uuid::parse_str(segment).map_err(|_| {
+        EnvelopeError::InvalidPath("conversation project ID must be a canonical UUID")
+    })?;
+    if project_id.hyphenated().to_string() != segment {
+        return Err(EnvelopeError::InvalidPath(
+            "conversation project ID must use lowercase hyphenated UUID spelling",
+        ));
+    }
+    Ok(Some(project_id))
 }
 
 fn decode_canonical_opaque_segment(segment: &str) -> Result<Zeroizing<String>, EnvelopeError> {
@@ -1269,6 +1302,59 @@ mod tests {
                     .is_err(),
                 "{invalid}"
             );
+        }
+    }
+
+    #[test]
+    fn conversation_project_item_paths_use_one_canonical_uuid_spelling() {
+        let encoded = "123e4567-e89b-12d3-a456-426614174000";
+        let path = format!("{CONVERSATION_PROJECT_ITEM_PATH_PREFIX}{encoded}");
+        for method in [
+            LogicalMethod::Get,
+            LogicalMethod::Post,
+            LogicalMethod::Delete,
+        ] {
+            assert_eq!(
+                decode_canonical_conversation_project_path(method, &path).unwrap(),
+                Some(Uuid::parse_str(encoded).unwrap())
+            );
+            validate_logical_path(method, &path, &EnvelopeLimits::default()).unwrap();
+        }
+
+        assert!(
+            decode_canonical_conversation_project_path(LogicalMethod::Put, &path)
+                .unwrap()
+                .is_none()
+        );
+        assert!(decode_canonical_conversation_project_path(
+            LogicalMethod::Get,
+            "/v1/conversation-project/123e4567-e89b-12d3-a456-426614174000",
+        )
+        .unwrap()
+        .is_none());
+    }
+
+    #[test]
+    fn conversation_project_item_paths_reject_uuid_aliases_and_malformed_ids() {
+        for method in [
+            LogicalMethod::Get,
+            LogicalMethod::Post,
+            LogicalMethod::Delete,
+        ] {
+            for invalid in [
+                "/v1/conversation-projects/",
+                "/v1/conversation-projects/123E4567-E89B-12D3-A456-426614174000",
+                "/v1/conversation-projects/123e4567e89b12d3a456426614174000",
+                "/v1/conversation-projects/{123e4567-e89b-12d3-a456-426614174000}",
+                "/v1/conversation-projects/123e4567%2De89b%2D12d3%2Da456%2D426614174000",
+                "/v1/conversation-projects/123e4567-e89b-12d3-a456-426614174000/extra",
+                "/v1/conversation-projects/not-a-uuid",
+            ] {
+                assert!(
+                    validate_logical_path(method, invalid, &EnvelopeLimits::default()).is_err(),
+                    "{method:?} {invalid}"
+                );
+            }
         }
     }
 

--- a/src/transport_v2/mod.rs
+++ b/src/transport_v2/mod.rs
@@ -12,6 +12,7 @@ mod envelope;
 mod gateway;
 mod session;
 mod session_cache;
+pub(crate) mod stored_resources;
 
 pub(crate) use gateway::{router, TransportV2State};
 

--- a/src/transport_v2/stored_resources.rs
+++ b/src/transport_v2/stored_resources.rs
@@ -1,0 +1,914 @@
+//! Bounded, transport-v2-only storage projections for encrypted resources.
+//!
+//! These queries deliberately do not reuse the transport-v1 row loaders. A
+//! database attacker can enlarge encrypted columns, so v2 first measures the
+//! exact page or item in a repeatable-read snapshot and only then loads the
+//! narrow ciphertext projection. Mutations return metadata rather than stored
+//! ciphertext whenever the caller already owns the final plaintext response.
+
+use chrono::{DateTime, Utc};
+use diesel::dsl::sql;
+use diesel::prelude::*;
+use diesel::sql_types::BigInt;
+use diesel::{Connection, OptionalExtension};
+use uuid::Uuid;
+use zeroize::Zeroize;
+
+use crate::models::responses::{NewUserInstruction, ProjectInstructionUpdate};
+use crate::models::schema::{conversation_projects, user_instructions};
+
+const AES_GCM_STORAGE_OVERHEAD_BYTES: usize = 12 + 16;
+
+type Pool = diesel::r2d2::Pool<diesel::r2d2::ConnectionManager<PgConnection>>;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum StoredResourceError {
+    #[error("conversation project not found")]
+    ConversationProjectNotFound,
+    #[error("instruction not found")]
+    InstructionNotFound,
+    #[error("stored output exceeds the logical response limit")]
+    OutputTooLarge,
+    #[error("stored output changed within a bounded snapshot")]
+    InconsistentSnapshot,
+    #[error("resource changed before its mutation could be committed")]
+    StaleResource,
+    #[error("database connection unavailable")]
+    Connection,
+    #[error("database error: {0}")]
+    Database(#[from] diesel::result::Error),
+}
+
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = conversation_projects)]
+pub(crate) struct ProjectCiphertextRow {
+    pub(crate) id: i64,
+    pub(crate) uuid: Uuid,
+    pub(crate) name_enc: Vec<u8>,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) updated_at: DateTime<Utc>,
+}
+
+impl Zeroize for ProjectCiphertextRow {
+    fn zeroize(&mut self) {
+        self.name_enc.zeroize();
+    }
+}
+
+impl Drop for ProjectCiphertextRow {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+pub(crate) struct ProjectWithInstructionCiphertext {
+    pub(crate) project: ProjectCiphertextRow,
+    pub(crate) prompt_enc: Option<Vec<u8>>,
+}
+
+impl Zeroize for ProjectWithInstructionCiphertext {
+    fn zeroize(&mut self) {
+        self.project.zeroize();
+        if let Some(prompt) = self.prompt_enc.as_mut() {
+            prompt.zeroize();
+        }
+    }
+}
+
+impl Drop for ProjectWithInstructionCiphertext {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+pub(crate) struct ProjectMutationMetadata {
+    pub(crate) uuid: Uuid,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) updated_at: DateTime<Utc>,
+}
+
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = user_instructions)]
+pub(crate) struct InstructionCiphertextRow {
+    pub(crate) id: i64,
+    pub(crate) uuid: Uuid,
+    pub(crate) name_enc: Option<Vec<u8>>,
+    pub(crate) prompt_enc: Vec<u8>,
+    pub(crate) prompt_tokens: i32,
+    pub(crate) is_default: bool,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) updated_at: DateTime<Utc>,
+}
+
+impl Zeroize for InstructionCiphertextRow {
+    fn zeroize(&mut self) {
+        if let Some(name) = self.name_enc.as_mut() {
+            name.zeroize();
+        }
+        self.prompt_enc.zeroize();
+    }
+}
+
+impl Drop for InstructionCiphertextRow {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+pub(crate) struct InstructionMutationMetadata {
+    pub(crate) uuid: Uuid,
+    pub(crate) prompt_tokens: i32,
+    pub(crate) is_default: bool,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) updated_at: DateTime<Utc>,
+}
+
+pub(crate) struct InstructionUpdateCiphertext {
+    pub(crate) name_enc: Vec<u8>,
+    pub(crate) prompt_enc: Vec<u8>,
+    pub(crate) prompt_tokens: i32,
+    pub(crate) is_default: bool,
+}
+
+fn map_default_instruction_conflict(error: StoredResourceError) -> StoredResourceError {
+    match error {
+        StoredResourceError::Database(diesel::result::Error::DatabaseError(
+            diesel::result::DatabaseErrorKind::UniqueViolation,
+            ref info,
+        )) if info.constraint_name() == Some("idx_user_instructions_one_default") => {
+            StoredResourceError::StaleResource
+        }
+        error => error,
+    }
+}
+
+fn checked_ciphertext_plaintext_len(length: i64) -> Result<usize, StoredResourceError> {
+    usize::try_from(length)
+        .map_err(|_| StoredResourceError::InconsistentSnapshot)?
+        .checked_sub(AES_GCM_STORAGE_OVERHEAD_BYTES)
+        .ok_or(StoredResourceError::InconsistentSnapshot)
+}
+
+fn validate_ciphertext_plaintext_total(
+    ciphertext_lengths: impl IntoIterator<Item = i64>,
+    logical_body_limit: usize,
+) -> Result<Vec<usize>, StoredResourceError> {
+    let mut expected = Vec::new();
+    let mut plaintext_total = 0_usize;
+    for length in ciphertext_lengths {
+        let ciphertext_length =
+            usize::try_from(length).map_err(|_| StoredResourceError::InconsistentSnapshot)?;
+        let plaintext_length = checked_ciphertext_plaintext_len(length)?;
+        plaintext_total = plaintext_total
+            .checked_add(plaintext_length)
+            .ok_or(StoredResourceError::OutputTooLarge)?;
+        if plaintext_total > logical_body_limit {
+            return Err(StoredResourceError::OutputTooLarge);
+        }
+        expected.push(ciphertext_length);
+    }
+    Ok(expected)
+}
+
+pub(crate) fn get_project(
+    pool: &Pool,
+    user_id: Uuid,
+    project_uuid: Uuid,
+    logical_body_limit: usize,
+) -> Result<ProjectWithInstructionCiphertext, StoredResourceError> {
+    let mut conn = pool.get().map_err(|_| StoredResourceError::Connection)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, StoredResourceError, _>(|conn| {
+            let (project_id, name_length) = conversation_projects::table
+                .filter(conversation_projects::uuid.eq(project_uuid))
+                .filter(conversation_projects::user_id.eq(user_id))
+                .select((
+                    conversation_projects::id,
+                    sql::<BigInt>("octet_length(name_enc)::bigint"),
+                ))
+                .first::<(i64, i64)>(conn)
+                .optional()?
+                .ok_or(StoredResourceError::ConversationProjectNotFound)?;
+
+            let prompt_length = user_instructions::table
+                .filter(user_instructions::user_id.eq(user_id))
+                .filter(user_instructions::project_id.eq(Some(project_id)))
+                .select(sql::<BigInt>("octet_length(prompt_enc)::bigint"))
+                .first::<i64>(conn)
+                .optional()?;
+
+            let mut measured_lengths = vec![name_length];
+            if let Some(prompt_length) = prompt_length {
+                measured_lengths.push(prompt_length);
+            }
+            let expected_lengths =
+                validate_ciphertext_plaintext_total(measured_lengths, logical_body_limit)?;
+
+            let project = conversation_projects::table
+                .filter(conversation_projects::id.eq(project_id))
+                .filter(conversation_projects::user_id.eq(user_id))
+                .select(ProjectCiphertextRow::as_select())
+                .first::<ProjectCiphertextRow>(conn)?;
+            if project.name_enc.len() != expected_lengths[0] {
+                return Err(StoredResourceError::InconsistentSnapshot);
+            }
+
+            let mut prompt_enc = user_instructions::table
+                .filter(user_instructions::user_id.eq(user_id))
+                .filter(user_instructions::project_id.eq(Some(project_id)))
+                .select(user_instructions::prompt_enc)
+                .first::<Vec<u8>>(conn)
+                .optional()?;
+            match (&prompt_enc, expected_lengths.get(1)) {
+                (None, None) => {}
+                (Some(prompt), Some(expected)) if prompt.len() == *expected => {}
+                _ => {
+                    if let Some(prompt) = prompt_enc.as_mut() {
+                        prompt.zeroize();
+                    }
+                    return Err(StoredResourceError::InconsistentSnapshot);
+                }
+            }
+
+            Ok(ProjectWithInstructionCiphertext {
+                project,
+                prompt_enc,
+            })
+        })
+}
+
+fn project_cursor(
+    conn: &mut PgConnection,
+    user_id: Uuid,
+    after: Option<Uuid>,
+) -> Result<Option<(DateTime<Utc>, i64)>, StoredResourceError> {
+    let Some(after) = after else {
+        return Ok(None);
+    };
+    conversation_projects::table
+        .filter(conversation_projects::uuid.eq(after))
+        .filter(conversation_projects::user_id.eq(user_id))
+        .select((conversation_projects::updated_at, conversation_projects::id))
+        .first::<(DateTime<Utc>, i64)>(conn)
+        .optional()
+        .map_err(StoredResourceError::Database)
+}
+
+fn project_measure_page(
+    conn: &mut PgConnection,
+    user_id: Uuid,
+    limit: i64,
+    cursor: Option<(DateTime<Utc>, i64)>,
+    order: &str,
+) -> Result<Vec<(Uuid, i64, i64)>, StoredResourceError> {
+    let mut query = conversation_projects::table
+        .filter(conversation_projects::user_id.eq(user_id))
+        .into_boxed();
+    if let Some((updated_at, id)) = cursor {
+        query = if order == "desc" {
+            query.filter(
+                conversation_projects::updated_at.lt(updated_at).or(
+                    conversation_projects::updated_at
+                        .eq(updated_at)
+                        .and(conversation_projects::id.lt(id)),
+                ),
+            )
+        } else {
+            query.filter(
+                conversation_projects::updated_at.gt(updated_at).or(
+                    conversation_projects::updated_at
+                        .eq(updated_at)
+                        .and(conversation_projects::id.gt(id)),
+                ),
+            )
+        };
+    }
+    query = if order == "desc" {
+        query.order((
+            conversation_projects::updated_at.desc(),
+            conversation_projects::id.desc(),
+        ))
+    } else {
+        query.order((
+            conversation_projects::updated_at.asc(),
+            conversation_projects::id.asc(),
+        ))
+    };
+    query
+        .select((
+            conversation_projects::uuid,
+            conversation_projects::id,
+            sql::<BigInt>("octet_length(name_enc)::bigint"),
+        ))
+        .limit(limit)
+        .load::<(Uuid, i64, i64)>(conn)
+        .map_err(StoredResourceError::Database)
+}
+
+fn project_fetch_page(
+    conn: &mut PgConnection,
+    user_id: Uuid,
+    limit: i64,
+    cursor: Option<(DateTime<Utc>, i64)>,
+    order: &str,
+) -> Result<Vec<ProjectCiphertextRow>, StoredResourceError> {
+    let mut query = conversation_projects::table
+        .filter(conversation_projects::user_id.eq(user_id))
+        .into_boxed();
+    if let Some((updated_at, id)) = cursor {
+        query = if order == "desc" {
+            query.filter(
+                conversation_projects::updated_at.lt(updated_at).or(
+                    conversation_projects::updated_at
+                        .eq(updated_at)
+                        .and(conversation_projects::id.lt(id)),
+                ),
+            )
+        } else {
+            query.filter(
+                conversation_projects::updated_at.gt(updated_at).or(
+                    conversation_projects::updated_at
+                        .eq(updated_at)
+                        .and(conversation_projects::id.gt(id)),
+                ),
+            )
+        };
+    }
+    query = if order == "desc" {
+        query.order((
+            conversation_projects::updated_at.desc(),
+            conversation_projects::id.desc(),
+        ))
+    } else {
+        query.order((
+            conversation_projects::updated_at.asc(),
+            conversation_projects::id.asc(),
+        ))
+    };
+    query
+        .select(ProjectCiphertextRow::as_select())
+        .limit(limit)
+        .load::<ProjectCiphertextRow>(conn)
+        .map_err(StoredResourceError::Database)
+}
+
+pub(crate) fn list_projects(
+    pool: &Pool,
+    user_id: Uuid,
+    limit: i64,
+    after: Option<Uuid>,
+    order: &str,
+    logical_body_limit: usize,
+) -> Result<(Vec<ProjectCiphertextRow>, bool), StoredResourceError> {
+    let mut conn = pool.get().map_err(|_| StoredResourceError::Connection)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, StoredResourceError, _>(|conn| {
+            let cursor = project_cursor(conn, user_id, after)?;
+            let sentinel_limit = limit
+                .checked_add(1)
+                .ok_or(StoredResourceError::OutputTooLarge)?;
+            let mut measured = project_measure_page(conn, user_id, sentinel_limit, cursor, order)?;
+            let has_more = measured.len()
+                > usize::try_from(limit).map_err(|_| StoredResourceError::OutputTooLarge)?;
+            if has_more {
+                measured.pop();
+            }
+            let expected_lengths = validate_ciphertext_plaintext_total(
+                measured.iter().map(|(_, _, length)| *length),
+                logical_body_limit,
+            )?;
+            let rows = project_fetch_page(conn, user_id, limit, cursor, order)?;
+            if rows.len() != measured.len() {
+                return Err(StoredResourceError::InconsistentSnapshot);
+            }
+            for ((row, (expected_uuid, expected_id, _)), expected_length) in
+                rows.iter().zip(measured.iter()).zip(expected_lengths)
+            {
+                if row.uuid != *expected_uuid
+                    || row.id != *expected_id
+                    || row.name_enc.len() != expected_length
+                {
+                    return Err(StoredResourceError::InconsistentSnapshot);
+                }
+            }
+            Ok((rows, has_more))
+        })
+}
+
+pub(crate) fn update_project(
+    pool: &Pool,
+    user_id: Uuid,
+    project_uuid: Uuid,
+    expected_updated_at: DateTime<Utc>,
+    name_enc: Option<Vec<u8>>,
+    instruction_update: ProjectInstructionUpdate,
+) -> Result<ProjectMutationMetadata, StoredResourceError> {
+    let mut conn = pool.get().map_err(|_| StoredResourceError::Connection)?;
+    conn.transaction::<_, StoredResourceError, _>(|conn| {
+        let (project_id, current_updated_at) = conversation_projects::table
+            .filter(conversation_projects::uuid.eq(project_uuid))
+            .filter(conversation_projects::user_id.eq(user_id))
+            .select((conversation_projects::id, conversation_projects::updated_at))
+            .for_update()
+            .first::<(i64, DateTime<Utc>)>(conn)
+            .optional()?
+            .ok_or(StoredResourceError::ConversationProjectNotFound)?;
+        if current_updated_at != expected_updated_at {
+            return Err(StoredResourceError::StaleResource);
+        }
+
+        if let Some(name_enc) = name_enc {
+            diesel::update(
+                conversation_projects::table
+                    .filter(conversation_projects::id.eq(project_id))
+                    .filter(conversation_projects::user_id.eq(user_id)),
+            )
+            .set((
+                conversation_projects::name_enc.eq(name_enc),
+                conversation_projects::updated_at.eq(diesel::dsl::now),
+            ))
+            .execute(conn)?;
+        }
+
+        match instruction_update {
+            ProjectInstructionUpdate::Unchanged => {}
+            ProjectInstructionUpdate::Set {
+                prompt_enc,
+                prompt_tokens,
+            } => {
+                let instruction_id = user_instructions::table
+                    .filter(user_instructions::user_id.eq(user_id))
+                    .filter(user_instructions::project_id.eq(Some(project_id)))
+                    .select(user_instructions::id)
+                    .for_update()
+                    .first::<i64>(conn)
+                    .optional()?;
+                if let Some(instruction_id) = instruction_id {
+                    diesel::update(
+                        user_instructions::table
+                            .filter(user_instructions::id.eq(instruction_id))
+                            .filter(user_instructions::user_id.eq(user_id)),
+                    )
+                    .set((
+                        user_instructions::prompt_enc.eq(prompt_enc),
+                        user_instructions::prompt_tokens.eq(prompt_tokens),
+                        user_instructions::is_default.eq(false),
+                        user_instructions::updated_at.eq(diesel::dsl::now),
+                    ))
+                    .execute(conn)?;
+                } else {
+                    diesel::insert_into(user_instructions::table)
+                        .values(&NewUserInstruction {
+                            uuid: Uuid::new_v4(),
+                            user_id,
+                            project_id: Some(project_id),
+                            name_enc: None,
+                            prompt_enc,
+                            prompt_tokens,
+                            is_default: false,
+                        })
+                        .execute(conn)?;
+                }
+                diesel::update(
+                    conversation_projects::table
+                        .filter(conversation_projects::id.eq(project_id))
+                        .filter(conversation_projects::user_id.eq(user_id)),
+                )
+                .set(conversation_projects::updated_at.eq(diesel::dsl::now))
+                .execute(conn)?;
+            }
+            ProjectInstructionUpdate::Clear => {
+                diesel::delete(
+                    user_instructions::table
+                        .filter(user_instructions::user_id.eq(user_id))
+                        .filter(user_instructions::project_id.eq(Some(project_id))),
+                )
+                .execute(conn)?;
+                diesel::update(
+                    conversation_projects::table
+                        .filter(conversation_projects::id.eq(project_id))
+                        .filter(conversation_projects::user_id.eq(user_id)),
+                )
+                .set(conversation_projects::updated_at.eq(diesel::dsl::now))
+                .execute(conn)?;
+            }
+        }
+
+        let (uuid, created_at, updated_at) = conversation_projects::table
+            .filter(conversation_projects::id.eq(project_id))
+            .filter(conversation_projects::user_id.eq(user_id))
+            .select((
+                conversation_projects::uuid,
+                conversation_projects::created_at,
+                conversation_projects::updated_at,
+            ))
+            .first::<(Uuid, DateTime<Utc>, DateTime<Utc>)>(conn)?;
+        Ok(ProjectMutationMetadata {
+            uuid,
+            created_at,
+            updated_at,
+        })
+    })
+}
+
+pub(crate) fn get_instruction(
+    pool: &Pool,
+    user_id: Uuid,
+    instruction_uuid: Uuid,
+    logical_body_limit: usize,
+) -> Result<InstructionCiphertextRow, StoredResourceError> {
+    let mut conn = pool.get().map_err(|_| StoredResourceError::Connection)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, StoredResourceError, _>(|conn| {
+            let measured = user_instructions::table
+                .filter(user_instructions::uuid.eq(instruction_uuid))
+                .filter(user_instructions::user_id.eq(user_id))
+                .filter(user_instructions::project_id.is_null())
+                .select((
+                    sql::<BigInt>("octet_length(name_enc)::bigint"),
+                    sql::<BigInt>("octet_length(prompt_enc)::bigint"),
+                ))
+                .first::<(i64, i64)>(conn)
+                .optional()?
+                .ok_or(StoredResourceError::InstructionNotFound)?;
+            let expected_lengths =
+                validate_ciphertext_plaintext_total([measured.0, measured.1], logical_body_limit)?;
+
+            let mut row = user_instructions::table
+                .filter(user_instructions::uuid.eq(instruction_uuid))
+                .filter(user_instructions::user_id.eq(user_id))
+                .filter(user_instructions::project_id.is_null())
+                .select(InstructionCiphertextRow::as_select())
+                .first::<InstructionCiphertextRow>(conn)?;
+            let Some(name) = row.name_enc.as_ref() else {
+                row.zeroize();
+                return Err(StoredResourceError::InconsistentSnapshot);
+            };
+            if name.len() != expected_lengths[0] || row.prompt_enc.len() != expected_lengths[1] {
+                row.zeroize();
+                return Err(StoredResourceError::InconsistentSnapshot);
+            }
+            Ok(row)
+        })
+}
+
+fn instruction_cursor(
+    conn: &mut PgConnection,
+    user_id: Uuid,
+    after: Option<Uuid>,
+) -> Result<Option<(DateTime<Utc>, i64)>, StoredResourceError> {
+    let Some(after) = after else {
+        return Ok(None);
+    };
+    user_instructions::table
+        .filter(user_instructions::uuid.eq(after))
+        .filter(user_instructions::user_id.eq(user_id))
+        .filter(user_instructions::project_id.is_null())
+        .select((user_instructions::updated_at, user_instructions::id))
+        .first::<(DateTime<Utc>, i64)>(conn)
+        .optional()
+        .map_err(StoredResourceError::Database)
+}
+
+fn instruction_measure_page(
+    conn: &mut PgConnection,
+    user_id: Uuid,
+    limit: i64,
+    cursor: Option<(DateTime<Utc>, i64)>,
+    order: &str,
+) -> Result<Vec<(Uuid, i64, i64, i64)>, StoredResourceError> {
+    let mut query = user_instructions::table
+        .filter(user_instructions::user_id.eq(user_id))
+        .filter(user_instructions::project_id.is_null())
+        .into_boxed();
+    if let Some((updated_at, id)) = cursor {
+        query = if order == "desc" {
+            query.filter(
+                user_instructions::updated_at
+                    .lt(updated_at)
+                    .or(user_instructions::updated_at
+                        .eq(updated_at)
+                        .and(user_instructions::id.lt(id))),
+            )
+        } else {
+            query.filter(
+                user_instructions::updated_at
+                    .gt(updated_at)
+                    .or(user_instructions::updated_at
+                        .eq(updated_at)
+                        .and(user_instructions::id.gt(id))),
+            )
+        };
+    }
+    query = if order == "desc" {
+        query.order((
+            user_instructions::updated_at.desc(),
+            user_instructions::id.desc(),
+        ))
+    } else {
+        query.order((
+            user_instructions::updated_at.asc(),
+            user_instructions::id.asc(),
+        ))
+    };
+    query
+        .select((
+            user_instructions::uuid,
+            user_instructions::id,
+            sql::<BigInt>("octet_length(name_enc)::bigint"),
+            sql::<BigInt>("octet_length(prompt_enc)::bigint"),
+        ))
+        .limit(limit)
+        .load::<(Uuid, i64, i64, i64)>(conn)
+        .map_err(StoredResourceError::Database)
+}
+
+fn instruction_fetch_page(
+    conn: &mut PgConnection,
+    user_id: Uuid,
+    limit: i64,
+    cursor: Option<(DateTime<Utc>, i64)>,
+    order: &str,
+) -> Result<Vec<InstructionCiphertextRow>, StoredResourceError> {
+    let mut query = user_instructions::table
+        .filter(user_instructions::user_id.eq(user_id))
+        .filter(user_instructions::project_id.is_null())
+        .into_boxed();
+    if let Some((updated_at, id)) = cursor {
+        query = if order == "desc" {
+            query.filter(
+                user_instructions::updated_at
+                    .lt(updated_at)
+                    .or(user_instructions::updated_at
+                        .eq(updated_at)
+                        .and(user_instructions::id.lt(id))),
+            )
+        } else {
+            query.filter(
+                user_instructions::updated_at
+                    .gt(updated_at)
+                    .or(user_instructions::updated_at
+                        .eq(updated_at)
+                        .and(user_instructions::id.gt(id))),
+            )
+        };
+    }
+    query = if order == "desc" {
+        query.order((
+            user_instructions::updated_at.desc(),
+            user_instructions::id.desc(),
+        ))
+    } else {
+        query.order((
+            user_instructions::updated_at.asc(),
+            user_instructions::id.asc(),
+        ))
+    };
+    query
+        .select(InstructionCiphertextRow::as_select())
+        .limit(limit)
+        .load::<InstructionCiphertextRow>(conn)
+        .map_err(StoredResourceError::Database)
+}
+
+pub(crate) fn list_instructions(
+    pool: &Pool,
+    user_id: Uuid,
+    limit: i64,
+    after: Option<Uuid>,
+    order: &str,
+    logical_body_limit: usize,
+) -> Result<(Vec<InstructionCiphertextRow>, bool), StoredResourceError> {
+    let mut conn = pool.get().map_err(|_| StoredResourceError::Connection)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, StoredResourceError, _>(|conn| {
+            let cursor = instruction_cursor(conn, user_id, after)?;
+            let sentinel_limit = limit
+                .checked_add(1)
+                .ok_or(StoredResourceError::OutputTooLarge)?;
+            let mut measured =
+                instruction_measure_page(conn, user_id, sentinel_limit, cursor, order)?;
+            let has_more = measured.len()
+                > usize::try_from(limit).map_err(|_| StoredResourceError::OutputTooLarge)?;
+            if has_more {
+                measured.pop();
+            }
+            let expected_lengths = validate_ciphertext_plaintext_total(
+                measured
+                    .iter()
+                    .flat_map(|(_, _, name_length, prompt_length)| [*name_length, *prompt_length]),
+                logical_body_limit,
+            )?;
+            let mut rows = instruction_fetch_page(conn, user_id, limit, cursor, order)?;
+            if rows.len() != measured.len() {
+                rows.zeroize();
+                return Err(StoredResourceError::InconsistentSnapshot);
+            }
+            for (index, (row, (expected_uuid, expected_id, _, _))) in
+                rows.iter().zip(measured.iter()).enumerate()
+            {
+                let Some(name) = row.name_enc.as_ref() else {
+                    rows.zeroize();
+                    return Err(StoredResourceError::InconsistentSnapshot);
+                };
+                if row.uuid != *expected_uuid
+                    || row.id != *expected_id
+                    || name.len() != expected_lengths[index * 2]
+                    || row.prompt_enc.len() != expected_lengths[index * 2 + 1]
+                {
+                    rows.zeroize();
+                    return Err(StoredResourceError::InconsistentSnapshot);
+                }
+            }
+            Ok((rows, has_more))
+        })
+}
+
+pub(crate) fn update_instruction(
+    pool: &Pool,
+    user_id: Uuid,
+    instruction_uuid: Uuid,
+    expected_updated_at: DateTime<Utc>,
+    update: InstructionUpdateCiphertext,
+) -> Result<InstructionMutationMetadata, StoredResourceError> {
+    let mut conn = pool.get().map_err(|_| StoredResourceError::Connection)?;
+    conn.transaction::<_, StoredResourceError, _>(|conn| {
+        let (instruction_id, current_updated_at) = user_instructions::table
+            .filter(user_instructions::uuid.eq(instruction_uuid))
+            .filter(user_instructions::user_id.eq(user_id))
+            .filter(user_instructions::project_id.is_null())
+            .select((user_instructions::id, user_instructions::updated_at))
+            .for_update()
+            .first::<(i64, DateTime<Utc>)>(conn)
+            .optional()?
+            .ok_or(StoredResourceError::InstructionNotFound)?;
+        if current_updated_at != expected_updated_at {
+            return Err(StoredResourceError::StaleResource);
+        }
+        if update.is_default {
+            diesel::update(
+                user_instructions::table
+                    .filter(user_instructions::user_id.eq(user_id))
+                    .filter(user_instructions::project_id.is_null())
+                    .filter(user_instructions::is_default.eq(true))
+                    .filter(user_instructions::id.ne(instruction_id)),
+            )
+            .set(user_instructions::is_default.eq(false))
+            .execute(conn)?;
+        }
+        let (uuid, prompt_tokens, is_default, created_at, updated_at) = diesel::update(
+            user_instructions::table
+                .filter(user_instructions::id.eq(instruction_id))
+                .filter(user_instructions::user_id.eq(user_id))
+                .filter(user_instructions::project_id.is_null()),
+        )
+        .set((
+            user_instructions::name_enc.eq(Some(update.name_enc)),
+            user_instructions::prompt_enc.eq(update.prompt_enc),
+            user_instructions::prompt_tokens.eq(update.prompt_tokens),
+            user_instructions::is_default.eq(update.is_default),
+            user_instructions::updated_at.eq(diesel::dsl::now),
+        ))
+        .returning((
+            user_instructions::uuid,
+            user_instructions::prompt_tokens,
+            user_instructions::is_default,
+            user_instructions::created_at,
+            user_instructions::updated_at,
+        ))
+        .get_result::<(Uuid, i32, bool, DateTime<Utc>, DateTime<Utc>)>(conn)?;
+        Ok(InstructionMutationMetadata {
+            uuid,
+            prompt_tokens,
+            is_default,
+            created_at,
+            updated_at,
+        })
+    })
+    .map_err(map_default_instruction_conflict)
+}
+
+pub(crate) fn set_default_instruction(
+    pool: &Pool,
+    user_id: Uuid,
+    instruction_uuid: Uuid,
+    expected_updated_at: DateTime<Utc>,
+) -> Result<InstructionMutationMetadata, StoredResourceError> {
+    let mut conn = pool.get().map_err(|_| StoredResourceError::Connection)?;
+    conn.transaction::<_, StoredResourceError, _>(|conn| {
+        let (instruction_id, current_is_default, current_updated_at) = user_instructions::table
+            .filter(user_instructions::uuid.eq(instruction_uuid))
+            .filter(user_instructions::user_id.eq(user_id))
+            .filter(user_instructions::project_id.is_null())
+            .select((
+                user_instructions::id,
+                user_instructions::is_default,
+                user_instructions::updated_at,
+            ))
+            .for_update()
+            .first::<(i64, bool, DateTime<Utc>)>(conn)
+            .optional()?
+            .ok_or(StoredResourceError::InstructionNotFound)?;
+        if current_updated_at != expected_updated_at {
+            return Err(StoredResourceError::StaleResource);
+        }
+        let (uuid, prompt_tokens, is_default, created_at, updated_at) = if current_is_default {
+            user_instructions::table
+                .filter(user_instructions::id.eq(instruction_id))
+                .select((
+                    user_instructions::uuid,
+                    user_instructions::prompt_tokens,
+                    user_instructions::is_default,
+                    user_instructions::created_at,
+                    user_instructions::updated_at,
+                ))
+                .first::<(Uuid, i32, bool, DateTime<Utc>, DateTime<Utc>)>(conn)?
+        } else {
+            diesel::update(
+                user_instructions::table
+                    .filter(user_instructions::user_id.eq(user_id))
+                    .filter(user_instructions::project_id.is_null())
+                    .filter(user_instructions::is_default.eq(true)),
+            )
+            .set(user_instructions::is_default.eq(false))
+            .execute(conn)?;
+            diesel::update(
+                user_instructions::table
+                    .filter(user_instructions::id.eq(instruction_id))
+                    .filter(user_instructions::user_id.eq(user_id))
+                    .filter(user_instructions::project_id.is_null()),
+            )
+            .set((
+                user_instructions::is_default.eq(true),
+                user_instructions::updated_at.eq(diesel::dsl::now),
+            ))
+            .returning((
+                user_instructions::uuid,
+                user_instructions::prompt_tokens,
+                user_instructions::is_default,
+                user_instructions::created_at,
+                user_instructions::updated_at,
+            ))
+            .get_result::<(Uuid, i32, bool, DateTime<Utc>, DateTime<Utc>)>(conn)?
+        };
+        Ok(InstructionMutationMetadata {
+            uuid,
+            prompt_tokens,
+            is_default,
+            created_at,
+            updated_at,
+        })
+    })
+    .map_err(map_default_instruction_conflict)
+}
+
+pub(crate) fn delete_instruction(
+    pool: &Pool,
+    user_id: Uuid,
+    instruction_uuid: Uuid,
+) -> Result<Uuid, StoredResourceError> {
+    let mut conn = pool.get().map_err(|_| StoredResourceError::Connection)?;
+    diesel::delete(
+        user_instructions::table
+            .filter(user_instructions::uuid.eq(instruction_uuid))
+            .filter(user_instructions::user_id.eq(user_id))
+            .filter(user_instructions::project_id.is_null()),
+    )
+    .returning(user_instructions::uuid)
+    .get_result::<Uuid>(&mut conn)
+    .optional()?
+    .ok_or(StoredResourceError::InstructionNotFound)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ciphertext_preflight_accounts_for_storage_overhead() {
+        assert_eq!(
+            validate_ciphertext_plaintext_total([28, 31], 3).unwrap(),
+            vec![28, 31]
+        );
+        assert!(matches!(
+            validate_ciphertext_plaintext_total([28, 32], 3),
+            Err(StoredResourceError::OutputTooLarge)
+        ));
+        assert!(matches!(
+            validate_ciphertext_plaintext_total([27], usize::MAX),
+            Err(StoredResourceError::InconsistentSnapshot)
+        ));
+        assert!(matches!(
+            validate_ciphertext_plaintext_total([-1], usize::MAX),
+            Err(StoredResourceError::InconsistentSnapshot)
+        ));
+    }
+}

--- a/src/web/responses/conversation_projects.rs
+++ b/src/web/responses/conversation_projects.rs
@@ -30,6 +30,7 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::debug;
 use uuid::Uuid;
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 struct ConversationProjectContext {
     project: crate::models::responses::ConversationProject,
@@ -63,7 +64,7 @@ impl ConversationProjectContext {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, Zeroize, ZeroizeOnDrop)]
 pub struct CreateConversationProjectRequest {
     pub name: String,
 }
@@ -76,13 +77,17 @@ pub struct UpdateConversationProjectRequest {
     pub instructions: NullableField<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Zeroize, ZeroizeOnDrop)]
 pub struct ConversationProjectResponse {
+    #[zeroize(skip)]
     pub id: Uuid,
+    #[zeroize(skip)]
     pub object: &'static str,
     pub name: String,
     pub instructions: Option<String>,
+    #[zeroize(skip)]
     pub created_at: i64,
+    #[zeroize(skip)]
     pub updated_at: i64,
 }
 
@@ -121,7 +126,7 @@ fn default_order() -> String {
     DEFAULT_PAGINATION_ORDER.to_string()
 }
 
-fn validate_project_name(name: &str) -> Result<String, ApiError> {
+pub(crate) fn validate_project_name(name: &str) -> Result<String, ApiError> {
     let trimmed = name.trim();
     if trimmed.is_empty() {
         Err(ApiError::BadRequest)
@@ -164,9 +169,28 @@ async fn create_conversation_project(
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<CreateConversationProjectRequest>,
 ) -> Result<Json<EncryptedResponse<ConversationProjectResponse>>, ApiError> {
-    let name = validate_project_name(&body.name)?;
+    let response = create_conversation_project_data(&state, &user, &auth_context, body).await?;
+    encrypt_response(&state, &session_id, &response).await
+}
+
+pub(crate) async fn create_conversation_project_data(
+    state: &AppState,
+    user: &User,
+    auth_context: &AuthContext,
+    body: CreateConversationProjectRequest,
+) -> Result<ConversationProjectResponse, ApiError> {
+    let name = Zeroizing::new(validate_project_name(&body.name)?);
+    create_conversation_project_with_name_data(state, user, auth_context, name).await
+}
+
+pub(crate) async fn create_conversation_project_with_name_data(
+    state: &AppState,
+    user: &User,
+    auth_context: &AuthContext,
+    mut name: Zeroizing<String>,
+) -> Result<ConversationProjectResponse, ApiError> {
     let user_key = state
-        .get_user_key(&user, &auth_context, None, None)
+        .get_user_key(user, auth_context, None, None)
         .await
         .map_err(|_| error_mapping::map_key_retrieval_error())?;
 
@@ -179,8 +203,11 @@ async fn create_conversation_project(
         })
         .map_err(error_mapping::map_conversation_project_error)?;
 
-    let response = build_project_response(&project, name, None);
-    encrypt_response(&state, &session_id, &response).await
+    Ok(build_project_response(
+        &project,
+        std::mem::take(&mut *name),
+        None,
+    ))
 }
 
 async fn list_conversation_projects(
@@ -326,6 +353,16 @@ async fn delete_conversation_project(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
 ) -> Result<Json<EncryptedResponse<DeletedObjectResponse>>, ApiError> {
+    delete_conversation_project_data(&state, &user, project_id)?;
+    let response = DeletedObjectResponse::conversation_project(project_id);
+    encrypt_response(&state, &session_id, &response).await
+}
+
+pub(crate) fn delete_conversation_project_data(
+    state: &AppState,
+    user: &User,
+    project_id: Uuid,
+) -> Result<(), ApiError> {
     debug!(
         "Deleting conversation project {} for user {}",
         project_id, user.uuid
@@ -341,8 +378,20 @@ async fn delete_conversation_project(
         .delete_conversation_project(project.id, user.uuid)
         .map_err(error_mapping::map_conversation_project_error)?;
 
-    let response = DeletedObjectResponse::conversation_project(project.uuid);
-    encrypt_response(&state, &session_id, &response).await
+    Ok(())
+}
+
+pub(crate) fn delete_conversation_project_by_uuid_data(
+    state: &AppState,
+    user: &User,
+    project_id: Uuid,
+) -> Result<(), ApiError> {
+    let deleted_project_id = state
+        .db
+        .delete_conversation_project_by_uuid_and_user(project_id, user.uuid)
+        .map_err(error_mapping::map_conversation_project_error)?;
+    debug_assert_eq!(deleted_project_id, project_id);
+    Ok(())
 }
 
 pub fn router(state: Arc<AppState>) -> Router {

--- a/src/web/responses/conversation_projects.rs
+++ b/src/web/responses/conversation_projects.rs
@@ -69,7 +69,7 @@ pub struct CreateConversationProjectRequest {
     pub name: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Zeroize, ZeroizeOnDrop)]
 pub struct UpdateConversationProjectRequest {
     #[serde(default)]
     pub name: Option<String>,
@@ -91,21 +91,29 @@ pub struct ConversationProjectResponse {
     pub updated_at: i64,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Zeroize, ZeroizeOnDrop)]
 pub struct ConversationProjectListItem {
+    #[zeroize(skip)]
     pub id: Uuid,
+    #[zeroize(skip)]
     pub object: &'static str,
     pub name: String,
+    #[zeroize(skip)]
     pub created_at: i64,
+    #[zeroize(skip)]
     pub updated_at: i64,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Zeroize, ZeroizeOnDrop)]
 pub struct ConversationProjectListResponse {
+    #[zeroize(skip)]
     pub object: &'static str,
     pub data: Vec<ConversationProjectListItem>,
+    #[zeroize(skip)]
     pub has_more: bool,
+    #[zeroize(skip)]
     pub first_id: Option<Uuid>,
+    #[zeroize(skip)]
     pub last_id: Option<Uuid>,
 }
 

--- a/src/web/responses/instructions.rs
+++ b/src/web/responses/instructions.rs
@@ -32,6 +32,7 @@ use std::sync::Arc;
 use tracing::warn;
 use tracing::{debug, error, trace};
 use uuid::Uuid;
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 // ============================================================================
 // Context Helper
@@ -116,7 +117,7 @@ impl InstructionContext {
 // ============================================================================
 
 /// Request to create a new user instruction
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, Zeroize, ZeroizeOnDrop)]
 pub struct CreateInstructionRequest {
     /// Name of the instruction
     pub name: String,
@@ -126,11 +127,12 @@ pub struct CreateInstructionRequest {
 
     /// Whether this should be the default instruction
     #[serde(default)]
+    #[zeroize(skip)]
     pub is_default: bool,
 }
 
 /// Request to update a user instruction
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, Zeroize, ZeroizeOnDrop)]
 pub struct UpdateInstructionRequest {
     /// Updated name (optional)
     pub name: Option<String>,
@@ -139,16 +141,19 @@ pub struct UpdateInstructionRequest {
     pub prompt: Option<String>,
 
     /// Whether this should be the default instruction (optional)
+    #[zeroize(skip)]
     pub is_default: Option<bool>,
 }
 
 /// Response for a user instruction object
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Zeroize, ZeroizeOnDrop)]
 pub struct InstructionResponse {
     /// Instruction ID
+    #[zeroize(skip)]
     pub id: Uuid,
 
     /// Object type (always "instruction")
+    #[zeroize(skip)]
     pub object: &'static str,
 
     /// Name of the instruction
@@ -158,25 +163,33 @@ pub struct InstructionResponse {
     pub prompt: String,
 
     /// Token count for the prompt
+    #[zeroize(skip)]
     pub prompt_tokens: i32,
 
     /// Whether this is the default instruction
+    #[zeroize(skip)]
     pub is_default: bool,
 
     /// Unix timestamp when created
+    #[zeroize(skip)]
     pub created_at: i64,
 
     /// Unix timestamp when last updated
+    #[zeroize(skip)]
     pub updated_at: i64,
 }
 
 /// Response for listing user instructions
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Zeroize, ZeroizeOnDrop)]
 pub struct InstructionListResponse {
+    #[zeroize(skip)]
     pub object: &'static str,
     pub data: Vec<InstructionResponse>,
+    #[zeroize(skip)]
     pub has_more: bool,
+    #[zeroize(skip)]
     pub first_id: Option<Uuid>,
+    #[zeroize(skip)]
     pub last_id: Option<Uuid>,
 }
 
@@ -252,29 +265,52 @@ async fn create_instruction(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(body): Extension<CreateInstructionRequest>,
+    Extension(mut body): Extension<CreateInstructionRequest>,
 ) -> Result<Json<EncryptedResponse<InstructionResponse>>, ApiError> {
     debug!("Creating new instruction for user: {}", user.uuid);
+    validate_instruction_content(&body.name, &body.prompt)?;
+    let name = Zeroizing::new(std::mem::take(&mut body.name));
+    let prompt = Zeroizing::new(std::mem::take(&mut body.prompt));
+    let response = create_instruction_with_content_data(
+        &state,
+        &user,
+        &auth_context,
+        name,
+        prompt,
+        body.is_default,
+    )
+    .await?;
+    encrypt_response(&state, &session_id, &response).await
+}
 
-    // Validate input
-    if body.name.trim().is_empty() {
+pub(crate) fn validate_instruction_content(name: &str, prompt: &str) -> Result<(), ApiError> {
+    if name.trim().is_empty() {
         error!("Empty instruction name provided");
         return Err(ApiError::BadRequest);
     }
-
-    if body.prompt.trim().is_empty() {
+    if prompt.trim().is_empty() {
         error!("Empty instruction prompt provided");
         return Err(ApiError::BadRequest);
     }
+    Ok(())
+}
 
+pub(crate) async fn create_instruction_with_content_data(
+    state: &AppState,
+    user: &User,
+    auth_context: &AuthContext,
+    mut name: Zeroizing<String>,
+    mut prompt: Zeroizing<String>,
+    is_default: bool,
+) -> Result<InstructionResponse, ApiError> {
     // Get user's encryption key
     let user_key = state
-        .get_user_key(&user, &auth_context, None, None)
+        .get_user_key(user, auth_context, None, None)
         .await
         .map_err(|_| error_mapping::map_key_retrieval_error())?;
 
     // Count tokens for the prompt
-    let token_count = count_tokens(&body.prompt);
+    let token_count = count_tokens(&prompt);
     let prompt_tokens = if token_count > i32::MAX as usize {
         warn!(
             "Prompt token count {} exceeds i32::MAX, clamping to i32::MAX",
@@ -286,8 +322,8 @@ async fn create_instruction(
     };
 
     // Encrypt name and prompt
-    let name_enc = encrypt_with_key(&user_key, body.name.as_bytes()).await;
-    let prompt_enc = encrypt_with_key(&user_key, body.prompt.as_bytes()).await;
+    let name_enc = encrypt_with_key(&user_key, name.as_bytes()).await;
+    let prompt_enc = encrypt_with_key(&user_key, prompt.as_bytes()).await;
 
     let new_instruction = NewUserInstruction {
         uuid: Uuid::new_v4(),
@@ -296,7 +332,7 @@ async fn create_instruction(
         name_enc: Some(name_enc),
         prompt_enc,
         prompt_tokens,
-        is_default: body.is_default,
+        is_default,
     };
 
     trace!("Creating instruction with: {:?}", new_instruction);
@@ -308,12 +344,16 @@ async fn create_instruction(
 
     trace!("Created instruction: {:?}", instruction);
 
-    let response = InstructionResponseBuilder::new(instruction)
-        .name(body.name.clone())
-        .prompt(body.prompt.clone())
-        .build();
-
-    encrypt_response(&state, &session_id, &response).await
+    Ok(InstructionResponse {
+        id: instruction.uuid,
+        object: "instruction",
+        name: std::mem::take(&mut *name),
+        prompt: std::mem::take(&mut *prompt),
+        prompt_tokens: instruction.prompt_tokens,
+        is_default: instruction.is_default,
+        created_at: instruction.created_at.timestamp(),
+        updated_at: instruction.updated_at.timestamp(),
+    })
 }
 
 /// GET /v1/instructions/{id} - Retrieve a single user instruction

--- a/src/web/responses/types.rs
+++ b/src/web/responses/types.rs
@@ -4,6 +4,7 @@
 //! to represent message content in various formats.
 
 use serde::{Deserialize, Deserializer, Serialize};
+use zeroize::Zeroize;
 
 // ============================================================================
 // Message Content Types (Input)
@@ -80,6 +81,15 @@ impl<T> Default for NullableField<T> {
 impl<T> NullableField<T> {
     pub fn is_missing(&self) -> bool {
         matches!(self, Self::Missing)
+    }
+}
+
+impl<T: Zeroize> Zeroize for NullableField<T> {
+    fn zeroize(&mut self) {
+        if let Self::Value(value) = self {
+            value.zeroize();
+        }
+        *self = Self::Missing;
     }
 }
 


### PR DESCRIPTION
## Summary

- project the complete conversation-project and general-instruction route families through the isolated transport-v2 application boundary
- add v2-only, owner-scoped storage projections that preflight encrypted stored output before narrow ciphertext reads
- preserve canonical paths, pagination quirks, nullable update semantics, default-instruction behavior, replay admission, and exact-session response encryption
- reject stale project and instruction mutations with encrypted conflicts and keep default changes transactional
- retain existing transport-v1 routes and wire behavior unchanged

## Security properties

- project and instruction reads are scoped to the bound user; general instructions additionally require a null project ID
- stored responses reserve the conservative 200 MiB output permit before replay claim and dispatch
- list lookahead rows carry metadata only and are excluded before ciphertext sizing and fetch
- plaintext and ciphertext holders zeroize on drop, including intermediate decrypted byte buffers
- project and instruction mutations preflight their response before side effects and use updated-at compare-and-swap checks

## Validation

- cargo fmt --all -- --check
- cargo clippy --locked --all-targets --all-features -- -D warnings
- cargo test --locked --all-features: 553 passed, 29 ignored
- disposable PostgreSQL project/instruction integration tests: 2 passed