### PR TITLE
Add v2 conversations and stored response controls

### DIFF
--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -22,6 +22,7 @@ use crate::jwt::{
     issue_transport_v2_user_tokens, validate_transport_v2_user_resumption, AuthContext,
 };
 use crate::kv::StoreError;
+use crate::models::responses::{ConversationProjectFilter, NewConversation, ResponseStatus};
 use crate::tokens::count_tokens;
 use crate::web::login_routes::{
     authenticate_login, logout_data, register_and_authenticate, verify_email_data, AuthResponse,
@@ -38,10 +39,18 @@ use crate::web::protected_routes::{
     InitiateAccountDeletionRequest, KvValue, PublicKeyQuery, SignMessageRequest,
     ThirdPartyTokenRequest,
 };
+use crate::web::responses::conversions::ReasoningContentItem;
+use crate::web::responses::handlers::{
+    ContentPart, InputTokenDetails, OutputItem, OutputTokenDetails, ResponseUsage,
+    ResponsesRetrieveResponse,
+};
+use crate::web::responses::types::ConversationContent;
 use crate::web::responses::{
     constants::{
-        DEFAULT_PAGINATION_LIMIT, MAX_PAGINATION_LIMIT, OBJECT_TYPE_CONVERSATION_PROJECT,
-        OBJECT_TYPE_LIST,
+        DEFAULT_PAGINATION_LIMIT, DEFAULT_TOOL_FUNCTION_NAME, MAX_PAGINATION_LIMIT,
+        OBJECT_TYPE_CONVERSATION, OBJECT_TYPE_CONVERSATION_DELETED,
+        OBJECT_TYPE_CONVERSATION_PROJECT, OBJECT_TYPE_LIST, OBJECT_TYPE_LIST_DELETED,
+        OBJECT_TYPE_RESPONSE, ROLE_ASSISTANT, ROLE_USER, STATUS_CANCELLED, STATUS_COMPLETED,
     },
     conversation_projects::{
         create_conversation_project_with_name_data, delete_conversation_project_by_uuid_data,
@@ -49,26 +58,37 @@ use crate::web::responses::{
         ConversationProjectResponse, CreateConversationProjectRequest,
         ListConversationProjectsParams, UpdateConversationProjectRequest,
     },
+    conversations::{
+        validate_metadata, BatchDeleteConversationsRequest, BatchDeleteConversationsResponse,
+        BatchDeleteItemResult, BatchUpdateConversationProjectRequest,
+        BatchUpdateConversationProjectResponse, ConversationItemListResponse,
+        ConversationListResponse, ConversationResponse, CreateConversationRequest,
+        ListConversationsParams, ListItemsParams, UpdateConversationRequest,
+        MAX_CONVERSATION_BATCH_SIZE,
+    },
     instructions::{
         create_instruction_with_content_data, validate_instruction_content,
         CreateInstructionRequest, InstructionListResponse, InstructionResponse,
         ListInstructionsParams, UpdateInstructionRequest,
     },
-    DeletedObjectResponse, NullableField,
+    ConversationItem, DeletedObjectResponse, MessageContent, NullableField,
 };
 use crate::{ApiError, AppState, VerifiedUserAuthentication};
 
 use super::envelope::{
-    decode_canonical_api_key_name_path, decode_canonical_conversation_project_path,
-    decode_canonical_instruction_path, decode_canonical_kv_item_path,
-    decode_canonical_verify_email_path, Credential, EncodedBytes, EnvelopeLimits, HeaderField,
-    InstructionItemPath, LogicalMethod, RequestEnvelope, RequestId, ResponseMode,
+    decode_canonical_api_key_name_path, decode_canonical_conversation_path,
+    decode_canonical_conversation_project_path, decode_canonical_instruction_path,
+    decode_canonical_kv_item_path, decode_canonical_response_path,
+    decode_canonical_verify_email_path, ConversationItemPath, Credential, EncodedBytes,
+    EnvelopeLimits, HeaderField, InstructionItemPath, LogicalMethod, RequestEnvelope, RequestId,
+    ResponseItemPath, ResponseMode,
 };
 use super::session::{
     AuthenticationReservation, AuthenticationStartError, AuthorityState, BoundAuthority,
     BoundPrincipal,
 };
 use super::session_cache::V2SessionLease;
+use super::stored_conversations::{self, ProjectAssignmentUpdate, StoredConversationError};
 use super::stored_resources::{self, StoredResourceError};
 
 const JSON_CONTENT_TYPE: &[u8] = b"application/json";
@@ -80,8 +100,16 @@ const MAX_ENCRYPTION_PLAINTEXT_BYTES: usize =
     (MAX_ENCRYPTED_DATA_BASE64_BYTES / 4) * 3 - AES_GCM_NONCE_AND_TAG_BYTES;
 const MAX_V2_KV_LIST_ROWS: usize = 65_536;
 const MAX_V2_API_KEY_LIST_ROWS: usize = 65_536;
+const MAX_CONVERSATION_JSON_DEPTH: usize = 64;
+const MAX_CONVERSATION_JSON_STRUCTURAL_TOKENS: usize = 131_072;
 
 type SensitiveBytes = Zeroizing<Vec<u8>>;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum JsonShapeError {
+    TooLarge,
+    Malformed,
+}
 
 pub(crate) enum OperationPreparation {
     Unsupported,
@@ -193,6 +221,46 @@ pub(crate) enum ProtectedUserOperation {
     SetDefaultInstruction {
         instruction_id: uuid::Uuid,
     },
+    CreateConversation {
+        body: SensitiveBytes,
+    },
+    ListConversations {
+        query: Option<String>,
+    },
+    GetConversation {
+        conversation_id: uuid::Uuid,
+    },
+    UpdateConversation {
+        conversation_id: uuid::Uuid,
+        body: SensitiveBytes,
+    },
+    DeleteConversation {
+        conversation_id: uuid::Uuid,
+    },
+    DeleteAllConversations,
+    BatchDeleteConversations {
+        body: SensitiveBytes,
+    },
+    BatchUpdateConversationProject {
+        body: SensitiveBytes,
+    },
+    ListConversationItems {
+        conversation_id: uuid::Uuid,
+        query: Option<String>,
+    },
+    GetConversationItem {
+        conversation_id: uuid::Uuid,
+        item_id: uuid::Uuid,
+    },
+    GetStoredResponse {
+        response_id: uuid::Uuid,
+    },
+    CancelStoredResponse {
+        response_id: uuid::Uuid,
+    },
+    DeleteStoredResponse {
+        response_id: uuid::Uuid,
+    },
     RequestAccountDeletion {
         body: SensitiveBytes,
     },
@@ -239,7 +307,14 @@ impl UserOperation {
                     | ProtectedUserOperation::ListInstructions { .. }
                     | ProtectedUserOperation::GetInstruction { .. }
                     | ProtectedUserOperation::UpdateInstruction { .. }
-                    | ProtectedUserOperation::SetDefaultInstruction { .. },
+                    | ProtectedUserOperation::SetDefaultInstruction { .. }
+                    | ProtectedUserOperation::ListConversations { .. }
+                    | ProtectedUserOperation::GetConversation { .. }
+                    | ProtectedUserOperation::UpdateConversation { .. }
+                    | ProtectedUserOperation::ListConversationItems { .. }
+                    | ProtectedUserOperation::GetConversationItem { .. }
+                    | ProtectedUserOperation::GetStoredResponse { .. }
+                    | ProtectedUserOperation::CancelStoredResponse { .. },
                 ..
             }
         )
@@ -280,6 +355,28 @@ struct InstructionResponsePreflight<'a> {
     is_default: bool,
     created_at: i64,
     updated_at: i64,
+}
+
+#[derive(Serialize)]
+struct ConversationResponsePreflight<'a> {
+    id: uuid::Uuid,
+    object: &'static str,
+    metadata: Option<&'a serde_json::Value>,
+    project_id: Option<uuid::Uuid>,
+    pinned: bool,
+    created_at: i64,
+    last_activity_at: i64,
+}
+
+#[derive(Serialize)]
+struct CancelledResponsePreflight<'a> {
+    id: uuid::Uuid,
+    object: &'static str,
+    created_at: i64,
+    status: &'static str,
+    model: &'a str,
+    usage: Option<serde_json::Value>,
+    output: &'static [serde_json::Value],
 }
 
 fn preflight_conversation_project_creation_response(name: &str) -> Result<(), ApiError> {
@@ -355,6 +452,57 @@ fn preflight_instruction_response_with_limit(
     };
     let response =
         LogicalUnaryResponse::json_with_limit(StatusCode::OK, &candidate, logical_body_bytes)?;
+    drop(response);
+    Ok(())
+}
+
+fn preflight_conversation_response(
+    metadata: Option<&serde_json::Value>,
+    project_id: Option<uuid::Uuid>,
+    pinned: bool,
+) -> Result<(), ApiError> {
+    let candidate = ConversationResponsePreflight {
+        id: uuid::Uuid::nil(),
+        object: OBJECT_TYPE_CONVERSATION,
+        metadata,
+        project_id,
+        pinned,
+        created_at: i64::MIN,
+        last_activity_at: i64::MIN,
+    };
+    let response = LogicalUnaryResponse::json(StatusCode::OK, &candidate)?;
+    drop(response);
+    Ok(())
+}
+
+fn preflight_batch_delete_conversations_response() -> Result<(), ApiError> {
+    let candidate = BatchDeleteConversationsResponse {
+        object: OBJECT_TYPE_LIST,
+        data: (0..MAX_CONVERSATION_BATCH_SIZE)
+            .map(|_| BatchDeleteItemResult {
+                id: uuid::Uuid::nil(),
+                object: OBJECT_TYPE_CONVERSATION_DELETED,
+                deleted: false,
+                error: Some("delete_failed"),
+            })
+            .collect(),
+    };
+    let response = LogicalUnaryResponse::json(StatusCode::OK, &candidate)?;
+    drop(response);
+    Ok(())
+}
+
+fn preflight_cancelled_response(model: &str) -> Result<(), ApiError> {
+    let candidate = CancelledResponsePreflight {
+        id: uuid::Uuid::nil(),
+        object: OBJECT_TYPE_RESPONSE,
+        created_at: i64::MIN,
+        status: STATUS_CANCELLED,
+        model,
+        usage: None,
+        output: &[],
+    };
+    let response = LogicalUnaryResponse::json(StatusCode::OK, &candidate)?;
     drop(response);
     Ok(())
 }
@@ -509,6 +657,19 @@ pub(crate) fn prepare_user_operation(
         UpdateInstruction,
         DeleteInstruction,
         SetDefaultInstruction,
+        CreateConversation,
+        ListConversations,
+        GetConversation,
+        UpdateConversation,
+        DeleteConversation,
+        DeleteAllConversations,
+        BatchDeleteConversations,
+        BatchUpdateConversationProject,
+        ListConversationItems,
+        GetConversationItem,
+        GetStoredResponse,
+        CancelStoredResponse,
+        DeleteStoredResponse,
         RequestAccountDeletion,
         ConfirmAccountDeletion,
         Logout,
@@ -552,6 +713,21 @@ pub(crate) fn prepare_user_operation(
             return rejected_bad_request();
         }
     };
+    let conversation_path = match decode_canonical_conversation_path(request.method, &request.path)
+    {
+        Ok(path) => path,
+        Err(_) => {
+            request.path.zeroize();
+            return rejected_bad_request();
+        }
+    };
+    let response_path = match decode_canonical_response_path(request.method, &request.path) {
+        Ok(path) => path,
+        Err(_) => {
+            request.path.zeroize();
+            return rejected_bad_request();
+        }
+    };
     let route = match (request.method, request.path.as_str()) {
         (LogicalMethod::Post, "/login") => Some(Route::Login),
         (LogicalMethod::Post, "/register") => Some(Route::Register),
@@ -578,6 +754,15 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Get, "/v1/conversation-projects") => Some(Route::ListConversationProjects),
         (LogicalMethod::Post, "/v1/instructions") => Some(Route::CreateInstruction),
         (LogicalMethod::Get, "/v1/instructions") => Some(Route::ListInstructions),
+        (LogicalMethod::Post, "/v1/conversations") => Some(Route::CreateConversation),
+        (LogicalMethod::Get, "/v1/conversations") => Some(Route::ListConversations),
+        (LogicalMethod::Delete, "/v1/conversations") => Some(Route::DeleteAllConversations),
+        (LogicalMethod::Post, "/v1/conversations/batch-delete") => {
+            Some(Route::BatchDeleteConversations)
+        }
+        (LogicalMethod::Post, "/v1/conversations/batch-update-project") => {
+            Some(Route::BatchUpdateConversationProject)
+        }
         (LogicalMethod::Post, "/protected/delete-account/request") => {
             Some(Route::RequestAccountDeletion)
         }
@@ -619,6 +804,49 @@ pub(crate) fn prepare_user_operation(
         {
             Some(Route::SetDefaultInstruction)
         }
+        (LogicalMethod::Get, _)
+            if matches!(
+                conversation_path,
+                Some(ConversationItemPath::Conversation(_))
+            ) =>
+        {
+            Some(Route::GetConversation)
+        }
+        (LogicalMethod::Post, _)
+            if matches!(
+                conversation_path,
+                Some(ConversationItemPath::Conversation(_))
+            ) =>
+        {
+            Some(Route::UpdateConversation)
+        }
+        (LogicalMethod::Delete, _)
+            if matches!(
+                conversation_path,
+                Some(ConversationItemPath::Conversation(_))
+            ) =>
+        {
+            Some(Route::DeleteConversation)
+        }
+        (LogicalMethod::Get, _)
+            if matches!(conversation_path, Some(ConversationItemPath::Items(_))) =>
+        {
+            Some(Route::ListConversationItems)
+        }
+        (LogicalMethod::Get, _)
+            if matches!(conversation_path, Some(ConversationItemPath::Item { .. })) =>
+        {
+            Some(Route::GetConversationItem)
+        }
+        (LogicalMethod::Get, _) if matches!(response_path, Some(ResponseItemPath::Item(_))) => {
+            Some(Route::GetStoredResponse)
+        }
+        (LogicalMethod::Delete, _) if matches!(response_path, Some(ResponseItemPath::Item(_))) => {
+            Some(Route::DeleteStoredResponse)
+        }
+        (LogicalMethod::Post, _) if matches!(response_path, Some(ResponseItemPath::Cancel(_))) => {
+            Some(Route::CancelStoredResponse)
+        }
         _ => None,
     };
     if kv_key.is_some()
@@ -626,6 +854,8 @@ pub(crate) fn prepare_user_operation(
         || verification_code.is_some()
         || conversation_project_id.is_some()
         || instruction_path.is_some()
+        || conversation_path.is_some()
+        || response_path.is_some()
     {
         request.path.zeroize();
     }
@@ -1193,6 +1423,171 @@ pub(crate) fn prepare_user_operation(
                             .into_bytes(),
                     ),
                 },
+            })
+        }
+        Route::CreateConversation
+        | Route::BatchDeleteConversations
+        | Route::BatchUpdateConversationProject => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            let body = Zeroizing::new(
+                request
+                    .body_base64
+                    .expect("validated conversation mutation body")
+                    .into_bytes(),
+            );
+            let operation = match route {
+                Route::CreateConversation => ProtectedUserOperation::CreateConversation { body },
+                Route::BatchDeleteConversations => {
+                    ProtectedUserOperation::BatchDeleteConversations { body }
+                }
+                Route::BatchUpdateConversationProject => {
+                    ProtectedUserOperation::BatchUpdateConversationProject { body }
+                }
+                _ => unreachable!("conversation collection mutation group is exhaustive"),
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation,
+            })
+        }
+        Route::UpdateConversation => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            let Some(ConversationItemPath::Conversation(conversation_id)) = conversation_path
+            else {
+                unreachable!("classified conversation update must use a conversation path")
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation: ProtectedUserOperation::UpdateConversation {
+                    conversation_id,
+                    body: Zeroizing::new(
+                        request
+                            .body_base64
+                            .expect("validated conversation update body")
+                            .into_bytes(),
+                    ),
+                },
+            })
+        }
+        Route::ListConversations | Route::ListConversationItems => {
+            if credential.is_some() || !request.headers.is_empty() || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            let operation = if matches!(route, Route::ListConversations) {
+                ProtectedUserOperation::ListConversations {
+                    query: request.query,
+                }
+            } else {
+                let Some(ConversationItemPath::Items(conversation_id)) = conversation_path else {
+                    unreachable!("classified conversation-item list must use an items path")
+                };
+                ProtectedUserOperation::ListConversationItems {
+                    conversation_id,
+                    query: request.query,
+                }
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation,
+            })
+        }
+        Route::GetConversation
+        | Route::DeleteConversation
+        | Route::DeleteAllConversations
+        | Route::GetConversationItem
+        | Route::GetStoredResponse
+        | Route::CancelStoredResponse
+        | Route::DeleteStoredResponse => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return rejection,
+            };
+            let operation = match route {
+                Route::GetConversation | Route::DeleteConversation => {
+                    let Some(ConversationItemPath::Conversation(conversation_id)) =
+                        conversation_path
+                    else {
+                        unreachable!("classified conversation item must use a conversation path")
+                    };
+                    if matches!(route, Route::GetConversation) {
+                        ProtectedUserOperation::GetConversation { conversation_id }
+                    } else {
+                        ProtectedUserOperation::DeleteConversation { conversation_id }
+                    }
+                }
+                Route::DeleteAllConversations => ProtectedUserOperation::DeleteAllConversations,
+                Route::GetConversationItem => {
+                    let Some(ConversationItemPath::Item {
+                        conversation_id,
+                        item_id,
+                    }) = conversation_path
+                    else {
+                        unreachable!("classified conversation item must use an item path")
+                    };
+                    ProtectedUserOperation::GetConversationItem {
+                        conversation_id,
+                        item_id,
+                    }
+                }
+                Route::GetStoredResponse | Route::DeleteStoredResponse => {
+                    let Some(ResponseItemPath::Item(response_id)) = response_path else {
+                        unreachable!("classified stored response must use an item path")
+                    };
+                    if matches!(route, Route::GetStoredResponse) {
+                        ProtectedUserOperation::GetStoredResponse { response_id }
+                    } else {
+                        ProtectedUserOperation::DeleteStoredResponse { response_id }
+                    }
+                }
+                Route::CancelStoredResponse => {
+                    let Some(ResponseItemPath::Cancel(response_id)) = response_path else {
+                        unreachable!("classified response cancellation must use a cancel path")
+                    };
+                    ProtectedUserOperation::CancelStoredResponse { response_id }
+                }
+                _ => unreachable!("bodyless conversation/response group is exhaustive"),
+            };
+            OperationPreparation::Ready(UserOperation::Protected {
+                authority,
+                operation,
             })
         }
     }
@@ -2015,6 +2410,460 @@ async fn execute_protected_user_operation(
             };
             LogicalUnaryResponse::json(StatusCode::OK, &value)
         }
+        ProtectedUserOperation::CreateConversation { body } => {
+            let request = parse_conversation_json_body::<CreateConversationRequest>(body)?;
+            if request
+                .items
+                .as_ref()
+                .is_some_and(|items| !items.is_empty())
+            {
+                return Err(ApiError::BadRequest);
+            }
+
+            let mut metadata = request.metadata.unwrap_or_else(|| serde_json::json!({}));
+            validate_metadata(&metadata)?;
+            if metadata.get("title").is_none() {
+                metadata["title"] = serde_json::json!("New Conversation");
+            }
+            let project_id = match request.project_id {
+                Some(project_uuid) => Some(
+                    stored_conversations::resolve_project_id(
+                        app_state.db.get_pool(),
+                        user.uuid,
+                        project_uuid,
+                    )
+                    .map_err(map_stored_conversation_error)?,
+                ),
+                None => None,
+            };
+            let pinned = request.pinned.unwrap_or(false);
+            preflight_conversation_response(Some(&metadata), request.project_id, pinned)?;
+
+            let user_key = app_state
+                .get_user_key(user, auth_context, None, None)
+                .await
+                .map_err(|_| crate::web::responses::error_mapping::map_key_retrieval_error())?;
+            let metadata_enc = Some(encrypt_json_value(&user_key, &metadata).await?);
+            let conversation_uuid = uuid::Uuid::new_v4();
+            let mut conversation = app_state
+                .db
+                .create_conversation(NewConversation {
+                    uuid: conversation_uuid,
+                    user_id: user.uuid,
+                    project_id,
+                    is_pinned: pinned,
+                    metadata_enc,
+                })
+                .map_err(crate::web::responses::error_mapping::map_generic_db_error)?;
+            let mut value = ConversationResponse {
+                id: conversation.uuid,
+                object: OBJECT_TYPE_CONVERSATION,
+                metadata: Some(metadata),
+                project_id: request.project_id,
+                pinned: conversation.is_pinned,
+                created_at: conversation.created_at.timestamp(),
+                last_activity_at: conversation.last_activity_at.timestamp(),
+            };
+            if let Some(ciphertext) = conversation.metadata_enc.as_mut() {
+                ciphertext.zeroize();
+            }
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value);
+            zeroize_conversation_response(&mut value);
+            response
+        }
+        ProtectedUserOperation::ListConversations { query } => {
+            let params = parse_logical_query::<ListConversationsParams>(query)?;
+            params.validate()?;
+            let limit = if params.limit <= 0 {
+                DEFAULT_PAGINATION_LIMIT
+            } else {
+                params.limit.min(MAX_PAGINATION_LIMIT)
+            };
+            let project_filter = if params.unassigned_project == Some(true) {
+                ConversationProjectFilter::Unassigned
+            } else if let Some(project_uuid) = params.project_id {
+                ConversationProjectFilter::Assigned(
+                    stored_conversations::resolve_project_id(
+                        app_state.db.get_pool(),
+                        user.uuid,
+                        project_uuid,
+                    )
+                    .map_err(map_stored_conversation_error)?,
+                )
+            } else {
+                ConversationProjectFilter::Any
+            };
+            let (stored, has_more) = stored_conversations::list_conversations(
+                app_state.db.get_pool(),
+                user.uuid,
+                limit,
+                params.after,
+                &params.order,
+                project_filter,
+                params.pinned,
+                EnvelopeLimits::default().logical_body_bytes,
+            )
+            .map_err(map_stored_conversation_error)?;
+            let user_key = app_state
+                .get_user_key(user, auth_context, None, None)
+                .await
+                .map_err(|_| crate::web::responses::error_mapping::map_key_retrieval_error())?;
+            let first_id = stored.first().map(|value| value.conversation.uuid);
+            let last_id = stored.last().map(|value| value.conversation.uuid);
+            let mut data = Vec::with_capacity(stored.len());
+            for value in &stored {
+                let metadata = decrypt_optional_json(
+                    &user_key,
+                    value.conversation.metadata_enc.as_ref(),
+                    "conversation metadata",
+                )?;
+                data.push(stored_conversation_response(value, metadata));
+            }
+            let mut value = ConversationListResponse {
+                object: OBJECT_TYPE_LIST,
+                data,
+                has_more,
+                first_id,
+                last_id,
+            };
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value);
+            value
+                .data
+                .iter_mut()
+                .for_each(zeroize_conversation_response);
+            response
+        }
+        ProtectedUserOperation::GetConversation { conversation_id } => {
+            let stored = stored_conversations::get_conversation(
+                app_state.db.get_pool(),
+                user.uuid,
+                conversation_id,
+                EnvelopeLimits::default().logical_body_bytes,
+            )
+            .map_err(map_stored_conversation_error)?;
+            let user_key = app_state
+                .get_user_key(user, auth_context, None, None)
+                .await
+                .map_err(|_| crate::web::responses::error_mapping::map_key_retrieval_error())?;
+            let metadata = decrypt_optional_json(
+                &user_key,
+                stored.conversation.metadata_enc.as_ref(),
+                "conversation metadata",
+            )?;
+            let mut value = stored_conversation_response(&stored, metadata);
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value);
+            zeroize_conversation_response(&mut value);
+            response
+        }
+        ProtectedUserOperation::UpdateConversation {
+            conversation_id,
+            body,
+        } => {
+            let mut request = parse_conversation_json_body::<UpdateConversationRequest>(body)?;
+            if request.metadata.is_none()
+                && request.project_id.is_missing()
+                && request.pinned.is_none()
+            {
+                return Err(ApiError::BadRequest);
+            }
+            let stored = stored_conversations::get_conversation(
+                app_state.db.get_pool(),
+                user.uuid,
+                conversation_id,
+                EnvelopeLimits::default().logical_body_bytes,
+            )
+            .map_err(map_stored_conversation_error)?;
+            let user_key = app_state
+                .get_user_key(user, auth_context, None, None)
+                .await
+                .map_err(|_| crate::web::responses::error_mapping::map_key_retrieval_error())?;
+
+            let supplied_metadata = request.metadata.is_some();
+            let final_metadata = match request.metadata.take() {
+                Some(metadata) => {
+                    validate_metadata(&metadata)?;
+                    Some(metadata)
+                }
+                None => decrypt_optional_json(
+                    &user_key,
+                    stored.conversation.metadata_enc.as_ref(),
+                    "conversation metadata",
+                )?,
+            };
+            let (project_update, final_project_uuid) = match request.project_id {
+                NullableField::Missing => (ProjectAssignmentUpdate::Unchanged, stored.project_uuid),
+                NullableField::Null => (ProjectAssignmentUpdate::Set(None), None),
+                NullableField::Value(project_uuid) => {
+                    let project_id = stored_conversations::resolve_project_id(
+                        app_state.db.get_pool(),
+                        user.uuid,
+                        project_uuid,
+                    )
+                    .map_err(map_stored_conversation_error)?;
+                    (
+                        ProjectAssignmentUpdate::Set(Some(project_id)),
+                        Some(project_uuid),
+                    )
+                }
+            };
+            let pinned = request.pinned.unwrap_or(stored.conversation.is_pinned);
+            preflight_conversation_response(final_metadata.as_ref(), final_project_uuid, pinned)?;
+            let metadata_enc = if supplied_metadata {
+                Some(
+                    encrypt_json_value(
+                        &user_key,
+                        final_metadata
+                            .as_ref()
+                            .expect("supplied metadata must remain available"),
+                    )
+                    .await?,
+                )
+            } else {
+                None
+            };
+            let metadata = stored_conversations::update_conversation(
+                app_state.db.get_pool(),
+                user.uuid,
+                conversation_id,
+                metadata_enc,
+                project_update,
+                request.pinned,
+            )
+            .map_err(map_stored_conversation_error)?;
+            let mut value = ConversationResponse {
+                id: metadata.uuid,
+                object: OBJECT_TYPE_CONVERSATION,
+                metadata: final_metadata,
+                project_id: metadata.project_uuid,
+                pinned: metadata.is_pinned,
+                created_at: metadata.created_at.timestamp(),
+                last_activity_at: metadata.last_activity_at.timestamp(),
+            };
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value);
+            zeroize_conversation_response(&mut value);
+            response
+        }
+        ProtectedUserOperation::DeleteConversation { conversation_id } => {
+            let value = DeletedObjectResponse::conversation(conversation_id);
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value)?;
+            stored_conversations::delete_conversation(
+                app_state.db.get_pool(),
+                user.uuid,
+                conversation_id,
+            )
+            .map_err(map_stored_conversation_error)?;
+            Ok(response)
+        }
+        ProtectedUserOperation::DeleteAllConversations => {
+            let value = serde_json::json!({
+                "object": OBJECT_TYPE_LIST_DELETED,
+                "deleted": true
+            });
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value)?;
+            stored_conversations::delete_all_conversations(app_state.db.get_pool(), user.uuid)
+                .map_err(map_stored_conversation_error)?;
+            Ok(response)
+        }
+        ProtectedUserOperation::BatchDeleteConversations { body } => {
+            let request = parse_json_body::<BatchDeleteConversationsRequest>(body)?;
+            if request.ids.is_empty() || request.ids.len() > MAX_CONVERSATION_BATCH_SIZE {
+                return Err(ApiError::BadRequest);
+            }
+            preflight_batch_delete_conversations_response()?;
+            let mut data = Vec::with_capacity(request.ids.len());
+            for conversation_id in request.ids {
+                let lookup = stored_conversations::lookup_conversation_id(
+                    app_state.db.get_pool(),
+                    user.uuid,
+                    conversation_id,
+                );
+                let Ok(internal_id) = lookup else {
+                    data.push(BatchDeleteItemResult {
+                        id: conversation_id,
+                        object: OBJECT_TYPE_CONVERSATION_DELETED,
+                        deleted: false,
+                        error: Some("not_found"),
+                    });
+                    continue;
+                };
+                data.push(match stored_conversations::delete_conversation_by_internal_id(
+                    app_state.db.get_pool(),
+                    user.uuid,
+                    internal_id,
+                ) {
+                    Ok(()) => BatchDeleteItemResult {
+                        id: conversation_id,
+                        object: OBJECT_TYPE_CONVERSATION_DELETED,
+                        deleted: true,
+                        error: None,
+                    },
+                    Err(error) => {
+                        tracing::error!(?error, %conversation_id, "Failed to batch-delete conversation");
+                        BatchDeleteItemResult {
+                            id: conversation_id,
+                            object: OBJECT_TYPE_CONVERSATION_DELETED,
+                            deleted: false,
+                            error: Some("delete_failed"),
+                        }
+                    }
+                });
+            }
+            LogicalUnaryResponse::json(
+                StatusCode::OK,
+                &BatchDeleteConversationsResponse {
+                    object: OBJECT_TYPE_LIST,
+                    data,
+                },
+            )
+        }
+        ProtectedUserOperation::BatchUpdateConversationProject { body } => {
+            let request = parse_json_body::<BatchUpdateConversationProjectRequest>(body)?;
+            if request.ids.is_empty() || request.ids.len() > MAX_CONVERSATION_BATCH_SIZE {
+                return Err(ApiError::BadRequest);
+            }
+            let target_project_id = match request.project_id {
+                NullableField::Missing => return Err(ApiError::BadRequest),
+                NullableField::Null => None,
+                NullableField::Value(project_uuid) => Some(
+                    stored_conversations::resolve_project_id(
+                        app_state.db.get_pool(),
+                        user.uuid,
+                        project_uuid,
+                    )
+                    .map_err(map_stored_conversation_error)?,
+                ),
+            };
+            let value = BatchUpdateConversationProjectResponse { success: true };
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value)?;
+            stored_conversations::batch_update_conversation_project(
+                app_state.db.get_pool(),
+                user.uuid,
+                &request.ids,
+                target_project_id,
+            )
+            .map_err(map_stored_conversation_error)?;
+            Ok(response)
+        }
+        ProtectedUserOperation::ListConversationItems {
+            conversation_id,
+            query,
+        } => {
+            let params = parse_logical_query::<ListItemsParams>(query)?;
+            let limit = if params.limit <= 0 {
+                DEFAULT_PAGINATION_LIMIT
+            } else {
+                params.limit.min(MAX_PAGINATION_LIMIT)
+            };
+            let (stored, has_more) = stored_conversations::list_conversation_items(
+                app_state.db.get_pool(),
+                user.uuid,
+                conversation_id,
+                limit,
+                params.after,
+                &params.order,
+                EnvelopeLimits::default().logical_body_bytes,
+            )
+            .map_err(map_stored_conversation_error)?;
+            let user_key = app_state
+                .get_user_key(user, auth_context, None, None)
+                .await
+                .map_err(|_| crate::web::responses::error_mapping::map_key_retrieval_error())?;
+            let data = stored
+                .into_iter()
+                .map(|item| stored_item_to_conversation_item(item, &user_key))
+                .collect::<Result<Vec<_>, _>>()?;
+            let first_id = data.first().map(conversation_item_id);
+            let last_id = data.last().map(conversation_item_id);
+            let mut value = ConversationItemListResponse {
+                object: OBJECT_TYPE_LIST,
+                data,
+                has_more,
+                first_id,
+                last_id,
+            };
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value);
+            value.data.iter_mut().for_each(zeroize_conversation_item);
+            response
+        }
+        ProtectedUserOperation::GetConversationItem {
+            conversation_id,
+            item_id,
+        } => {
+            let stored = stored_conversations::get_conversation_item(
+                app_state.db.get_pool(),
+                user.uuid,
+                conversation_id,
+                item_id,
+                EnvelopeLimits::default().logical_body_bytes,
+            )
+            .map_err(map_stored_conversation_error)?;
+            let user_key = app_state
+                .get_user_key(user, auth_context, None, None)
+                .await
+                .map_err(|_| crate::web::responses::error_mapping::map_key_retrieval_error())?;
+            let mut value = stored_item_to_conversation_item(stored, &user_key)?;
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value);
+            zeroize_conversation_item(&mut value);
+            response
+        }
+        ProtectedUserOperation::GetStoredResponse { response_id } => {
+            let stored = stored_conversations::get_stored_response(
+                app_state.db.get_pool(),
+                user.uuid,
+                response_id,
+                EnvelopeLimits::default().logical_body_bytes,
+            )
+            .map_err(map_stored_conversation_error)?;
+            let user_key = app_state
+                .get_user_key(user, auth_context, None, None)
+                .await
+                .map_err(|_| crate::web::responses::error_mapping::map_key_retrieval_error())?;
+            let mut value = stored_response_to_wire(stored, &user_key)?;
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value);
+            zeroize_stored_response(&mut value);
+            response
+        }
+        ProtectedUserOperation::CancelStoredResponse { response_id } => {
+            let metadata = stored_conversations::get_cancelable_response_metadata(
+                app_state.db.get_pool(),
+                user.uuid,
+                response_id,
+                EnvelopeLimits::default().logical_body_bytes,
+            )
+            .map_err(map_stored_conversation_error)?;
+            preflight_cancelled_response(&metadata.model)?;
+            let mut value = ResponsesRetrieveResponse {
+                id: metadata.uuid,
+                object: OBJECT_TYPE_RESPONSE,
+                created_at: metadata.created_at.timestamp(),
+                status: STATUS_CANCELLED.to_owned(),
+                model: metadata.model,
+                usage: None,
+                output: Vec::new(),
+            };
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value)?;
+            zeroize_stored_response(&mut value);
+            let transitioned = stored_conversations::transition_stored_response_to_cancelled(
+                app_state.db.get_pool(),
+                user.uuid,
+                response_id,
+            )
+            .map_err(map_stored_conversation_error)?;
+            debug_assert_eq!(transitioned, response_id);
+            let _ = app_state.cancellation_broadcast.send(response_id);
+            Ok(response)
+        }
+        ProtectedUserOperation::DeleteStoredResponse { response_id } => {
+            let value = DeletedObjectResponse::response(response_id);
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value)?;
+            stored_conversations::delete_stored_response(
+                app_state.db.get_pool(),
+                user.uuid,
+                response_id,
+            )
+            .map_err(map_stored_conversation_error)?;
+            Ok(response)
+        }
         ProtectedUserOperation::RequestAccountDeletion { body } => {
             let request = parse_json_body::<InitiateAccountDeletionRequest>(body)?;
             let value = initiate_account_deletion_data(app_state, user, request).await?;
@@ -2065,6 +2914,418 @@ fn map_instruction_storage_error(error: StoredResourceError) -> ApiError {
             ApiError::InternalServerError
         }
     }
+}
+
+fn map_stored_conversation_error(error: StoredConversationError) -> ApiError {
+    match error {
+        StoredConversationError::ConversationNotFound
+        | StoredConversationError::ConversationProjectNotFound
+        | StoredConversationError::ConversationItemNotFound
+        | StoredConversationError::ResponseNotFound => ApiError::NotFound,
+        StoredConversationError::Validation => ApiError::BadRequest,
+        StoredConversationError::OutputTooLarge => ApiError::PayloadTooLarge,
+        error => {
+            tracing::error!(?error, "Failed to access bounded conversation state");
+            ApiError::InternalServerError
+        }
+    }
+}
+
+fn decrypt_optional_json(
+    user_key: &secp256k1::SecretKey,
+    ciphertext: Option<&Vec<u8>>,
+    description: &'static str,
+) -> Result<Option<serde_json::Value>, ApiError> {
+    let Some(ciphertext) = ciphertext else {
+        return Ok(None);
+    };
+    let plaintext = Zeroizing::new(decrypt_with_key(user_key, ciphertext).map_err(|_| {
+        tracing::error!(description, "Failed to decrypt bounded stored JSON");
+        ApiError::InternalServerError
+    })?);
+    match validate_json_shape(&plaintext) {
+        Ok(()) => {}
+        Err(JsonShapeError::TooLarge) => return Err(ApiError::PayloadTooLarge),
+        Err(JsonShapeError::Malformed) => {
+            tracing::error!(description, "Malformed bounded stored JSON");
+            return Err(ApiError::InternalServerError);
+        }
+    }
+    serde_json::from_slice(&plaintext).map(Some).map_err(|_| {
+        tracing::error!(description, "Failed to parse bounded stored JSON");
+        ApiError::InternalServerError
+    })
+}
+
+async fn encrypt_json_value(
+    user_key: &secp256k1::SecretKey,
+    value: &serde_json::Value,
+) -> Result<Vec<u8>, ApiError> {
+    let plaintext = Zeroizing::new(serde_json::to_vec(value).map_err(|_| {
+        tracing::error!("Failed to serialize conversation metadata");
+        ApiError::InternalServerError
+    })?);
+    Ok(encrypt_with_key(user_key, &plaintext).await)
+}
+
+fn stored_conversation_response(
+    stored: &stored_conversations::StoredConversation,
+    metadata: Option<serde_json::Value>,
+) -> ConversationResponse {
+    ConversationResponse {
+        id: stored.conversation.uuid,
+        object: OBJECT_TYPE_CONVERSATION,
+        metadata,
+        project_id: stored.project_uuid,
+        pinned: stored.conversation.is_pinned,
+        created_at: stored.conversation.created_at.timestamp(),
+        last_activity_at: stored.conversation.last_activity_at.timestamp(),
+    }
+}
+
+fn zeroize_json_value(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::String(value) => value.zeroize(),
+        serde_json::Value::Array(values) => values.iter_mut().for_each(zeroize_json_value),
+        serde_json::Value::Object(values) => {
+            for (mut key, mut value) in std::mem::take(values) {
+                key.zeroize();
+                zeroize_json_value(&mut value);
+            }
+        }
+        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {}
+    }
+}
+
+fn zeroize_conversation_response(value: &mut ConversationResponse) {
+    if let Some(metadata) = value.metadata.as_mut() {
+        zeroize_json_value(metadata);
+    }
+}
+
+fn zeroize_conversation_item(item: &mut ConversationItem) {
+    match item {
+        ConversationItem::Message {
+            status,
+            role,
+            content,
+            ..
+        } => {
+            if let Some(status) = status.as_mut() {
+                status.zeroize();
+            }
+            role.zeroize();
+            for part in content {
+                match part {
+                    ConversationContent::Text { text }
+                    | ConversationContent::InputText { text }
+                    | ConversationContent::OutputText { text } => text.zeroize(),
+                    ConversationContent::InputImage { image_url } => image_url.zeroize(),
+                    ConversationContent::InputFile { filename } => filename.zeroize(),
+                }
+            }
+        }
+        ConversationItem::FunctionToolCall {
+            name,
+            arguments,
+            status,
+            ..
+        } => {
+            name.zeroize();
+            arguments.zeroize();
+            if let Some(status) = status.as_mut() {
+                status.zeroize();
+            }
+        }
+        ConversationItem::FunctionToolCallOutput { output, status, .. } => {
+            output.zeroize();
+            if let Some(status) = status.as_mut() {
+                status.zeroize();
+            }
+        }
+        ConversationItem::Reasoning {
+            content, status, ..
+        } => {
+            for ReasoningContentItem::Text { text } in content {
+                text.zeroize();
+            }
+            if let Some(status) = status.as_mut() {
+                status.zeroize();
+            }
+        }
+    }
+}
+
+fn zeroize_stored_response(value: &mut ResponsesRetrieveResponse) {
+    value.status.zeroize();
+    value.model.zeroize();
+    for item in &mut value.output {
+        item.output_type.zeroize();
+        item.id.zeroize();
+        item.status.zeroize();
+        if let Some(role) = item.role.as_mut() {
+            role.zeroize();
+        }
+        if let Some(content) = item.content.as_mut() {
+            for part in content {
+                part.part_type.zeroize();
+                part.text.zeroize();
+            }
+        }
+        for value in [
+            &mut item.call_id,
+            &mut item.name,
+            &mut item.arguments,
+            &mut item.output,
+        ] {
+            if let Some(value) = value.as_mut() {
+                value.zeroize();
+            }
+        }
+    }
+}
+
+fn conversation_item_id(item: &ConversationItem) -> uuid::Uuid {
+    match item {
+        ConversationItem::Message { id, .. }
+        | ConversationItem::FunctionToolCall { id, .. }
+        | ConversationItem::FunctionToolCallOutput { id, .. }
+        | ConversationItem::Reasoning { id, .. } => *id,
+    }
+}
+
+fn stored_item_to_conversation_item(
+    mut item: stored_conversations::StoredConversationItem,
+    user_key: &secp256k1::SecretKey,
+) -> Result<ConversationItem, ApiError> {
+    let mut content = decrypt_optional_string(
+        user_key,
+        item.content_enc.as_ref(),
+        "conversation item content",
+    )?
+    .unwrap_or_else(|| Zeroizing::new(String::new()));
+    let id = item.uuid;
+    let created_at = Some(item.created_at.timestamp());
+    let status = item.status.take();
+
+    match item.message_type.as_str() {
+        "user" => {
+            let message_content =
+                serde_json::from_str::<MessageContent>(&content).map_err(|_| {
+                    tracing::error!("Failed to parse bounded user-message content");
+                    ApiError::InternalServerError
+                })?;
+            Ok(ConversationItem::Message {
+                id,
+                status,
+                role: ROLE_USER.to_owned(),
+                content: Vec::<ConversationContent>::from(message_content),
+                created_at,
+            })
+        }
+        "assistant" => {
+            let content = if content.is_empty() {
+                Vec::new()
+            } else {
+                vec![ConversationContent::OutputText {
+                    text: std::mem::take(&mut *content),
+                }]
+            };
+            Ok(ConversationItem::Message {
+                id,
+                status,
+                role: ROLE_ASSISTANT.to_owned(),
+                content,
+                created_at,
+            })
+        }
+        "tool_call" => Ok(ConversationItem::FunctionToolCall {
+            id,
+            call_id: item.tool_call_id.ok_or_else(|| {
+                tracing::error!("Stored tool call is missing its call ID");
+                ApiError::InternalServerError
+            })?,
+            name: item
+                .tool_name
+                .take()
+                .unwrap_or_else(|| DEFAULT_TOOL_FUNCTION_NAME.to_owned()),
+            arguments: std::mem::take(&mut *content),
+            status,
+            created_at,
+        }),
+        "tool_output" => Ok(ConversationItem::FunctionToolCallOutput {
+            id,
+            call_id: item.tool_call_id.ok_or_else(|| {
+                tracing::error!("Stored tool output is missing its call ID");
+                ApiError::InternalServerError
+            })?,
+            output: std::mem::take(&mut *content),
+            status,
+            created_at,
+        }),
+        "reasoning" => {
+            let content = if content.is_empty() {
+                Vec::new()
+            } else {
+                vec![ReasoningContentItem::Text {
+                    text: std::mem::take(&mut *content),
+                }]
+            };
+            Ok(ConversationItem::Reasoning {
+                id,
+                content,
+                status,
+                created_at,
+            })
+        }
+        unknown => {
+            tracing::error!(
+                message_type = unknown,
+                "Unknown bounded conversation-item type"
+            );
+            Err(ApiError::InternalServerError)
+        }
+    }
+}
+
+fn response_status_string(status: ResponseStatus) -> String {
+    serde_json::to_value(status)
+        .ok()
+        .and_then(|value| value.as_str().map(str::to_owned))
+        .unwrap_or_else(|| "unknown".to_owned())
+}
+
+fn stored_response_to_wire(
+    stored: stored_conversations::StoredResponse,
+    user_key: &secp256k1::SecretKey,
+) -> Result<ResponsesRetrieveResponse, ApiError> {
+    let completed = stored.response.status == ResponseStatus::Completed;
+    let mut input_tokens = 0i32;
+    let mut output_tokens = 0i32;
+    let mut reasoning_tokens = 0i32;
+    let mut output = Vec::new();
+
+    for mut item in stored.items {
+        let tokens = item.token_count.unwrap_or_default();
+        if completed {
+            match item.message_type.as_str() {
+                "user" | "tool_call" | "tool_output" => {
+                    input_tokens = input_tokens.saturating_add(tokens);
+                }
+                "assistant" => {
+                    output_tokens = output_tokens.saturating_add(tokens);
+                }
+                "reasoning" => {
+                    output_tokens = output_tokens.saturating_add(tokens);
+                    reasoning_tokens = reasoning_tokens.saturating_add(tokens);
+                }
+                _ => {}
+            }
+        }
+
+        let status = item
+            .status
+            .take()
+            .unwrap_or_else(|| STATUS_COMPLETED.to_owned());
+        match item.message_type.as_str() {
+            "user" => {}
+            "assistant" => {
+                let content = decrypt_optional_string(
+                    user_key,
+                    item.content_enc.as_ref(),
+                    "assistant message content",
+                )?
+                .map_or_else(Vec::new, |mut text| {
+                    vec![ContentPart {
+                        part_type: "output_text".to_owned(),
+                        annotations: Vec::new(),
+                        logprobs: Vec::new(),
+                        text: std::mem::take(&mut *text),
+                    }]
+                });
+                output.push(OutputItem {
+                    id: item.uuid.to_string(),
+                    output_type: "message".to_owned(),
+                    status,
+                    role: Some(ROLE_ASSISTANT.to_owned()),
+                    content: Some(content),
+                    call_id: None,
+                    name: None,
+                    arguments: None,
+                    output: None,
+                });
+            }
+            "tool_call" => {
+                let arguments = decrypt_optional_string(
+                    user_key,
+                    item.content_enc.as_ref(),
+                    "tool call arguments",
+                )?
+                .map(|mut value| std::mem::take(&mut *value));
+                output.push(OutputItem {
+                    id: item.uuid.to_string(),
+                    output_type: "tool_call".to_owned(),
+                    status,
+                    role: None,
+                    content: None,
+                    call_id: Some(item.tool_call_id.unwrap_or(item.uuid).to_string()),
+                    name: Some(
+                        item.tool_name
+                            .take()
+                            .unwrap_or_else(|| DEFAULT_TOOL_FUNCTION_NAME.to_owned()),
+                    ),
+                    arguments,
+                    output: None,
+                });
+            }
+            "tool_output" => {
+                let tool_output =
+                    decrypt_optional_string(user_key, item.content_enc.as_ref(), "tool output")?
+                        .map(|mut value| std::mem::take(&mut *value));
+                output.push(OutputItem {
+                    id: item.uuid.to_string(),
+                    output_type: "tool_output".to_owned(),
+                    status,
+                    role: None,
+                    content: None,
+                    call_id: item.tool_call_id.map(|id| id.to_string()),
+                    name: None,
+                    arguments: None,
+                    output: tool_output,
+                });
+            }
+            "reasoning" => output.push(OutputItem {
+                id: item.uuid.to_string(),
+                output_type: "reasoning".to_owned(),
+                status,
+                role: None,
+                content: Some(Vec::new()),
+                call_id: None,
+                name: None,
+                arguments: None,
+                output: None,
+            }),
+            _ => {}
+        }
+    }
+
+    let usage = completed.then(|| ResponseUsage {
+        input_tokens,
+        input_tokens_details: InputTokenDetails { cached_tokens: 0 },
+        output_tokens,
+        output_tokens_details: OutputTokenDetails { reasoning_tokens },
+        total_tokens: input_tokens.saturating_add(output_tokens),
+    });
+
+    Ok(ResponsesRetrieveResponse {
+        id: stored.response.uuid,
+        object: OBJECT_TYPE_RESPONSE,
+        created_at: stored.response.created_at.timestamp(),
+        status: response_status_string(stored.response.status),
+        model: stored.response.model,
+        usage,
+        output,
+    })
 }
 
 fn decrypt_instruction_content(
@@ -2118,6 +3379,78 @@ fn decrypt_optional_string(
 
 fn parse_json_body<T: DeserializeOwned>(body: SensitiveBytes) -> Result<T, ApiError> {
     serde_json::from_slice::<T>(&body).map_err(|_| ApiError::BadRequest)
+}
+
+/// Bounds JSON container amplification before serde allocates an object tree.
+///
+/// Strings are skipped without allocation, so structural punctuation inside a
+/// metadata value cannot inflate the count. Full syntax validation remains the
+/// responsibility of serde immediately after this preflight.
+fn validate_json_shape(bytes: &[u8]) -> Result<(), JsonShapeError> {
+    let mut depth = 0usize;
+    let mut structural_tokens = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for byte in bytes {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if *byte == b'\\' {
+                escaped = true;
+            } else if *byte == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        match *byte {
+            b'"' => in_string = true,
+            b'{' | b'[' => {
+                depth = depth.checked_add(1).ok_or(JsonShapeError::TooLarge)?;
+                structural_tokens = structural_tokens
+                    .checked_add(1)
+                    .ok_or(JsonShapeError::TooLarge)?;
+                if depth > MAX_CONVERSATION_JSON_DEPTH
+                    || structural_tokens > MAX_CONVERSATION_JSON_STRUCTURAL_TOKENS
+                {
+                    return Err(JsonShapeError::TooLarge);
+                }
+            }
+            b'}' | b']' => {
+                depth = depth.checked_sub(1).ok_or(JsonShapeError::Malformed)?;
+                structural_tokens = structural_tokens
+                    .checked_add(1)
+                    .ok_or(JsonShapeError::TooLarge)?;
+                if structural_tokens > MAX_CONVERSATION_JSON_STRUCTURAL_TOKENS {
+                    return Err(JsonShapeError::TooLarge);
+                }
+            }
+            b',' | b':' => {
+                structural_tokens = structural_tokens
+                    .checked_add(1)
+                    .ok_or(JsonShapeError::TooLarge)?;
+                if structural_tokens > MAX_CONVERSATION_JSON_STRUCTURAL_TOKENS {
+                    return Err(JsonShapeError::TooLarge);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if in_string || depth != 0 {
+        Err(JsonShapeError::Malformed)
+    } else {
+        Ok(())
+    }
+}
+
+fn parse_conversation_json_body<T: DeserializeOwned>(body: SensitiveBytes) -> Result<T, ApiError> {
+    match validate_json_shape(&body) {
+        Ok(()) => parse_json_body(body),
+        Err(JsonShapeError::TooLarge) => Err(ApiError::PayloadTooLarge),
+        Err(JsonShapeError::Malformed) => Err(ApiError::BadRequest),
+    }
 }
 
 fn parse_logical_query<T: DeserializeOwned>(query: Option<String>) -> Result<T, ApiError> {
@@ -3321,6 +4654,242 @@ mod tests {
     }
 
     #[test]
+    fn conversation_item_and_stored_response_families_are_exact_and_classified_by_storage_risk() {
+        let conversation = "123e4567-e89b-12d3-a456-426614174000";
+        let item = "223e4567-e89b-12d3-a456-426614174000";
+        let response = "323e4567-e89b-12d3-a456-426614174000";
+        let conversation_path = format!("/v1/conversations/{conversation}");
+        let items_path = format!("{conversation_path}/items");
+        let response_path = format!("/v1/responses/{response}");
+
+        let cases = [
+            (
+                envelope(
+                    LogicalMethod::Post,
+                    "/v1/conversations",
+                    json_header(),
+                    Some(br#"{}"#),
+                    None,
+                ),
+                "create_conversation",
+                false,
+            ),
+            (
+                {
+                    let mut request = envelope(
+                        LogicalMethod::Get,
+                        "/v1/conversations",
+                        Vec::new(),
+                        None,
+                        None,
+                    );
+                    request.request.query = Some("limit=10&order=desc".to_owned());
+                    request
+                },
+                "list_conversations",
+                true,
+            ),
+            (
+                envelope(
+                    LogicalMethod::Get,
+                    &conversation_path,
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                "get_conversation",
+                true,
+            ),
+            (
+                envelope(
+                    LogicalMethod::Post,
+                    &conversation_path,
+                    json_header(),
+                    Some(br#"{"pinned":true}"#),
+                    None,
+                ),
+                "update_conversation",
+                true,
+            ),
+            (
+                envelope(
+                    LogicalMethod::Delete,
+                    &conversation_path,
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                "delete_conversation",
+                false,
+            ),
+            (
+                envelope(
+                    LogicalMethod::Delete,
+                    "/v1/conversations",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                "delete_all_conversations",
+                false,
+            ),
+            (
+                envelope(
+                    LogicalMethod::Post,
+                    "/v1/conversations/batch-delete",
+                    json_header(),
+                    Some(br#"{"ids":["123e4567-e89b-12d3-a456-426614174000"]}"#),
+                    None,
+                ),
+                "batch_delete_conversations",
+                false,
+            ),
+            (
+                envelope(
+                    LogicalMethod::Post,
+                    "/v1/conversations/batch-update-project",
+                    json_header(),
+                    Some(br#"{"ids":["123e4567-e89b-12d3-a456-426614174000"],"project_id":null}"#),
+                    None,
+                ),
+                "batch_update_conversation_project",
+                false,
+            ),
+            (
+                {
+                    let mut request =
+                        envelope(LogicalMethod::Get, &items_path, Vec::new(), None, None);
+                    request.request.query = Some("limit=5&include=ignored".to_owned());
+                    request
+                },
+                "list_conversation_items",
+                true,
+            ),
+            (
+                envelope(
+                    LogicalMethod::Get,
+                    &format!("{items_path}/{item}"),
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                "get_conversation_item",
+                true,
+            ),
+            (
+                envelope(LogicalMethod::Get, &response_path, Vec::new(), None, None),
+                "get_stored_response",
+                true,
+            ),
+            (
+                envelope(
+                    LogicalMethod::Post,
+                    &format!("{response_path}/cancel"),
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                "cancel_stored_response",
+                true,
+            ),
+            (
+                envelope(
+                    LogicalMethod::Delete,
+                    &response_path,
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                "delete_stored_response",
+                false,
+            ),
+        ];
+
+        for (request, expected, stored_output) in cases {
+            let prepared = prepare_user_operation(request, bound_user_authority());
+            let OperationPreparation::Ready(operation) = prepared else {
+                panic!("{expected} must be admitted");
+            };
+            let UserOperation::Protected {
+                operation: protected,
+                ..
+            } = &operation
+            else {
+                panic!("{expected} must be a protected user operation");
+            };
+            let actual = match protected {
+                ProtectedUserOperation::CreateConversation { .. } => "create_conversation",
+                ProtectedUserOperation::ListConversations { .. } => "list_conversations",
+                ProtectedUserOperation::GetConversation { .. } => "get_conversation",
+                ProtectedUserOperation::UpdateConversation { .. } => "update_conversation",
+                ProtectedUserOperation::DeleteConversation { .. } => "delete_conversation",
+                ProtectedUserOperation::DeleteAllConversations => "delete_all_conversations",
+                ProtectedUserOperation::BatchDeleteConversations { .. } => {
+                    "batch_delete_conversations"
+                }
+                ProtectedUserOperation::BatchUpdateConversationProject { .. } => {
+                    "batch_update_conversation_project"
+                }
+                ProtectedUserOperation::ListConversationItems { .. } => "list_conversation_items",
+                ProtectedUserOperation::GetConversationItem { .. } => "get_conversation_item",
+                ProtectedUserOperation::GetStoredResponse { .. } => "get_stored_response",
+                ProtectedUserOperation::CancelStoredResponse { .. } => "cancel_stored_response",
+                ProtectedUserOperation::DeleteStoredResponse { .. } => "delete_stored_response",
+                _ => panic!("unexpected operation for {expected}"),
+            };
+            assert_eq!(actual, expected);
+            assert_eq!(
+                operation.requires_stored_output_reservation(),
+                stored_output
+            );
+        }
+
+        for request in [
+            envelope(
+                LogicalMethod::Get,
+                &conversation_path,
+                Vec::new(),
+                None,
+                None,
+            ),
+            envelope(LogicalMethod::Get, &response_path, Vec::new(), None, None),
+        ] {
+            assert!(matches!(
+                prepare_user_operation(request, AuthorityState::Anonymous),
+                OperationPreparation::Rejected(response)
+                    if response.status == StatusCode::UNAUTHORIZED
+            ));
+        }
+
+        let mut transplanted_body = envelope(
+            LogicalMethod::Delete,
+            &conversation_path,
+            Vec::new(),
+            None,
+            None,
+        );
+        transplanted_body.request.body_base64 = Some(EncodedBytes::from_bytes(b"{}".to_vec()));
+        assert!(matches!(
+            prepare_user_operation(transplanted_body, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+
+        let disabled_item_post = envelope(
+            LogicalMethod::Post,
+            &items_path,
+            json_header(),
+            Some(br#"{"items":[]}"#),
+            None,
+        );
+        assert!(matches!(
+            prepare_user_operation(disabled_item_post, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::BAD_REQUEST
+        ));
+    }
+
+    #[test]
     fn conversation_project_creation_preflight_matches_wire_shape_and_bounds_before_insert() {
         let name = "quoted \\\" project ☃";
         let candidate = ConversationProjectCreationResponsePreflight {
@@ -3381,6 +4950,254 @@ mod tests {
             preflight_instruction_response_with_limit(name, prompt, true, 8),
             Err(ApiError::PayloadTooLarge)
         ));
+    }
+
+    fn stored_item_fixture(
+        message_type: &str,
+        uuid: uuid::Uuid,
+        content_enc: Option<Vec<u8>>,
+        token_count: i32,
+    ) -> stored_conversations::StoredConversationItem {
+        stored_conversations::StoredConversationItem {
+            message_type: message_type.to_owned(),
+            id: 1,
+            type_rank: 1,
+            uuid,
+            content_enc,
+            status: Some(STATUS_COMPLETED.to_owned()),
+            created_at: Utc::now(),
+            model: None,
+            token_count: Some(token_count),
+            tool_call_id: None,
+            finish_reason: None,
+            tool_name: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn bounded_conversation_items_preserve_each_existing_wire_variant() {
+        let user_key = secp256k1::SecretKey::from_slice(&[0x51; 32]).unwrap();
+        let user_id = uuid::Uuid::from_bytes([0x52; 16]);
+        let assistant_id = uuid::Uuid::from_bytes([0x53; 16]);
+        let tool_call_id = uuid::Uuid::from_bytes([0x54; 16]);
+        let tool_output_id = uuid::Uuid::from_bytes([0x55; 16]);
+        let reasoning_id = uuid::Uuid::from_bytes([0x56; 16]);
+
+        let user_plaintext =
+            Zeroizing::new(serde_json::to_vec(&MessageContent::Text("hello".to_owned())).unwrap());
+        let user = stored_item_fixture(
+            "user",
+            user_id,
+            Some(encrypt_with_key(&user_key, &user_plaintext).await),
+            1,
+        );
+        let user_timestamp = user.created_at.timestamp();
+
+        let assistant = stored_item_fixture(
+            "assistant",
+            assistant_id,
+            Some(encrypt_with_key(&user_key, b"answer").await),
+            2,
+        );
+        let assistant_timestamp = assistant.created_at.timestamp();
+
+        let mut tool_call = stored_item_fixture(
+            "tool_call",
+            tool_call_id,
+            Some(encrypt_with_key(&user_key, br#"{"city":"Oslo"}"#).await),
+            3,
+        );
+        tool_call.tool_call_id = Some(tool_call_id);
+        tool_call.tool_name = Some("weather".to_owned());
+        let tool_call_timestamp = tool_call.created_at.timestamp();
+
+        let mut tool_output = stored_item_fixture(
+            "tool_output",
+            tool_output_id,
+            Some(encrypt_with_key(&user_key, b"sunny").await),
+            4,
+        );
+        tool_output.tool_call_id = Some(tool_call_id);
+        let tool_output_timestamp = tool_output.created_at.timestamp();
+
+        let reasoning = stored_item_fixture(
+            "reasoning",
+            reasoning_id,
+            Some(encrypt_with_key(&user_key, b"private thought").await),
+            5,
+        );
+        let reasoning_timestamp = reasoning.created_at.timestamp();
+
+        let actual = [user, assistant, tool_call, tool_output, reasoning]
+            .into_iter()
+            .map(|item| {
+                serde_json::to_value(stored_item_to_conversation_item(item, &user_key).unwrap())
+                    .unwrap()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            actual,
+            vec![
+                serde_json::json!({
+                    "type": "message", "id": user_id, "status": "completed", "role": "user",
+                    "content": [{"type":"input_text","text":"hello"}],
+                    "created_at": user_timestamp
+                }),
+                serde_json::json!({
+                    "type": "message", "id": assistant_id, "status": "completed", "role": "assistant",
+                    "content": [{"type":"output_text","text":"answer"}],
+                    "created_at": assistant_timestamp
+                }),
+                serde_json::json!({
+                    "type": "function_call", "id": tool_call_id, "call_id": tool_call_id,
+                    "name": "weather", "arguments": "{\"city\":\"Oslo\"}",
+                    "status": "completed", "created_at": tool_call_timestamp
+                }),
+                serde_json::json!({
+                    "type": "function_call_output", "id": tool_output_id, "call_id": tool_call_id,
+                    "output": "sunny", "status": "completed", "created_at": tool_output_timestamp
+                }),
+                serde_json::json!({
+                    "type": "reasoning", "id": reasoning_id,
+                    "content": [{"type":"text","text":"private thought"}],
+                    "status": "completed", "created_at": reasoning_timestamp
+                }),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_stored_response_preserves_output_filtering_and_usage_math() {
+        let user_key = secp256k1::SecretKey::from_slice(&[0x61; 32]).unwrap();
+        let response_id = uuid::Uuid::from_bytes([0x62; 16]);
+        let user_item_id = uuid::Uuid::from_bytes([0x64; 16]);
+        let assistant_id = uuid::Uuid::from_bytes([0x65; 16]);
+        let empty_assistant_id = uuid::Uuid::from_bytes([0x69; 16]);
+        let call_id = uuid::Uuid::from_bytes([0x66; 16]);
+        let output_id = uuid::Uuid::from_bytes([0x67; 16]);
+        let reasoning_id = uuid::Uuid::from_bytes([0x68; 16]);
+
+        let user = stored_item_fixture("user", user_item_id, None, 3);
+        let assistant = stored_item_fixture(
+            "assistant",
+            assistant_id,
+            Some(encrypt_with_key(&user_key, b"answer").await),
+            5,
+        );
+        let empty_assistant = stored_item_fixture("assistant", empty_assistant_id, None, 0);
+        let mut tool_call = stored_item_fixture(
+            "tool_call",
+            call_id,
+            Some(encrypt_with_key(&user_key, b"{}").await),
+            2,
+        );
+        tool_call.tool_call_id = Some(call_id);
+        tool_call.tool_name = Some("lookup".to_owned());
+        let mut tool_output = stored_item_fixture(
+            "tool_output",
+            output_id,
+            Some(encrypt_with_key(&user_key, b"ok").await),
+            4,
+        );
+        tool_output.tool_call_id = Some(call_id);
+        let reasoning = stored_item_fixture("reasoning", reasoning_id, None, 7);
+        let created_at = Utc::now();
+        let stored = stored_conversations::StoredResponse {
+            response: stored_conversations::StoredResponseMetadata {
+                id: 1,
+                uuid: response_id,
+                conversation_id: 2,
+                status: ResponseStatus::Completed,
+                model: "test-model".to_owned(),
+                created_at,
+            },
+            items: vec![
+                user,
+                assistant,
+                empty_assistant,
+                tool_call,
+                tool_output,
+                reasoning,
+            ],
+        };
+
+        let actual =
+            serde_json::to_value(stored_response_to_wire(stored, &user_key).unwrap()).unwrap();
+        assert_eq!(actual["id"], serde_json::json!(response_id));
+        assert_eq!(actual["status"], "completed");
+        assert_eq!(actual["model"], "test-model");
+        assert_eq!(actual["usage"]["input_tokens"], 9);
+        assert_eq!(actual["usage"]["output_tokens"], 12);
+        assert_eq!(
+            actual["usage"]["output_tokens_details"]["reasoning_tokens"],
+            7
+        );
+        assert_eq!(actual["usage"]["total_tokens"], 21);
+        assert_eq!(
+            actual["output"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|item| item["type"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            vec![
+                "message",
+                "message",
+                "tool_call",
+                "tool_output",
+                "reasoning"
+            ]
+        );
+        assert_eq!(actual["output"][1]["content"], serde_json::json!([]));
+        assert_eq!(actual["output"][4]["content"], serde_json::json!([]));
+        assert!(actual["output"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|item| item["id"] != serde_json::json!(user_item_id)));
+    }
+
+    #[test]
+    fn conversation_json_shape_is_bounded_before_value_allocation() {
+        assert_eq!(
+            validate_json_shape(
+                br#"{"metadata":{"title":"{[,:","escaped":"quote: \" ok"},"future":true}"#
+            ),
+            Ok(())
+        );
+
+        let too_deep = format!(
+            "{}0{}",
+            "[".repeat(MAX_CONVERSATION_JSON_DEPTH + 1),
+            "]".repeat(MAX_CONVERSATION_JSON_DEPTH + 1)
+        );
+        assert_eq!(
+            validate_json_shape(too_deep.as_bytes()),
+            Err(JsonShapeError::TooLarge)
+        );
+
+        let mut too_wide = String::from("[");
+        for index in 0..=MAX_CONVERSATION_JSON_STRUCTURAL_TOKENS {
+            if index != 0 {
+                too_wide.push(',');
+            }
+            too_wide.push('0');
+        }
+        too_wide.push(']');
+        assert_eq!(
+            validate_json_shape(too_wide.as_bytes()),
+            Err(JsonShapeError::TooLarge)
+        );
+        assert_eq!(
+            validate_json_shape(br#"{"metadata":"unterminated}"#),
+            Err(JsonShapeError::Malformed)
+        );
+
+        let parsed = parse_conversation_json_body::<UpdateConversationRequest>(Zeroizing::new(
+            br#"{"pinned":true,"future":{"shape":"ignored"}}"#.to_vec(),
+        ))
+        .expect("unknown fields must remain accepted after structural preflight");
+        assert_eq!(parsed.pinned, Some(true));
     }
 
     #[test]

--- a/src/transport_v2/envelope.rs
+++ b/src/transport_v2/envelope.rs
@@ -374,12 +374,30 @@ const KV_ITEM_PATH_PREFIX: &str = "/protected/kv/";
 const API_KEY_ITEM_PATH_PREFIX: &str = "/protected/api-keys/";
 const VERIFY_EMAIL_PATH_PREFIX: &str = "/verify-email/";
 const CONVERSATION_PROJECT_ITEM_PATH_PREFIX: &str = "/v1/conversation-projects/";
+const CONVERSATION_ITEM_PATH_PREFIX: &str = "/v1/conversations/";
 const INSTRUCTION_ITEM_PATH_PREFIX: &str = "/v1/instructions/";
+const RESPONSE_ITEM_PATH_PREFIX: &str = "/v1/responses/";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum InstructionItemPath {
     Item(Uuid),
     SetDefault(Uuid),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ConversationItemPath {
+    Conversation(Uuid),
+    Items(Uuid),
+    Item {
+        conversation_id: Uuid,
+        item_id: Uuid,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ResponseItemPath {
+    Item(Uuid),
+    Cancel(Uuid),
 }
 
 fn validate_logical_path(
@@ -400,7 +418,13 @@ fn validate_logical_path(
     if decode_canonical_conversation_project_path(method, path)?.is_some() {
         return Ok(());
     }
+    if decode_canonical_conversation_path(method, path)?.is_some() {
+        return Ok(());
+    }
     if decode_canonical_instruction_path(method, path)?.is_some() {
+        return Ok(());
+    }
+    if decode_canonical_response_path(method, path)?.is_some() {
         return Ok(());
     }
     validate_path(path, limits)
@@ -553,6 +577,103 @@ pub(crate) fn decode_canonical_instruction_path(
     } else {
         InstructionItemPath::Item(instruction_id)
     }))
+}
+
+/// Decodes canonical conversation, item-collection, and individual-item paths.
+///
+/// Fixed collection actions are excluded before UUID parsing. Item suffixes are
+/// recognized before the ordinary conversation form so an admitted operation
+/// has one unambiguous lowercase-hyphenated spelling.
+pub(crate) fn decode_canonical_conversation_path(
+    method: LogicalMethod,
+    path: &str,
+) -> Result<Option<ConversationItemPath>, EnvelopeError> {
+    let Some(suffix) = path.strip_prefix(CONVERSATION_ITEM_PATH_PREFIX) else {
+        return Ok(None);
+    };
+    if matches!(suffix, "batch-delete" | "batch-update-project") {
+        return Ok(None);
+    }
+
+    if method == LogicalMethod::Get {
+        if let Some((conversation, item)) = suffix.split_once("/items/") {
+            if item.contains('/') {
+                return Err(EnvelopeError::InvalidPath(
+                    "conversation item path has extra segments",
+                ));
+            }
+            return Ok(Some(ConversationItemPath::Item {
+                conversation_id: decode_canonical_uuid_segment(
+                    conversation,
+                    "conversation ID must use lowercase hyphenated UUID spelling",
+                )?,
+                item_id: decode_canonical_uuid_segment(
+                    item,
+                    "conversation item ID must use lowercase hyphenated UUID spelling",
+                )?,
+            }));
+        }
+        if let Some(conversation) = suffix.strip_suffix("/items") {
+            return Ok(Some(ConversationItemPath::Items(
+                decode_canonical_uuid_segment(
+                    conversation,
+                    "conversation ID must use lowercase hyphenated UUID spelling",
+                )?,
+            )));
+        }
+    }
+
+    if !matches!(
+        method,
+        LogicalMethod::Get | LogicalMethod::Post | LogicalMethod::Delete
+    ) {
+        return Ok(None);
+    }
+    Ok(Some(ConversationItemPath::Conversation(
+        decode_canonical_uuid_segment(
+            suffix,
+            "conversation ID must use lowercase hyphenated UUID spelling",
+        )?,
+    )))
+}
+
+/// Decodes canonical stored-response item and cancellation paths.
+pub(crate) fn decode_canonical_response_path(
+    method: LogicalMethod,
+    path: &str,
+) -> Result<Option<ResponseItemPath>, EnvelopeError> {
+    let Some(suffix) = path.strip_prefix(RESPONSE_ITEM_PATH_PREFIX) else {
+        return Ok(None);
+    };
+    if let Some(response) = suffix.strip_suffix("/cancel") {
+        if method != LogicalMethod::Post {
+            return Ok(None);
+        }
+        return Ok(Some(ResponseItemPath::Cancel(
+            decode_canonical_uuid_segment(
+                response,
+                "response ID must use lowercase hyphenated UUID spelling",
+            )?,
+        )));
+    }
+    if !matches!(method, LogicalMethod::Get | LogicalMethod::Delete) {
+        return Ok(None);
+    }
+    Ok(Some(ResponseItemPath::Item(decode_canonical_uuid_segment(
+        suffix,
+        "response ID must use lowercase hyphenated UUID spelling",
+    )?)))
+}
+
+fn decode_canonical_uuid_segment(
+    segment: &str,
+    error: &'static str,
+) -> Result<Uuid, EnvelopeError> {
+    let id = Uuid::parse_str(segment).map_err(|_| EnvelopeError::InvalidPath(error))?;
+    if id.hyphenated().to_string() != segment {
+        return Err(EnvelopeError::InvalidPath(error));
+    }
+    Ok(id)
 }
 
 fn decode_canonical_opaque_segment(segment: &str) -> Result<Zeroizing<String>, EnvelopeError> {
@@ -1461,6 +1582,115 @@ mod tests {
                 "{invalid}"
             );
         }
+    }
+
+    #[test]
+    fn conversation_and_item_paths_are_canonical_and_distinct() {
+        let conversation = "123e4567-e89b-12d3-a456-426614174000";
+        let item = "223e4567-e89b-12d3-a456-426614174000";
+        let conversation_id = Uuid::parse_str(conversation).unwrap();
+        let item_id = Uuid::parse_str(item).unwrap();
+        let conversation_path = format!("{CONVERSATION_ITEM_PATH_PREFIX}{conversation}");
+
+        for method in [
+            LogicalMethod::Get,
+            LogicalMethod::Post,
+            LogicalMethod::Delete,
+        ] {
+            assert_eq!(
+                decode_canonical_conversation_path(method, &conversation_path).unwrap(),
+                Some(ConversationItemPath::Conversation(conversation_id))
+            );
+        }
+
+        let items_path = format!("{conversation_path}/items");
+        assert_eq!(
+            decode_canonical_conversation_path(LogicalMethod::Get, &items_path).unwrap(),
+            Some(ConversationItemPath::Items(conversation_id))
+        );
+        let item_path = format!("{items_path}/{item}");
+        assert_eq!(
+            decode_canonical_conversation_path(LogicalMethod::Get, &item_path).unwrap(),
+            Some(ConversationItemPath::Item {
+                conversation_id,
+                item_id,
+            })
+        );
+        validate_logical_path(LogicalMethod::Get, &item_path, &EnvelopeLimits::default()).unwrap();
+
+        for action in ["batch-delete", "batch-update-project"] {
+            assert!(decode_canonical_conversation_path(
+                LogicalMethod::Post,
+                &format!("{CONVERSATION_ITEM_PATH_PREFIX}{action}"),
+            )
+            .unwrap()
+            .is_none());
+        }
+    }
+
+    #[test]
+    fn conversation_paths_reject_uuid_aliases_and_suffix_ambiguity() {
+        for invalid in [
+            "/v1/conversations/",
+            "/v1/conversations/123E4567-E89B-12D3-A456-426614174000",
+            "/v1/conversations/123e4567e89b12d3a456426614174000",
+            "/v1/conversations/{123e4567-e89b-12d3-a456-426614174000}",
+            "/v1/conversations/123e4567-e89b-12d3-a456-426614174000/extra",
+            "/v1/conversations/123e4567-e89b-12d3-a456-426614174000/items/",
+            "/v1/conversations/123e4567-e89b-12d3-a456-426614174000/items/not-a-uuid",
+            "/v1/conversations/123e4567-e89b-12d3-a456-426614174000/items/223e4567-e89b-12d3-a456-426614174000/extra",
+        ] {
+            assert!(
+                validate_logical_path(LogicalMethod::Get, invalid, &EnvelopeLimits::default())
+                    .is_err(),
+                "{invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn stored_response_item_and_cancel_paths_are_canonical() {
+        let encoded = "123e4567-e89b-12d3-a456-426614174000";
+        let id = Uuid::parse_str(encoded).unwrap();
+        let item = format!("{RESPONSE_ITEM_PATH_PREFIX}{encoded}");
+        assert_eq!(
+            decode_canonical_response_path(LogicalMethod::Get, &item).unwrap(),
+            Some(ResponseItemPath::Item(id))
+        );
+        assert_eq!(
+            decode_canonical_response_path(LogicalMethod::Delete, &item).unwrap(),
+            Some(ResponseItemPath::Item(id))
+        );
+        let cancel = format!("{item}/cancel");
+        assert_eq!(
+            decode_canonical_response_path(LogicalMethod::Post, &cancel).unwrap(),
+            Some(ResponseItemPath::Cancel(id))
+        );
+        validate_logical_path(LogicalMethod::Post, &cancel, &EnvelopeLimits::default()).unwrap();
+    }
+
+    #[test]
+    fn stored_response_paths_reject_uuid_aliases_and_suffix_ambiguity() {
+        for invalid in [
+            "/v1/responses/",
+            "/v1/responses/123E4567-E89B-12D3-A456-426614174000",
+            "/v1/responses/123e4567e89b12d3a456426614174000",
+            "/v1/responses/{123e4567-e89b-12d3-a456-426614174000}",
+            "/v1/responses/123e4567-e89b-12d3-a456-426614174000/extra",
+            "/v1/responses/123e4567-e89b-12d3-a456-426614174000/cancel/extra",
+        ] {
+            assert!(
+                validate_logical_path(LogicalMethod::Get, invalid, &EnvelopeLimits::default())
+                    .is_err(),
+                "{invalid}"
+            );
+        }
+        assert!(validate_logical_path(
+            LogicalMethod::Post,
+            "/v1/responses/not-a-uuid/cancel",
+            &EnvelopeLimits::default(),
+        )
+        .is_err());
     }
 
     #[test]

--- a/src/transport_v2/mod.rs
+++ b/src/transport_v2/mod.rs
@@ -12,6 +12,7 @@ mod envelope;
 mod gateway;
 mod session;
 mod session_cache;
+pub(crate) mod stored_conversations;
 pub(crate) mod stored_resources;
 
 pub(crate) use gateway::{router, TransportV2State};

--- a/src/transport_v2/stored_conversations.rs
+++ b/src/transport_v2/stored_conversations.rs
@@ -1,0 +1,2404 @@
+//! Bounded, transport-v2-only projections for conversations and stored responses.
+//!
+//! The transport-v1 loaders intentionally remain untouched. Every v2 read that
+//! can materialize persisted ciphertext first measures the exact returned page
+//! or object inside a repeatable-read transaction, validates the aggregate
+//! plaintext and database-controlled string sizes, and only then fetches the
+//! narrow ciphertext projection. List sentinels are metadata-only and are
+//! removed before ciphertext sizing and fetch.
+//!
+//! Mutations are owner-scoped and return only the metadata required to build
+//! the existing application response. Conversation updates deliberately retain
+//! v1's last-writer-wins behavior; the preloaded response can be stale if two
+//! updates race, but no unbounded stored value is reloaded after the write.
+
+use std::collections::HashSet;
+
+use chrono::{DateTime, Utc};
+use diesel::dsl::sql;
+use diesel::prelude::*;
+use diesel::sql_query;
+use diesel::sql_types::{BigInt, Integer, Nullable, Text, Timestamptz};
+use diesel::{Connection, OptionalExtension, QueryableByName};
+use uuid::Uuid;
+use zeroize::{Zeroize, Zeroizing};
+
+use crate::models::responses::{ConversationProjectFilter, ResponseStatus};
+use crate::models::schema::{conversation_projects, conversations, responses};
+
+const AES_GCM_STORAGE_OVERHEAD_BYTES: usize = 12 + 16;
+const MAX_PAGE_SIZE: i64 = 100;
+const MAX_CONVERSATION_BATCH_SIZE: usize = 20;
+
+/// A hard row-count guard for the unpaginated response-retrieval contract.
+///
+/// The byte budget remains authoritative. This separate guard prevents a
+/// database attacker from replacing a bounded response with millions of tiny
+/// child rows and forcing unbounded metadata allocation before byte accounting.
+const MAX_STORED_RESPONSE_ITEMS: i64 = 10_000;
+const ACCOUNTED_BYTES_PER_STORED_ITEM: usize = 256;
+
+type Pool = diesel::r2d2::Pool<diesel::r2d2::ConnectionManager<PgConnection>>;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum StoredConversationError {
+    #[error("conversation not found")]
+    ConversationNotFound,
+    #[error("conversation project not found")]
+    ConversationProjectNotFound,
+    #[error("conversation item not found")]
+    ConversationItemNotFound,
+    #[error("response not found")]
+    ResponseNotFound,
+    #[error("request violates the existing conversation contract")]
+    Validation,
+    #[error("stored output exceeds the logical response limit")]
+    OutputTooLarge,
+    #[error("stored output changed within a bounded snapshot")]
+    InconsistentSnapshot,
+    #[error("database connection unavailable")]
+    Connection,
+    #[error("database error: {0}")]
+    Database(#[from] diesel::result::Error),
+}
+
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = conversations)]
+pub(crate) struct ConversationCiphertextRow {
+    pub(crate) id: i64,
+    pub(crate) uuid: Uuid,
+    pub(crate) metadata_enc: Option<Vec<u8>>,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) updated_at: DateTime<Utc>,
+    pub(crate) project_id: Option<i64>,
+    pub(crate) is_pinned: bool,
+    pub(crate) last_activity_at: DateTime<Utc>,
+}
+
+impl Zeroize for ConversationCiphertextRow {
+    fn zeroize(&mut self) {
+        if let Some(metadata) = self.metadata_enc.as_mut() {
+            metadata.zeroize();
+        }
+    }
+}
+
+impl Drop for ConversationCiphertextRow {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+pub(crate) struct StoredConversation {
+    pub(crate) conversation: ConversationCiphertextRow,
+    pub(crate) project_uuid: Option<Uuid>,
+}
+
+pub(crate) struct ConversationMutationMetadata {
+    pub(crate) uuid: Uuid,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) updated_at: DateTime<Utc>,
+    pub(crate) project_uuid: Option<Uuid>,
+    pub(crate) is_pinned: bool,
+    pub(crate) last_activity_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProjectAssignmentUpdate {
+    Unchanged,
+    Set(Option<i64>),
+}
+
+#[derive(AsChangeset, Default)]
+#[diesel(table_name = conversations)]
+struct ConversationChanges<'a> {
+    metadata_enc: Option<&'a Vec<u8>>,
+    project_id: Option<Option<i64>>,
+    is_pinned: Option<bool>,
+}
+
+#[derive(QueryableByName)]
+struct ItemMeasurement {
+    #[diesel(sql_type = Text)]
+    message_type: String,
+    #[diesel(sql_type = BigInt)]
+    id: i64,
+    #[diesel(sql_type = Integer)]
+    type_rank: i32,
+    #[diesel(sql_type = diesel::sql_types::Uuid)]
+    uuid: Uuid,
+    #[diesel(sql_type = Timestamptz)]
+    created_at: DateTime<Utc>,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    content_length: Option<i64>,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    status_length: Option<i64>,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    model_length: Option<i64>,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    finish_reason_length: Option<i64>,
+    #[diesel(sql_type = Nullable<BigInt>)]
+    tool_name_length: Option<i64>,
+}
+
+#[derive(QueryableByName, Debug)]
+pub(crate) struct StoredConversationItem {
+    #[diesel(sql_type = Text)]
+    pub(crate) message_type: String,
+    #[diesel(sql_type = BigInt)]
+    pub(crate) id: i64,
+    #[diesel(sql_type = Integer)]
+    pub(crate) type_rank: i32,
+    #[diesel(sql_type = diesel::sql_types::Uuid)]
+    pub(crate) uuid: Uuid,
+    #[diesel(sql_type = Nullable<diesel::sql_types::Bytea>)]
+    pub(crate) content_enc: Option<Vec<u8>>,
+    #[diesel(sql_type = Nullable<Text>)]
+    pub(crate) status: Option<String>,
+    #[diesel(sql_type = Timestamptz)]
+    pub(crate) created_at: DateTime<Utc>,
+    #[diesel(sql_type = Nullable<Text>)]
+    pub(crate) model: Option<String>,
+    #[diesel(sql_type = Nullable<Integer>)]
+    pub(crate) token_count: Option<i32>,
+    #[diesel(sql_type = Nullable<diesel::sql_types::Uuid>)]
+    pub(crate) tool_call_id: Option<Uuid>,
+    #[diesel(sql_type = Nullable<Text>)]
+    pub(crate) finish_reason: Option<String>,
+    #[diesel(sql_type = Nullable<Text>)]
+    pub(crate) tool_name: Option<String>,
+}
+
+impl Zeroize for StoredConversationItem {
+    fn zeroize(&mut self) {
+        if let Some(content) = self.content_enc.as_mut() {
+            content.zeroize();
+        }
+    }
+}
+
+impl Drop for StoredConversationItem {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = responses)]
+pub(crate) struct StoredResponseMetadata {
+    pub(crate) id: i64,
+    pub(crate) uuid: Uuid,
+    pub(crate) conversation_id: i64,
+    pub(crate) status: ResponseStatus,
+    pub(crate) model: String,
+    pub(crate) created_at: DateTime<Utc>,
+}
+
+pub(crate) struct StoredResponse {
+    pub(crate) response: StoredResponseMetadata,
+    pub(crate) items: Vec<StoredConversationItem>,
+}
+
+#[derive(Queryable, Selectable)]
+#[diesel(table_name = responses)]
+pub(crate) struct ResponseMutationMetadata {
+    pub(crate) uuid: Uuid,
+    pub(crate) status: ResponseStatus,
+    pub(crate) model: String,
+    pub(crate) created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ExpectedItemLengths {
+    content: Option<usize>,
+    status: Option<usize>,
+    model: Option<usize>,
+    finish_reason: Option<usize>,
+    tool_name: Option<usize>,
+}
+
+fn checked_length(length: i64) -> Result<usize, StoredConversationError> {
+    usize::try_from(length).map_err(|_| StoredConversationError::InconsistentSnapshot)
+}
+
+fn checked_ciphertext_length(length: i64) -> Result<(usize, usize), StoredConversationError> {
+    let ciphertext_length = checked_length(length)?;
+    let plaintext_length = ciphertext_length
+        .checked_sub(AES_GCM_STORAGE_OVERHEAD_BYTES)
+        .ok_or(StoredConversationError::InconsistentSnapshot)?;
+    Ok((ciphertext_length, plaintext_length))
+}
+
+fn account_bytes(
+    total: &mut usize,
+    bytes: usize,
+    logical_body_limit: usize,
+) -> Result<(), StoredConversationError> {
+    *total = total
+        .checked_add(bytes)
+        .ok_or(StoredConversationError::OutputTooLarge)?;
+    if *total > logical_body_limit {
+        return Err(StoredConversationError::OutputTooLarge);
+    }
+    Ok(())
+}
+
+fn account_ciphertext(
+    total: &mut usize,
+    length: Option<i64>,
+    logical_body_limit: usize,
+) -> Result<Option<usize>, StoredConversationError> {
+    let Some(length) = length else {
+        return Ok(None);
+    };
+    let (ciphertext_length, plaintext_length) = checked_ciphertext_length(length)?;
+    account_bytes(total, plaintext_length, logical_body_limit)?;
+    Ok(Some(ciphertext_length))
+}
+
+fn account_string(
+    total: &mut usize,
+    length: Option<i64>,
+    logical_body_limit: usize,
+) -> Result<Option<usize>, StoredConversationError> {
+    let Some(length) = length else {
+        return Ok(None);
+    };
+    let length = checked_length(length)?;
+    account_bytes(total, length, logical_body_limit)?;
+    Ok(Some(length))
+}
+
+fn validate_page_limit(limit: i64) -> Result<(), StoredConversationError> {
+    if (1..=MAX_PAGE_SIZE).contains(&limit) {
+        Ok(())
+    } else {
+        Err(StoredConversationError::Validation)
+    }
+}
+
+fn drop_page_sentinel<T>(rows: &mut Vec<T>, limit: i64) -> Result<bool, StoredConversationError> {
+    let limit = usize::try_from(limit).map_err(|_| StoredConversationError::Validation)?;
+    let has_more = rows.len() > limit;
+    if has_more {
+        rows.pop();
+    }
+    Ok(has_more)
+}
+
+fn validate_item_measurements(
+    measurements: &[ItemMeasurement],
+    logical_body_limit: usize,
+    initial_total: usize,
+) -> Result<Vec<ExpectedItemLengths>, StoredConversationError> {
+    if initial_total > logical_body_limit {
+        return Err(StoredConversationError::OutputTooLarge);
+    }
+    let mut total = initial_total;
+    account_bytes(
+        &mut total,
+        measurements
+            .len()
+            .checked_mul(ACCOUNTED_BYTES_PER_STORED_ITEM)
+            .ok_or(StoredConversationError::OutputTooLarge)?,
+        logical_body_limit,
+    )?;
+    measurements
+        .iter()
+        .map(|measurement| {
+            Ok(ExpectedItemLengths {
+                content: account_ciphertext(
+                    &mut total,
+                    measurement.content_length,
+                    logical_body_limit,
+                )?,
+                status: account_string(&mut total, measurement.status_length, logical_body_limit)?,
+                model: account_string(&mut total, measurement.model_length, logical_body_limit)?,
+                finish_reason: account_string(
+                    &mut total,
+                    measurement.finish_reason_length,
+                    logical_body_limit,
+                )?,
+                tool_name: account_string(
+                    &mut total,
+                    measurement.tool_name_length,
+                    logical_body_limit,
+                )?,
+            })
+        })
+        .collect()
+}
+
+fn option_len(value: Option<&Vec<u8>>) -> Option<usize> {
+    value.map(Vec::len)
+}
+
+fn option_string_len(value: Option<&String>) -> Option<usize> {
+    value.map(String::len)
+}
+
+fn validate_fetched_items(
+    rows: &mut Vec<StoredConversationItem>,
+    measurements: &[ItemMeasurement],
+    expected: &[ExpectedItemLengths],
+) -> Result<(), StoredConversationError> {
+    if rows.len() != measurements.len() || rows.len() != expected.len() {
+        rows.zeroize();
+        return Err(StoredConversationError::InconsistentSnapshot);
+    }
+
+    for ((row, measurement), expected) in rows.iter().zip(measurements).zip(expected) {
+        if row.message_type != measurement.message_type
+            || row.id != measurement.id
+            || row.type_rank != measurement.type_rank
+            || row.uuid != measurement.uuid
+            || row.created_at != measurement.created_at
+            || option_len(row.content_enc.as_ref()) != expected.content
+            || option_string_len(row.status.as_ref()) != expected.status
+            || option_string_len(row.model.as_ref()) != expected.model
+            || option_string_len(row.finish_reason.as_ref()) != expected.finish_reason
+            || option_string_len(row.tool_name.as_ref()) != expected.tool_name
+        {
+            rows.zeroize();
+            return Err(StoredConversationError::InconsistentSnapshot);
+        }
+    }
+
+    Ok(())
+}
+
+fn project_uuid_for_internal_id(
+    conn: &mut PgConnection,
+    user_id: Uuid,
+    project_id: Option<i64>,
+) -> Result<Option<Uuid>, StoredConversationError> {
+    let Some(project_id) = project_id else {
+        return Ok(None);
+    };
+    conversation_projects::table
+        .filter(conversation_projects::id.eq(project_id))
+        .filter(conversation_projects::user_id.eq(user_id))
+        .select(conversation_projects::uuid)
+        .first::<Uuid>(conn)
+        .optional()?
+        .map(Some)
+        .ok_or(StoredConversationError::InconsistentSnapshot)
+}
+
+/// Resolve a public project UUID without loading its encrypted name.
+pub(crate) fn resolve_project_id(
+    pool: &Pool,
+    user_id: Uuid,
+    project_uuid: Uuid,
+) -> Result<i64, StoredConversationError> {
+    let mut conn = pool
+        .get()
+        .map_err(|_| StoredConversationError::Connection)?;
+    conversation_projects::table
+        .filter(conversation_projects::uuid.eq(project_uuid))
+        .filter(conversation_projects::user_id.eq(user_id))
+        .select(conversation_projects::id)
+        .first::<i64>(&mut conn)
+        .optional()?
+        .ok_or(StoredConversationError::ConversationProjectNotFound)
+}
+
+pub(crate) fn get_conversation(
+    pool: &Pool,
+    user_id: Uuid,
+    conversation_uuid: Uuid,
+    logical_body_limit: usize,
+) -> Result<StoredConversation, StoredConversationError> {
+    let mut conn = pool
+        .get()
+        .map_err(|_| StoredConversationError::Connection)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, StoredConversationError, _>(|conn| {
+            let (conversation_id, metadata_length, project_id) = conversations::table
+                .filter(conversations::uuid.eq(conversation_uuid))
+                .filter(conversations::user_id.eq(user_id))
+                .select((
+                    conversations::id,
+                    sql::<Nullable<BigInt>>("octet_length(metadata_enc)::bigint"),
+                    conversations::project_id,
+                ))
+                .first::<(i64, Option<i64>, Option<i64>)>(conn)
+                .optional()?
+                .ok_or(StoredConversationError::ConversationNotFound)?;
+
+            let mut total = 0;
+            let expected_metadata =
+                account_ciphertext(&mut total, metadata_length, logical_body_limit)?;
+            let project_uuid = project_uuid_for_internal_id(conn, user_id, project_id)?;
+
+            let mut conversation = conversations::table
+                .filter(conversations::id.eq(conversation_id))
+                .filter(conversations::user_id.eq(user_id))
+                .select(ConversationCiphertextRow::as_select())
+                .first::<ConversationCiphertextRow>(conn)?;
+            if option_len(conversation.metadata_enc.as_ref()) != expected_metadata
+                || conversation.project_id != project_id
+            {
+                conversation.zeroize();
+                return Err(StoredConversationError::InconsistentSnapshot);
+            }
+
+            Ok(StoredConversation {
+                conversation,
+                project_uuid,
+            })
+        })
+}
+
+fn conversation_cursor(
+    conn: &mut PgConnection,
+    user_id: Uuid,
+    after: Option<Uuid>,
+) -> Result<Option<(DateTime<Utc>, i64)>, StoredConversationError> {
+    let Some(after) = after else {
+        return Ok(None);
+    };
+    conversations::table
+        .filter(conversations::uuid.eq(after))
+        .filter(conversations::user_id.eq(user_id))
+        .select((conversations::last_activity_at, conversations::id))
+        .first::<(DateTime<Utc>, i64)>(conn)
+        .optional()
+        .map_err(StoredConversationError::Database)
+}
+
+type ConversationMeasurement = (
+    Uuid,
+    i64,
+    Option<i64>,
+    Option<i64>,
+    Option<Uuid>,
+    DateTime<Utc>,
+);
+
+fn conversation_measure_page(
+    conn: &mut PgConnection,
+    user_id: Uuid,
+    limit: i64,
+    cursor: Option<(DateTime<Utc>, i64)>,
+    order: &str,
+    project_filter: ConversationProjectFilter,
+    pinned: Option<bool>,
+) -> Result<Vec<ConversationMeasurement>, StoredConversationError> {
+    let mut query = conversations::table
+        .left_join(
+            conversation_projects::table.on(conversation_projects::id
+                .nullable()
+                .eq(conversations::project_id)
+                .and(conversation_projects::user_id.eq(user_id))),
+        )
+        .filter(conversations::user_id.eq(user_id))
+        .into_boxed();
+
+    query = match project_filter {
+        ConversationProjectFilter::Any => query,
+        ConversationProjectFilter::Assigned(project_id) => {
+            query.filter(conversations::project_id.eq(Some(project_id)))
+        }
+        ConversationProjectFilter::Unassigned => query.filter(conversations::project_id.is_null()),
+    };
+    if let Some(pinned) = pinned {
+        query = query.filter(conversations::is_pinned.eq(pinned));
+    }
+    if let Some((last_activity_at, id)) = cursor {
+        query = if order == "desc" {
+            query.filter(
+                conversations::last_activity_at.lt(last_activity_at).or(
+                    conversations::last_activity_at
+                        .eq(last_activity_at)
+                        .and(conversations::id.lt(id)),
+                ),
+            )
+        } else {
+            query.filter(
+                conversations::last_activity_at.gt(last_activity_at).or(
+                    conversations::last_activity_at
+                        .eq(last_activity_at)
+                        .and(conversations::id.gt(id)),
+                ),
+            )
+        };
+    }
+    query = if order == "desc" {
+        query.order((
+            conversations::last_activity_at.desc(),
+            conversations::id.desc(),
+        ))
+    } else {
+        query.order((
+            conversations::last_activity_at.asc(),
+            conversations::id.asc(),
+        ))
+    };
+
+    query
+        .select((
+            conversations::uuid,
+            conversations::id,
+            sql::<Nullable<BigInt>>("octet_length(conversations.metadata_enc)::bigint"),
+            conversations::project_id,
+            conversation_projects::uuid.nullable(),
+            conversations::last_activity_at,
+        ))
+        .limit(limit)
+        .load::<ConversationMeasurement>(conn)
+        .map_err(StoredConversationError::Database)
+}
+
+fn conversation_fetch_page(
+    conn: &mut PgConnection,
+    user_id: Uuid,
+    limit: i64,
+    cursor: Option<(DateTime<Utc>, i64)>,
+    order: &str,
+    project_filter: ConversationProjectFilter,
+    pinned: Option<bool>,
+) -> Result<Vec<(ConversationCiphertextRow, Option<Uuid>)>, StoredConversationError> {
+    let mut query = conversations::table
+        .left_join(
+            conversation_projects::table.on(conversation_projects::id
+                .nullable()
+                .eq(conversations::project_id)
+                .and(conversation_projects::user_id.eq(user_id))),
+        )
+        .filter(conversations::user_id.eq(user_id))
+        .into_boxed();
+
+    query = match project_filter {
+        ConversationProjectFilter::Any => query,
+        ConversationProjectFilter::Assigned(project_id) => {
+            query.filter(conversations::project_id.eq(Some(project_id)))
+        }
+        ConversationProjectFilter::Unassigned => query.filter(conversations::project_id.is_null()),
+    };
+    if let Some(pinned) = pinned {
+        query = query.filter(conversations::is_pinned.eq(pinned));
+    }
+    if let Some((last_activity_at, id)) = cursor {
+        query = if order == "desc" {
+            query.filter(
+                conversations::last_activity_at.lt(last_activity_at).or(
+                    conversations::last_activity_at
+                        .eq(last_activity_at)
+                        .and(conversations::id.lt(id)),
+                ),
+            )
+        } else {
+            query.filter(
+                conversations::last_activity_at.gt(last_activity_at).or(
+                    conversations::last_activity_at
+                        .eq(last_activity_at)
+                        .and(conversations::id.gt(id)),
+                ),
+            )
+        };
+    }
+    query = if order == "desc" {
+        query.order((
+            conversations::last_activity_at.desc(),
+            conversations::id.desc(),
+        ))
+    } else {
+        query.order((
+            conversations::last_activity_at.asc(),
+            conversations::id.asc(),
+        ))
+    };
+
+    query
+        .select((
+            ConversationCiphertextRow::as_select(),
+            conversation_projects::uuid.nullable(),
+        ))
+        .limit(limit)
+        .load::<(ConversationCiphertextRow, Option<Uuid>)>(conn)
+        .map_err(StoredConversationError::Database)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn list_conversations(
+    pool: &Pool,
+    user_id: Uuid,
+    limit: i64,
+    after: Option<Uuid>,
+    order: &str,
+    project_filter: ConversationProjectFilter,
+    pinned: Option<bool>,
+    logical_body_limit: usize,
+) -> Result<(Vec<StoredConversation>, bool), StoredConversationError> {
+    validate_page_limit(limit)?;
+    let mut conn = pool
+        .get()
+        .map_err(|_| StoredConversationError::Connection)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, StoredConversationError, _>(|conn| {
+            // V1 resolves the cursor by owner only, independently of filters.
+            let cursor = conversation_cursor(conn, user_id, after)?;
+            let sentinel_limit = limit
+                .checked_add(1)
+                .ok_or(StoredConversationError::OutputTooLarge)?;
+            let mut measured = conversation_measure_page(
+                conn,
+                user_id,
+                sentinel_limit,
+                cursor,
+                order,
+                project_filter,
+                pinned,
+            )?;
+            let has_more = drop_page_sentinel(&mut measured, limit)?;
+
+            let mut total = 0;
+            let expected_lengths = measured
+                .iter()
+                .map(|(_, _, length, project_id, project_uuid, _)| {
+                    if project_id.is_some() != project_uuid.is_some() {
+                        return Err(StoredConversationError::InconsistentSnapshot);
+                    }
+                    account_ciphertext(&mut total, *length, logical_body_limit)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            let mut rows = conversation_fetch_page(
+                conn,
+                user_id,
+                limit,
+                cursor,
+                order,
+                project_filter,
+                pinned,
+            )?;
+            if rows.len() != measured.len() {
+                for (row, _) in &mut rows {
+                    row.zeroize();
+                }
+                return Err(StoredConversationError::InconsistentSnapshot);
+            }
+
+            for (((row, project_uuid), measured), expected_length) in
+                rows.iter().zip(&measured).zip(&expected_lengths)
+            {
+                if row.uuid != measured.0
+                    || row.id != measured.1
+                    || option_len(row.metadata_enc.as_ref()) != *expected_length
+                    || row.project_id != measured.3
+                    || *project_uuid != measured.4
+                    || row.last_activity_at != measured.5
+                {
+                    for (row, _) in &mut rows {
+                        row.zeroize();
+                    }
+                    return Err(StoredConversationError::InconsistentSnapshot);
+                }
+            }
+
+            Ok((
+                rows.into_iter()
+                    .map(|(conversation, project_uuid)| StoredConversation {
+                        conversation,
+                        project_uuid,
+                    })
+                    .collect(),
+                has_more,
+            ))
+        })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn update_conversation(
+    pool: &Pool,
+    user_id: Uuid,
+    conversation_uuid: Uuid,
+    metadata_enc: Option<Vec<u8>>,
+    project_update: ProjectAssignmentUpdate,
+    is_pinned: Option<bool>,
+) -> Result<ConversationMutationMetadata, StoredConversationError> {
+    let mut conn = pool
+        .get()
+        .map_err(|_| StoredConversationError::Connection)?;
+    conn.transaction::<_, StoredConversationError, _>(|conn| {
+        let project_id = match project_update {
+            ProjectAssignmentUpdate::Unchanged => None,
+            ProjectAssignmentUpdate::Set(project_id) => {
+                if let Some(project_id) = project_id {
+                    let exists = conversation_projects::table
+                        .filter(conversation_projects::id.eq(project_id))
+                        .filter(conversation_projects::user_id.eq(user_id))
+                        .select(conversation_projects::id)
+                        .for_update()
+                        .first::<i64>(conn)
+                        .optional()?;
+                    if exists.is_none() {
+                        return Err(StoredConversationError::ConversationProjectNotFound);
+                    }
+                }
+                Some(project_id)
+            }
+        };
+
+        let metadata_enc = metadata_enc.map(Zeroizing::new);
+        let changes = ConversationChanges {
+            metadata_enc: metadata_enc.as_deref(),
+            project_id,
+            is_pinned,
+        };
+
+        let metadata = if changes.metadata_enc.is_none()
+            && changes.project_id.is_none()
+            && changes.is_pinned.is_none()
+        {
+            conversations::table
+                .filter(conversations::uuid.eq(conversation_uuid))
+                .filter(conversations::user_id.eq(user_id))
+                .select((
+                    conversations::uuid,
+                    conversations::created_at,
+                    conversations::updated_at,
+                    conversations::project_id,
+                    conversations::is_pinned,
+                    conversations::last_activity_at,
+                ))
+                .first::<(
+                    Uuid,
+                    DateTime<Utc>,
+                    DateTime<Utc>,
+                    Option<i64>,
+                    bool,
+                    DateTime<Utc>,
+                )>(conn)
+                .optional()?
+                .ok_or(StoredConversationError::ConversationNotFound)?
+        } else {
+            diesel::update(
+                conversations::table
+                    .filter(conversations::uuid.eq(conversation_uuid))
+                    .filter(conversations::user_id.eq(user_id)),
+            )
+            .set(&changes)
+            .returning((
+                conversations::uuid,
+                conversations::created_at,
+                conversations::updated_at,
+                conversations::project_id,
+                conversations::is_pinned,
+                conversations::last_activity_at,
+            ))
+            .get_result::<(
+                Uuid,
+                DateTime<Utc>,
+                DateTime<Utc>,
+                Option<i64>,
+                bool,
+                DateTime<Utc>,
+            )>(conn)
+            .optional()?
+            .ok_or(StoredConversationError::ConversationNotFound)?
+        };
+
+        let project_uuid = project_uuid_for_internal_id(conn, user_id, metadata.3)?;
+        Ok(ConversationMutationMetadata {
+            uuid: metadata.0,
+            created_at: metadata.1,
+            updated_at: metadata.2,
+            project_uuid,
+            is_pinned: metadata.4,
+            last_activity_at: metadata.5,
+        })
+    })
+}
+
+pub(crate) fn delete_conversation(
+    pool: &Pool,
+    user_id: Uuid,
+    conversation_uuid: Uuid,
+) -> Result<Uuid, StoredConversationError> {
+    let mut conn = pool
+        .get()
+        .map_err(|_| StoredConversationError::Connection)?;
+    diesel::delete(
+        conversations::table
+            .filter(conversations::uuid.eq(conversation_uuid))
+            .filter(conversations::user_id.eq(user_id)),
+    )
+    .returning(conversations::uuid)
+    .get_result::<Uuid>(&mut conn)
+    .optional()?
+    .ok_or(StoredConversationError::ConversationNotFound)
+}
+
+pub(crate) fn delete_all_conversations(
+    pool: &Pool,
+    user_id: Uuid,
+) -> Result<usize, StoredConversationError> {
+    let mut conn = pool
+        .get()
+        .map_err(|_| StoredConversationError::Connection)?;
+    diesel::delete(conversations::table.filter(conversations::user_id.eq(user_id)))
+        .execute(&mut conn)
+        .map_err(StoredConversationError::Database)
+}
+
+pub(crate) fn batch_update_conversation_project(
+    pool: &Pool,
+    user_id: Uuid,
+    conversation_uuids: &[Uuid],
+    target_project_id: Option<i64>,
+) -> Result<usize, StoredConversationError> {
+    if conversation_uuids.is_empty()
+        || conversation_uuids.len() > MAX_CONVERSATION_BATCH_SIZE
+        || conversation_uuids
+            .iter()
+            .copied()
+            .collect::<HashSet<_>>()
+            .len()
+            != conversation_uuids.len()
+    {
+        return Err(StoredConversationError::Validation);
+    }
+
+    let mut conn = pool
+        .get()
+        .map_err(|_| StoredConversationError::Connection)?;
+    conn.transaction::<_, StoredConversationError, _>(|conn| {
+        if let Some(target_project_id) = target_project_id {
+            let target = conversation_projects::table
+                .filter(conversation_projects::id.eq(target_project_id))
+                .filter(conversation_projects::user_id.eq(user_id))
+                .select(conversation_projects::id)
+                .for_update()
+                .first::<i64>(conn)
+                .optional()?;
+            if target.is_none() {
+                return Err(StoredConversationError::ConversationProjectNotFound);
+            }
+        }
+
+        let existing = conversations::table
+            .filter(conversations::user_id.eq(user_id))
+            .filter(conversations::uuid.eq_any(conversation_uuids))
+            .select((conversations::uuid, conversations::project_id))
+            .for_update()
+            .load::<(Uuid, Option<i64>)>(conn)?;
+        if existing.len() != conversation_uuids.len() {
+            return Err(StoredConversationError::ConversationNotFound);
+        }
+        let source_project = existing
+            .first()
+            .map(|(_, project_id)| *project_id)
+            .ok_or(StoredConversationError::Validation)?;
+        if existing
+            .iter()
+            .any(|(_, project_id)| *project_id != source_project)
+        {
+            return Err(StoredConversationError::Validation);
+        }
+
+        let updated = diesel::update(
+            conversations::table
+                .filter(conversations::user_id.eq(user_id))
+                .filter(conversations::uuid.eq_any(conversation_uuids)),
+        )
+        .set(conversations::project_id.eq(target_project_id))
+        .execute(conn)?;
+        if updated != conversation_uuids.len() {
+            return Err(StoredConversationError::ConversationNotFound);
+        }
+        Ok(updated)
+    })
+}
+
+fn lookup_conversation_id_on_connection(
+    conn: &mut PgConnection,
+    user_id: Uuid,
+    conversation_uuid: Uuid,
+) -> Result<i64, StoredConversationError> {
+    conversations::table
+        .filter(conversations::uuid.eq(conversation_uuid))
+        .filter(conversations::user_id.eq(user_id))
+        .select(conversations::id)
+        .first::<i64>(conn)
+        .optional()?
+        .ok_or(StoredConversationError::ConversationNotFound)
+}
+
+/// Resolve a public conversation UUID without loading its encrypted metadata.
+pub(crate) fn lookup_conversation_id(
+    pool: &Pool,
+    user_id: Uuid,
+    conversation_uuid: Uuid,
+) -> Result<i64, StoredConversationError> {
+    let mut conn = pool
+        .get()
+        .map_err(|_| StoredConversationError::Connection)?;
+    lookup_conversation_id_on_connection(&mut conn, user_id, conversation_uuid)
+}
+
+/// Delete a previously resolved conversation without loading any ciphertext.
+///
+/// Keeping lookup and delete separate lets the v1-compatible batch endpoint
+/// classify lookup failures as `not_found`, delete failures as
+/// `delete_failed`, and a duplicate UUID as success followed by `not_found`.
+pub(crate) fn delete_conversation_by_internal_id(
+    pool: &Pool,
+    user_id: Uuid,
+    conversation_id: i64,
+) -> Result<(), StoredConversationError> {
+    let mut conn = pool
+        .get()
+        .map_err(|_| StoredConversationError::Connection)?;
+    let deleted = diesel::delete(
+        conversations::table
+            .filter(conversations::id.eq(conversation_id))
+            .filter(conversations::user_id.eq(user_id)),
+    )
+    .execute(&mut conn)?;
+    if deleted == 0 {
+        return Err(StoredConversationError::ConversationNotFound);
+    }
+    Ok(())
+}
+
+/// Source rows for the Conversations items API.
+///
+/// Each branch independently binds both the authenticated user and the
+/// owner-scoped parent ID. The response and tool-call joins repeat the same
+/// bindings instead of trusting a database-controlled foreign key.
+const CONVERSATION_ITEM_SOURCE: &str = r#"
+WITH item_rows AS (
+    SELECT
+        'user'::text AS message_type,
+        um.id,
+        1::integer AS type_rank,
+        um.uuid,
+        um.content_enc,
+        'completed'::text AS status,
+        um.created_at,
+        r.model,
+        um.prompt_tokens AS token_count,
+        NULL::uuid AS tool_call_id,
+        NULL::text AS finish_reason,
+        NULL::text AS tool_name
+    FROM user_messages um
+    LEFT JOIN responses r
+      ON r.id = um.response_id
+     AND r.user_id = $2
+     AND r.conversation_id = $1
+    WHERE um.conversation_id = $1 AND um.user_id = $2
+
+    UNION ALL
+
+    SELECT
+        'assistant'::text,
+        am.id,
+        2::integer,
+        am.uuid,
+        am.content_enc,
+        am.status,
+        am.created_at,
+        r.model,
+        am.completion_tokens,
+        NULL::uuid,
+        am.finish_reason,
+        NULL::text
+    FROM assistant_messages am
+    LEFT JOIN responses r
+      ON r.id = am.response_id
+     AND r.user_id = $2
+     AND r.conversation_id = $1
+    WHERE am.conversation_id = $1 AND am.user_id = $2
+
+    UNION ALL
+
+    SELECT
+        'tool_call'::text,
+        tc.id,
+        3::integer,
+        tc.uuid,
+        tc.arguments_enc,
+        'completed'::text,
+        tc.created_at,
+        NULL::text,
+        tc.argument_tokens,
+        tc.uuid,
+        NULL::text,
+        tc.name
+    FROM tool_calls tc
+    WHERE tc.conversation_id = $1 AND tc.user_id = $2
+
+    UNION ALL
+
+    SELECT
+        'tool_output'::text,
+        tto.id,
+        4::integer,
+        tto.uuid,
+        tto.output_enc,
+        'completed'::text,
+        tto.created_at,
+        NULL::text,
+        tto.output_tokens,
+        tc.uuid,
+        NULL::text,
+        tc.name
+    FROM tool_outputs tto
+    JOIN tool_calls tc
+      ON tc.id = tto.tool_call_fk
+     AND tc.user_id = $2
+     AND tc.conversation_id = $1
+    WHERE tto.conversation_id = $1 AND tto.user_id = $2
+
+    UNION ALL
+
+    SELECT
+        'reasoning'::text,
+        ri.id,
+        5::integer,
+        ri.uuid,
+        ri.content_enc,
+        ri.status,
+        ri.created_at,
+        NULL::text,
+        ri.reasoning_tokens,
+        NULL::uuid,
+        NULL::text,
+        NULL::text
+    FROM reasoning_items ri
+    WHERE ri.conversation_id = $1 AND ri.user_id = $2
+)
+"#;
+
+/// Source rows for a single stored response.
+///
+/// User and reasoning ciphertext are intentionally projected as NULL because
+/// v1 uses those rows only for token accounting and emits no corresponding
+/// plaintext in the response output. All five row families remain present.
+const STORED_RESPONSE_ITEM_SOURCE: &str = r#"
+WITH item_rows AS (
+    SELECT
+        'user'::text AS message_type,
+        um.id,
+        1::integer AS type_rank,
+        um.uuid,
+        NULL::bytea AS content_enc,
+        'completed'::text AS status,
+        um.created_at,
+        NULL::text AS model,
+        um.prompt_tokens AS token_count,
+        NULL::uuid AS tool_call_id,
+        NULL::text AS finish_reason,
+        NULL::text AS tool_name
+    FROM user_messages um
+    WHERE um.response_id = $1 AND um.user_id = $2 AND um.conversation_id = $3
+
+    UNION ALL
+
+    SELECT
+        'assistant'::text,
+        am.id,
+        2::integer,
+        am.uuid,
+        am.content_enc,
+        am.status,
+        am.created_at,
+        NULL::text,
+        am.completion_tokens,
+        NULL::uuid,
+        am.finish_reason,
+        NULL::text
+    FROM assistant_messages am
+    WHERE am.response_id = $1 AND am.user_id = $2 AND am.conversation_id = $3
+
+    UNION ALL
+
+    SELECT
+        'tool_call'::text,
+        tc.id,
+        3::integer,
+        tc.uuid,
+        tc.arguments_enc,
+        'completed'::text,
+        tc.created_at,
+        NULL::text,
+        tc.argument_tokens,
+        tc.uuid,
+        NULL::text,
+        tc.name
+    FROM tool_calls tc
+    WHERE tc.response_id = $1 AND tc.user_id = $2 AND tc.conversation_id = $3
+
+    UNION ALL
+
+    SELECT
+        'tool_output'::text,
+        tto.id,
+        4::integer,
+        tto.uuid,
+        tto.output_enc,
+        'completed'::text,
+        tto.created_at,
+        NULL::text,
+        tto.output_tokens,
+        tc.uuid,
+        NULL::text,
+        NULL::text
+    FROM tool_outputs tto
+    JOIN tool_calls tc
+      ON tc.id = tto.tool_call_fk
+     AND tc.response_id = $1
+     AND tc.user_id = $2
+     AND tc.conversation_id = $3
+    WHERE tto.response_id = $1 AND tto.user_id = $2 AND tto.conversation_id = $3
+
+    UNION ALL
+
+    SELECT
+        'reasoning'::text,
+        ri.id,
+        5::integer,
+        ri.uuid,
+        NULL::bytea,
+        ri.status,
+        ri.created_at,
+        NULL::text,
+        ri.reasoning_tokens,
+        NULL::uuid,
+        NULL::text,
+        NULL::text
+    FROM reasoning_items ri
+    WHERE ri.response_id = $1 AND ri.user_id = $2 AND ri.conversation_id = $3
+)
+"#;
+
+const ITEM_MEASUREMENT_SELECT: &str = r#"
+SELECT
+    items.message_type,
+    items.id,
+    items.type_rank,
+    items.uuid,
+    items.created_at,
+    octet_length(items.content_enc)::bigint AS content_length,
+    octet_length(items.status)::bigint AS status_length,
+    octet_length(items.model)::bigint AS model_length,
+    octet_length(items.finish_reason)::bigint AS finish_reason_length,
+    octet_length(items.tool_name)::bigint AS tool_name_length
+FROM item_rows items
+"#;
+
+const ITEM_FETCH_SELECT: &str = r#"
+SELECT
+    items.message_type,
+    items.id,
+    items.type_rank,
+    items.uuid,
+    items.content_enc,
+    items.status,
+    items.created_at,
+    items.model,
+    items.token_count,
+    items.tool_call_id,
+    items.finish_reason,
+    items.tool_name
+FROM item_rows items
+"#;
+
+fn conversation_item_page_sql(after: bool, order: &str, measurement: bool) -> String {
+    let select = if measurement {
+        ITEM_MEASUREMENT_SELECT
+    } else {
+        ITEM_FETCH_SELECT
+    };
+    let ordering = if order == "desc" {
+        "ORDER BY items.created_at DESC, items.id DESC, items.type_rank DESC"
+    } else {
+        "ORDER BY items.created_at ASC, items.id ASC, items.type_rank ASC"
+    };
+    if after {
+        let predicate = if order == "desc" {
+            "(items.created_at < cursor_item.created_at) OR \
+             (items.created_at = cursor_item.created_at AND (\
+                 items.id < cursor_item.id OR (\
+                     items.id = cursor_item.id AND items.type_rank < cursor_item.type_rank\
+                 )\
+             ))"
+        } else {
+            "(items.created_at > cursor_item.created_at) OR \
+             (items.created_at = cursor_item.created_at AND (\
+                 items.id > cursor_item.id OR (\
+                     items.id = cursor_item.id AND items.type_rank > cursor_item.type_rank\
+                 )\
+             ))"
+        };
+        format!(
+            "{CONVERSATION_ITEM_SOURCE}, cursor_item AS (\
+                SELECT created_at, id, type_rank FROM item_rows WHERE uuid = $3 \
+                ORDER BY created_at ASC, id ASC, type_rank ASC LIMIT 1\
+             ) {select}, cursor_item WHERE {predicate} {ordering} LIMIT $4"
+        )
+    } else {
+        format!("{CONVERSATION_ITEM_SOURCE} {select} {ordering} LIMIT $3")
+    }
+}
+
+fn conversation_item_get_sql(measurement: bool) -> String {
+    let select = if measurement {
+        ITEM_MEASUREMENT_SELECT
+    } else {
+        ITEM_FETCH_SELECT
+    };
+    format!(
+        "{CONVERSATION_ITEM_SOURCE} {select} \
+         WHERE items.uuid = $3 \
+         ORDER BY items.created_at ASC, items.id ASC, items.type_rank ASC LIMIT 1"
+    )
+}
+
+fn stored_response_items_sql(measurement: bool) -> String {
+    let select = if measurement {
+        ITEM_MEASUREMENT_SELECT
+    } else {
+        ITEM_FETCH_SELECT
+    };
+    format!(
+        "{STORED_RESPONSE_ITEM_SOURCE} {select} \
+         ORDER BY items.created_at ASC, items.id ASC, items.type_rank ASC LIMIT $4"
+    )
+}
+
+fn load_conversation_item_measurements(
+    conn: &mut PgConnection,
+    conversation_id: i64,
+    user_id: Uuid,
+    limit: i64,
+    after: Option<Uuid>,
+    order: &str,
+) -> Result<Vec<ItemMeasurement>, StoredConversationError> {
+    let query = conversation_item_page_sql(after.is_some(), order, true);
+    match after {
+        Some(after) => sql_query(query)
+            .bind::<BigInt, _>(conversation_id)
+            .bind::<diesel::sql_types::Uuid, _>(user_id)
+            .bind::<diesel::sql_types::Uuid, _>(after)
+            .bind::<BigInt, _>(limit)
+            .load::<ItemMeasurement>(conn),
+        None => sql_query(query)
+            .bind::<BigInt, _>(conversation_id)
+            .bind::<diesel::sql_types::Uuid, _>(user_id)
+            .bind::<BigInt, _>(limit)
+            .load::<ItemMeasurement>(conn),
+    }
+    .map_err(StoredConversationError::Database)
+}
+
+fn load_conversation_items(
+    conn: &mut PgConnection,
+    conversation_id: i64,
+    user_id: Uuid,
+    limit: i64,
+    after: Option<Uuid>,
+    order: &str,
+) -> Result<Vec<StoredConversationItem>, StoredConversationError> {
+    let query = conversation_item_page_sql(after.is_some(), order, false);
+    match after {
+        Some(after) => sql_query(query)
+            .bind::<BigInt, _>(conversation_id)
+            .bind::<diesel::sql_types::Uuid, _>(user_id)
+            .bind::<diesel::sql_types::Uuid, _>(after)
+            .bind::<BigInt, _>(limit)
+            .load::<StoredConversationItem>(conn),
+        None => sql_query(query)
+            .bind::<BigInt, _>(conversation_id)
+            .bind::<diesel::sql_types::Uuid, _>(user_id)
+            .bind::<BigInt, _>(limit)
+            .load::<StoredConversationItem>(conn),
+    }
+    .map_err(StoredConversationError::Database)
+}
+
+pub(crate) fn list_conversation_items(
+    pool: &Pool,
+    user_id: Uuid,
+    conversation_uuid: Uuid,
+    limit: i64,
+    after: Option<Uuid>,
+    order: &str,
+    logical_body_limit: usize,
+) -> Result<(Vec<StoredConversationItem>, bool), StoredConversationError> {
+    validate_page_limit(limit)?;
+    let mut conn = pool
+        .get()
+        .map_err(|_| StoredConversationError::Connection)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, StoredConversationError, _>(|conn| {
+            let conversation_id =
+                lookup_conversation_id_on_connection(conn, user_id, conversation_uuid)?;
+            let sentinel_limit = limit
+                .checked_add(1)
+                .ok_or(StoredConversationError::OutputTooLarge)?;
+            let mut measured = load_conversation_item_measurements(
+                conn,
+                conversation_id,
+                user_id,
+                sentinel_limit,
+                after,
+                order,
+            )?;
+            let has_more = drop_page_sentinel(&mut measured, limit)?;
+            let expected = validate_item_measurements(&measured, logical_body_limit, 0)?;
+            let mut rows =
+                load_conversation_items(conn, conversation_id, user_id, limit, after, order)?;
+            validate_fetched_items(&mut rows, &measured, &expected)?;
+            Ok((rows, has_more))
+        })
+}
+
+pub(crate) fn get_conversation_item(
+    pool: &Pool,
+    user_id: Uuid,
+    conversation_uuid: Uuid,
+    item_uuid: Uuid,
+    logical_body_limit: usize,
+) -> Result<StoredConversationItem, StoredConversationError> {
+    let mut conn = pool
+        .get()
+        .map_err(|_| StoredConversationError::Connection)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, StoredConversationError, _>(|conn| {
+            let conversation_id =
+                lookup_conversation_id_on_connection(conn, user_id, conversation_uuid)?;
+            let measurement = sql_query(conversation_item_get_sql(true))
+                .bind::<BigInt, _>(conversation_id)
+                .bind::<diesel::sql_types::Uuid, _>(user_id)
+                .bind::<diesel::sql_types::Uuid, _>(item_uuid)
+                .get_result::<ItemMeasurement>(conn)
+                .optional()?
+                .ok_or(StoredConversationError::ConversationItemNotFound)?;
+            let expected = validate_item_measurements(
+                std::slice::from_ref(&measurement),
+                logical_body_limit,
+                0,
+            )?;
+            let row = sql_query(conversation_item_get_sql(false))
+                .bind::<BigInt, _>(conversation_id)
+                .bind::<diesel::sql_types::Uuid, _>(user_id)
+                .bind::<diesel::sql_types::Uuid, _>(item_uuid)
+                .get_result::<StoredConversationItem>(conn)
+                .optional()?
+                .ok_or(StoredConversationError::InconsistentSnapshot)?;
+            let mut rows = vec![row];
+            validate_fetched_items(&mut rows, std::slice::from_ref(&measurement), &expected)?;
+            rows.pop()
+                .ok_or(StoredConversationError::InconsistentSnapshot)
+        })
+}
+
+fn load_stored_response_item_measurements(
+    conn: &mut PgConnection,
+    response_id: i64,
+    user_id: Uuid,
+    conversation_id: i64,
+    limit: i64,
+) -> Result<Vec<ItemMeasurement>, StoredConversationError> {
+    sql_query(stored_response_items_sql(true))
+        .bind::<BigInt, _>(response_id)
+        .bind::<diesel::sql_types::Uuid, _>(user_id)
+        .bind::<BigInt, _>(conversation_id)
+        .bind::<BigInt, _>(limit)
+        .load::<ItemMeasurement>(conn)
+        .map_err(StoredConversationError::Database)
+}
+
+fn load_stored_response_items(
+    conn: &mut PgConnection,
+    response_id: i64,
+    user_id: Uuid,
+    conversation_id: i64,
+    limit: i64,
+) -> Result<Vec<StoredConversationItem>, StoredConversationError> {
+    sql_query(stored_response_items_sql(false))
+        .bind::<BigInt, _>(response_id)
+        .bind::<diesel::sql_types::Uuid, _>(user_id)
+        .bind::<BigInt, _>(conversation_id)
+        .bind::<BigInt, _>(limit)
+        .load::<StoredConversationItem>(conn)
+        .map_err(StoredConversationError::Database)
+}
+
+pub(crate) fn get_stored_response(
+    pool: &Pool,
+    user_id: Uuid,
+    response_uuid: Uuid,
+    logical_body_limit: usize,
+) -> Result<StoredResponse, StoredConversationError> {
+    let mut conn = pool
+        .get()
+        .map_err(|_| StoredConversationError::Connection)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, StoredConversationError, _>(|conn| {
+            let (response_id, conversation_id, model_length) = responses::table
+                .filter(responses::uuid.eq(response_uuid))
+                .filter(responses::user_id.eq(user_id))
+                .select((
+                    responses::id,
+                    responses::conversation_id,
+                    sql::<BigInt>("octet_length(model)::bigint"),
+                ))
+                .first::<(i64, i64, i64)>(conn)
+                .optional()?
+                .ok_or(StoredConversationError::ResponseNotFound)?;
+
+            // Do not trust a tampered response-to-conversation relationship.
+            let parent_exists = conversations::table
+                .filter(conversations::id.eq(conversation_id))
+                .filter(conversations::user_id.eq(user_id))
+                .select(conversations::id)
+                .first::<i64>(conn)
+                .optional()?;
+            if parent_exists.is_none() {
+                return Err(StoredConversationError::InconsistentSnapshot);
+            }
+
+            let model_length = checked_length(model_length)?;
+            if model_length > logical_body_limit {
+                return Err(StoredConversationError::OutputTooLarge);
+            }
+
+            let sentinel_limit = MAX_STORED_RESPONSE_ITEMS
+                .checked_add(1)
+                .ok_or(StoredConversationError::OutputTooLarge)?;
+            let measured = load_stored_response_item_measurements(
+                conn,
+                response_id,
+                user_id,
+                conversation_id,
+                sentinel_limit,
+            )?;
+            if measured.len()
+                > usize::try_from(MAX_STORED_RESPONSE_ITEMS)
+                    .map_err(|_| StoredConversationError::OutputTooLarge)?
+            {
+                return Err(StoredConversationError::OutputTooLarge);
+            }
+            let expected = validate_item_measurements(&measured, logical_body_limit, model_length)?;
+
+            let response = responses::table
+                .filter(responses::id.eq(response_id))
+                .filter(responses::user_id.eq(user_id))
+                .select(StoredResponseMetadata::as_select())
+                .first::<StoredResponseMetadata>(conn)?;
+            if response.conversation_id != conversation_id || response.model.len() != model_length {
+                return Err(StoredConversationError::InconsistentSnapshot);
+            }
+
+            let fetch_limit = i64::try_from(measured.len())
+                .map_err(|_| StoredConversationError::OutputTooLarge)?;
+            let mut items = load_stored_response_items(
+                conn,
+                response_id,
+                user_id,
+                conversation_id,
+                fetch_limit,
+            )?;
+            validate_fetched_items(&mut items, &measured, &expected)?;
+            Ok(StoredResponse { response, items })
+        })
+}
+
+/// Bounded metadata read for the cancel response.
+///
+/// The application serializes the exact cancelled-response JSON from this
+/// projection before calling [`transition_stored_response_to_cancelled`]. That
+/// keeps a database-controlled model string from causing a post-mutation
+/// serialization/capacity failure.
+pub(crate) fn get_cancelable_response_metadata(
+    pool: &Pool,
+    user_id: Uuid,
+    response_uuid: Uuid,
+    logical_body_limit: usize,
+) -> Result<ResponseMutationMetadata, StoredConversationError> {
+    let mut conn = pool
+        .get()
+        .map_err(|_| StoredConversationError::Connection)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, StoredConversationError, _>(|conn| {
+            let (response_id, conversation_id, status, model_length) = responses::table
+                .filter(responses::uuid.eq(response_uuid))
+                .filter(responses::user_id.eq(user_id))
+                .select((
+                    responses::id,
+                    responses::conversation_id,
+                    responses::status,
+                    sql::<BigInt>("octet_length(model)::bigint"),
+                ))
+                .first::<(i64, i64, ResponseStatus, i64)>(conn)
+                .optional()?
+                .ok_or(StoredConversationError::ResponseNotFound)?;
+
+            if !matches!(status, ResponseStatus::Queued | ResponseStatus::InProgress) {
+                return Err(StoredConversationError::Validation);
+            }
+            let model_length = checked_length(model_length)?;
+            if model_length > logical_body_limit {
+                return Err(StoredConversationError::OutputTooLarge);
+            }
+            let parent_exists = conversations::table
+                .filter(conversations::id.eq(conversation_id))
+                .filter(conversations::user_id.eq(user_id))
+                .select(conversations::id)
+                .first::<i64>(conn)
+                .optional()?;
+            if parent_exists.is_none() {
+                return Err(StoredConversationError::InconsistentSnapshot);
+            }
+
+            let result = responses::table
+                .filter(responses::id.eq(response_id))
+                .filter(responses::user_id.eq(user_id))
+                .select(ResponseMutationMetadata::as_select())
+                .first::<ResponseMutationMetadata>(conn)?;
+            if result.status != status || result.model.len() != model_length {
+                return Err(StoredConversationError::InconsistentSnapshot);
+            }
+            Ok(result)
+        })
+}
+
+/// Atomically transition a response after its exact success body was
+/// preflighted by the application.
+///
+/// A terminal-state race remains the existing 400 validation outcome. A
+/// deletion race, missing UUID, or foreign UUID remains the existing 404.
+pub(crate) fn transition_stored_response_to_cancelled(
+    pool: &Pool,
+    user_id: Uuid,
+    response_uuid: Uuid,
+) -> Result<Uuid, StoredConversationError> {
+    let mut conn = pool
+        .get()
+        .map_err(|_| StoredConversationError::Connection)?;
+    let updated = diesel::update(
+        responses::table
+            .filter(responses::uuid.eq(response_uuid))
+            .filter(responses::user_id.eq(user_id))
+            .filter(
+                responses::status
+                    .eq(ResponseStatus::Queued)
+                    .or(responses::status.eq(ResponseStatus::InProgress)),
+            ),
+    )
+    .set((
+        responses::status.eq(ResponseStatus::Cancelled),
+        responses::completed_at.eq(diesel::dsl::now),
+        responses::updated_at.eq(diesel::dsl::now),
+    ))
+    .returning(responses::uuid)
+    .get_result::<Uuid>(&mut conn)
+    .optional()?;
+    if let Some(uuid) = updated {
+        return Ok(uuid);
+    }
+
+    let exists = responses::table
+        .filter(responses::uuid.eq(response_uuid))
+        .filter(responses::user_id.eq(user_id))
+        .select(responses::uuid)
+        .first::<Uuid>(&mut conn)
+        .optional()?;
+    if exists.is_some() {
+        Err(StoredConversationError::Validation)
+    } else {
+        Err(StoredConversationError::ResponseNotFound)
+    }
+}
+
+pub(crate) fn delete_stored_response(
+    pool: &Pool,
+    user_id: Uuid,
+    response_uuid: Uuid,
+) -> Result<Uuid, StoredConversationError> {
+    let mut conn = pool
+        .get()
+        .map_err(|_| StoredConversationError::Connection)?;
+    diesel::delete(
+        responses::table
+            .filter(responses::uuid.eq(response_uuid))
+            .filter(responses::user_id.eq(user_id)),
+    )
+    .returning(responses::uuid)
+    .get_result::<Uuid>(&mut conn)
+    .optional()?
+    .ok_or(StoredConversationError::ResponseNotFound)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        account_ciphertext, batch_update_conversation_project, conversation_item_page_sql,
+        delete_all_conversations, delete_conversation_by_internal_id, delete_stored_response,
+        drop_page_sentinel, get_cancelable_response_metadata, get_conversation,
+        get_conversation_item, get_stored_response, list_conversation_items, list_conversations,
+        lookup_conversation_id, stored_response_items_sql, transition_stored_response_to_cancelled,
+        update_conversation, validate_page_limit, ItemMeasurement, Pool, ProjectAssignmentUpdate,
+        StoredConversationError, StoredConversationItem, AES_GCM_STORAGE_OVERHEAD_BYTES,
+    };
+    use crate::models::{
+        responses::{
+            ConversationProjectFilter, NewAssistantMessage, NewConversation,
+            NewConversationProject, NewReasoningItem, NewResponse, NewToolCall, NewToolOutput,
+            NewUserMessage, ResponseStatus,
+        },
+        schema::{conversations, org_projects, users},
+        users::NewUser,
+    };
+    use chrono::{Duration, Utc};
+    use diesel::prelude::*;
+    use diesel::r2d2::ConnectionManager;
+    use std::collections::HashSet;
+    use uuid::Uuid;
+
+    const TEST_MODEL: &str = "stored-conversation-v2-test-model";
+
+    struct TestUsers {
+        pool: Pool,
+        user_ids: Vec<Uuid>,
+    }
+
+    impl Drop for TestUsers {
+        fn drop(&mut self) {
+            let Ok(mut conn) = self.pool.get() else {
+                return;
+            };
+            let _ = diesel::delete(users::table.filter(users::uuid.eq_any(&self.user_ids)))
+                .execute(&mut conn);
+        }
+    }
+
+    struct ItemStackFixture {
+        conversation_uuid: Uuid,
+        response_uuid: Uuid,
+        assistant_uuid: Uuid,
+        foreign_message_uuid: Uuid,
+    }
+
+    fn disposable_pool() -> Option<Pool> {
+        let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+            eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+            return None;
+        };
+        let manager = ConnectionManager::<PgConnection>::new(database_url);
+        Some(
+            diesel::r2d2::Pool::builder()
+                .max_size(6)
+                .build(manager)
+                .expect("connect to disposable migrated PostgreSQL"),
+        )
+    }
+
+    fn first_active_org_project_id(conn: &mut PgConnection) -> i32 {
+        org_projects::table
+            .filter(org_projects::status.eq("active"))
+            .order(org_projects::id.asc())
+            .select(org_projects::id)
+            .first(conn)
+            .expect("test database should contain the migrated active project")
+    }
+
+    fn insert_test_user(conn: &mut PgConnection, org_project_id: i32, label: &str) -> Uuid {
+        let marker = Uuid::new_v4();
+        NewUser::new(
+            Some(format!("stored-v2-{label}-{marker}@example.com")),
+            None,
+            org_project_id,
+        )
+        .insert(conn)
+        .expect("test user should insert")
+        .uuid
+    }
+
+    fn storage_ciphertext(payload_bytes: usize, marker: u8) -> Vec<u8> {
+        vec![marker; AES_GCM_STORAGE_OVERHEAD_BYTES + payload_bytes]
+    }
+
+    fn insert_conversation(
+        conn: &mut PgConnection,
+        user_id: Uuid,
+        project_id: Option<i64>,
+        payload_bytes: usize,
+        marker: u8,
+    ) -> crate::models::responses::Conversation {
+        NewConversation {
+            uuid: Uuid::new_v4(),
+            user_id,
+            project_id,
+            is_pinned: false,
+            metadata_enc: Some(storage_ciphertext(payload_bytes, marker)),
+        }
+        .insert(conn)
+        .expect("test conversation should insert")
+    }
+
+    fn insert_item_stack(
+        conn: &mut PgConnection,
+        owner_id: Uuid,
+        foreign_user_id: Uuid,
+        status: ResponseStatus,
+    ) -> ItemStackFixture {
+        let conversation = insert_conversation(conn, owner_id, None, 4, 10);
+        let response = NewResponse {
+            uuid: Uuid::new_v4(),
+            user_id: owner_id,
+            conversation_id: conversation.id,
+            status,
+            model: TEST_MODEL.to_string(),
+            temperature: None,
+            top_p: None,
+            max_output_tokens: None,
+            tool_choice: None,
+            parallel_tool_calls: false,
+            store: true,
+            metadata_enc: None,
+        }
+        .insert(conn)
+        .expect("test response should insert");
+
+        let user_message_uuid = Uuid::new_v4();
+        NewUserMessage {
+            uuid: user_message_uuid,
+            conversation_id: conversation.id,
+            response_id: Some(response.id),
+            user_id: owner_id,
+            content_enc: storage_ciphertext(5, 11),
+            prompt_tokens: 3,
+        }
+        .insert(conn)
+        .expect("test user message should insert");
+
+        let base = Utc::now();
+        let assistant_uuid = Uuid::new_v4();
+        let assistant = NewAssistantMessage {
+            uuid: assistant_uuid,
+            conversation_id: conversation.id,
+            response_id: Some(response.id),
+            user_id: owner_id,
+            content_enc: Some(storage_ciphertext(6, 12)),
+            completion_tokens: 4,
+            status: "completed".to_string(),
+            finish_reason: Some("stop".to_string()),
+            created_at: base + Duration::milliseconds(1),
+        }
+        .insert(conn)
+        .expect("test assistant message should insert");
+
+        let tool_call = NewToolCall {
+            uuid: Uuid::new_v4(),
+            conversation_id: conversation.id,
+            response_id: Some(response.id),
+            user_id: owner_id,
+            name: "lookup".to_string(),
+            arguments_enc: Some(storage_ciphertext(7, 13)),
+            argument_tokens: 5,
+            status: "completed".to_string(),
+            created_at: base + Duration::milliseconds(2),
+        }
+        .insert(conn)
+        .expect("test tool call should insert");
+
+        NewToolOutput {
+            uuid: Uuid::new_v4(),
+            conversation_id: conversation.id,
+            response_id: Some(response.id),
+            user_id: owner_id,
+            tool_call_fk: tool_call.id,
+            output_enc: storage_ciphertext(8, 14),
+            output_tokens: 6,
+            status: "completed".to_string(),
+            error: None,
+            created_at: base + Duration::milliseconds(3),
+        }
+        .insert(conn)
+        .expect("test tool output should insert");
+
+        NewReasoningItem {
+            uuid: Uuid::new_v4(),
+            conversation_id: conversation.id,
+            response_id: Some(response.id),
+            assistant_message_id: Some(assistant.id),
+            user_id: owner_id,
+            content_enc: Some(storage_ciphertext(9, 15)),
+            summary_enc: None,
+            reasoning_tokens: 7,
+            status: "completed".to_string(),
+            created_at: base + Duration::milliseconds(4),
+        }
+        .insert(conn)
+        .expect("test reasoning item should insert");
+
+        // This intentionally inconsistent child proves every item branch binds
+        // the authenticated owner in addition to trusting the parent IDs.
+        let foreign_message_uuid = Uuid::new_v4();
+        NewUserMessage {
+            uuid: foreign_message_uuid,
+            conversation_id: conversation.id,
+            response_id: Some(response.id),
+            user_id: foreign_user_id,
+            content_enc: storage_ciphertext(10, 16),
+            prompt_tokens: 99,
+        }
+        .insert(conn)
+        .expect("cross-owner tamper fixture should be representable");
+
+        ItemStackFixture {
+            conversation_uuid: conversation.uuid,
+            response_uuid: response.uuid,
+            assistant_uuid,
+            foreign_message_uuid,
+        }
+    }
+
+    #[test]
+    fn ciphertext_accounting_removes_exact_storage_overhead() {
+        let mut total = 0;
+        let expected = account_ciphertext(
+            &mut total,
+            Some((AES_GCM_STORAGE_OVERHEAD_BYTES + 17) as i64),
+            17,
+        )
+        .expect("exact limit");
+        assert_eq!(expected, Some(AES_GCM_STORAGE_OVERHEAD_BYTES + 17));
+        assert_eq!(total, 17);
+    }
+
+    #[test]
+    fn ciphertext_accounting_rejects_short_and_oversized_values() {
+        let mut total = 0;
+        assert!(matches!(
+            account_ciphertext(
+                &mut total,
+                Some((AES_GCM_STORAGE_OVERHEAD_BYTES - 1) as i64),
+                usize::MAX,
+            ),
+            Err(StoredConversationError::InconsistentSnapshot)
+        ));
+
+        let mut total = 0;
+        assert!(matches!(
+            account_ciphertext(
+                &mut total,
+                Some((AES_GCM_STORAGE_OVERHEAD_BYTES + 2) as i64),
+                1,
+            ),
+            Err(StoredConversationError::OutputTooLarge)
+        ));
+    }
+
+    #[test]
+    fn list_sentinel_is_removed_before_returned_page_accounting() {
+        let mut rows = vec![1, 2, 3];
+        assert!(drop_page_sentinel(&mut rows, 2).expect("valid page"));
+        assert_eq!(rows, vec![1, 2]);
+    }
+
+    #[test]
+    fn page_bounds_match_the_existing_normalized_contract() {
+        assert!(validate_page_limit(1).is_ok());
+        assert!(validate_page_limit(100).is_ok());
+        assert!(matches!(
+            validate_page_limit(0),
+            Err(StoredConversationError::Validation)
+        ));
+        assert!(matches!(
+            validate_page_limit(101),
+            Err(StoredConversationError::Validation)
+        ));
+    }
+
+    #[test]
+    fn item_queries_scope_every_child_family_to_owner_and_parent() {
+        let conversation_sql = conversation_item_page_sql(true, "desc", true);
+        for table_alias in ["um", "am", "tc", "tto", "ri"] {
+            assert!(conversation_sql.contains(&format!(
+                "{table_alias}.conversation_id = $1 AND {table_alias}.user_id = $2"
+            )));
+        }
+        assert!(conversation_sql.contains("cursor_item"));
+
+        let response_sql = stored_response_items_sql(true);
+        for table_alias in ["um", "am", "tc", "tto", "ri"] {
+            assert!(response_sql.contains(&format!(
+                "{table_alias}.response_id = $1 AND {table_alias}.user_id = $2 AND {table_alias}.conversation_id = $3"
+            )));
+        }
+    }
+
+    #[test]
+    fn only_exact_desc_selects_descending_item_order() {
+        assert!(conversation_item_page_sql(false, "desc", true)
+            .contains("ORDER BY items.created_at DESC, items.id DESC, items.type_rank DESC"));
+        assert!(conversation_item_page_sql(false, "DESC", true)
+            .contains("ORDER BY items.created_at ASC, items.id ASC, items.type_rank ASC"));
+    }
+
+    #[test]
+    fn item_cursor_uses_the_same_total_order_as_the_page() {
+        let sql = conversation_item_page_sql(true, "desc", true);
+        assert!(sql.contains("SELECT created_at, id, type_rank FROM item_rows"));
+        assert!(
+            sql.contains("items.id = cursor_item.id AND items.type_rank < cursor_item.type_rank")
+        );
+    }
+
+    #[test]
+    #[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+    fn database_conversation_reads_and_mutations_preserve_owner_and_batch_contracts() {
+        let Some(pool) = disposable_pool() else {
+            return;
+        };
+        let mut conn = pool.get().expect("test database connection");
+        let org_project_id = first_active_org_project_id(&mut conn);
+        let owner_id = insert_test_user(&mut conn, org_project_id, "conversation-owner");
+        let foreign_id = insert_test_user(&mut conn, org_project_id, "conversation-foreign");
+        let _cleanup = TestUsers {
+            pool: pool.clone(),
+            user_ids: vec![owner_id, foreign_id],
+        };
+
+        let source_project = NewConversationProject {
+            uuid: Uuid::new_v4(),
+            user_id: owner_id,
+            name_enc: storage_ciphertext(2, 21),
+        }
+        .insert(&mut conn)
+        .expect("source project should insert");
+        let target_project = NewConversationProject {
+            uuid: Uuid::new_v4(),
+            user_id: owner_id,
+            name_enc: storage_ciphertext(2, 22),
+        }
+        .insert(&mut conn)
+        .expect("target project should insert");
+
+        let first = insert_conversation(&mut conn, owner_id, Some(source_project.id), 3, 31);
+        let second = insert_conversation(&mut conn, owner_id, Some(source_project.id), 3, 32);
+        let oversized_sentinel = insert_conversation(&mut conn, owner_id, None, 4_096, 33);
+        let foreign = insert_conversation(&mut conn, foreign_id, None, 3, 34);
+
+        let base = Utc::now();
+        for (conversation_id, last_activity_at) in [
+            (first.id, base + Duration::seconds(3)),
+            (second.id, base + Duration::seconds(2)),
+            (oversized_sentinel.id, base + Duration::seconds(1)),
+        ] {
+            diesel::update(conversations::table.filter(conversations::id.eq(conversation_id)))
+                .set(conversations::last_activity_at.eq(last_activity_at))
+                .execute(&mut conn)
+                .expect("test ordering timestamp should update");
+        }
+
+        // The third row is only the limit+1 sentinel. Its oversized metadata
+        // must not be loaded or charged to the returned page.
+        let (page, has_more) = list_conversations(
+            &pool,
+            owner_id,
+            2,
+            None,
+            "desc",
+            ConversationProjectFilter::Any,
+            None,
+            6,
+        )
+        .expect("sentinel ciphertext must be excluded from page accounting");
+        assert!(has_more);
+        assert_eq!(
+            page.iter()
+                .map(|row| row.conversation.uuid)
+                .collect::<Vec<_>>(),
+            vec![first.uuid, second.uuid]
+        );
+
+        let (baseline, baseline_more) = list_conversations(
+            &pool,
+            owner_id,
+            100,
+            None,
+            "desc",
+            ConversationProjectFilter::Any,
+            None,
+            16_384,
+        )
+        .expect("owner conversation list should load");
+        let (missing_cursor, missing_cursor_more) = list_conversations(
+            &pool,
+            owner_id,
+            100,
+            Some(Uuid::new_v4()),
+            "desc",
+            ConversationProjectFilter::Any,
+            None,
+            16_384,
+        )
+        .expect("missing conversation cursor should be ignored");
+        assert_eq!(baseline_more, missing_cursor_more);
+        assert_eq!(
+            baseline
+                .iter()
+                .map(|row| row.conversation.uuid)
+                .collect::<Vec<_>>(),
+            missing_cursor
+                .iter()
+                .map(|row| row.conversation.uuid)
+                .collect::<Vec<_>>()
+        );
+        assert!(matches!(
+            get_conversation(&pool, owner_id, foreign.uuid, 1_024),
+            Err(StoredConversationError::ConversationNotFound)
+        ));
+
+        let updated = update_conversation(
+            &pool,
+            owner_id,
+            first.uuid,
+            Some(storage_ciphertext(5, 35)),
+            ProjectAssignmentUpdate::Set(Some(target_project.id)),
+            Some(true),
+        )
+        .expect("owner-scoped update should succeed");
+        assert_eq!(updated.project_uuid, Some(target_project.uuid));
+        assert!(updated.is_pinned);
+        let reloaded = get_conversation(&pool, owner_id, first.uuid, 1_024)
+            .expect("updated conversation should reload");
+        assert_eq!(reloaded.project_uuid, Some(target_project.uuid));
+        assert_eq!(
+            reloaded.conversation.metadata_enc.as_deref(),
+            Some(storage_ciphertext(5, 35).as_slice())
+        );
+
+        let fourth = insert_conversation(&mut conn, owner_id, Some(source_project.id), 3, 36);
+        assert!(matches!(
+            batch_update_conversation_project(
+                &pool,
+                owner_id,
+                &[second.uuid, foreign.uuid],
+                Some(target_project.id),
+            ),
+            Err(StoredConversationError::ConversationNotFound)
+        ));
+        assert_eq!(
+            get_conversation(&pool, owner_id, second.uuid, 1_024)
+                .expect("failed batch must be atomic")
+                .project_uuid,
+            Some(source_project.uuid)
+        );
+        assert!(matches!(
+            batch_update_conversation_project(
+                &pool,
+                owner_id,
+                &[second.uuid, second.uuid],
+                Some(target_project.id),
+            ),
+            Err(StoredConversationError::Validation)
+        ));
+        assert_eq!(
+            batch_update_conversation_project(
+                &pool,
+                owner_id,
+                &[second.uuid, fourth.uuid],
+                Some(target_project.id),
+            )
+            .expect("same-source owner batch should update"),
+            2
+        );
+
+        let delete_id = lookup_conversation_id(&pool, owner_id, oversized_sentinel.uuid)
+            .expect("batch-delete lookup should find owner conversation");
+        delete_conversation_by_internal_id(&pool, owner_id, delete_id)
+            .expect("resolved owner conversation should delete");
+        assert!(matches!(
+            lookup_conversation_id(&pool, owner_id, oversized_sentinel.uuid),
+            Err(StoredConversationError::ConversationNotFound)
+        ));
+        assert_eq!(
+            delete_all_conversations(&pool, owner_id).expect("delete-all should be owner scoped"),
+            3
+        );
+        assert_eq!(
+            get_conversation(&pool, foreign_id, foreign.uuid, 1_024)
+                .expect("owner delete-all must preserve foreign conversation")
+                .conversation
+                .uuid,
+            foreign.uuid
+        );
+    }
+
+    #[test]
+    #[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+    fn database_conversation_items_cover_all_families_cursors_bounds_and_owner_scope() {
+        let Some(pool) = disposable_pool() else {
+            return;
+        };
+        let mut conn = pool.get().expect("test database connection");
+        let org_project_id = first_active_org_project_id(&mut conn);
+        let owner_id = insert_test_user(&mut conn, org_project_id, "items-owner");
+        let foreign_id = insert_test_user(&mut conn, org_project_id, "items-foreign");
+        let _cleanup = TestUsers {
+            pool: pool.clone(),
+            user_ids: vec![owner_id, foreign_id],
+        };
+        let fixture = insert_item_stack(&mut conn, owner_id, foreign_id, ResponseStatus::Completed);
+
+        let (items, has_more) = list_conversation_items(
+            &pool,
+            owner_id,
+            fixture.conversation_uuid,
+            100,
+            None,
+            "asc",
+            16_384,
+        )
+        .expect("all owner item families should load");
+        assert!(!has_more);
+        assert_eq!(items.len(), 5, "cross-owner child must be excluded");
+        assert_eq!(
+            items
+                .iter()
+                .map(|item| item.message_type.as_str())
+                .collect::<HashSet<_>>(),
+            HashSet::from(["user", "assistant", "tool_call", "tool_output", "reasoning"])
+        );
+
+        let (page, has_more) = list_conversation_items(
+            &pool,
+            owner_id,
+            fixture.conversation_uuid,
+            2,
+            None,
+            "asc",
+            16_384,
+        )
+        .expect("bounded item page should load");
+        assert_eq!(page.len(), 2);
+        assert!(has_more);
+
+        let cursor = page.last().expect("first page must have a cursor").uuid;
+        let (after_page, after_has_more) = list_conversation_items(
+            &pool,
+            owner_id,
+            fixture.conversation_uuid,
+            100,
+            Some(cursor),
+            "asc",
+            16_384,
+        )
+        .expect("existing item cursor should return the remaining ordered items");
+        assert!(!after_has_more);
+        assert_eq!(
+            after_page.iter().map(|item| item.uuid).collect::<Vec<_>>(),
+            items
+                .iter()
+                .skip(page.len())
+                .map(|item| item.uuid)
+                .collect::<Vec<_>>()
+        );
+
+        let (after_missing, has_more) = list_conversation_items(
+            &pool,
+            owner_id,
+            fixture.conversation_uuid,
+            100,
+            Some(Uuid::new_v4()),
+            "asc",
+            16_384,
+        )
+        .expect("missing item cursor should produce an empty page");
+        assert!(after_missing.is_empty());
+        assert!(!has_more);
+
+        assert_eq!(
+            get_conversation_item(
+                &pool,
+                owner_id,
+                fixture.conversation_uuid,
+                fixture.assistant_uuid,
+                4_096,
+            )
+            .expect("direct owner-scoped item lookup should succeed")
+            .message_type,
+            "assistant"
+        );
+        assert!(matches!(
+            get_conversation_item(
+                &pool,
+                owner_id,
+                fixture.conversation_uuid,
+                fixture.foreign_message_uuid,
+                4_096,
+            ),
+            Err(StoredConversationError::ConversationItemNotFound)
+        ));
+        assert!(matches!(
+            list_conversation_items(
+                &pool,
+                foreign_id,
+                fixture.conversation_uuid,
+                100,
+                None,
+                "asc",
+                16_384,
+            ),
+            Err(StoredConversationError::ConversationNotFound)
+        ));
+        assert!(matches!(
+            list_conversation_items(
+                &pool,
+                owner_id,
+                fixture.conversation_uuid,
+                1,
+                None,
+                "asc",
+                255,
+            ),
+            Err(StoredConversationError::OutputTooLarge)
+        ));
+    }
+
+    #[test]
+    #[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+    fn database_stored_response_retrieval_cancel_preflight_transition_and_delete_are_scoped() {
+        let Some(pool) = disposable_pool() else {
+            return;
+        };
+        let mut conn = pool.get().expect("test database connection");
+        let org_project_id = first_active_org_project_id(&mut conn);
+        let owner_id = insert_test_user(&mut conn, org_project_id, "response-owner");
+        let foreign_id = insert_test_user(&mut conn, org_project_id, "response-foreign");
+        let _cleanup = TestUsers {
+            pool: pool.clone(),
+            user_ids: vec![owner_id, foreign_id],
+        };
+        let fixture = insert_item_stack(&mut conn, owner_id, foreign_id, ResponseStatus::Queued);
+
+        let stored = get_stored_response(&pool, owner_id, fixture.response_uuid, 16_384)
+            .expect("owner response should load");
+        assert_eq!(stored.items.len(), 5, "cross-owner child must be excluded");
+        assert_eq!(stored.response.status, ResponseStatus::Queued);
+        for item in &stored.items {
+            if matches!(item.message_type.as_str(), "user" | "reasoning") {
+                assert!(
+                    item.content_enc.is_none(),
+                    "user and reasoning ciphertext must not enter the stored-response projection"
+                );
+            }
+        }
+        assert!(matches!(
+            get_stored_response(&pool, foreign_id, fixture.response_uuid, 16_384),
+            Err(StoredConversationError::ResponseNotFound)
+        ));
+        assert!(matches!(
+            get_stored_response(
+                &pool,
+                owner_id,
+                fixture.response_uuid,
+                TEST_MODEL.len() + 255,
+            ),
+            Err(StoredConversationError::OutputTooLarge)
+        ));
+
+        assert!(matches!(
+            get_cancelable_response_metadata(
+                &pool,
+                owner_id,
+                fixture.response_uuid,
+                TEST_MODEL.len() - 1,
+            ),
+            Err(StoredConversationError::OutputTooLarge)
+        ));
+        assert_eq!(
+            get_cancelable_response_metadata(
+                &pool,
+                owner_id,
+                fixture.response_uuid,
+                TEST_MODEL.len(),
+            )
+            .expect("failed preflight must not mutate status")
+            .status,
+            ResponseStatus::Queued
+        );
+        assert!(matches!(
+            transition_stored_response_to_cancelled(&pool, foreign_id, fixture.response_uuid),
+            Err(StoredConversationError::ResponseNotFound)
+        ));
+        assert_eq!(
+            transition_stored_response_to_cancelled(&pool, owner_id, fixture.response_uuid)
+                .expect("owner queued response should cancel"),
+            fixture.response_uuid
+        );
+        assert!(matches!(
+            transition_stored_response_to_cancelled(&pool, owner_id, fixture.response_uuid),
+            Err(StoredConversationError::Validation)
+        ));
+        assert_eq!(
+            get_stored_response(&pool, owner_id, fixture.response_uuid, 16_384)
+                .expect("cancelled response should remain retrievable")
+                .response
+                .status,
+            ResponseStatus::Cancelled
+        );
+        assert!(matches!(
+            delete_stored_response(&pool, foreign_id, fixture.response_uuid),
+            Err(StoredConversationError::ResponseNotFound)
+        ));
+        assert_eq!(
+            delete_stored_response(&pool, owner_id, fixture.response_uuid)
+                .expect("owner response should delete"),
+            fixture.response_uuid
+        );
+        assert!(matches!(
+            get_stored_response(&pool, owner_id, fixture.response_uuid, 16_384),
+            Err(StoredConversationError::ResponseNotFound)
+        ));
+    }
+
+    #[test]
+    #[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+    fn item_cursor_measure_and_fetch_sql_execute_without_ambiguous_columns() {
+        let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+            eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+            return;
+        };
+        let mut conn = diesel::PgConnection::establish(&database_url)
+            .expect("connect to disposable migrated PostgreSQL");
+
+        let measured = diesel::sql_query(conversation_item_page_sql(true, "desc", true))
+            .bind::<diesel::sql_types::BigInt, _>(i64::MIN)
+            .bind::<diesel::sql_types::Uuid, _>(Uuid::nil())
+            .bind::<diesel::sql_types::Uuid, _>(Uuid::nil())
+            .bind::<diesel::sql_types::BigInt, _>(1_i64)
+            .load::<ItemMeasurement>(&mut conn)
+            .expect("cursor measurement SQL must be valid");
+        assert!(measured.is_empty());
+
+        let fetched = diesel::sql_query(conversation_item_page_sql(true, "desc", false))
+            .bind::<diesel::sql_types::BigInt, _>(i64::MIN)
+            .bind::<diesel::sql_types::Uuid, _>(Uuid::nil())
+            .bind::<diesel::sql_types::Uuid, _>(Uuid::nil())
+            .bind::<diesel::sql_types::BigInt, _>(1_i64)
+            .load::<StoredConversationItem>(&mut conn)
+            .expect("cursor fetch SQL must be valid");
+        assert!(fetched.is_empty());
+    }
+}

--- a/src/web/responses/conversations.rs
+++ b/src/web/responses/conversations.rs
@@ -267,7 +267,7 @@ pub struct ListConversationsParams {
 }
 
 impl ListConversationsParams {
-    fn validate(&self) -> Result<(), ApiError> {
+    pub(crate) fn validate(&self) -> Result<(), ApiError> {
         if self.project_id.is_some() && self.unassigned_project == Some(true) {
             return Err(ApiError::BadRequest);
         }
@@ -322,7 +322,7 @@ fn resolve_conversation_project_filter(
     Ok(ConversationProjectFilter::Any)
 }
 
-fn validate_metadata(metadata: &Value) -> Result<(), ApiError> {
+pub(crate) fn validate_metadata(metadata: &Value) -> Result<(), ApiError> {
     if metadata.is_object() {
         Ok(())
     } else {
@@ -769,7 +769,7 @@ async fn delete_all_conversations(
 }
 
 /// Maximum number of conversations allowed in a single batch operation request
-const MAX_CONVERSATION_BATCH_SIZE: usize = 20;
+pub(crate) const MAX_CONVERSATION_BATCH_SIZE: usize = 20;
 
 /// POST /v1/conversations/batch-delete - Delete multiple specific conversations
 async fn batch_delete_conversations(


### PR DESCRIPTION
## Summary

- project all supported conversation CRUD, batch, item-read, and stored-response control routes through the authenticated v2 request envelope
- add owner-scoped, measure-before-fetch storage reads with aggregate plaintext bounds and exact item ordering
- preserve existing v1 handlers and wire contracts while binding authorization, request execution, and response encryption to one v2 session
- keep streaming response creation out of this capability PR for the later authenticated-streaming layer

## Security properties

- every storage query is scoped to the authenticated owner and relevant parent IDs
- ciphertext size is preflighted before fetch/decrypt; response retrieval never fetches user or reasoning ciphertext
- cancellation preflights the response, then uses an atomic owner/status transition before broadcasting
- decrypted metadata and output buffers are zeroized after bounded serialization
- conversation JSON receives depth and structural-token limits before serde allocation

## Verification

- nix develop --no-update-lock-file -c cargo test --all-features
- nix develop --no-update-lock-file -c cargo clippy --all-features -- -D warnings
- four ignored PostgreSQL integration tests run against the disposable migrated local database
- git diff --check codex-session-v2-projects-instructions...HEAD

No v1 route or handler behavior changes are introduced.