### PR TITLE
Project unary providers over transport v2

### DIFF
--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -231,6 +231,7 @@ The decrypted request is a strict JSON envelope:
   "request_id": "00112233445566778899aabbccddeeff",
   "response_mode": "auto",
   "credential": null,
+  "cache_namespace_root_base64": null,
   "request": {
     "method": "POST",
     "path": "/v1/responses",
@@ -262,6 +263,12 @@ Fields have these meanings:
   credential bytes in canonical padded standard base64. Password, registration,
   OAuth, and recovery credentials remain part of their logical operation body;
   they do not become generic transport credentials.
+- `cache_namespace_root_base64` is a required-nullable field. When non-null it
+  is canonical padded standard base64 for exactly 32 client-generated random
+  bytes. The envelope codec accepts either shape, while application admission
+  permits a non-null value only on the request that transitions an anonymous
+  session to a user or API-key authority. It is `null` on platform transitions
+  and every request made after binding.
 - `method` is a supported uppercase HTTP method.
 - `path` is one origin-relative application path with no query or fragment.
 - `query` is either `null` or the exact query string without a leading `?`.
@@ -433,10 +440,87 @@ The existing raw API key is sent once inside the encrypted initial credential
 transition. It is not rotated. A successful transition binds a distinct
 inference-only API-key principal and the triggering request may proceed.
 
-The binding retains a non-secret key identity/hash and rechecks current key
-existence before every operation so deletion remains immediately effective.
-API-key sessions can reach only the same inference operation set that accepts
-API keys today; they never become general user sessions.
+The binding retains only the database key identity, owning user identity, and
+derived provider-cache namespace. It rechecks that exact key-to-owner
+relationship before every operation so deletion or ownership changes remain
+immediately effective. API-key sessions can reach only model catalog,
+non-streaming chat completions, speech synthesis, audio transcription, and
+embeddings. They never become general user sessions.
+
+### 8.4 Provider cache namespace binding
+
+User and API-key authentication transitions carry a client-generated cache
+namespace root in `cache_namespace_root_base64`. The client persists this root
+inside the corresponding local authentication/API-key context so a newly
+attested session can recover provider cache hits after application or enclave
+restart. Losing or deliberately replacing the root only creates a fresh cache
+namespace; it does not change account authority or data access.
+
+The enclave derives the namespace only after it has verified the user UUID (or
+the owning user UUID for an API key):
+
+```text
+HMAC-SHA256(
+  cache_namespace_root[32],
+  UTF8("opensecret/provider-cache/tinfoil/user-cache-namespace/v1")
+  || 0x00
+  || verified_user_uuid_bytes[16]
+)
+```
+
+UUID bytes are the 16 RFC 9562 network-order bytes, not UUID text. The fixed,
+versioned label domain-separates this value from every other use of the client
+root. Tinfoil receives the 32-byte result as 64 lowercase hexadecimal
+characters in its provider-managed `user_cache_secret` field. OpenSecret never
+logs or intentionally includes the client root, derived bytes, or encoded
+provider secret in an application response. Provider responses remain
+untrusted and could echo arbitrary request fields; any such echo remains inside
+the response encrypted to the same authenticated client and is never accepted
+as authority.
+
+The bound user or API-key authority retains only an `Arc`-backed derived
+namespace. Clones share that allocation and its bytes are zeroized when the
+last clone drops. The input root is zeroized when the transition request is
+released and is never retained in session state. Platform authorities retain
+neither value. This makes a user cache namespace stable for a cooperating
+client while preventing the parent/operator, which sees neither the root
+plaintext nor the enclave-held derivation result, from computing it from a
+UUID.
+
+### 8.5 Unary inference projection
+
+The initial unary-inference layer admits exactly these logical operations:
+
+| Logical operation | Bound user | API-key session | Anonymous |
+| --- | :---: | :---: | :---: |
+| `GET /v1/models` | yes | yes | yes |
+| `GET /v1/models/catalog` | yes | yes | no |
+| `POST /v1/chat/completions` with streaming absent or false | yes | yes | no |
+| `POST /v1/audio/speech` | yes | yes | no |
+| `POST /v1/audio/transcriptions` | yes | yes | no |
+| `POST /v1/embeddings` | yes | yes | no |
+| `POST /v1/web/search` | yes | no | no |
+| `POST /v1/web/extract` | yes | no | no |
+
+`GET /v1/models` is public and therefore never accepts a credential or cache
+root. The five API-key operations may perform the one-time encrypted API-key
+transition described above; web operations require a bound user. Platform
+authority is rejected for every operation in this layer. Chat streaming and
+the Responses API remain unsupported until the authenticated-streaming layer.
+
+Every admitted unary provider operation reserves 128 MiB of aggregate provider
+output working set before claiming replay identity or dispatching. V2 caps
+provider JSON at 28 MiB and structurally preflights it before deserialization.
+Speech synthesis uses a smaller raw-byte ceiling so base64 plus logical JSON
+still fits the 28 MiB response bound. Audio transcription additionally caps
+retained chunks at four and 64 MiB aggregate, caps each multipart provider
+request at 32 MiB, divides both raw response bytes and JSON structural-token
+allowance across the admitted chunks, processes chunks sequentially, and does
+not retry an ambiguous provider attempt. V2 provider failures log only provider
+identity and status while draining a small bounded prefix; provider-controlled
+error bodies never enter enclave logs. These are v2-only admission rules;
+transport v1 retains its existing limits, concurrency, retry behavior, error
+logging, and provider-cache derivation.
 
 ## 9. First-party and third-party tokens
 
@@ -498,7 +582,9 @@ does not look up a session again from an outer UUID. The SDK verifies response
 AAD and exact `request_id` before accepting status, headers, or body.
 
 Response headers use a strict allowlist and exclude transport framing, cookies,
-server internals, and credentials.
+server internals, and credentials. Application errors preserve the established
+`x-opensecret-error-contract` header and optional
+`x-opensecret-error-code` header inside this authenticated logical envelope.
 
 Failures before a valid session can be leased and the request identifier can be
 recovered are generic bounded plaintext transport errors. They are untrusted
@@ -648,112 +734,42 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
 
 ## 14. Planned pull-request stack
 
-1. **Protocol contract**: this document and byte-level review decisions.
-2. **V1 transport seam**: behavior-neutral response/session context and
-   characterization tests; no v2 routes.
-3. **Dormant v2 core**: codecs, key schedule, directional AEAD, separate session
-   state/cache, absolute expiry, replay registry, budgets, and vectors; no
-   public routes.
-4. **Isolated v2 gateway**: separate attestation/key-exchange/request endpoints,
-   bounded session allocation, strict outer parsing, exact-session decryption,
-   and encrypted unsupported-operation responses; no application dispatch.
-5. **User binding and first unary slice**: password login, registration,
-   v2-only resumption, immutable user/project/`AuthContext` authority, live
-   seed-wrap revalidation, and bodyless `GET /protected/user`. This layer also
-   activates exact unordered replay claims for supported operations. Platform,
-   API-key, OAuth, and all other application paths still receive the encrypted
-   unsupported-operation response.
-6. **Sensitive user-key projection**: project root/derived mnemonic and private
-   key export, public-key derivation, signing, and third-party token issuance
-   through the live bound-user check. Sensitive intermediate response values
-   are zeroized, decoded byte fields and prepared sensitive operations wipe on
-   drop across rejection/cancellation paths, and serialized logical responses
-   are bounded before gateway encryption. Large encrypt/decrypt utilities
-   remain unsupported until their base64 and JSON expansion has an exact
-   pre-dispatch limit.
-7. **Bounded user crypto utilities**: project user-key encrypt/decrypt with an
-   exact v2-only plaintext ceiling derived from AES-GCM, base64, and JSON
-   expansion. Logical JSON serialization writes through a bounded buffer so a
-   highly escaped decrypted string cannot allocate beyond the response limit.
-8. **Dynamic-path and response-resource seams**: admit only route-scoped,
-   canonical KV item segments and retain request working-set reservations
-   through final response serialization/body lifetime. Tiny-request operations
-   with uncorrelated stored output remain unsupported until they reserve that
-   output before dispatch.
-9. **KV mutations**: project PUT item, DELETE item, and DELETE all through
-   transport-neutral helpers. Preserve existing response and error behavior,
-   claim replay identifiers before every mutation, sanitize storage errors, and
-   wipe decoded keys and values. GET item and list remain unsupported here.
-10. **Bounded KV reads**: project GET item and list through a v2-only,
-   read-only repeatable-read storage seam. Promote each admitted read to a
-   conservative 200 MiB reservation from the shared 256 MiB request/response
-   pool before replay claim or dispatch; contention returns an authenticated
-   503 without consuming the request identifier. Bound item ciphertext, list
-   aggregate plaintext, and list rows before loading narrow ciphertext
-   projections, then retain the merged reservation through final HTTP body
-   consumption. Preserve `null`, string, bare-array, timestamp, ordering, and
-   whole-list failure behavior from v1 while leaving every v1 query untouched.
-11. **Remaining protected user operations**: project account-lifecycle and user
-   API-key-management families in reviewable sub-stacks. Start API-key
-   administration with bounded create/delete mutations: retain the existing
-   raw UUID key format without rotation, return it only through the original
-   bound-session response, wipe its plaintext response value on drop, and use
-   the canonical validated name segment for deletion. Add list in a following
-   slice using the same conservative stored-output admission as KV reads and a
-   v2-only read-only repeatable-read database path. Preflight the user-scoped
-   row count and aggregate name bytes, cap the list at 65,536 rows, fetch only
-   `name` and `created_at`, recheck the snapshot totals, retain unspecified
-   server ordering, and bound final JSON serialization. The v1 full-row query
-   remains untouched. Project verification-email resend as a bound-user unary
-   mutation with no logical body or metadata; preserve its existing 200 JSON
-   outcomes while claiming replay state before any database or email side
-   effect. Project `GET /verify-email/{code}` as a code-authorized operation
-   that accepts either an anonymous or already-bound session without changing
-   its authority. Require one lowercase hyphenated UUID path spelling, reject
-   all logical metadata, and preserve the existing invalid/expired 400 plus
-   success/already-verified 200 outcomes. Project account-deletion request as
-   an exact bound-user JSON mutation, preserving the generic success response,
-   independent fresh attempts, and background email behavior while claiming
-   replay state before request creation. Account-deletion confirmation must
-   pre-serialize its fixed success response before committing deletion, then
-   explicitly close the now-invalid bound session only after that commit.
-   Invalid codes, secrets, requests, expiry, and database failures return their
-   existing encrypted errors without closing an otherwise valid session.
-   Project user logout as an exact bound-user JSON operation with the existing
-   refresh-token request and success body, then close the admitted session only
-   after the response is prepared. This remains session-local logout: matching
-   transport-v1 behavior, the submitted resumption credential is not revoked
-   server-side. The v2 SDK must treat the request as terminal, never
-   transparently retry or resume the logout attempt, and use generation-safe
-   local cleanup after the final response attempt. Exact cleanup behavior for
-   an ambiguous outcome is fixed in the SDK cutover PR. Project password change
-   as an exact bound-user JSON mutation with its existing logical request and
-   response fields. Prepare and locally verify the replacement password wrap,
-   issue both replacement v2 credentials, and bound-serialize the success
-   response before attempting the existing password-ciphertext CAS transaction.
-   A successful commit or any failure after the commit attempt terminally
-   closes the old session; definite parse, current-password, preparation, and
-   serialization failures retain a still-valid session. A lost final response
-   is never retried: the client recovers through a fresh login with the
-   submitted new password.
-12. **Stored user unary operations**: project conversations, conversation
-   projects, instructions, response control, and web-provider unary routes in
-   ownership-preserving families before the client cutover.
-13. **API-key and platform binding**: bind existing raw API keys inside
-   ciphertext without rotating them, enforce their current inference-only
-   scope, and add platform authentication/authorization with live organization
-   checks. OAuth continuation receives an explicit session-binding design in
-   this layer rather than being inferred from password login.
-14. **Streaming projection**: project current inference streams with ordered,
-   request-bound, authenticated terminal records while preserving the SDK's
-   caller-visible SSE behavior.
-15. **Additive SDK v2 internals**: TypeScript and Rust codecs/session managers
-   behind private seams, still not selected by public calls.
-16. **Atomic SDK cutover**: v2-only network behavior, no downgrade, one-time
-   fresh login, and Maple/proxy integration.
-17. **SDK major/version packaging**: package metadata, locks, integration pin,
-   compatibility matrix, and release rehearsal. Publication/deployment remain
-   separate authorized actions.
+The implementation is intentionally consolidated into at most fourteen
+capability PRs. Each PR targets the branch immediately below it:
+
+1. **Protocol and v1-neutral seam**: freeze the contract and introduce shared
+   application seams without changing transport-v1 behavior.
+2. **Dormant crypto, session, and replay core**: codecs, key schedule,
+   directional AEAD, separate caches, exact unordered replay registry, budgets,
+   and golden vectors without a public v2 route.
+3. **Isolated gateway**: v2 attestation, key exchange, bounded request
+   admission, same-lease response encryption, and encrypted unsupported-route
+   responses.
+4. **User authority and sensitive crypto**: password registration/login,
+   resumption, immutable user binding, sensitive key operations, and bounded
+   encrypt/decrypt utilities.
+5. **Complete bounded KV**: canonical key routing, mutations, bounded reads,
+   and held output reservations.
+6. **User credentials and account lifecycle**: API-key administration,
+   verification, logout, password changes, and account deletion.
+7. **Conversation projects and instructions**: owner-scoped project and
+   instruction CRUD.
+8. **Conversations, items, and stored response control**: bounded encrypted
+   storage operations and response cancellation/deletion.
+9. **Unary providers and API-key binding**: the exact unary route table in
+   section 8.5, one-time encrypted API-key authority transition, live key-owner
+   revalidation, and client-random Tinfoil cache namespaces.
+10. **Session-bound user OAuth**: bind OAuth continuation to its originating
+    v2 session without exposing credentials outside ciphertext.
+11. **Platform v2 end to end**: platform authentication and authorization with
+    live organization checks.
+12. **Authenticated streaming**: ordered, request-bound records and an
+    authenticated terminal event while preserving caller-visible streaming.
+13. **Dormant TypeScript and Rust SDK engines**: shared vectors and private v2
+    session/transport implementations that public calls do not yet select.
+14. **Atomic v2 cutover and packaging**: switch new SDK majors to v2-only,
+    update Maple and maple-proxy dependencies, and run compatibility/release
+    rehearsal. Publication and deployment remain separately authorized.
 
 Each implementation PR receives one focused security review and one focused
 compatibility review. Reviews should report credible vulnerabilities,

--- a/src/db.rs
+++ b/src/db.rs
@@ -41,7 +41,9 @@ use crate::models::responses::{
 };
 use crate::models::schema::users;
 use crate::models::token_usage::{NewTokenUsage, TokenUsage, TokenUsageError};
-use crate::models::user_api_keys::{NewUserApiKey, UserApiKey, UserApiKeyError};
+use crate::models::user_api_keys::{
+    NewUserApiKey, ResolvedUserApiKey, UserApiKey, UserApiKeyError,
+};
 use crate::models::user_seed_wrappings::{
     NewUserSeedWrapping, UserSeedWrapping, UserSeedWrappingError,
 };
@@ -504,6 +506,15 @@ pub trait DBConnection {
     fn get_user_api_key_by_id(&self, id: i32) -> Result<Option<UserApiKey>, DBError>;
     fn get_user_api_key_by_hash(&self, key_hash: &str) -> Result<Option<UserApiKey>, DBError>;
     fn get_user_by_api_key_hash(&self, key_hash: &str) -> Result<Option<User>, DBError>;
+    fn resolve_user_api_key_by_hash(
+        &self,
+        canonical_key_hash: &str,
+    ) -> Result<Option<ResolvedUserApiKey>, DBError>;
+    fn revalidate_user_api_key_owner(
+        &self,
+        api_key_id: i32,
+        user_id: Uuid,
+    ) -> Result<Option<User>, DBError>;
     fn get_all_user_api_keys_for_user(&self, user_id: Uuid) -> Result<Vec<UserApiKey>, DBError>;
     fn delete_user_api_key(&self, id: i32, user_id: Uuid) -> Result<(), DBError>;
     fn delete_user_api_key_by_name(&self, name: &str, user_id: Uuid) -> Result<(), DBError>;
@@ -2069,6 +2080,23 @@ impl DBConnection for PostgresConnection {
             .first::<User>(conn)
             .optional()
             .map_err(DBError::from)
+    }
+
+    fn resolve_user_api_key_by_hash(
+        &self,
+        canonical_key_hash: &str,
+    ) -> Result<Option<ResolvedUserApiKey>, DBError> {
+        let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
+        UserApiKey::resolve_by_key_hash(conn, canonical_key_hash).map_err(DBError::from)
+    }
+
+    fn revalidate_user_api_key_owner(
+        &self,
+        api_key_id: i32,
+        user_id: Uuid,
+    ) -> Result<Option<User>, DBError> {
+        let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
+        UserApiKey::revalidate_owner(conn, api_key_id, user_id).map_err(DBError::from)
     }
 
     fn get_all_user_api_keys_for_user(&self, user_id: Uuid) -> Result<Vec<UserApiKey>, DBError> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,7 @@ mod models;
 mod oauth;
 mod os_flags;
 mod private_key;
+mod provider_cache;
 mod provider_client;
 mod provider_routing;
 mod proxy_config;

--- a/src/models/user_api_keys.rs
+++ b/src/models/user_api_keys.rs
@@ -1,4 +1,5 @@
-use crate::models::schema::user_api_keys;
+use crate::models::schema::{user_api_keys, users};
+use crate::models::users::User;
 use chrono::{DateTime, Utc};
 use diesel::dsl::{count_star, sql};
 use diesel::prelude::*;
@@ -33,6 +34,25 @@ pub struct UserApiKey {
     pub name: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+/// The authority resolved from a live API-key row and its current owning user.
+///
+/// This deliberately excludes the stored key hash so callers cannot retain or
+/// accidentally log authentication material after the lookup completes.
+#[derive(Clone)]
+pub struct ResolvedUserApiKey {
+    pub api_key_id: i32,
+    pub user: User,
+}
+
+impl std::fmt::Debug for ResolvedUserApiKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResolvedUserApiKey")
+            .field("api_key_id", &self.api_key_id)
+            .field("user_id", &self.user.uuid)
+            .finish()
+    }
 }
 
 /// Narrow metadata projection used only by bounded transport-v2 list reads.
@@ -131,6 +151,40 @@ impl UserApiKey {
             .map_err(UserApiKeyError::DatabaseError)
     }
 
+    /// Resolve a canonical API-key hash and its current owner in one query.
+    pub fn resolve_by_key_hash(
+        conn: &mut PgConnection,
+        canonical_key_hash: &str,
+    ) -> Result<Option<ResolvedUserApiKey>, UserApiKeyError> {
+        user_api_keys::table
+            .inner_join(users::table.on(users::uuid.eq(user_api_keys::user_id)))
+            .filter(user_api_keys::key_hash.eq(canonical_key_hash))
+            .select((user_api_keys::id, users::all_columns))
+            .first::<(i32, User)>(conn)
+            .optional()
+            .map(|resolved| {
+                resolved.map(|(api_key_id, user)| ResolvedUserApiKey { api_key_id, user })
+            })
+            .map_err(UserApiKeyError::DatabaseError)
+    }
+
+    /// Revalidate that a previously bound API-key ID still belongs to the
+    /// exact user and return that current user row in one query.
+    pub fn revalidate_owner(
+        conn: &mut PgConnection,
+        lookup_api_key_id: i32,
+        lookup_user_id: Uuid,
+    ) -> Result<Option<User>, UserApiKeyError> {
+        users::table
+            .inner_join(user_api_keys::table.on(users::uuid.eq(user_api_keys::user_id)))
+            .filter(user_api_keys::id.eq(lookup_api_key_id))
+            .filter(user_api_keys::user_id.eq(lookup_user_id))
+            .select(users::all_columns)
+            .first::<User>(conn)
+            .optional()
+            .map_err(UserApiKeyError::DatabaseError)
+    }
+
     pub fn get_all_for_user(
         conn: &mut PgConnection,
         user_id: Uuid,
@@ -224,6 +278,65 @@ impl UserApiKey {
         } else {
             Ok(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::schema::org_projects;
+    use crate::models::users::NewUser;
+    use sha2::Digest;
+
+    #[test]
+    #[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+    fn joined_resolution_and_live_owner_revalidation_fail_closed() {
+        let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+            eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+            return;
+        };
+        let mut conn = PgConnection::establish(&database_url)
+            .expect("connect to disposable migrated PostgreSQL");
+
+        conn.test_transaction::<_, diesel::result::Error, _>(|conn| {
+            let project_id = org_projects::table
+                .select(org_projects::id)
+                .first::<i32>(conn)
+                .expect("disposable database must contain an organization project");
+            let user = NewUser::new(None, None, project_id)
+                .insert(conn)
+                .expect("insert API-key owner");
+            let key_hash = hex::encode(sha2::Sha256::digest(b"v2-api-key-storage-test"));
+            let key = NewUserApiKey::new(user.uuid, key_hash.clone(), "v2-test".to_owned())
+                .insert(conn)
+                .expect("insert API key");
+            let key_id = key.id;
+
+            let resolved = UserApiKey::resolve_by_key_hash(conn, &key_hash)
+                .expect("joined authentication lookup")
+                .expect("live key must resolve");
+            assert_eq!(resolved.api_key_id, key_id);
+            assert_eq!(resolved.user.uuid, user.uuid);
+            assert!(UserApiKey::resolve_by_key_hash(conn, "missing")
+                .unwrap()
+                .is_none());
+
+            assert_eq!(
+                UserApiKey::revalidate_owner(conn, key_id, user.uuid)
+                    .unwrap()
+                    .map(|owner| owner.uuid),
+                Some(user.uuid)
+            );
+            assert!(UserApiKey::revalidate_owner(conn, key_id, Uuid::new_v4())
+                .unwrap()
+                .is_none());
+
+            key.delete(conn).expect("delete API key");
+            assert!(UserApiKey::revalidate_owner(conn, key_id, user.uuid)
+                .unwrap()
+                .is_none());
+            Ok(())
+        });
     }
 }
 

--- a/src/provider_cache.rs
+++ b/src/provider_cache.rs
@@ -1,0 +1,218 @@
+use std::fmt;
+use std::sync::Arc;
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use hmac::{Hmac, Mac};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use sha2::Sha256;
+use uuid::Uuid;
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
+
+pub(crate) const CACHE_NAMESPACE_ROOT_BYTES: usize = 32;
+const CACHE_NAMESPACE_ROOT_BASE64_BYTES: usize = 44;
+
+/// Versioned domain separation for the Tinfoil user-cache namespace.
+///
+/// The trailing zero byte makes the UTF-8 label self-delimiting before the
+/// fixed-width UUID bytes.
+const TINFOIL_CACHE_NAMESPACE_V1_LABEL: &[u8] =
+    b"opensecret/provider-cache/tinfoil/user-cache-namespace/v1";
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Client-generated root material used only while binding a v2 authority.
+///
+/// The root is never retained in a bound session. Its wire representation is
+/// canonical padded standard base64 for exactly 32 bytes.
+#[derive(Clone, Eq, PartialEq, Zeroize, ZeroizeOnDrop)]
+pub(crate) struct CacheNamespaceRoot([u8; CACHE_NAMESPACE_ROOT_BYTES]);
+
+impl CacheNamespaceRoot {
+    #[cfg(test)]
+    pub(crate) const fn from_bytes(bytes: [u8; CACHE_NAMESPACE_ROOT_BYTES]) -> Self {
+        Self(bytes)
+    }
+
+    const fn as_bytes(&self) -> &[u8; CACHE_NAMESPACE_ROOT_BYTES] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for CacheNamespaceRoot {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("CacheNamespaceRoot([REDACTED])")
+    }
+}
+
+impl Serialize for CacheNamespaceRoot {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let encoded = Zeroizing::new(STANDARD.encode(self.0));
+        serializer.serialize_str(encoded.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for CacheNamespaceRoot {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct CacheNamespaceRootVisitor;
+
+        impl de::Visitor<'_> for CacheNamespaceRootVisitor {
+            type Value = CacheNamespaceRoot;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("canonical padded standard base64 encoding exactly 32 bytes")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                if value.len() != CACHE_NAMESPACE_ROOT_BASE64_BYTES {
+                    return Err(E::custom("cache namespace root must decode to 32 bytes"));
+                }
+
+                let mut decoded = Zeroizing::new([0_u8; CACHE_NAMESPACE_ROOT_BYTES]);
+                let decoded_bytes = STANDARD
+                    .decode_slice(value.as_bytes(), &mut decoded[..])
+                    .map_err(|_| E::custom("invalid standard base64 cache namespace root"))?;
+                if decoded_bytes != CACHE_NAMESPACE_ROOT_BYTES {
+                    return Err(E::custom("cache namespace root must decode to 32 bytes"));
+                }
+
+                let mut canonical = Zeroizing::new([0_u8; CACHE_NAMESPACE_ROOT_BASE64_BYTES]);
+                let encoded_bytes = STANDARD
+                    .encode_slice(&decoded[..], &mut canonical[..])
+                    .map_err(|_| E::custom("invalid cache namespace root"))?;
+                if encoded_bytes != value.len() || &canonical[..encoded_bytes] != value.as_bytes() {
+                    return Err(E::custom(
+                        "non-canonical standard base64 cache namespace root",
+                    ));
+                }
+
+                Ok(CacheNamespaceRoot(*decoded))
+            }
+        }
+
+        deserializer.deserialize_str(CacheNamespaceRootVisitor)
+    }
+}
+
+#[derive(Eq, PartialEq, Zeroize, ZeroizeOnDrop)]
+struct DerivedCacheNamespaceBytes([u8; 32]);
+
+/// Cloneable provider cache namespace retained by a bound user or API key.
+///
+/// Clones share one allocation. The final `Arc` drop zeroizes the derived
+/// bytes, while `Debug` never exposes them.
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) struct DerivedCacheNamespace(Arc<DerivedCacheNamespaceBytes>);
+
+impl DerivedCacheNamespace {
+    /// Tinfoil's `user_cache_secret` representation.
+    ///
+    /// The returned lowercase hexadecimal string is provider-bound secret
+    /// material and must not be logged or returned to the client.
+    pub(crate) fn tinfoil_user_cache_secret(&self) -> String {
+        hex::encode(self.0.as_ref().0)
+    }
+}
+
+impl fmt::Debug for DerivedCacheNamespace {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("DerivedCacheNamespace([REDACTED])")
+    }
+}
+
+/// Derive a stable Tinfoil cache namespace for one verified user identity.
+///
+/// The exact derivation is:
+///
+/// ```text
+/// HMAC-SHA256(
+///   cache_namespace_root,
+///   UTF8("opensecret/provider-cache/tinfoil/user-cache-namespace/v1")
+///   || 0x00
+///   || verified_user_uuid_bytes[16]
+/// )
+/// ```
+pub(crate) fn derive_tinfoil_cache_namespace(
+    root: &CacheNamespaceRoot,
+    verified_user_id: Uuid,
+) -> DerivedCacheNamespace {
+    let mut hmac = HmacSha256::new_from_slice(root.as_bytes())
+        .expect("HMAC-SHA256 accepts cache namespace roots of any length");
+    hmac.update(TINFOIL_CACHE_NAMESPACE_V1_LABEL);
+    hmac.update(&[0]);
+    hmac.update(verified_user_id.as_bytes());
+
+    let bytes = Zeroizing::new(<[u8; 32]>::from(hmac.finalize().into_bytes()));
+    DerivedCacheNamespace(Arc::new(DerivedCacheNamespaceBytes(*bytes)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ROOT_BYTES: [u8; 32] = [
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+        0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d,
+        0x1e, 0x1f,
+    ];
+    const USER_ID: Uuid = Uuid::from_bytes([
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee,
+        0xff,
+    ]);
+
+    #[test]
+    fn cache_namespace_root_and_final_derived_allocation_zeroize_on_drop() {
+        fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
+
+        assert_zeroize_on_drop::<CacheNamespaceRoot>();
+        assert_zeroize_on_drop::<DerivedCacheNamespaceBytes>();
+    }
+
+    #[test]
+    fn derivation_is_deterministic_and_domain_versioned() {
+        let root = CacheNamespaceRoot::from_bytes(ROOT_BYTES);
+        let first = derive_tinfoil_cache_namespace(&root, USER_ID);
+        let second = derive_tinfoil_cache_namespace(&root, USER_ID);
+
+        assert_eq!(first, second);
+        assert_eq!(
+            first.tinfoil_user_cache_secret(),
+            "1e30544852f2ef1db03bbd8d3a34bb106120d89b0769d4e199a40a99d7150927"
+        );
+
+        let other_user = derive_tinfoil_cache_namespace(&root, Uuid::from_u128(1));
+        assert_ne!(first, other_user);
+
+        let other_root = CacheNamespaceRoot::from_bytes([0x55; 32]);
+        assert_ne!(first, derive_tinfoil_cache_namespace(&other_root, USER_ID));
+    }
+
+    #[test]
+    fn derived_namespace_is_redacted_and_clones_share_final_drop_allocation() {
+        let root = CacheNamespaceRoot::from_bytes(ROOT_BYTES);
+        assert_eq!(format!("{root:?}"), "CacheNamespaceRoot([REDACTED])");
+        let namespace = derive_tinfoil_cache_namespace(&root, USER_ID);
+        let expected = namespace.tinfoil_user_cache_secret();
+        let clone = namespace.clone();
+
+        assert!(Arc::ptr_eq(&namespace.0, &clone.0));
+        assert_eq!(Arc::strong_count(&namespace.0), 2);
+        assert_eq!(
+            format!("{namespace:?}"),
+            "DerivedCacheNamespace([REDACTED])"
+        );
+        assert!(!format!("{namespace:?}").contains(&expected));
+
+        drop(namespace);
+        assert_eq!(Arc::strong_count(&clone.0), 1);
+        assert_eq!(clone.tinfoil_user_cache_secret(), expected);
+    }
+}

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -9,11 +9,12 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use axum::extract::Query;
-use axum::http::StatusCode;
-use axum::http::Uri;
+use axum::http::{header, HeaderMap, HeaderName, HeaderValue, StatusCode, Uri};
+use axum::response::IntoResponse;
 use chrono::{DateTime, Utc};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 use zeroize::{Zeroize, Zeroizing};
 
 use crate::bounded_json::BoundedJsonBuffer;
@@ -23,11 +24,20 @@ use crate::jwt::{
 };
 use crate::kv::StoreError;
 use crate::models::responses::{ConversationProjectFilter, NewConversation, ResponseStatus};
+use crate::provider_cache::{
+    derive_tinfoil_cache_namespace, CacheNamespaceRoot, DerivedCacheNamespace,
+};
 use crate::tokens::count_tokens;
 use crate::web::login_routes::{
     authenticate_login, logout_data, register_and_authenticate, verify_email_data, AuthResponse,
     Credentials, LogoutRequest, RefreshResponse, RegisterCredentials,
 };
+use crate::web::openai::{
+    openai_embeddings_v2_data, openai_model_catalog_data, openai_models_v2_data,
+    openai_nonstream_chat_completion_v2_data, openai_transcription_v2_data, openai_tts_v2_data,
+    EmbeddingRequest, TTSRequest, TranscriptionRequest,
+};
+use crate::web::openai_auth::AuthMethod as OpenAiAuthMethod;
 use crate::web::protected_routes::{
     confirm_account_deletion_data, create_api_key_data, decrypt_data_value, delete_all_kv_values,
     delete_api_key_by_name, delete_kv_value, encrypt_data_value, initiate_account_deletion_data,
@@ -73,7 +83,13 @@ use crate::web::responses::{
     },
     ConversationItem, DeletedObjectResponse, MessageContent, NullableField,
 };
-use crate::{ApiError, AppState, VerifiedUserAuthentication};
+use crate::web::web_routes::{
+    execute_web_extract, execute_web_search, parse_web_extract_request, parse_web_search_request,
+    WebRouteError,
+};
+use crate::{
+    ApiError, AppState, VerifiedUserAuthentication, ERROR_CODE_HEADER, ERROR_CONTRACT_HEADER,
+};
 
 use super::envelope::{
     decode_canonical_api_key_name_path, decode_canonical_conversation_path,
@@ -120,12 +136,15 @@ pub(crate) enum OperationPreparation {
 pub(crate) enum UserOperation {
     Login {
         body: SensitiveBytes,
+        cache_namespace_root: CacheNamespaceRoot,
     },
     Register {
         body: SensitiveBytes,
+        cache_namespace_root: CacheNamespaceRoot,
     },
     Resume {
         credential: SensitiveBytes,
+        cache_namespace_root: CacheNamespaceRoot,
     },
     VerifyEmail {
         code: uuid::Uuid,
@@ -141,6 +160,51 @@ pub(crate) enum UserOperation {
         authority: BoundUserAuthority,
         operation: ProtectedUserOperation,
     },
+    Inference {
+        authority: InferenceAuthority,
+        operation: InferenceOperation,
+    },
+}
+
+pub(crate) enum InferenceOperation {
+    Models,
+    ModelCatalog,
+    Chat {
+        body: SensitiveBytes,
+        headers: HeaderMap,
+    },
+    TextToSpeech {
+        body: SensitiveBytes,
+    },
+    Transcription {
+        body: SensitiveBytes,
+    },
+    Embeddings {
+        body: SensitiveBytes,
+    },
+    WebSearch {
+        body: SensitiveBytes,
+    },
+    WebExtract {
+        body: SensitiveBytes,
+    },
+}
+
+pub(crate) enum InferenceAuthority {
+    Public,
+    User(BoundUserAuthority),
+    ApiKey(BoundApiKeyAuthority),
+    AuthenticateApiKey {
+        credential: SensitiveBytes,
+        cache_namespace_root: CacheNamespaceRoot,
+    },
+}
+
+#[derive(Clone)]
+pub(crate) struct BoundApiKeyAuthority {
+    api_key_id: i32,
+    user_id: uuid::Uuid,
+    cache_namespace: DerivedCacheNamespace,
 }
 
 pub(crate) enum ProtectedUserOperation {
@@ -284,14 +348,25 @@ pub(crate) struct BoundUserAuthority {
     user_id: uuid::Uuid,
     project_id: i32,
     auth_context: AuthContext,
+    cache_namespace: DerivedCacheNamespace,
 }
 
 impl UserOperation {
     pub(crate) const fn requires_authentication_transition(&self) -> bool {
         matches!(
             self,
-            Self::Login { .. } | Self::Register { .. } | Self::Resume { .. }
+            Self::Login { .. }
+                | Self::Register { .. }
+                | Self::Resume { .. }
+                | Self::Inference {
+                    authority: InferenceAuthority::AuthenticateApiKey { .. },
+                    ..
+                }
         )
+    }
+
+    pub(crate) const fn requires_provider_output_reservation(&self) -> bool {
+        matches!(self, Self::Inference { .. })
     }
 
     pub(crate) const fn requires_stored_output_reservation(&self) -> bool {
@@ -324,6 +399,7 @@ impl UserOperation {
         match self {
             Self::Logout { .. } | Self::ChangePassword { .. } => SessionEffect::Close,
             Self::Protected { operation, .. } => operation.session_effect_on_success(),
+            Self::Inference { .. } => SessionEffect::Retain,
             _ => SessionEffect::Retain,
         }
     }
@@ -539,9 +615,20 @@ impl LogicalUnaryResponse {
         })
     }
 
-    pub(crate) fn api_error(error: &ApiError) -> Self {
+    pub(crate) fn api_error(error: ApiError) -> Self {
         match Self::json(error.status_code(), &error.response_body()) {
-            Ok(response) => response,
+            Ok(mut response) => {
+                let api_response = error.into_response();
+                for name in [ERROR_CONTRACT_HEADER, ERROR_CODE_HEADER] {
+                    if let Some(value) = api_response.headers().get(name) {
+                        response.headers.push(HeaderField {
+                            name: name.to_owned(),
+                            value_base64: EncodedBytes::from_bytes(value.as_bytes().to_vec()),
+                        });
+                    }
+                }
+                response
+            }
             Err(_) => Self::protocol_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "internal_error",
@@ -599,14 +686,14 @@ impl ApplicationOutcome {
 
     fn error(error: ApiError) -> Self {
         Self {
-            response: LogicalUnaryResponse::api_error(&error),
+            response: LogicalUnaryResponse::api_error(error),
             session_effect: SessionEffect::Retain,
         }
     }
 
     fn closing_error(error: ApiError) -> Self {
         Self {
-            response: LogicalUnaryResponse::api_error(&error),
+            response: LogicalUnaryResponse::api_error(error),
             session_effect: SessionEffect::Close,
         }
     }
@@ -619,6 +706,7 @@ pub(crate) fn prepare_user_operation(
     let RequestEnvelope {
         response_mode,
         credential,
+        cache_namespace_root_base64,
         mut request,
         ..
     } = envelope;
@@ -674,6 +762,14 @@ pub(crate) fn prepare_user_operation(
         ConfirmAccountDeletion,
         Logout,
         ChangePassword,
+        Models,
+        ModelCatalog,
+        ChatCompletions,
+        TextToSpeech,
+        Transcription,
+        Embeddings,
+        WebSearch,
+        WebExtract,
     }
 
     let kv_key = match decode_canonical_kv_item_path(request.method, &request.path) {
@@ -771,6 +867,14 @@ pub(crate) fn prepare_user_operation(
         }
         (LogicalMethod::Post, "/protected/change_password") => Some(Route::ChangePassword),
         (LogicalMethod::Post, "/logout") => Some(Route::Logout),
+        (LogicalMethod::Get, "/v1/models") => Some(Route::Models),
+        (LogicalMethod::Get, "/v1/models/catalog") => Some(Route::ModelCatalog),
+        (LogicalMethod::Post, "/v1/chat/completions") => Some(Route::ChatCompletions),
+        (LogicalMethod::Post, "/v1/audio/speech") => Some(Route::TextToSpeech),
+        (LogicalMethod::Post, "/v1/audio/transcriptions") => Some(Route::Transcription),
+        (LogicalMethod::Post, "/v1/embeddings") => Some(Route::Embeddings),
+        (LogicalMethod::Post, "/v1/web/search") => Some(Route::WebSearch),
+        (LogicalMethod::Post, "/v1/web/extract") => Some(Route::WebExtract),
         (LogicalMethod::Get, _) if kv_key.is_some() => Some(Route::GetKv),
         (LogicalMethod::Put, _) if kv_key.is_some() => Some(Route::PutKv),
         (LogicalMethod::Delete, _) if kv_key.is_some() => Some(Route::DeleteKv),
@@ -867,6 +971,22 @@ pub(crate) fn prepare_user_operation(
         return rejected_bad_request();
     }
 
+    if cache_namespace_root_base64.is_some()
+        && !matches!(
+            route,
+            Route::Login
+                | Route::Register
+                | Route::Resume
+                | Route::ModelCatalog
+                | Route::ChatCompletions
+                | Route::TextToSpeech
+                | Route::Transcription
+                | Route::Embeddings
+        )
+    {
+        return rejected_bad_request();
+    }
+
     match route {
         Route::Login | Route::Register => {
             if credential.is_some()
@@ -886,6 +1006,9 @@ pub(crate) fn prepare_user_operation(
                     "Session is already authenticated",
                 ));
             }
+            let Some(cache_namespace_root) = cache_namespace_root_base64 else {
+                return rejected_bad_request();
+            };
 
             let body = request
                 .body_base64
@@ -893,9 +1016,15 @@ pub(crate) fn prepare_user_operation(
                 .into_bytes();
             let body = Zeroizing::new(body);
             if matches!(route, Route::Login) {
-                OperationPreparation::Ready(UserOperation::Login { body })
+                OperationPreparation::Ready(UserOperation::Login {
+                    body,
+                    cache_namespace_root,
+                })
             } else {
-                OperationPreparation::Ready(UserOperation::Register { body })
+                OperationPreparation::Ready(UserOperation::Register {
+                    body,
+                    cache_namespace_root,
+                })
             }
         }
         Route::Resume => {
@@ -918,8 +1047,12 @@ pub(crate) fn prepare_user_operation(
             if value_base64.is_empty() {
                 return rejected_bad_request();
             }
+            let Some(cache_namespace_root) = cache_namespace_root_base64 else {
+                return rejected_bad_request();
+            };
             OperationPreparation::Ready(UserOperation::Resume {
                 credential: Zeroizing::new(value_base64.into_bytes()),
+                cache_namespace_root,
             })
         }
         Route::VerifyEmail => {
@@ -957,7 +1090,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             let operation = match route {
                 Route::GetUser => ProtectedUserOperation::GetUser,
@@ -987,7 +1120,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             OperationPreparation::Ready(UserOperation::Protected {
                 authority,
@@ -1013,7 +1146,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             let body = request
                 .body_base64
@@ -1058,7 +1191,7 @@ pub(crate) fn prepare_user_operation(
                 return rejected_bad_request();
             }
             if let Err(rejection) = bound_user_authority(authority) {
-                return rejection;
+                return OperationPreparation::Rejected(rejection);
             }
             OperationPreparation::Ready(UserOperation::Logout {
                 body: Zeroizing::new(
@@ -1082,7 +1215,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             let body = request
                 .body_base64
@@ -1107,7 +1240,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             let operation = if matches!(route, Route::GetKv) {
                 ProtectedUserOperation::GetKv {
@@ -1131,7 +1264,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             let operation = if matches!(route, Route::DeleteKv) {
                 ProtectedUserOperation::DeleteKv {
@@ -1158,7 +1291,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             let body = request
                 .body_base64
@@ -1181,7 +1314,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             OperationPreparation::Ready(UserOperation::Protected {
                 authority,
@@ -1198,7 +1331,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             OperationPreparation::Ready(UserOperation::Protected {
                 authority,
@@ -1221,7 +1354,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             let body = request
                 .body_base64
@@ -1241,7 +1374,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             OperationPreparation::Ready(UserOperation::Protected {
                 authority,
@@ -1260,7 +1393,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             OperationPreparation::Ready(UserOperation::Protected {
                 authority,
@@ -1283,7 +1416,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             OperationPreparation::Ready(UserOperation::Protected {
                 authority,
@@ -1309,7 +1442,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             OperationPreparation::Ready(UserOperation::Protected {
                 authority,
@@ -1332,7 +1465,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             OperationPreparation::Ready(UserOperation::Protected {
                 authority,
@@ -1353,7 +1486,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             OperationPreparation::Ready(UserOperation::Protected {
                 authority,
@@ -1372,7 +1505,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             let instruction_id = match instruction_path
                 .expect("classified instruction route must have a decoded path")
@@ -1407,7 +1540,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             let Some(InstructionItemPath::Item(instruction_id)) = instruction_path else {
                 unreachable!("classified instruction update must use an item path")
@@ -1440,7 +1573,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             let body = Zeroizing::new(
                 request
@@ -1476,7 +1609,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             let Some(ConversationItemPath::Conversation(conversation_id)) = conversation_path
             else {
@@ -1502,7 +1635,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             let operation = if matches!(route, Route::ListConversations) {
                 ProtectedUserOperation::ListConversations {
@@ -1538,7 +1671,7 @@ pub(crate) fn prepare_user_operation(
             }
             let authority = match bound_user_authority(authority) {
                 Ok(authority) => authority,
-                Err(rejection) => return rejection,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             let operation = match route {
                 Route::GetConversation | Route::DeleteConversation => {
@@ -1590,28 +1723,217 @@ pub(crate) fn prepare_user_operation(
                 operation,
             })
         }
+        Route::Models => {
+            if credential.is_some()
+                || cache_namespace_root_base64.is_some()
+                || request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            match authority {
+                AuthorityState::Anonymous | AuthorityState::Bound(_) => {}
+                AuthorityState::Authenticating(_) => {
+                    return OperationPreparation::Rejected(authentication_start_error(
+                        AuthenticationStartError::AuthenticationInProgress,
+                    ));
+                }
+                AuthorityState::Closing => {
+                    return OperationPreparation::Rejected(authentication_start_error(
+                        AuthenticationStartError::Closing,
+                    ));
+                }
+            }
+            OperationPreparation::Ready(UserOperation::Inference {
+                authority: InferenceAuthority::Public,
+                operation: InferenceOperation::Models,
+            })
+        }
+        Route::ModelCatalog
+        | Route::ChatCompletions
+        | Route::TextToSpeech
+        | Route::Transcription
+        | Route::Embeddings => {
+            if request.query.is_some() {
+                return rejected_bad_request();
+            }
+
+            let operation = match route {
+                Route::ModelCatalog => {
+                    if !request.headers.is_empty() || request.body_base64.is_some() {
+                        return rejected_bad_request();
+                    }
+                    InferenceOperation::ModelCatalog
+                }
+                Route::ChatCompletions => {
+                    let Some(body) = request.body_base64.take() else {
+                        return rejected_bad_request();
+                    };
+                    if body.is_empty() {
+                        return rejected_bad_request();
+                    }
+                    let headers = match prepare_chat_provider_headers(request.headers) {
+                        Ok(headers) => headers,
+                        Err(()) => return rejected_bad_request(),
+                    };
+                    InferenceOperation::Chat {
+                        body: Zeroizing::new(body.into_bytes()),
+                        headers,
+                    }
+                }
+                Route::TextToSpeech | Route::Transcription | Route::Embeddings => {
+                    if !has_exact_json_content_type(&request.headers) {
+                        return rejected_bad_request();
+                    }
+                    let Some(body) = request.body_base64.take() else {
+                        return rejected_bad_request();
+                    };
+                    if body.is_empty() {
+                        return rejected_bad_request();
+                    }
+                    let body = Zeroizing::new(body.into_bytes());
+                    match route {
+                        Route::TextToSpeech => InferenceOperation::TextToSpeech { body },
+                        Route::Transcription => InferenceOperation::Transcription { body },
+                        Route::Embeddings => InferenceOperation::Embeddings { body },
+                        _ => unreachable!("typed OpenAI route group is exhaustive"),
+                    }
+                }
+                _ => unreachable!("OpenAI unary route group is exhaustive"),
+            };
+
+            let authority = match prepare_inference_authority(
+                authority,
+                credential,
+                cache_namespace_root_base64,
+            ) {
+                Ok(authority) => authority,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
+            };
+            OperationPreparation::Ready(UserOperation::Inference {
+                authority,
+                operation,
+            })
+        }
+        Route::WebSearch | Route::WebExtract => {
+            if credential.is_some()
+                || cache_namespace_root_base64.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+            {
+                return rejected_bad_request();
+            }
+            let Some(body) = request.body_base64.take() else {
+                return rejected_bad_request();
+            };
+            if body.is_empty() {
+                return rejected_bad_request();
+            }
+            let authority = match bound_user_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
+            };
+            let operation = if matches!(route, Route::WebSearch) {
+                InferenceOperation::WebSearch {
+                    body: Zeroizing::new(body.into_bytes()),
+                }
+            } else {
+                InferenceOperation::WebExtract {
+                    body: Zeroizing::new(body.into_bytes()),
+                }
+            };
+            OperationPreparation::Ready(UserOperation::Inference {
+                authority: InferenceAuthority::User(authority),
+                operation,
+            })
+        }
     }
 }
 
 fn bound_user_authority(
     authority: AuthorityState,
-) -> Result<BoundUserAuthority, OperationPreparation> {
+) -> Result<BoundUserAuthority, LogicalUnaryResponse> {
     let AuthorityState::Bound(bound) = authority else {
-        return Err(rejected_authentication_required());
+        return Err(authentication_required_response());
     };
     let BoundPrincipal::User {
         user_id,
         project_id,
         auth_context,
+        cache_namespace,
     } = bound.principal()
     else {
-        return Err(rejected_authentication_required());
+        return Err(authentication_required_response());
     };
     Ok(BoundUserAuthority {
         user_id: *user_id,
         project_id: *project_id,
         auth_context: auth_context.clone(),
+        cache_namespace: cache_namespace.clone(),
     })
+}
+
+fn prepare_inference_authority(
+    authority: AuthorityState,
+    credential: Option<Credential>,
+    cache_namespace_root: Option<CacheNamespaceRoot>,
+) -> Result<InferenceAuthority, LogicalUnaryResponse> {
+    match authority {
+        AuthorityState::Anonymous => {
+            let Some(Credential::ApiKey { value_base64 }) = credential else {
+                return Err(authentication_required_response());
+            };
+            let Some(cache_namespace_root) = cache_namespace_root else {
+                return Err(bad_request_response());
+            };
+            if value_base64.is_empty() {
+                return Err(bad_request_response());
+            }
+            Ok(InferenceAuthority::AuthenticateApiKey {
+                credential: Zeroizing::new(value_base64.into_bytes()),
+                cache_namespace_root,
+            })
+        }
+        AuthorityState::Bound(bound) => {
+            if credential.is_some() || cache_namespace_root.is_some() {
+                return Err(LogicalUnaryResponse::protocol_error(
+                    StatusCode::CONFLICT,
+                    "session_already_bound",
+                    "Session is already authenticated",
+                ));
+            }
+            match bound.principal() {
+                BoundPrincipal::User {
+                    user_id,
+                    project_id,
+                    auth_context,
+                    cache_namespace,
+                } => Ok(InferenceAuthority::User(BoundUserAuthority {
+                    user_id: *user_id,
+                    project_id: *project_id,
+                    auth_context: auth_context.clone(),
+                    cache_namespace: cache_namespace.clone(),
+                })),
+                BoundPrincipal::ApiKey {
+                    api_key_id,
+                    user_id,
+                    cache_namespace,
+                } => Ok(InferenceAuthority::ApiKey(BoundApiKeyAuthority {
+                    api_key_id: *api_key_id,
+                    user_id: *user_id,
+                    cache_namespace: cache_namespace.clone(),
+                })),
+                BoundPrincipal::Platform { .. } => Err(authentication_required_response()),
+            }
+        }
+        AuthorityState::Authenticating(_) => Err(authentication_start_error(
+            AuthenticationStartError::AuthenticationInProgress,
+        )),
+        AuthorityState::Closing => Err(authentication_start_error(
+            AuthenticationStartError::Closing,
+        )),
+    }
 }
 
 pub(crate) fn begin_authentication_transition(
@@ -1653,7 +1975,10 @@ pub(crate) async fn execute_user_operation(
 ) -> ApplicationOutcome {
     let session_effect_on_success = operation.session_effect_on_success();
     match operation {
-        UserOperation::Login { body } => {
+        UserOperation::Login {
+            body,
+            cache_namespace_root,
+        } => {
             let parsed =
                 serde_json::from_slice::<Credentials>(&body).map_err(|_| ApiError::BadRequest);
             let credentials = match parsed {
@@ -1671,9 +1996,13 @@ pub(crate) async fn execute_user_operation(
                 authentication.expect("login requires authentication reservation"),
                 monotonic_now,
                 UserAuthResponseKind::Login,
+                cache_namespace_root,
             )
         }
-        UserOperation::Register { body } => {
+        UserOperation::Register {
+            body,
+            cache_namespace_root,
+        } => {
             let parsed = serde_json::from_slice::<RegisterCredentials>(&body)
                 .map_err(|_| ApiError::BadRequest);
             let credentials = match parsed {
@@ -1692,9 +2021,13 @@ pub(crate) async fn execute_user_operation(
                 authentication.expect("registration requires authentication reservation"),
                 monotonic_now,
                 UserAuthResponseKind::Login,
+                cache_namespace_root,
             )
         }
-        UserOperation::Resume { mut credential } => {
+        UserOperation::Resume {
+            mut credential,
+            cache_namespace_root,
+        } => {
             let bytes = std::mem::take(&mut *credential);
             let credential = match String::from_utf8(bytes) {
                 Ok(credential) => Zeroizing::new(credential),
@@ -1715,6 +2048,7 @@ pub(crate) async fn execute_user_operation(
                 authentication.expect("resumption requires authentication reservation"),
                 monotonic_now,
                 UserAuthResponseKind::Refresh,
+                cache_namespace_root,
             )
         }
         UserOperation::VerifyEmail { code } => {
@@ -1858,7 +2192,259 @@ pub(crate) async fn execute_user_operation(
             };
             ApplicationOutcome::success(response, session_effect_on_success)
         }
+        UserOperation::Inference {
+            authority,
+            operation,
+        } => {
+            execute_inference_operation(
+                &app_state,
+                operation,
+                authority,
+                authentication,
+                monotonic_now,
+            )
+            .await
+        }
     }
+}
+
+async fn execute_inference_operation(
+    app_state: &Arc<AppState>,
+    operation: InferenceOperation,
+    authority: InferenceAuthority,
+    authentication: Option<AuthenticationReservation>,
+    monotonic_now: Instant,
+) -> ApplicationOutcome {
+    match authority {
+        InferenceAuthority::Public => {
+            debug_assert!(authentication.is_none());
+            if !matches!(operation, InferenceOperation::Models) {
+                return ApplicationOutcome::error(ApiError::Unauthorized);
+            }
+            let response = match openai_models_v2_data(app_state)
+                .await
+                .and_then(|value| LogicalUnaryResponse::json(StatusCode::OK, &value))
+            {
+                Ok(response) => response,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            ApplicationOutcome::success(response, SessionEffect::Retain)
+        }
+        InferenceAuthority::User(authority) => {
+            debug_assert!(authentication.is_none());
+            let user = match app_state.verify_bound_user(
+                authority.user_id,
+                authority.project_id,
+                &authority.auth_context,
+            ) {
+                Ok(user) => user,
+                Err(error) => {
+                    if matches!(error, ApiError::Unauthorized | ApiError::InvalidJwt) {
+                        return ApplicationOutcome::closing_error(error);
+                    }
+                    return ApplicationOutcome::error(error);
+                }
+            };
+            let response = execute_inference_for_user(
+                app_state,
+                &user,
+                OpenAiAuthMethod::Jwt,
+                &authority.cache_namespace,
+                operation,
+            )
+            .await;
+            ApplicationOutcome::success(response, SessionEffect::Retain)
+        }
+        InferenceAuthority::ApiKey(authority) => {
+            debug_assert!(authentication.is_none());
+            let user = match app_state
+                .db
+                .revalidate_user_api_key_owner(authority.api_key_id, authority.user_id)
+            {
+                Ok(Some(user)) => user,
+                Ok(None) => return ApplicationOutcome::closing_error(ApiError::Unauthorized),
+                Err(error) => {
+                    tracing::error!(
+                        api_key_id = authority.api_key_id,
+                        "Failed to revalidate a bound API-key authority: {error:?}"
+                    );
+                    return ApplicationOutcome::error(ApiError::InternalServerError);
+                }
+            };
+            let response = execute_inference_for_user(
+                app_state,
+                &user,
+                OpenAiAuthMethod::ApiKey,
+                &authority.cache_namespace,
+                operation,
+            )
+            .await;
+            ApplicationOutcome::success(response, SessionEffect::Retain)
+        }
+        InferenceAuthority::AuthenticateApiKey {
+            credential,
+            cache_namespace_root,
+        } => {
+            let Some(authentication) = authentication else {
+                return ApplicationOutcome::error(ApiError::InternalServerError);
+            };
+            let key_hash = match canonical_api_key_hash(credential) {
+                Ok(key_hash) => key_hash,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            let resolved = match app_state.db.resolve_user_api_key_by_hash(&key_hash) {
+                Ok(Some(resolved)) => resolved,
+                Ok(None) => return ApplicationOutcome::error(ApiError::Unauthorized),
+                Err(error) => {
+                    tracing::error!("Failed to authenticate a v2 API key: {error:?}");
+                    return ApplicationOutcome::error(ApiError::InternalServerError);
+                }
+            };
+            drop(key_hash);
+            let cache_namespace =
+                derive_tinfoil_cache_namespace(&cache_namespace_root, resolved.user.get_id());
+            drop(cache_namespace_root);
+            let authority = BoundAuthority::api_key(
+                resolved.api_key_id,
+                resolved.user.get_id(),
+                cache_namespace.clone(),
+            );
+            if authentication.commit_at(authority, monotonic_now).is_err() {
+                return ApplicationOutcome::error(ApiError::InternalServerError);
+            }
+
+            let response = execute_inference_for_user(
+                app_state,
+                &resolved.user,
+                OpenAiAuthMethod::ApiKey,
+                &cache_namespace,
+                operation,
+            )
+            .await;
+            // Once the authority commits, every application outcome must carry
+            // NewlyBound. The gateway can then close the session if this first
+            // authenticated response cannot be encrypted for the client.
+            ApplicationOutcome::success(response, SessionEffect::NewlyBound)
+        }
+    }
+}
+
+async fn execute_inference_for_user(
+    app_state: &Arc<AppState>,
+    user: &crate::User,
+    auth_method: OpenAiAuthMethod,
+    cache_namespace: &DerivedCacheNamespace,
+    operation: InferenceOperation,
+) -> LogicalUnaryResponse {
+    let result = match operation {
+        InferenceOperation::Models => Err(ApiError::Unauthorized),
+        InferenceOperation::ModelCatalog => {
+            let value = openai_model_catalog_data(app_state, user).await;
+            LogicalUnaryResponse::json(StatusCode::OK, &value)
+        }
+        InferenceOperation::Chat { body, headers } => {
+            let body = match parse_provider_json_body::<serde_json::Value>(body) {
+                Ok(body) => body,
+                Err(error) => return LogicalUnaryResponse::api_error(error),
+            };
+            openai_nonstream_chat_completion_v2_data(
+                app_state,
+                user,
+                auth_method,
+                body,
+                &headers,
+                cache_namespace,
+            )
+            .await
+            .and_then(|value| LogicalUnaryResponse::json(StatusCode::OK, &value))
+        }
+        InferenceOperation::TextToSpeech { body } => {
+            let request = match parse_provider_json_body::<TTSRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return LogicalUnaryResponse::api_error(error),
+            };
+            openai_tts_v2_data(app_state, user, request)
+                .await
+                .and_then(|value| LogicalUnaryResponse::json(StatusCode::OK, &value))
+        }
+        InferenceOperation::Transcription { body } => {
+            let request = match parse_provider_json_body::<TranscriptionRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return LogicalUnaryResponse::api_error(error),
+            };
+            openai_transcription_v2_data(app_state, user, request)
+                .await
+                .and_then(|value| LogicalUnaryResponse::json(StatusCode::OK, &value))
+        }
+        InferenceOperation::Embeddings { body } => {
+            let request = match parse_provider_json_body::<EmbeddingRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return LogicalUnaryResponse::api_error(error),
+            };
+            openai_embeddings_v2_data(app_state, user, auth_method, request)
+                .await
+                .and_then(|value| LogicalUnaryResponse::json(StatusCode::OK, &value))
+        }
+        InferenceOperation::WebSearch { body } => {
+            let body = match parse_provider_json_body::<serde_json::Value>(body) {
+                Ok(body) => body,
+                Err(error) => return LogicalUnaryResponse::api_error(error),
+            };
+            let request = match parse_web_search_request(body) {
+                Ok(request) => request,
+                Err(error) => {
+                    return logical_web_error(error).unwrap_or_else(LogicalUnaryResponse::api_error)
+                }
+            };
+            match execute_web_search(app_state, user, request).await {
+                Ok(value) => LogicalUnaryResponse::json(StatusCode::OK, &value),
+                Err(error) => logical_web_error(error),
+            }
+        }
+        InferenceOperation::WebExtract { body } => {
+            let body = match parse_provider_json_body::<serde_json::Value>(body) {
+                Ok(body) => body,
+                Err(error) => return LogicalUnaryResponse::api_error(error),
+            };
+            let request = match parse_web_extract_request(body) {
+                Ok(request) => request,
+                Err(error) => {
+                    return logical_web_error(error).unwrap_or_else(LogicalUnaryResponse::api_error)
+                }
+            };
+            match execute_web_extract(app_state, user, request).await {
+                Ok(value) => LogicalUnaryResponse::json(StatusCode::OK, &value),
+                Err(error) => logical_web_error(error),
+            }
+        }
+    };
+
+    match result {
+        Ok(response) => response,
+        Err(error) => LogicalUnaryResponse::api_error(error),
+    }
+}
+
+fn logical_web_error(error: WebRouteError) -> Result<LogicalUnaryResponse, ApiError> {
+    let (status, body) = error.into_logical_parts();
+    LogicalUnaryResponse::json(status, &body)
+}
+
+fn canonical_api_key_hash(mut credential: SensitiveBytes) -> Result<Zeroizing<String>, ApiError> {
+    let bytes = std::mem::take(&mut *credential);
+    let value = match String::from_utf8(bytes) {
+        Ok(value) => Zeroizing::new(value),
+        Err(error) => {
+            let mut bytes = error.into_bytes();
+            bytes.zeroize();
+            return Err(ApiError::Unauthorized);
+        }
+    };
+    let key_id = uuid::Uuid::parse_str(&value).map_err(|_| ApiError::Unauthorized)?;
+    let canonical = Zeroizing::new(key_id.hyphenated().to_string());
+    Ok(Zeroizing::new(hex::encode(Sha256::digest(
+        canonical.as_bytes(),
+    ))))
 }
 
 fn bound_user_error_outcome(
@@ -3453,6 +4039,14 @@ fn parse_conversation_json_body<T: DeserializeOwned>(body: SensitiveBytes) -> Re
     }
 }
 
+fn parse_provider_json_body<T: DeserializeOwned>(body: SensitiveBytes) -> Result<T, ApiError> {
+    match validate_json_shape(&body) {
+        Ok(()) => parse_json_body(body),
+        Err(JsonShapeError::TooLarge) => Err(ApiError::PayloadTooLarge),
+        Err(JsonShapeError::Malformed) => Err(ApiError::BadRequest),
+    }
+}
+
 fn parse_logical_query<T: DeserializeOwned>(query: Option<String>) -> Result<T, ApiError> {
     let path_and_query = match query {
         Some(query) => format!("/?{query}"),
@@ -3494,6 +4088,7 @@ fn finish_user_binding(
     authentication: AuthenticationReservation,
     monotonic_now: Instant,
     response_kind: UserAuthResponseKind,
+    cache_namespace_root: CacheNamespaceRoot,
 ) -> ApplicationOutcome {
     let issued =
         match issue_transport_v2_user_tokens(&verified.user, &verified.auth_context, app_state) {
@@ -3542,7 +4137,11 @@ fn finish_user_binding(
         Err(error) => return ApplicationOutcome::error(error),
     };
 
-    let authority = BoundAuthority::verified_user(&verified, authentication_expires_at);
+    let cache_namespace =
+        derive_tinfoil_cache_namespace(&cache_namespace_root, verified.user.get_id());
+    drop(cache_namespace_root);
+    let authority =
+        BoundAuthority::verified_user(&verified, authentication_expires_at, cache_namespace);
     if authentication.commit_at(authority, monotonic_now).is_err() {
         return ApplicationOutcome::error(ApiError::InternalServerError);
     }
@@ -3570,19 +4169,27 @@ fn monotonic_authentication_expiry(
 }
 
 fn rejected_bad_request() -> OperationPreparation {
-    OperationPreparation::Rejected(LogicalUnaryResponse::protocol_error(
+    OperationPreparation::Rejected(bad_request_response())
+}
+
+fn bad_request_response() -> LogicalUnaryResponse {
+    LogicalUnaryResponse::protocol_error(
         StatusCode::BAD_REQUEST,
         "invalid_request",
         "Invalid request",
-    ))
+    )
 }
 
 fn rejected_authentication_required() -> OperationPreparation {
-    OperationPreparation::Rejected(LogicalUnaryResponse::protocol_error(
+    OperationPreparation::Rejected(authentication_required_response())
+}
+
+fn authentication_required_response() -> LogicalUnaryResponse {
+    LogicalUnaryResponse::protocol_error(
         StatusCode::UNAUTHORIZED,
         "authentication_required",
         "Authentication required",
-    ))
+    )
 }
 
 fn has_exact_json_content_type(headers: &[HeaderField]) -> bool {
@@ -3592,7 +4199,11 @@ fn has_exact_json_content_type(headers: &[HeaderField]) -> bool {
     if header.name != "content-type" {
         return false;
     }
-    let Ok(value) = std::str::from_utf8(header.value_base64.as_slice()) else {
+    is_json_content_type(header.value_base64.as_slice())
+}
+
+fn is_json_content_type(value: &[u8]) -> bool {
+    let Ok(value) = std::str::from_utf8(value) else {
         return false;
     };
     let mut parts = value.split(';');
@@ -3621,6 +4232,60 @@ fn has_exact_json_content_type(headers: &[HeaderField]) -> bool {
     true
 }
 
+fn prepare_chat_provider_headers(headers: Vec<HeaderField>) -> Result<HeaderMap, ()> {
+    let mut prepared = HeaderMap::new();
+    let mut saw_content_type = false;
+
+    for header in headers {
+        let name = HeaderName::from_bytes(header.name.as_bytes()).map_err(|_| ())?;
+        if is_forbidden_chat_provider_header(&name) {
+            return Err(());
+        }
+        if name == header::CONTENT_TYPE {
+            if saw_content_type || !is_json_content_type(header.value_base64.as_slice()) {
+                return Err(());
+            }
+            saw_content_type = true;
+        }
+        let mut value = HeaderValue::from_bytes(header.value_base64.as_slice()).map_err(|_| ())?;
+        value.set_sensitive(true);
+        prepared.append(name, value);
+    }
+
+    saw_content_type.then_some(prepared).ok_or(())
+}
+
+fn is_forbidden_chat_provider_header(name: &HeaderName) -> bool {
+    matches!(
+        name.as_str(),
+        "authorization"
+            | "proxy-authorization"
+            | "proxy-authenticate"
+            | "cookie"
+            | "set-cookie"
+            | "host"
+            | "content-length"
+            | "content-encoding"
+            | "accept-encoding"
+            | "connection"
+            | "keep-alive"
+            | "proxy-connection"
+            | "te"
+            | "trailer"
+            | "transfer-encoding"
+            | "upgrade"
+            | "x-session-id"
+            | "x-api-key"
+            | "api-key"
+            | "x-openai-api-key"
+            | "x-tinfoil-api-key"
+            | "x-goog-api-key"
+            | "x-anthropic-api-key"
+            | "openai-organization"
+            | "openai-project"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3635,11 +4300,15 @@ mod tests {
         body: Option<&[u8]>,
         credential: Option<Credential>,
     ) -> RequestEnvelope {
+        let cache_namespace_root_base64 = (matches!(path, "/login" | "/register")
+            || matches!(credential, Some(Credential::Resumption { .. })))
+        .then(|| CacheNamespaceRoot::from_bytes([0x30; 32]));
         RequestEnvelope {
             version: Version2,
             request_id: RequestId::from_bytes([0x31; 16]),
             response_mode: ResponseMode::Unary,
             credential,
+            cache_namespace_root_base64,
             request: LogicalRequest {
                 method,
                 path: path.to_owned(),
@@ -3657,13 +4326,29 @@ mod tests {
         }]
     }
 
+    fn logical_header_value<'a>(
+        response: &'a LogicalUnaryResponse,
+        name: &str,
+    ) -> Option<&'a [u8]> {
+        response
+            .headers
+            .iter()
+            .find(|header| header.name == name)
+            .map(|header| header.value_base64.as_slice())
+    }
+
     fn bound_user_authority() -> AuthorityState {
         let auth_context = AuthContext::new(AuthMethod::Password, 7, [0x32; 32]);
+        let cache_namespace = derive_tinfoil_cache_namespace(
+            &CacheNamespaceRoot::from_bytes([0x34; 32]),
+            uuid::Uuid::from_bytes([0x33; 16]),
+        );
         AuthorityState::Bound(BoundAuthority::user(
             uuid::Uuid::from_bytes([0x33; 16]),
             7,
             &auth_context,
             Instant::now() + std::time::Duration::from_secs(60),
+            cache_namespace,
         ))
     }
 
@@ -3995,6 +4680,10 @@ mod tests {
                 AuthorityState::Bound(BoundAuthority::api_key(
                     17,
                     uuid::Uuid::from_bytes([0x43; 16]),
+                    derive_tinfoil_cache_namespace(
+                        &CacheNamespaceRoot::from_bytes([0x44; 32]),
+                        uuid::Uuid::from_bytes([0x43; 16]),
+                    ),
                 )),
             ),
             OperationPreparation::Rejected(response)
@@ -5401,6 +6090,51 @@ mod tests {
     }
 
     #[test]
+    fn coded_api_errors_preserve_the_established_error_contract_inside_v2() {
+        let response = LogicalUnaryResponse::api_error(ApiError::SessionNotFound);
+
+        assert_eq!(response.status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response.body.as_ref().map(|body| body.as_slice()),
+            Some(br#"{"status":400,"message":"Bad Request"}"#.as_slice())
+        );
+        assert_eq!(response.headers.len(), 3);
+        assert_eq!(
+            logical_header_value(&response, "content-type"),
+            Some(JSON_CONTENT_TYPE)
+        );
+        assert_eq!(
+            logical_header_value(&response, ERROR_CONTRACT_HEADER),
+            Some(b"1".as_slice())
+        );
+        assert_eq!(
+            logical_header_value(&response, ERROR_CODE_HEADER),
+            Some(b"session_not_found".as_slice())
+        );
+    }
+
+    #[test]
+    fn uncoded_api_errors_include_only_the_established_contract_header_inside_v2() {
+        let response = LogicalUnaryResponse::api_error(ApiError::BadRequest);
+
+        assert_eq!(response.status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            response.body.as_ref().map(|body| body.as_slice()),
+            Some(br#"{"status":400,"message":"Bad Request"}"#.as_slice())
+        );
+        assert_eq!(response.headers.len(), 2);
+        assert_eq!(
+            logical_header_value(&response, "content-type"),
+            Some(JSON_CONTENT_TYPE)
+        );
+        assert_eq!(
+            logical_header_value(&response, ERROR_CONTRACT_HEADER),
+            Some(b"1".as_slice())
+        );
+        assert_eq!(logical_header_value(&response, ERROR_CODE_HEADER), None);
+    }
+
+    #[test]
     fn api_key_list_keeps_existing_json_wire_shape() {
         use crate::web::protected_routes::{ApiKeyInfo, ListApiKeysResponse};
 
@@ -5842,6 +6576,606 @@ mod tests {
         assert!(matches!(
             validate_encrypted_data_base64_length(MAX_ENCRYPTED_DATA_BASE64_BYTES + 1),
             Err(ApiError::PayloadTooLarge)
+        ));
+    }
+
+    fn api_key_credential(value: &[u8]) -> Credential {
+        Credential::ApiKey {
+            value_base64: EncodedBytes::from_bytes(value.to_vec()),
+        }
+    }
+
+    fn api_key_binding_envelope(
+        method: LogicalMethod,
+        path: &str,
+        headers: Vec<HeaderField>,
+        body: Option<&[u8]>,
+    ) -> RequestEnvelope {
+        let mut request = envelope(
+            method,
+            path,
+            headers,
+            body,
+            Some(api_key_credential(b"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")),
+        );
+        request.cache_namespace_root_base64 = Some(CacheNamespaceRoot::from_bytes([0xa1; 32]));
+        request
+    }
+
+    fn bound_api_key_authority() -> AuthorityState {
+        let user_id = uuid::Uuid::from_bytes([0xa2; 16]);
+        let cache_namespace =
+            derive_tinfoil_cache_namespace(&CacheNamespaceRoot::from_bytes([0xa3; 32]), user_id);
+        AuthorityState::Bound(BoundAuthority::api_key(17, user_id, cache_namespace))
+    }
+
+    fn bound_platform_authority() -> AuthorityState {
+        AuthorityState::Bound(BoundAuthority::platform(
+            uuid::Uuid::from_bytes([0xa4; 16]),
+            Instant::now() + std::time::Duration::from_secs(60),
+        ))
+    }
+
+    fn inference_kind(operation: &InferenceOperation) -> &'static str {
+        match operation {
+            InferenceOperation::Models => "models",
+            InferenceOperation::ModelCatalog => "catalog",
+            InferenceOperation::Chat { .. } => "chat",
+            InferenceOperation::TextToSpeech { .. } => "speech",
+            InferenceOperation::Transcription { .. } => "transcription",
+            InferenceOperation::Embeddings { .. } => "embeddings",
+            InferenceOperation::WebSearch { .. } => "web-search",
+            InferenceOperation::WebExtract { .. } => "web-extract",
+        }
+    }
+
+    fn rejected_status(preparation: OperationPreparation) -> StatusCode {
+        match preparation {
+            OperationPreparation::Rejected(response) => response.status,
+            OperationPreparation::Unsupported => panic!("expected a classified rejection"),
+            OperationPreparation::Ready(_) => panic!("expected the request to be rejected"),
+        }
+    }
+
+    #[test]
+    fn exact_eight_route_unary_inference_matrix_is_classified_and_reserved() {
+        let cases = [
+            (
+                envelope(LogicalMethod::Get, "/v1/models", Vec::new(), None, None),
+                AuthorityState::Anonymous,
+                "models",
+                true,
+            ),
+            (
+                envelope(
+                    LogicalMethod::Get,
+                    "/v1/models/catalog",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                bound_user_authority(),
+                "catalog",
+                false,
+            ),
+            (
+                envelope(
+                    LogicalMethod::Post,
+                    "/v1/chat/completions",
+                    json_header(),
+                    Some(br#"{"model":"model","messages":[]}"#),
+                    None,
+                ),
+                bound_user_authority(),
+                "chat",
+                false,
+            ),
+            (
+                envelope(
+                    LogicalMethod::Post,
+                    "/v1/audio/speech",
+                    json_header(),
+                    Some(br#"{"model":"model","input":"hello","voice":"alloy"}"#),
+                    None,
+                ),
+                bound_user_authority(),
+                "speech",
+                false,
+            ),
+            (
+                envelope(
+                    LogicalMethod::Post,
+                    "/v1/audio/transcriptions",
+                    json_header(),
+                    Some(br#"{"model":"model","file":"AA=="}"#),
+                    None,
+                ),
+                bound_user_authority(),
+                "transcription",
+                false,
+            ),
+            (
+                envelope(
+                    LogicalMethod::Post,
+                    "/v1/embeddings",
+                    json_header(),
+                    Some(br#"{"model":"model","input":"hello"}"#),
+                    None,
+                ),
+                bound_user_authority(),
+                "embeddings",
+                false,
+            ),
+            (
+                envelope(
+                    LogicalMethod::Post,
+                    "/v1/web/search",
+                    json_header(),
+                    Some(br#"{"query":"maple"}"#),
+                    None,
+                ),
+                bound_user_authority(),
+                "web-search",
+                false,
+            ),
+            (
+                envelope(
+                    LogicalMethod::Post,
+                    "/v1/web/extract",
+                    json_header(),
+                    Some(br#"{"urls":["https://example.com/"]}"#),
+                    None,
+                ),
+                bound_user_authority(),
+                "web-extract",
+                false,
+            ),
+        ];
+
+        for (request, authority, expected_kind, expects_public_authority) in cases {
+            let OperationPreparation::Ready(operation) = prepare_user_operation(request, authority)
+            else {
+                panic!("{expected_kind} must be admitted by the exact unary matrix");
+            };
+            assert!(
+                operation.requires_provider_output_reservation(),
+                "{expected_kind} must reserve bounded provider-output capacity"
+            );
+            let UserOperation::Inference {
+                authority,
+                operation,
+            } = operation
+            else {
+                panic!("{expected_kind} must classify as inference");
+            };
+            assert_eq!(inference_kind(&operation), expected_kind);
+            assert_eq!(
+                matches!(authority, InferenceAuthority::Public),
+                expects_public_authority,
+                "only the public models route may use public authority"
+            );
+            if !expects_public_authority {
+                assert!(matches!(authority, InferenceAuthority::User(_)));
+            }
+        }
+    }
+
+    #[test]
+    fn exact_five_route_api_key_first_binding_matrix_requires_transition() {
+        let cases = [
+            (
+                api_key_binding_envelope(
+                    LogicalMethod::Get,
+                    "/v1/models/catalog",
+                    Vec::new(),
+                    None,
+                ),
+                "catalog",
+            ),
+            (
+                api_key_binding_envelope(
+                    LogicalMethod::Post,
+                    "/v1/chat/completions",
+                    json_header(),
+                    Some(br#"{"model":"model","messages":[]}"#),
+                ),
+                "chat",
+            ),
+            (
+                api_key_binding_envelope(
+                    LogicalMethod::Post,
+                    "/v1/audio/speech",
+                    json_header(),
+                    Some(br#"{"model":"model","input":"hello","voice":"alloy"}"#),
+                ),
+                "speech",
+            ),
+            (
+                api_key_binding_envelope(
+                    LogicalMethod::Post,
+                    "/v1/audio/transcriptions",
+                    json_header(),
+                    Some(br#"{"model":"model","file":"AA=="}"#),
+                ),
+                "transcription",
+            ),
+            (
+                api_key_binding_envelope(
+                    LogicalMethod::Post,
+                    "/v1/embeddings",
+                    json_header(),
+                    Some(br#"{"model":"model","input":"hello"}"#),
+                ),
+                "embeddings",
+            ),
+        ];
+
+        for (request, expected_kind) in cases {
+            let OperationPreparation::Ready(operation) =
+                prepare_user_operation(request, AuthorityState::Anonymous)
+            else {
+                panic!("{expected_kind} must admit an encrypted first-use API key");
+            };
+            assert!(operation.requires_authentication_transition());
+            assert!(operation.requires_provider_output_reservation());
+            let UserOperation::Inference {
+                authority:
+                    InferenceAuthority::AuthenticateApiKey {
+                        credential,
+                        cache_namespace_root: _,
+                    },
+                operation,
+            } = operation
+            else {
+                panic!("{expected_kind} must classify as an API-key binding operation");
+            };
+            assert_eq!(
+                credential.as_slice(),
+                b"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+            );
+            assert_eq!(inference_kind(&operation), expected_kind);
+        }
+    }
+
+    #[test]
+    fn public_models_refuses_credentials_and_cache_roots() {
+        for mut request in [
+            envelope(
+                LogicalMethod::Get,
+                "/v1/models",
+                Vec::new(),
+                None,
+                Some(api_key_credential(b"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")),
+            ),
+            envelope(LogicalMethod::Get, "/v1/models", Vec::new(), None, None),
+        ] {
+            if request.credential.is_none() {
+                request.cache_namespace_root_base64 =
+                    Some(CacheNamespaceRoot::from_bytes([0xa5; 32]));
+            }
+            assert_eq!(
+                rejected_status(prepare_user_operation(request, AuthorityState::Anonymous)),
+                StatusCode::BAD_REQUEST
+            );
+        }
+
+        assert_eq!(
+            rejected_status(prepare_user_operation(
+                envelope(
+                    LogicalMethod::Get,
+                    "/v1/models",
+                    Vec::new(),
+                    None,
+                    Some(api_key_credential(b"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",)),
+                ),
+                bound_user_authority(),
+            )),
+            StatusCode::BAD_REQUEST
+        );
+    }
+
+    #[test]
+    fn web_routes_are_user_only_and_reject_authentication_transplants() {
+        for path in ["/v1/web/search", "/v1/web/extract"] {
+            for authority in [
+                AuthorityState::Anonymous,
+                bound_api_key_authority(),
+                bound_platform_authority(),
+            ] {
+                assert_eq!(
+                    rejected_status(prepare_user_operation(
+                        envelope(
+                            LogicalMethod::Post,
+                            path,
+                            json_header(),
+                            Some(br#"{"query":"maple"}"#),
+                            None,
+                        ),
+                        authority,
+                    )),
+                    StatusCode::UNAUTHORIZED
+                );
+            }
+
+            let with_credential = envelope(
+                LogicalMethod::Post,
+                path,
+                json_header(),
+                Some(br#"{"query":"maple"}"#),
+                Some(api_key_credential(b"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")),
+            );
+            assert_eq!(
+                rejected_status(prepare_user_operation(
+                    with_credential,
+                    AuthorityState::Anonymous,
+                )),
+                StatusCode::BAD_REQUEST
+            );
+
+            let mut with_root = envelope(
+                LogicalMethod::Post,
+                path,
+                json_header(),
+                Some(br#"{"query":"maple"}"#),
+                None,
+            );
+            with_root.cache_namespace_root_base64 =
+                Some(CacheNamespaceRoot::from_bytes([0xa6; 32]));
+            assert_eq!(
+                rejected_status(prepare_user_operation(with_root, bound_user_authority())),
+                StatusCode::BAD_REQUEST
+            );
+        }
+    }
+
+    #[test]
+    fn cache_namespace_root_is_required_only_for_authority_binding() {
+        let mut login = envelope(
+            LogicalMethod::Post,
+            "/login",
+            json_header(),
+            Some(b"{}"),
+            None,
+        );
+        login.cache_namespace_root_base64 = None;
+        let mut register = envelope(
+            LogicalMethod::Post,
+            "/register",
+            json_header(),
+            Some(b"{}"),
+            None,
+        );
+        register.cache_namespace_root_base64 = None;
+        let mut resume = envelope(
+            LogicalMethod::Post,
+            "/refresh",
+            Vec::new(),
+            None,
+            Some(Credential::Resumption {
+                value_base64: EncodedBytes::from_bytes(b"resumption".to_vec()),
+            }),
+        );
+        resume.cache_namespace_root_base64 = None;
+        let api_key_without_root = envelope(
+            LogicalMethod::Get,
+            "/v1/models/catalog",
+            Vec::new(),
+            None,
+            Some(api_key_credential(b"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")),
+        );
+
+        for request in [login, register, resume, api_key_without_root] {
+            assert_eq!(
+                rejected_status(prepare_user_operation(request, AuthorityState::Anonymous)),
+                StatusCode::BAD_REQUEST
+            );
+        }
+
+        let mut protected_transplant = envelope(
+            LogicalMethod::Get,
+            "/protected/user",
+            Vec::new(),
+            None,
+            None,
+        );
+        protected_transplant.cache_namespace_root_base64 =
+            Some(CacheNamespaceRoot::from_bytes([0xa7; 32]));
+        assert_eq!(
+            rejected_status(prepare_user_operation(
+                protected_transplant,
+                bound_user_authority(),
+            )),
+            StatusCode::BAD_REQUEST
+        );
+
+        for authority in [bound_user_authority(), bound_api_key_authority()] {
+            let follow_up = envelope(
+                LogicalMethod::Get,
+                "/v1/models/catalog",
+                Vec::new(),
+                None,
+                None,
+            );
+            assert!(matches!(
+                prepare_user_operation(follow_up, authority),
+                OperationPreparation::Ready(UserOperation::Inference { .. })
+            ));
+        }
+
+        let mut user_root_transplant = envelope(
+            LogicalMethod::Get,
+            "/v1/models/catalog",
+            Vec::new(),
+            None,
+            None,
+        );
+        user_root_transplant.cache_namespace_root_base64 =
+            Some(CacheNamespaceRoot::from_bytes([0xa8; 32]));
+        let mut api_key_root_transplant = envelope(
+            LogicalMethod::Get,
+            "/v1/models/catalog",
+            Vec::new(),
+            None,
+            None,
+        );
+        api_key_root_transplant.cache_namespace_root_base64 =
+            Some(CacheNamespaceRoot::from_bytes([0xa9; 32]));
+
+        for (authority, request) in [
+            (
+                bound_user_authority(),
+                envelope(
+                    LogicalMethod::Get,
+                    "/v1/models/catalog",
+                    Vec::new(),
+                    None,
+                    Some(api_key_credential(b"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")),
+                ),
+            ),
+            (bound_user_authority(), user_root_transplant),
+            (
+                bound_api_key_authority(),
+                envelope(
+                    LogicalMethod::Get,
+                    "/v1/models/catalog",
+                    Vec::new(),
+                    None,
+                    Some(api_key_credential(b"aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")),
+                ),
+            ),
+            (bound_api_key_authority(), api_key_root_transplant),
+        ] {
+            assert_eq!(
+                rejected_status(prepare_user_operation(request, authority)),
+                StatusCode::CONFLICT
+            );
+        }
+    }
+
+    #[test]
+    fn chat_classifier_rejects_non_unary_mode_missing_body_and_unsafe_headers() {
+        let mut streaming = envelope(
+            LogicalMethod::Post,
+            "/v1/chat/completions",
+            json_header(),
+            Some(br#"{"stream":true}"#),
+            None,
+        );
+        streaming.response_mode = ResponseMode::Stream;
+        assert!(matches!(
+            prepare_user_operation(streaming, bound_user_authority()),
+            OperationPreparation::Rejected(_)
+        ));
+
+        for body in [None, Some(&b""[..])] {
+            assert!(matches!(
+                prepare_user_operation(
+                    envelope(
+                        LogicalMethod::Post,
+                        "/v1/chat/completions",
+                        json_header(),
+                        body,
+                        None,
+                    ),
+                    bound_user_authority(),
+                ),
+                OperationPreparation::Rejected(_)
+            ));
+        }
+
+        for forbidden in [
+            "authorization",
+            "proxy-authorization",
+            "proxy-authenticate",
+            "cookie",
+            "set-cookie",
+            "host",
+            "content-length",
+            "content-encoding",
+            "accept-encoding",
+            "connection",
+            "keep-alive",
+            "proxy-connection",
+            "te",
+            "trailer",
+            "transfer-encoding",
+            "upgrade",
+            "x-session-id",
+            "x-api-key",
+            "api-key",
+            "x-openai-api-key",
+            "x-tinfoil-api-key",
+            "x-goog-api-key",
+            "x-anthropic-api-key",
+            "openai-organization",
+            "openai-project",
+        ] {
+            let mut headers = json_header();
+            headers.push(HeaderField {
+                name: forbidden.to_owned(),
+                value_base64: EncodedBytes::from_bytes(b"opaque".to_vec()),
+            });
+            assert!(
+                prepare_chat_provider_headers(headers).is_err(),
+                "{forbidden} must never cross the provider boundary"
+            );
+        }
+
+        let duplicate_content_type = vec![json_header()[0].clone(), json_header()[0].clone()];
+        assert!(prepare_chat_provider_headers(duplicate_content_type).is_err());
+        assert!(prepare_chat_provider_headers(vec![HeaderField {
+            name: "invalid header name".to_owned(),
+            value_base64: EncodedBytes::from_bytes(b"opaque".to_vec()),
+        }])
+        .is_err());
+
+        let safe_headers = vec![
+            json_header()[0].clone(),
+            HeaderField {
+                name: "x-client-hint".to_owned(),
+                value_base64: EncodedBytes::from_bytes(b"first".to_vec()),
+            },
+            HeaderField {
+                name: "x-client-hint".to_owned(),
+                value_base64: EncodedBytes::from_bytes(b"second".to_vec()),
+            },
+        ];
+        let prepared =
+            prepare_chat_provider_headers(safe_headers).expect("safe opaque headers are retained");
+        let values = prepared
+            .get_all("x-client-hint")
+            .iter()
+            .map(|value| value.as_bytes())
+            .collect::<Vec<_>>();
+        assert_eq!(values, vec![&b"first"[..], &b"second"[..]]);
+        assert!(prepared
+            .get_all("x-client-hint")
+            .iter()
+            .all(HeaderValue::is_sensitive));
+    }
+
+    #[test]
+    fn canonical_api_key_hash_matches_v1_uuid_canonicalization() {
+        let parsed = uuid::Uuid::parse_str("AAAAAAAA-BBBB-4CCC-8DDD-EEEEEEEEEEEE").unwrap();
+        let expected = hex::encode(Sha256::digest(parsed.to_string().as_bytes()));
+
+        for representation in [
+            parsed.to_string(),
+            parsed.to_string().to_ascii_uppercase(),
+            parsed.simple().to_string(),
+        ] {
+            let hash = canonical_api_key_hash(Zeroizing::new(representation.into_bytes()))
+                .expect("all UUID spellings accepted by v1 canonicalize identically");
+            assert_eq!(&*hash, &expected);
+        }
+
+        assert!(matches!(
+            canonical_api_key_hash(Zeroizing::new(vec![0xff])),
+            Err(ApiError::Unauthorized)
+        ));
+        assert!(matches!(
+            canonical_api_key_hash(Zeroizing::new(b"not-a-uuid".to_vec())),
+            Err(ApiError::Unauthorized)
         ));
     }
 }

--- a/src/transport_v2/envelope.rs
+++ b/src/transport_v2/envelope.rs
@@ -5,6 +5,8 @@ use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
+use crate::provider_cache::CacheNamespaceRoot;
+
 const MIB: usize = 1024 * 1024;
 const KIB: usize = 1024;
 
@@ -328,6 +330,8 @@ pub(crate) struct RequestEnvelope {
     pub(crate) response_mode: ResponseMode,
     #[serde(deserialize_with = "deserialize_required_nullable")]
     pub(crate) credential: Option<Credential>,
+    #[serde(deserialize_with = "deserialize_required_nullable")]
+    pub(crate) cache_namespace_root_base64: Option<CacheNamespaceRoot>,
     pub(crate) request: LogicalRequest,
 }
 
@@ -1100,6 +1104,7 @@ mod tests {
         fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
 
         assert_zeroize_on_drop::<EncodedBytes>();
+        assert_zeroize_on_drop::<CacheNamespaceRoot>();
     }
 
     fn request_json(body: &str) -> String {
@@ -1109,6 +1114,7 @@ mod tests {
                 "request_id":"{REQUEST_ID}",
                 "response_mode":"auto",
                 "credential":null,
+                "cache_namespace_root_base64":null,
                 "request":{{
                     "method":"POST",
                     "path":"/v1/responses",
@@ -1189,6 +1195,49 @@ mod tests {
             &EnvelopeLimits::default()
         )
         .is_err());
+
+        let missing_cache_namespace_root =
+            request_json("null").replace("\"cache_namespace_root_base64\":null,", "");
+        assert!(RequestEnvelope::from_json_slice(
+            missing_cache_namespace_root.as_bytes(),
+            &EnvelopeLimits::default()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn cache_namespace_root_requires_canonical_padded_base64_for_exactly_32_bytes() {
+        let encoded_root = STANDARD.encode([0x5a; 32]);
+        let with_root = request_json("null").replace(
+            "\"cache_namespace_root_base64\":null",
+            &format!("\"cache_namespace_root_base64\":\"{encoded_root}\""),
+        );
+        let parsed =
+            RequestEnvelope::from_json_slice(with_root.as_bytes(), &EnvelopeLimits::default())
+                .expect("canonical 32-byte cache namespace root");
+        assert_eq!(
+            serde_json::to_value(parsed.cache_namespace_root_base64.as_ref().unwrap()).unwrap(),
+            serde_json::Value::String(encoded_root.clone())
+        );
+
+        for invalid_root in [
+            STANDARD.encode([0x5a; 31]),
+            STANDARD.encode([0x5a; 33]),
+            encoded_root.trim_end_matches('=').to_string(),
+            format!("{}A", encoded_root.trim_end_matches('=')),
+            format!("{}p=", &encoded_root[..42]),
+            "___________________________________________=".to_string(),
+        ] {
+            let invalid = request_json("null").replace(
+                "\"cache_namespace_root_base64\":null",
+                &format!("\"cache_namespace_root_base64\":\"{invalid_root}\""),
+            );
+            assert!(
+                RequestEnvelope::from_json_slice(invalid.as_bytes(), &EnvelopeLimits::default(),)
+                    .is_err(),
+                "accepted invalid cache namespace root: {invalid_root}"
+            );
+        }
     }
 
     #[test]

--- a/src/transport_v2/gateway.rs
+++ b/src/transport_v2/gateway.rs
@@ -58,6 +58,9 @@ const REQUEST_WORKING_SET_UNITS: usize =
 const STORED_OUTPUT_WORKING_SET_BYTES: usize = 200 * 1024 * 1024;
 const STORED_OUTPUT_WORKING_SET_UNITS: usize =
     STORED_OUTPUT_WORKING_SET_BYTES / REQUEST_WORKING_SET_UNIT_BYTES;
+const PROVIDER_OUTPUT_WORKING_SET_BYTES: usize = 128 * 1024 * 1024;
+const PROVIDER_OUTPUT_WORKING_SET_UNITS: usize =
+    PROVIDER_OUTPUT_WORKING_SET_BYTES / REQUEST_WORKING_SET_UNIT_BYTES;
 const SESSION_ID_HEADER: &str = "x-session-id";
 
 type PendingAttestationKey = [u8; 32];
@@ -340,7 +343,22 @@ impl TransportV2State {
         &self,
         permit: &mut OwnedSemaphorePermit,
     ) -> Result<(), GatewayError> {
-        let additional_units = STORED_OUTPUT_WORKING_SET_UNITS
+        self.promote_working_set(permit, STORED_OUTPUT_WORKING_SET_UNITS)
+    }
+
+    fn promote_provider_output_working_set(
+        &self,
+        permit: &mut OwnedSemaphorePermit,
+    ) -> Result<(), GatewayError> {
+        self.promote_working_set(permit, PROVIDER_OUTPUT_WORKING_SET_UNITS)
+    }
+
+    fn promote_working_set(
+        &self,
+        permit: &mut OwnedSemaphorePermit,
+        target_units: usize,
+    ) -> Result<(), GatewayError> {
+        let additional_units = target_units
             .checked_sub(permit.num_permits())
             .unwrap_or_default();
         if additional_units == 0 {
@@ -466,6 +484,22 @@ impl TransportV2State {
                     StatusCode::SERVICE_UNAVAILABLE,
                     "stored_output_unavailable",
                     "Stored response capacity is unavailable",
+                ),
+            );
+        }
+        if operation.requires_provider_output_reservation()
+            && self
+                .promote_provider_output_working_set(working_set_permit)
+                .is_err()
+        {
+            return encrypt_reserved_logical_response(
+                lease,
+                request_id,
+                reservation,
+                LogicalUnaryResponse::protocol_error(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "provider_output_unavailable",
+                    "Provider response capacity is unavailable",
                 ),
             );
         }
@@ -872,6 +906,7 @@ fn reject_forbidden_outer_headers(
         "proxy-authorization",
         header::COOKIE.as_str(),
         header::CONTENT_ENCODING.as_str(),
+        header::TRANSFER_ENCODING.as_str(),
     ] {
         if headers.contains_key(name) {
             return Err(GatewayError::InvalidRequest);
@@ -1031,6 +1066,7 @@ mod tests {
         HeaderField, LogicalMethod, LogicalRequest, RequestId, ResponseMode,
     };
     use crate::transport_v2::session::{AuthorityState, BoundAuthority};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     fn test_session(
         session_id: Uuid,
@@ -1054,6 +1090,7 @@ mod tests {
             request_id,
             response_mode: ResponseMode::Unary,
             credential: None,
+            cache_namespace_root_base64: None,
             request: LogicalRequest {
                 method: LogicalMethod::Get,
                 path: "/v1/protected/private_key".to_owned(),
@@ -1070,6 +1107,9 @@ mod tests {
             request_id,
             response_mode: ResponseMode::Unary,
             credential: None,
+            cache_namespace_root_base64: Some(
+                crate::provider_cache::CacheNamespaceRoot::from_bytes([0x42; 32]),
+            ),
             request: LogicalRequest {
                 method: LogicalMethod::Post,
                 path: "/login".to_owned(),
@@ -1089,6 +1129,7 @@ mod tests {
             request_id,
             response_mode: ResponseMode::Unary,
             credential: None,
+            cache_namespace_root_base64: None,
             request: LogicalRequest {
                 method: LogicalMethod::Get,
                 path: "/protected/user".to_owned(),
@@ -1235,6 +1276,7 @@ mod tests {
             "proxy-authorization",
             header::COOKIE.as_str(),
             header::CONTENT_ENCODING.as_str(),
+            header::TRANSFER_ENCODING.as_str(),
         ] {
             let mut rejected = headers.clone();
             rejected.insert(forbidden, "value".parse().unwrap());
@@ -1243,6 +1285,59 @@ mod tests {
                 "{forbidden}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn content_length_before_chunked_transfer_is_rejected_at_outer_boundary() {
+        let handler_calls = Arc::new(AtomicUsize::new(0));
+        let calls = Arc::clone(&handler_calls);
+        let app = Router::new().route(
+            "/v2/request",
+            post(move |request: Request<Body>| {
+                let calls = Arc::clone(&calls);
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    match validate_fixed_outer_request(request.uri(), request.headers(), false) {
+                        Ok(()) => StatusCode::OK,
+                        Err(_) => StatusCode::BAD_REQUEST,
+                    }
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let address = listener.local_addr().expect("read test address");
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve raw HTTP regression");
+        });
+
+        let session_id = Uuid::new_v4();
+        let request = format!(
+            "POST /v2/request HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nx-session-id: {session_id}\r\nContent-Length: 1\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n1\r\nx\r\n0\r\n\r\n"
+        );
+        let mut stream = tokio::net::TcpStream::connect(address)
+            .await
+            .expect("connect raw client");
+        stream
+            .write_all(request.as_bytes())
+            .await
+            .expect("write raw request");
+        let mut response = Vec::new();
+        stream
+            .read_to_end(&mut response)
+            .await
+            .expect("read raw response");
+        server.abort();
+
+        let response = String::from_utf8(response).expect("HTTP response is ASCII");
+        assert!(
+            response.starts_with("HTTP/1.1 400 Bad Request"),
+            "{response}"
+        );
+        assert_eq!(handler_calls.load(Ordering::SeqCst), 1);
     }
 
     #[test]
@@ -1624,6 +1719,10 @@ mod tests {
                     7,
                     &auth_context,
                     now + Duration::from_secs(30),
+                    crate::provider_cache::derive_tinfoil_cache_namespace(
+                        &crate::provider_cache::CacheNamespaceRoot::from_bytes([0x66; 32]),
+                        Uuid::from_bytes([0x64; 16]),
+                    ),
                 ),
                 now,
             )
@@ -1712,6 +1811,10 @@ mod tests {
                     7,
                     &AuthContext::new(AuthMethod::Password, 7, [0x84; 32]),
                     now + Duration::from_secs(30),
+                    crate::provider_cache::derive_tinfoil_cache_namespace(
+                        &crate::provider_cache::CacheNamespaceRoot::from_bytes([0x86; 32]),
+                        Uuid::from_bytes([0x83; 16]),
+                    ),
                 ),
                 now,
             )
@@ -1779,6 +1882,10 @@ mod tests {
                     7,
                     &AuthContext::new(AuthMethod::Password, 7, [0x94; 32]),
                     now + Duration::from_secs(30),
+                    crate::provider_cache::derive_tinfoil_cache_namespace(
+                        &crate::provider_cache::CacheNamespaceRoot::from_bytes([0x96; 32]),
+                        Uuid::from_bytes([0x93; 16]),
+                    ),
                 ),
                 now,
             )
@@ -1870,6 +1977,12 @@ mod tests {
                                 7,
                                 &AuthContext::new(AuthMethod::Password, 7, [0xa4; 32]),
                                 now + Duration::from_secs(30),
+                                crate::provider_cache::derive_tinfoil_cache_namespace(
+                                    &crate::provider_cache::CacheNamespaceRoot::from_bytes(
+                                        [0xa6; 32],
+                                    ),
+                                    Uuid::from_bytes([0xa3; 16]),
+                                ),
                             ),
                             now,
                         )
@@ -1937,6 +2050,12 @@ mod tests {
                                 7,
                                 &AuthContext::new(AuthMethod::Password, 7, [0xb4; 32]),
                                 now + Duration::from_secs(30),
+                                crate::provider_cache::derive_tinfoil_cache_namespace(
+                                    &crate::provider_cache::CacheNamespaceRoot::from_bytes(
+                                        [0xb6; 32],
+                                    ),
+                                    Uuid::from_bytes([0xb3; 16]),
+                                ),
                             ),
                             now,
                         )
@@ -1984,6 +2103,10 @@ mod tests {
                     7,
                     &auth_context,
                     now + Duration::from_secs(30),
+                    crate::provider_cache::derive_tinfoil_cache_namespace(
+                        &crate::provider_cache::CacheNamespaceRoot::from_bytes([0x76; 32]),
+                        Uuid::from_bytes([0x74; 16]),
+                    ),
                 ),
                 now,
             )
@@ -2079,5 +2202,83 @@ mod tests {
         let expired_at = Instant::now() + PENDING_ATTESTATION_TTL;
         assert_eq!(state.cleanup_expired_at(expired_at).await, 1);
         assert!(state.take_pending_attestation(&nonce).await.is_err());
+    }
+
+    #[test]
+    fn provider_output_promotion_reaches_the_bounded_response_reservation() {
+        let state = TransportV2State::new();
+        let mut permit = Arc::clone(&state.request_working_set)
+            .try_acquire_owned()
+            .unwrap();
+        state
+            .promote_provider_output_working_set(&mut permit)
+            .unwrap();
+        assert_eq!(permit.num_permits(), PROVIDER_OUTPUT_WORKING_SET_UNITS);
+        assert_eq!(
+            state.request_working_set.available_permits(),
+            REQUEST_WORKING_SET_UNITS - PROVIDER_OUTPUT_WORKING_SET_UNITS
+        );
+
+        state
+            .promote_provider_output_working_set(&mut permit)
+            .unwrap();
+        assert_eq!(permit.num_permits(), PROVIDER_OUTPUT_WORKING_SET_UNITS);
+    }
+
+    #[tokio::test]
+    async fn provider_output_contention_is_authenticated_before_replay_or_dispatch() {
+        let mut state = TransportV2State::new();
+        state.request_working_set = Arc::new(Semaphore::new(1));
+        let now = Instant::now();
+        let session_id = Uuid::new_v4();
+        let master_bytes = [0xc1; 32];
+        let session = test_session(
+            session_id,
+            master_bytes,
+            now + Duration::from_secs(60),
+            Arc::clone(&state.global_replay_budget),
+        );
+        state.insert_session(session).await.unwrap();
+
+        let request_id = RequestId::from_bytes([0xc2; 16]);
+        let mut envelope = request_envelope(request_id);
+        envelope.request.path = "/v1/models".to_owned();
+        let lease = state.acquire_session(&session_id, now).await.unwrap();
+        let OperationPreparation::Ready(operation) =
+            prepare_user_operation(envelope, lease.state().authority())
+        else {
+            panic!("public models operation must be ready");
+        };
+        assert!(operation.requires_provider_output_reservation());
+
+        let mut working_set_permit = Arc::clone(&state.request_working_set)
+            .try_acquire_owned()
+            .unwrap();
+        let dispatches = Arc::new(AtomicUsize::new(0));
+        let observed_dispatches = Arc::clone(&dispatches);
+        let response = state
+            .process_ready_operation(
+                &lease,
+                request_id,
+                operation,
+                &mut working_set_permit,
+                now,
+                move |_lease, _operation, _authentication, _| async move {
+                    observed_dispatches.fetch_add(1, Ordering::SeqCst);
+                    successful_test_outcome()
+                },
+            )
+            .await
+            .unwrap();
+
+        let master = SessionMaster::from_bytes(master_bytes);
+        let client_keys = DirectionalKeys::derive(&master).unwrap();
+        assert_eq!(
+            response_status(&client_keys, &session_id, &request_id, &response),
+            503
+        );
+        assert_eq!(dispatches.load(Ordering::SeqCst), 0);
+        assert_eq!(lease.state().replay_id_count(), 0);
+        assert_eq!(working_set_permit.num_permits(), 1);
     }
 }

--- a/src/transport_v2/session.rs
+++ b/src/transport_v2/session.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, Instant};
 use uuid::Uuid;
 
 use crate::jwt::AuthContext;
+use crate::provider_cache::DerivedCacheNamespace;
 use crate::VerifiedUserAuthentication;
 
 use super::crypto::{CryptoError, DirectionalKeys};
@@ -203,6 +204,7 @@ pub(crate) enum BoundPrincipal {
         user_id: Uuid,
         project_id: i32,
         auth_context: AuthContext,
+        cache_namespace: DerivedCacheNamespace,
     },
     Platform {
         platform_user_id: Uuid,
@@ -210,6 +212,7 @@ pub(crate) enum BoundPrincipal {
     ApiKey {
         api_key_id: i32,
         user_id: Uuid,
+        cache_namespace: DerivedCacheNamespace,
     },
 }
 
@@ -219,7 +222,9 @@ pub(crate) enum BoundPrincipal {
 /// accepted at binding so later requests can revalidate that same authority
 /// against live application state. API keys have no independent token expiry,
 /// so their authority remains bounded by the session's absolute expiry and
-/// live database checks.
+/// live database checks. Both retain only the provider cache namespace derived
+/// from the client root and verified owner UUID; the root itself is not session
+/// state.
 #[derive(Clone, Eq, PartialEq)]
 pub(crate) struct BoundAuthority {
     principal: BoundPrincipal,
@@ -230,12 +235,14 @@ impl BoundAuthority {
     pub(crate) fn verified_user(
         verified: &VerifiedUserAuthentication,
         authentication_expires_at: Instant,
+        cache_namespace: DerivedCacheNamespace,
     ) -> Self {
         Self {
             principal: BoundPrincipal::User {
                 user_id: verified.user.get_id(),
                 project_id: verified.user.project_id,
                 auth_context: verified.auth_context.clone(),
+                cache_namespace,
             },
             authentication_expires_at: Some(authentication_expires_at),
         }
@@ -247,12 +254,14 @@ impl BoundAuthority {
         project_id: i32,
         auth_context: &AuthContext,
         authentication_expires_at: Instant,
+        cache_namespace: DerivedCacheNamespace,
     ) -> Self {
         Self {
             principal: BoundPrincipal::User {
                 user_id,
                 project_id,
                 auth_context: auth_context.clone(),
+                cache_namespace,
             },
             authentication_expires_at: Some(authentication_expires_at),
         }
@@ -268,11 +277,16 @@ impl BoundAuthority {
         }
     }
 
-    pub(crate) const fn api_key(api_key_id: i32, user_id: Uuid) -> Self {
+    pub(crate) fn api_key(
+        api_key_id: i32,
+        user_id: Uuid,
+        cache_namespace: DerivedCacheNamespace,
+    ) -> Self {
         Self {
             principal: BoundPrincipal::ApiKey {
                 api_key_id,
                 user_id,
+                cache_namespace,
             },
             authentication_expires_at: None,
         }
@@ -284,6 +298,18 @@ impl BoundAuthority {
 
     pub(crate) const fn authentication_expires_at(&self) -> Option<Instant> {
         self.authentication_expires_at
+    }
+
+    pub(crate) fn cache_namespace(&self) -> Option<&DerivedCacheNamespace> {
+        match &self.principal {
+            BoundPrincipal::User {
+                cache_namespace, ..
+            }
+            | BoundPrincipal::ApiKey {
+                cache_namespace, ..
+            } => Some(cache_namespace),
+            BoundPrincipal::Platform { .. } => None,
+        }
     }
 
     fn is_expired_at(&self, now: Instant) -> bool {
@@ -964,12 +990,17 @@ mod tests {
     use std::thread;
 
     use crate::jwt::AuthMethod;
+    use crate::provider_cache::{derive_tinfoil_cache_namespace, CacheNamespaceRoot};
 
     use super::super::crypto::SessionMaster;
     use super::*;
 
     fn request_id(value: u128) -> RequestId {
         RequestId::from_bytes(value.to_be_bytes())
+    }
+
+    fn cache_namespace(user_id: Uuid) -> DerivedCacheNamespace {
+        derive_tinfoil_cache_namespace(&CacheNamespaceRoot::from_bytes([0x42; 32]), user_id)
     }
 
     fn session(
@@ -1120,7 +1151,13 @@ mod tests {
             .begin(request_id(1))
             .expect("reserve auth")
             .commit_at(
-                BoundAuthority::user(user, 17, &auth_context, now + Duration::from_secs(30)),
+                BoundAuthority::user(
+                    user,
+                    17,
+                    &auth_context,
+                    now + Duration::from_secs(30),
+                    cache_namespace(user),
+                ),
                 now,
             )
             .expect("commit auth");
@@ -1134,6 +1171,7 @@ mod tests {
                         user_id,
                         project_id,
                         auth_context: bound_auth_context,
+                        ..
                     } if *user_id == user
                         && *project_id == 17
                         && bound_auth_context == &expected_auth_context
@@ -1162,20 +1200,56 @@ mod tests {
     }
 
     #[test]
+    fn only_user_and_api_key_authorities_retain_cache_namespaces() {
+        let now = Instant::now();
+        let user_id = Uuid::new_v4();
+        let namespace = cache_namespace(user_id);
+        let expected_secret = namespace.tinfoil_user_cache_secret();
+
+        let user = BoundAuthority::user(
+            user_id,
+            7,
+            &user_auth_context(7),
+            now + Duration::from_secs(30),
+            namespace.clone(),
+        );
+        assert_eq!(
+            user.cache_namespace()
+                .expect("user cache namespace")
+                .tinfoil_user_cache_secret(),
+            expected_secret
+        );
+
+        let api_key = BoundAuthority::api_key(11, user_id, namespace);
+        assert_eq!(
+            api_key
+                .cache_namespace()
+                .expect("API-key cache namespace")
+                .tinfoil_user_cache_secret(),
+            expected_secret
+        );
+
+        let platform = BoundAuthority::platform(Uuid::new_v4(), now + Duration::from_secs(30));
+        assert!(platform.cache_namespace().is_none());
+    }
+
+    #[test]
     fn authentication_commit_only_changes_its_matching_request() {
         let authority = Arc::new(AuthorityCell::new());
         let now = Instant::now();
         let reservation = authority.begin(request_id(1)).expect("reserve auth");
         let auth_context = user_auth_context(7);
+        let user_id = Uuid::new_v4();
 
         *lock_unpoisoned(&authority.state) = AuthorityState::Authenticating(request_id(2));
         let error = reservation
             .commit_at(
                 BoundAuthority::user(
-                    Uuid::new_v4(),
+                    user_id,
                     7,
                     &auth_context,
                     now + Duration::from_secs(30),
+                    cache_namespace(user_id),
                 ),
                 now,
             )
@@ -1274,6 +1348,7 @@ mod tests {
     fn bound_authentication_expiry_is_exact_and_closes_fail_closed() {
         let now = Instant::now();
         let auth_expiry = now + Duration::from_secs(10);
+        let user_id = Uuid::new_v4();
         let state = session(
             now + Duration::from_secs(30),
             SessionLimits::new(4, 4, 4),
@@ -1284,7 +1359,13 @@ mod tests {
             .begin_authentication(request_id(1))
             .expect("reserve auth")
             .commit_at(
-                BoundAuthority::user(Uuid::new_v4(), 3, &user_auth_context(3), auth_expiry),
+                BoundAuthority::user(
+                    user_id,
+                    3,
+                    &user_auth_context(3),
+                    auth_expiry,
+                    cache_namespace(user_id),
+                ),
                 now,
             )
             .expect("bind authority");

--- a/src/web/audio_utils.rs
+++ b/src/web/audio_utils.rs
@@ -35,6 +35,12 @@ pub struct AudioSplitter {
     overlap_seconds: f64,
 }
 
+#[derive(Clone, Copy)]
+struct AudioSplitBounds {
+    max_chunks: usize,
+    max_total_chunk_bytes: usize,
+}
+
 impl Default for AudioSplitter {
     fn default() -> Self {
         Self {
@@ -54,6 +60,81 @@ impl AudioSplitter {
     }
 
     pub fn split_audio(
+        &self,
+        audio_data: &[u8],
+        content_type: &str,
+    ) -> Result<Vec<AudioChunk>, String> {
+        self.split_audio_unbounded(audio_data, content_type)
+    }
+
+    /// Split owned audio while bounding both the number of output chunks and
+    /// their aggregate allocation. The ordinary v1 path intentionally
+    /// continues through [`Self::split_audio`] with no new behavior change.
+    ///
+    /// Taking ownership lets the bounded caller move a non-WAV or already-small
+    /// upload directly into its only chunk instead of retaining a second copy.
+    pub fn split_audio_bounded(
+        &self,
+        audio_data: Vec<u8>,
+        content_type: &str,
+        max_chunks: usize,
+        max_total_chunk_bytes: usize,
+    ) -> Result<Vec<AudioChunk>, String> {
+        if max_chunks == 0 {
+            return Err("Audio chunk limit must be non-zero".to_string());
+        }
+        if max_total_chunk_bytes == 0 {
+            return Err("Audio chunk byte limit must be non-zero".to_string());
+        }
+
+        if !self.should_split(&audio_data) {
+            if audio_data.len() > max_total_chunk_bytes {
+                return Err("Audio exceeds bounded aggregate chunk bytes".to_string());
+            }
+            info!(
+                "File size {} bytes is under limit, returning as single chunk",
+                audio_data.len()
+            );
+            return Ok(vec![AudioChunk {
+                data: audio_data,
+                start_time: 0.0,
+                end_time: 0.0,
+                index: 0,
+            }]);
+        }
+
+        info!(
+            "File size {} bytes exceeds limit, splitting audio",
+            audio_data.len()
+        );
+
+        match content_type {
+            "audio/wav" | "audio/wave" => self.split_wav(
+                &audio_data,
+                Some(AudioSplitBounds {
+                    max_chunks,
+                    max_total_chunk_bytes,
+                }),
+            ),
+            _ => {
+                if audio_data.len() > max_total_chunk_bytes {
+                    return Err("Audio exceeds bounded aggregate chunk bytes".to_string());
+                }
+                info!(
+                    "Non-WAV format ({}), returning entire file as single chunk",
+                    content_type
+                );
+                Ok(vec![AudioChunk {
+                    data: audio_data,
+                    start_time: 0.0,
+                    end_time: 0.0,
+                    index: 0,
+                }])
+            }
+        }
+    }
+
+    fn split_audio_unbounded(
         &self,
         audio_data: &[u8],
         content_type: &str,
@@ -80,7 +161,7 @@ impl AudioSplitter {
         // For WAV files, use simple WAV splitting
         // For other formats, we'll need to decode and re-encode
         match content_type {
-            "audio/wav" | "audio/wave" => self.split_wav(audio_data),
+            "audio/wav" | "audio/wave" => self.split_wav(audio_data, None),
             _ => {
                 // For MP3 and other formats return full file as 1 chunk
                 info!(
@@ -97,7 +178,11 @@ impl AudioSplitter {
         }
     }
 
-    fn split_wav(&self, audio_data: &[u8]) -> Result<Vec<AudioChunk>, String> {
+    fn split_wav(
+        &self,
+        audio_data: &[u8],
+        bounds: Option<AudioSplitBounds>,
+    ) -> Result<Vec<AudioChunk>, String> {
         // WAV file structure:
         // - RIFF header (12 bytes)
         // - fmt chunk (usually 24 bytes)
@@ -256,6 +341,20 @@ impl AudioSplitter {
             overlap_bytes = 0; // Disable overlap if it would exceed chunk size
         }
 
+        // A large untrusted metadata header is copied into every generated WAV
+        // chunk. Preflight the complete bounded plan before allocating the
+        // first chunk so hostile metadata cannot create a partial amplification
+        // up to the point at which a later limit check fails.
+        if let Some(bounds) = bounds {
+            Self::preflight_bounded_wav_chunks(
+                audio_samples.len(),
+                header_overhead,
+                chunk_duration_bytes,
+                overlap_bytes,
+                bounds,
+            )?;
+        }
+
         let mut chunks = Vec::new();
         let mut offset = 0;
         let mut index = 0;
@@ -307,12 +406,65 @@ impl AudioSplitter {
         Ok(chunks)
     }
 
+    fn preflight_bounded_wav_chunks(
+        audio_sample_bytes: usize,
+        header_overhead: usize,
+        chunk_duration_bytes: usize,
+        overlap_bytes: usize,
+        bounds: AudioSplitBounds,
+    ) -> Result<(), String> {
+        let mut aggregate_chunk_bytes = 0_usize;
+        let mut offset = 0_usize;
+        let mut chunk_count = 0_usize;
+
+        while offset < audio_sample_bytes {
+            if chunk_count >= bounds.max_chunks {
+                return Err("WAV file requires too many bounded audio chunks".to_string());
+            }
+            let start = if chunk_count > 0 && offset >= overlap_bytes {
+                offset - overlap_bytes
+            } else {
+                offset
+            };
+            let end = start
+                .checked_add(chunk_duration_bytes)
+                .ok_or_else(|| "WAV chunk plan overflow".to_string())?
+                .min(audio_sample_bytes);
+            if end <= offset {
+                return Err(
+                    "Split produced a non-progressing window; check max_chunk_size/overlap"
+                        .to_string(),
+                );
+            }
+
+            let chunk_bytes = header_overhead
+                .checked_add(end - start)
+                .ok_or_else(|| "WAV chunk allocation overflow".to_string())?;
+            aggregate_chunk_bytes = aggregate_chunk_bytes
+                .checked_add(chunk_bytes)
+                .ok_or_else(|| "WAV aggregate chunk allocation overflow".to_string())?;
+            if aggregate_chunk_bytes > bounds.max_total_chunk_bytes {
+                return Err("WAV chunks exceed bounded aggregate chunk bytes".to_string());
+            }
+
+            offset = end;
+            chunk_count += 1;
+        }
+
+        Ok(())
+    }
+
     fn create_wav_from_samples(
         &self,
         original_header: &[u8],
         samples: &[u8],
     ) -> Result<Vec<u8>, String> {
-        let mut wav = Vec::new();
+        let output_bytes = original_header
+            .len()
+            .checked_add(8)
+            .and_then(|length| length.checked_add(samples.len()))
+            .ok_or_else(|| "WAV chunk allocation overflow".to_string())?;
+        let mut wav = Vec::with_capacity(output_bytes);
 
         // Copy the original header up to the data chunk
         wav.extend_from_slice(original_header);
@@ -398,6 +550,30 @@ pub fn merge_transcriptions(
 mod tests {
     use super::*;
 
+    fn wav_with_large_header(junk_bytes: usize, sample_bytes: usize) -> Vec<u8> {
+        let mut wav = Vec::new();
+        wav.extend_from_slice(b"RIFF");
+        wav.extend_from_slice(&0_u32.to_le_bytes());
+        wav.extend_from_slice(b"WAVE");
+        wav.extend_from_slice(b"fmt ");
+        wav.extend_from_slice(&16_u32.to_le_bytes());
+        wav.extend_from_slice(&1_u16.to_le_bytes());
+        wav.extend_from_slice(&1_u16.to_le_bytes());
+        wav.extend_from_slice(&1_000_u32.to_le_bytes());
+        wav.extend_from_slice(&1_000_u32.to_le_bytes());
+        wav.extend_from_slice(&1_u16.to_le_bytes());
+        wav.extend_from_slice(&8_u16.to_le_bytes());
+        wav.extend_from_slice(b"JUNK");
+        wav.extend_from_slice(&(junk_bytes as u32).to_le_bytes());
+        wav.resize(wav.len() + junk_bytes, 0);
+        wav.extend_from_slice(b"data");
+        wav.extend_from_slice(&(sample_bytes as u32).to_le_bytes());
+        wav.resize(wav.len() + sample_bytes, 0x7f);
+        let riff_size = u32::try_from(wav.len() - 8).unwrap();
+        wav[4..8].copy_from_slice(&riff_size.to_le_bytes());
+        wav
+    }
+
     #[test]
     fn test_should_split() {
         let splitter = AudioSplitter::new();
@@ -417,6 +593,52 @@ mod tests {
         // Test data significantly over limit
         let large_data = vec![0u8; MAX_CHUNK_SIZE * 2];
         assert!(splitter.should_split(&large_data));
+    }
+
+    #[test]
+    fn bounded_split_rejects_header_amplified_chunk_counts() {
+        let splitter = AudioSplitter {
+            max_chunk_size: 128,
+            overlap_seconds: 0.0,
+        };
+        let wav = wav_with_large_header(72, 32);
+        assert!(wav.len() > splitter.max_chunk_size);
+
+        let error = splitter
+            .split_audio_bounded(wav, "audio/wav", 1, usize::MAX)
+            .expect_err("large header should exceed bounded chunk count");
+        assert_eq!(error, "WAV file requires too many bounded audio chunks");
+    }
+
+    #[test]
+    fn bounded_split_preflights_hostile_header_aggregate_before_chunking() {
+        let splitter = AudioSplitter {
+            max_chunk_size: 128,
+            overlap_seconds: 0.0,
+        };
+        // The 124-byte per-chunk header leaves only four sample bytes in each
+        // 128-byte output. Without an aggregate preflight, this tiny input
+        // expands into eight almost-all-metadata WAV allocations.
+        let wav = wav_with_large_header(72, 32);
+
+        let error = splitter
+            .split_audio_bounded(wav, "audio/wav", 16, 512)
+            .expect_err("repeated hostile metadata must exceed the aggregate bound");
+        assert_eq!(error, "WAV chunks exceed bounded aggregate chunk bytes");
+    }
+
+    #[test]
+    fn bounded_unsplit_audio_moves_the_owned_allocation() {
+        let splitter = AudioSplitter::new();
+        let audio = vec![0x5a; 1024];
+        let allocation = audio.as_ptr();
+
+        let chunks = splitter
+            .split_audio_bounded(audio, "audio/mpeg", 1, 1024)
+            .expect("small bounded audio should remain one chunk");
+
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].data.as_ptr(), allocation);
     }
 
     #[test]
@@ -450,13 +672,13 @@ mod tests {
 
         // Test with file too small to be valid WAV
         let tiny_file = vec![0u8; 10];
-        let result = splitter.split_wav(&tiny_file);
+        let result = splitter.split_wav(&tiny_file, None);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("too small"));
 
         // Test with file that's large enough but not a WAV
         let not_wav = vec![0u8; 100];
-        let result = splitter.split_wav(&not_wav);
+        let result = splitter.split_wav(&not_wav, None);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Not a valid WAV"));
     }

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -4,7 +4,7 @@ pub mod encryption_middleware;
 mod health_routes;
 pub mod login_routes;
 mod oauth_routes;
-mod openai;
+pub(crate) mod openai;
 pub mod openai_auth;
 pub mod platform;
 pub mod protected_routes;

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -2121,7 +2121,7 @@ pub(crate) async fn openai_model_catalog_data(state: &Arc<AppState>, user: &User
     let model_plan = ModelPlan::from_is_paid(
         billing_access.is_some_and(crate::billing::ChatBillingAccess::is_paid),
     );
-    let alias_targets = state.model_alias_targets(user.uuid, model_plan).await;
+    let alias_targets = ModelAliasTargets::for_plan(model_plan);
     model_catalog_response(alias_targets)
 }
 

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -3,6 +3,7 @@ use crate::model_config::{
 };
 use crate::models::token_usage::NewTokenUsage;
 use crate::models::users::User;
+use crate::provider_cache::DerivedCacheNamespace;
 use crate::provider_client::{
     ProviderClient, ProviderRequest, ProviderRequestError, ProviderResponse,
 };
@@ -49,9 +50,110 @@ const TTS_BILLING_CHECK_TIMEOUT: Duration = Duration::from_secs(5);
 const TTS_PROVIDER_TIMEOUT: Duration = Duration::from_secs(120);
 const MAX_TTS_INPUT_CHARS: usize = 100_000;
 const MAX_BOUNDED_PROVIDER_RESPONSE_BYTES: usize = 256 * 1024;
+const V2_MAX_PROVIDER_RESPONSE_BYTES: usize = 28 * 1024 * 1024;
+// TTS wraps provider bytes in padded base64 plus a small JSON object. Keep the
+// raw response below three quarters of the logical v2 response ceiling so the
+// transport's bounded serializer always has room for that expansion.
+const V2_MAX_TTS_PROVIDER_RESPONSE_BYTES: usize = (V2_MAX_PROVIDER_RESPONSE_BYTES - 1024) / 4 * 3;
+const V2_MAX_PROVIDER_JSON_DEPTH: usize = 128;
+const V2_MAX_PROVIDER_JSON_STRUCTURAL_TOKENS: usize = 1_048_576;
+const V2_MAX_TRANSCRIPTION_CHUNKS: usize = 4;
+// The v2 gateway holds a 128 MiB provider working-set reservation. Bound
+// retained chunk allocations to 64 MiB, then process them sequentially. With
+// one at-most-32 MiB multipart body and the per-chunk share of the 28 MiB
+// provider response bound, this leaves allocator and metadata headroom.
+const V2_MAX_TRANSCRIPTION_CHUNK_BYTES: usize = 64 * 1024 * 1024;
+const V2_MAX_TRANSCRIPTION_MULTIPART_BYTES: usize = 32 * 1024 * 1024;
 
 const PROVIDER_MANAGED_CACHE_SALT_FIELD: &str = "cache_salt";
 const PROVIDER_MANAGED_USER_CACHE_SECRET_FIELD: &str = "user_cache_secret";
+
+/// Cache isolation is a required input to every completion dispatch. Keeping
+/// the legacy derivation as an explicit variant prevents a new transport from
+/// silently inheriting the v1 SHA256(UUID) namespace.
+pub(crate) enum CompletionCachePolicy<'a> {
+    LegacyV1,
+    BoundV2(&'a DerivedCacheNamespace),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProviderResponseBodyPolicy {
+    Unbounded,
+    Bounded {
+        limit_bytes: usize,
+        max_json_structural_tokens: Option<usize>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProviderErrorBodyPolicy {
+    LegacyBody,
+    StatusOnly { drain_limit_bytes: usize },
+}
+
+impl ProviderResponseBodyPolicy {
+    const fn error_body(self) -> ProviderErrorBodyPolicy {
+        match self {
+            Self::Unbounded => ProviderErrorBodyPolicy::LegacyBody,
+            Self::Bounded { .. } => ProviderErrorBodyPolicy::StatusOnly {
+                drain_limit_bytes: MAX_BOUNDED_PROVIDER_RESPONSE_BYTES,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProviderRetryPolicy {
+    LegacyV1,
+    NoAmbiguousRetry,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct UnaryProviderPolicy {
+    response_body: ProviderResponseBodyPolicy,
+    retry: ProviderRetryPolicy,
+}
+
+impl UnaryProviderPolicy {
+    const LEGACY_V1: Self = Self {
+        response_body: ProviderResponseBodyPolicy::Unbounded,
+        retry: ProviderRetryPolicy::LegacyV1,
+    };
+
+    const V2: Self = Self {
+        response_body: ProviderResponseBodyPolicy::Bounded {
+            limit_bytes: V2_MAX_PROVIDER_RESPONSE_BYTES,
+            max_json_structural_tokens: Some(V2_MAX_PROVIDER_JSON_STRUCTURAL_TOKENS),
+        },
+        retry: ProviderRetryPolicy::NoAmbiguousRetry,
+    };
+
+    const V2_TTS: Self = Self {
+        response_body: ProviderResponseBodyPolicy::Bounded {
+            limit_bytes: V2_MAX_TTS_PROVIDER_RESPONSE_BYTES,
+            max_json_structural_tokens: None,
+        },
+        retry: ProviderRetryPolicy::NoAmbiguousRetry,
+    };
+
+    fn divide_bounded_response_across(self, parts: usize) -> Self {
+        let response_body = match self.response_body {
+            ProviderResponseBodyPolicy::Unbounded => ProviderResponseBodyPolicy::Unbounded,
+            ProviderResponseBodyPolicy::Bounded {
+                limit_bytes,
+                max_json_structural_tokens,
+            } => ProviderResponseBodyPolicy::Bounded {
+                limit_bytes: limit_bytes / parts.max(1),
+                max_json_structural_tokens: max_json_structural_tokens
+                    .map(|limit| limit / parts.max(1)),
+            },
+        };
+        Self {
+            response_body,
+            retry: self.retry,
+        }
+    }
+}
 
 #[derive(Clone, Default)]
 struct CompletionRequestLogMetadata {
@@ -343,6 +445,98 @@ fn json_value_len(value: &Value) -> usize {
         .unwrap_or_default()
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProviderJsonShapeError {
+    TooLarge,
+    Malformed,
+}
+
+/// Bound JSON container amplification before serde allocates provider-owned
+/// arrays and maps. Strings are skipped without allocation; serde remains the
+/// authoritative syntax validator after this v2-only preflight.
+fn validate_provider_json_shape(
+    bytes: &[u8],
+    max_structural_tokens: usize,
+) -> Result<(), ProviderJsonShapeError> {
+    let mut depth = 0usize;
+    let mut structural_tokens = 0usize;
+    let mut in_string = false;
+    let mut escaped = false;
+
+    for byte in bytes {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if *byte == b'\\' {
+                escaped = true;
+            } else if *byte == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        match *byte {
+            b'"' => in_string = true,
+            b'{' | b'[' => {
+                depth = depth
+                    .checked_add(1)
+                    .ok_or(ProviderJsonShapeError::TooLarge)?;
+                structural_tokens = structural_tokens
+                    .checked_add(1)
+                    .ok_or(ProviderJsonShapeError::TooLarge)?;
+                if depth > V2_MAX_PROVIDER_JSON_DEPTH || structural_tokens > max_structural_tokens {
+                    return Err(ProviderJsonShapeError::TooLarge);
+                }
+            }
+            b'}' | b']' => {
+                depth = depth
+                    .checked_sub(1)
+                    .ok_or(ProviderJsonShapeError::Malformed)?;
+                structural_tokens = structural_tokens
+                    .checked_add(1)
+                    .ok_or(ProviderJsonShapeError::TooLarge)?;
+                if structural_tokens > max_structural_tokens {
+                    return Err(ProviderJsonShapeError::TooLarge);
+                }
+            }
+            b',' | b':' => {
+                structural_tokens = structural_tokens
+                    .checked_add(1)
+                    .ok_or(ProviderJsonShapeError::TooLarge)?;
+                if structural_tokens > max_structural_tokens {
+                    return Err(ProviderJsonShapeError::TooLarge);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if in_string || depth != 0 {
+        Err(ProviderJsonShapeError::Malformed)
+    } else {
+        Ok(())
+    }
+}
+
+fn preflight_provider_json(
+    bytes: &[u8],
+    response_body_policy: ProviderResponseBodyPolicy,
+) -> Result<(), ApiError> {
+    let ProviderResponseBodyPolicy::Bounded {
+        max_json_structural_tokens: Some(max_structural_tokens),
+        ..
+    } = response_body_policy
+    else {
+        return Ok(());
+    };
+
+    match validate_provider_json_shape(bytes, max_structural_tokens) {
+        Ok(()) => Ok(()),
+        Err(ProviderJsonShapeError::TooLarge) => Err(ApiError::PayloadTooLarge),
+        Err(ProviderJsonShapeError::Malformed) => Err(ApiError::InternalServerError),
+    }
+}
+
 fn image_part_url(part: &Value) -> Option<&str> {
     part.get("image_url")
         .and_then(|image| {
@@ -368,7 +562,7 @@ struct TranscriptionParams<'a> {
 /// Request structure for TTS (Text-to-Speech) endpoints
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(transparent)]
-struct TTSRequest {
+pub(crate) struct TTSRequest {
     provider_payload: serde_json::Map<String, Value>,
 }
 
@@ -446,8 +640,17 @@ fn prepare_tts_request(
     })
 }
 
-fn build_tts_response_payload(body_bytes: &[u8], content_type: &str) -> (Value, bool) {
-    let is_json_response = serde_json::from_slice::<Value>(body_bytes).is_ok();
+fn build_tts_response_payload_with_policy(
+    body_bytes: &[u8],
+    content_type: &str,
+    avoid_provider_value_allocation: bool,
+) -> (Value, bool) {
+    let is_json_response = if avoid_provider_value_allocation {
+        serde_json::from_slice::<serde::de::IgnoredAny>(body_bytes).is_ok()
+    } else {
+        // Preserve v1's exact JSON detection behavior.
+        serde_json::from_slice::<Value>(body_bytes).is_ok()
+    };
     (
         json!({
             "content_base64": general_purpose::STANDARD.encode(body_bytes),
@@ -459,7 +662,7 @@ fn build_tts_response_payload(body_bytes: &[u8], content_type: &str) -> (Value, 
 
 /// Request structure for transcription endpoints
 #[derive(Debug, Clone, serde::Deserialize)]
-struct TranscriptionRequest {
+pub(crate) struct TranscriptionRequest {
     file: String, // Base64 encoded audio file
     #[serde(default = "default_transcription_filename")]
     filename: String,
@@ -492,7 +695,7 @@ fn default_transcription_response_format() -> String {
 
 /// Request structure for embeddings endpoints
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
-struct EmbeddingRequest {
+pub(crate) struct EmbeddingRequest {
     input: serde_json::Value, // string or array of strings
     #[serde(default = "default_embedding_model")]
     model: String,
@@ -758,8 +961,32 @@ async fn proxy_openai(
     axum::Extension(session_id): axum::Extension<TransportSession>,
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(auth_method): axum::Extension<AuthMethod>,
-    axum::Extension(mut body): axum::Extension<Value>,
+    axum::Extension(body): axum::Extension<Value>,
 ) -> Result<Response, ApiError> {
+    let completion = openai_chat_completion_data(
+        &state,
+        &user,
+        auth_method,
+        body,
+        &headers,
+        CompletionCachePolicy::LegacyV1,
+        ProviderResponseBodyPolicy::Unbounded,
+    )
+    .await?;
+
+    openai_completion_v1_response(&state, &session_id, completion).await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn openai_chat_completion_data(
+    state: &Arc<AppState>,
+    user: &User,
+    auth_method: AuthMethod,
+    mut body: Value,
+    headers: &HeaderMap,
+    cache_policy: CompletionCachePolicy<'_>,
+    response_body_policy: ProviderResponseBodyPolicy,
+) -> Result<CompletionStream, ApiError> {
     let billing_access = state
         .chat_billing_access(user.uuid, auth_method == AuthMethod::ApiKey)
         .await;
@@ -807,10 +1034,75 @@ async fn proxy_openai(
     let billing_context = BillingContext::new(auth_method, requested_model_name);
 
     // Get the completion stream - billing happens automatically inside!
-    let completion =
-        get_chat_completion_response(&state, &user, body, &headers, billing_context, model_plan)
-            .await?;
+    get_chat_completion_response_with_expected_route(
+        state,
+        user,
+        body,
+        headers,
+        billing_context,
+        model_plan,
+        None,
+        cache_policy,
+        response_body_policy,
+    )
+    .await
+}
 
+/// Execute the non-streaming Chat Completions application contract and return
+/// plaintext logical JSON for transport v2. Provider output is collected under
+/// the v2 bound before JSON allocation, and the cache namespace must come from
+/// the session's already-bound authority.
+pub(crate) async fn openai_nonstream_chat_completion_v2_data(
+    state: &Arc<AppState>,
+    user: &User,
+    auth_method: AuthMethod,
+    body: Value,
+    headers: &HeaderMap,
+    cache_namespace: &DerivedCacheNamespace,
+) -> Result<Value, ApiError> {
+    ensure_nonstream_chat_completion(&body)?;
+
+    let completion = openai_chat_completion_data(
+        state,
+        user,
+        auth_method,
+        body,
+        headers,
+        CompletionCachePolicy::BoundV2(cache_namespace),
+        UnaryProviderPolicy::V2.response_body,
+    )
+    .await?;
+
+    if completion.metadata.is_streaming {
+        error!("Unary Chat Completions unexpectedly produced a stream");
+        return Err(ApiError::InternalServerError);
+    }
+
+    let mut stream = completion.stream;
+    match stream.recv().await {
+        Some(CompletionChunk::FullResponse(response)) => Ok(response),
+        _ => {
+            error!("Unary Chat Completions did not produce a full response");
+            Err(ApiError::InternalServerError)
+        }
+    }
+}
+
+fn ensure_nonstream_chat_completion(body: &Value) -> Result<(), ApiError> {
+    match body.get("stream") {
+        None | Some(Value::Bool(false)) => Ok(()),
+        Some(_) => {
+            error!("Chat Completions stream must be absent or Boolean false for unary v2");
+            Err(ApiError::BadRequest)
+        }
+    }
+}
+
+async fn openai_completion_v1_response(
+    state: &Arc<AppState>,
+    session_id: &TransportSession,
+    completion: CompletionStream,
+) -> Result<Response, ApiError> {
     debug!(
         "Received completion from provider: {} (streaming: {})",
         completion.metadata.provider_name, completion.metadata.is_streaming
@@ -826,7 +1118,7 @@ async fn proxy_openai(
         if let Some(CompletionChunk::FullResponse(response_json)) = rx.recv().await {
             // Billing already happened in get_chat_completion_response!
             // Just encrypt and return
-            let encrypted_response = encrypt_response(&state, &session_id, &response_json).await?;
+            let encrypted_response = encrypt_response(state, session_id, &response_json).await?;
             return Ok(encrypted_response.into_response());
         } else {
             error!("Expected FullResponse chunk but got something else");
@@ -837,13 +1129,15 @@ async fn proxy_openai(
     // For streaming responses, process CompletionChunk stream
     debug!("Handling streaming response");
     let mut rx = completion.stream;
+    let stream_state = Arc::clone(state);
+    let stream_session = session_id.clone();
 
     let stream = async_stream::stream! {
         while let Some(chunk) = rx.recv().await {
             match chunk {
                 CompletionChunk::StreamChunk(json) => {
                     // Pass through full JSON (includes all metadata from upstream)
-                    match encrypt_sse_event(&state, &session_id, &json).await {
+                    match encrypt_sse_event(&stream_state, &stream_session, &json).await {
                         Ok(event) => yield Ok::<Event, std::convert::Infallible>(event),
                         Err(e) => {
                             error!("Failed to encrypt event data: {:?}", e);
@@ -897,6 +1191,8 @@ pub async fn get_chat_completion_response(
         billing_context,
         model_plan,
         None,
+        CompletionCachePolicy::LegacyV1,
+        ProviderResponseBodyPolicy::Unbounded,
     )
     .await
 }
@@ -928,6 +1224,8 @@ pub(crate) async fn get_chat_completion_response_for_expected_route(
             provider_model_id: route.provider_model_id,
             continuum_cache_salt,
         }),
+        CompletionCachePolicy::LegacyV1,
+        ProviderResponseBodyPolicy::Unbounded,
     )
     .await
 }
@@ -953,6 +1251,8 @@ async fn get_chat_completion_response_with_expected_route(
     mut billing_context: BillingContext,
     model_plan: ModelPlan,
     expected_route: Option<ExpectedCompletionRoute<'_>>,
+    cache_policy: CompletionCachePolicy<'_>,
+    response_body_policy: ProviderResponseBodyPolicy,
 ) -> Result<CompletionStream, ApiError> {
     if body.is_null() || body.as_object().is_none_or(|obj| obj.is_empty()) {
         error!("Request body is empty or invalid");
@@ -1061,6 +1361,7 @@ async fn get_chat_completion_response_with_expected_route(
         &mut modified_body,
         &selected_route.proxy.provider_name,
         user.uuid,
+        &cache_policy,
     );
     if let Some(expected_route) = &expected_route {
         apply_server_selected_cache_isolation(
@@ -1144,26 +1445,30 @@ async fn get_chat_completion_response_with_expected_route(
         // The request's streaming fields are forwarded unchanged, but this
         // encrypted endpoint currently buffers one byte-exact response carrier.
         let body_bytes = if expected_route.is_some() {
-            bytes::Bytes::from(
-                collect_bounded_provider_response_body(
-                    res.bytes_stream(),
-                    MAX_BOUNDED_PROVIDER_RESPONSE_BYTES,
-                )
-                .await
-                .map_err(|error| {
-                    error!("Failed to read bounded server-selected response body: {error}");
-                    ApiError::InternalServerError
-                })?,
+            collect_provider_response_body(
+                res,
+                ProviderResponseBodyPolicy::Bounded {
+                    limit_bytes: MAX_BOUNDED_PROVIDER_RESPONSE_BYTES,
+                    max_json_structural_tokens: None,
+                },
             )
-        } else {
-            // Preserve the ordinary Chat Completions path's existing unbounded
-            // response-body behavior. Only server-selected image descriptor
-            // calls opt into the defensive cap above.
-            res.bytes().await.map_err(|e| {
-                error!("Failed to read response body: {:?}", e);
+            .await
+            .map_err(|error| {
+                error!("Failed to read bounded server-selected response body: {error}");
                 ApiError::InternalServerError
             })?
+        } else {
+            collect_provider_response_body(res, response_body_policy)
+                .await
+                .map_err(|error| {
+                    error!("Failed to read response body: {error}");
+                    error
+                })?
         };
+
+        preflight_provider_json(&body_bytes, response_body_policy).inspect_err(|_| {
+            error!("Completion provider response failed structural JSON preflight");
+        })?;
 
         let mut response_json: Value = serde_json::from_str(&String::from_utf8_lossy(&body_bytes))
             .map_err(|e| {
@@ -1451,6 +1756,7 @@ fn apply_provider_managed_request_fields(
     body: &mut serde_json::Map<String, Value>,
     provider_name: &str,
     user_uuid: Uuid,
+    cache_policy: &CompletionCachePolicy<'_>,
 ) {
     if body.remove(PROVIDER_MANAGED_CACHE_SALT_FIELD).is_some() {
         debug!("Stripped provider-managed completion request field: cache_salt");
@@ -1461,9 +1767,13 @@ fn apply_provider_managed_request_fields(
         .is_some();
 
     if provider_name == ProviderName::Tinfoil.as_str() {
+        let user_cache_secret = match cache_policy {
+            CompletionCachePolicy::LegacyV1 => tinfoil_user_cache_secret(user_uuid),
+            CompletionCachePolicy::BoundV2(namespace) => namespace.tinfoil_user_cache_secret(),
+        };
         body.insert(
             PROVIDER_MANAGED_USER_CACHE_SECRET_FIELD.to_string(),
-            json!(tinfoil_user_cache_secret(user_uuid)),
+            json!(user_cache_secret),
         );
         if replaced_user_cache_secret {
             debug!("Replaced provider-managed completion request field: user_cache_secret");
@@ -1712,18 +2022,37 @@ async fn proxy_models(
     user: Option<axum::Extension<User>>,
 ) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
     let _ = user;
-    let proxy_config = state.proxy_router.get_completion_proxy();
-    let models_response = if proxy_config.provider_name == "tinfoil" {
-        openai_models_response()
-    } else {
-        fetch_provider_models(&state.provider_client, &proxy_config).await?
-    };
+    let models_response = openai_models_data(&state, UnaryProviderPolicy::LEGACY_V1).await?;
     encrypt_response(&state, &session_id, &models_response).await
+}
+
+async fn openai_models_data(
+    state: &Arc<AppState>,
+    provider_policy: UnaryProviderPolicy,
+) -> Result<Value, ApiError> {
+    let proxy_config = state.proxy_router.get_completion_proxy();
+    if proxy_config.provider_name == "tinfoil" {
+        Ok(openai_models_response())
+    } else {
+        fetch_provider_models(
+            &state.provider_client,
+            &proxy_config,
+            provider_policy.response_body,
+        )
+        .await
+    }
+}
+
+/// Fetch the OpenAI-shaped model listing without applying either transport's
+/// response encryption. The v2 adapter owns the bounded logical response.
+pub(crate) async fn openai_models_v2_data(state: &Arc<AppState>) -> Result<Value, ApiError> {
+    openai_models_data(state, UnaryProviderPolicy::V2).await
 }
 
 async fn fetch_provider_models(
     client: &ProviderClient,
     proxy_config: &ProxyConfig,
+    response_body_policy: ProviderResponseBodyPolicy,
 ) -> Result<Value, ApiError> {
     let res = client
         .send(
@@ -1745,20 +2074,27 @@ async fn fetch_provider_models(
 
     if !res.is_success() {
         let status = res.status_code();
-        let body_bytes = res.bytes().await.ok();
-        let error_msg = body_bytes
-            .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
-            .unwrap_or_else(|| status.to_string());
-        error!(
-            "Provider {} returned non-success status for models: {} - {}",
-            proxy_config.provider_name, status, error_msg
-        );
+        match collect_provider_error_body_for_log(res, response_body_policy, status).await {
+            ProviderErrorBodyForLog::Legacy(error_msg) => error!(
+                "Provider {} returned non-success status for models: {} - {}",
+                proxy_config.provider_name, status, error_msg
+            ),
+            ProviderErrorBodyForLog::StatusOnly => error!(
+                "Provider {} returned non-success status for models: {}",
+                proxy_config.provider_name, status
+            ),
+        }
         return Err(ApiError::InternalServerError);
     }
 
-    let body_bytes = res.bytes().await.map_err(|e| {
-        error!("Failed to read models response body: {:?}", e);
-        ApiError::InternalServerError
+    let body_bytes = collect_provider_response_body(res, response_body_policy)
+        .await
+        .map_err(|error| {
+            error!("Failed to read models response body: {error}");
+            error
+        })?;
+    preflight_provider_json(&body_bytes, response_body_policy).inspect_err(|_| {
+        error!("Models provider response failed structural JSON preflight");
     })?;
 
     serde_json::from_slice(&body_bytes).map_err(|e| {
@@ -1775,13 +2111,18 @@ async fn proxy_model_catalog(
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(_body): axum::Extension<()>,
 ) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
+    let catalog_response = openai_model_catalog_data(&state, &user).await;
+    encrypt_response(&state, &session_id, &catalog_response).await
+}
+
+/// Build the entitled model catalog independently of the outer transport.
+pub(crate) async fn openai_model_catalog_data(state: &Arc<AppState>, user: &User) -> Value {
     let billing_access = state.chat_billing_access(user.uuid, false).await;
     let model_plan = ModelPlan::from_is_paid(
         billing_access.is_some_and(crate::billing::ChatBillingAccess::is_paid),
     );
-    let alias_targets = ModelAliasTargets::for_plan(model_plan);
-    let catalog_response = model_catalog_response(alias_targets);
-    encrypt_response(&state, &session_id, &catalog_response).await
+    let alias_targets = state.model_alias_targets(user.uuid, model_plan).await;
+    model_catalog_response(alias_targets)
 }
 
 fn transcription_model_for_provider(model_name: &str, provider_name: &str) -> String {
@@ -1801,8 +2142,12 @@ async fn send_transcription_with_retries(
     fallback_provider: Option<&ProxyConfig>,
     model_name: &str,
     params: &TranscriptionParams<'_>,
+    provider_policy: UnaryProviderPolicy,
 ) -> Result<Value, ApiError> {
-    let max_cycles = 3;
+    let max_cycles = match provider_policy.retry {
+        ProviderRetryPolicy::LegacyV1 => 3,
+        ProviderRetryPolicy::NoAmbiguousRetry => 1,
+    };
     let mut last_error = None;
 
     for cycle in 0..max_cycles {
@@ -1821,7 +2166,15 @@ async fn send_transcription_with_retries(
         let primary_model =
             transcription_model_for_provider(model_name, &primary_provider.provider_name);
 
-        match send_transcription_request(client, primary_provider, &primary_model, params).await {
+        match send_transcription_request(
+            client,
+            primary_provider,
+            &primary_model,
+            params,
+            provider_policy.response_body,
+        )
+        .await
+        {
             Ok(response) => {
                 info!(
                     "Successfully got transcription from primary provider {} on cycle {}",
@@ -1841,7 +2194,10 @@ async fn send_transcription_with_retries(
             }
         }
 
-        if let Some(fallback_provider) = fallback_provider {
+        if provider_policy.retry == ProviderRetryPolicy::LegacyV1 {
+            let Some(fallback_provider) = fallback_provider else {
+                continue;
+            };
             debug!(
                 "Cycle {}: Trying fallback provider {} for transcription",
                 cycle + 1,
@@ -1851,8 +2207,14 @@ async fn send_transcription_with_retries(
             let fallback_model =
                 transcription_model_for_provider(model_name, &fallback_provider.provider_name);
 
-            match send_transcription_request(client, fallback_provider, &fallback_model, params)
-                .await
+            match send_transcription_request(
+                client,
+                fallback_provider,
+                &fallback_model,
+                params,
+                provider_policy.response_body,
+            )
+            .await
             {
                 Ok(response) => {
                     info!(
@@ -1890,6 +2252,22 @@ async fn proxy_transcription(
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(transcription_request): axum::Extension<TranscriptionRequest>,
 ) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
+    let response = openai_transcription_data(
+        &state,
+        &user,
+        transcription_request,
+        UnaryProviderPolicy::LEGACY_V1,
+    )
+    .await?;
+    encrypt_response(&state, &session_id, &response).await
+}
+
+async fn openai_transcription_data(
+    state: &Arc<AppState>,
+    user: &User,
+    mut transcription_request: TranscriptionRequest,
+    provider_policy: UnaryProviderPolicy,
+) -> Result<Value, ApiError> {
     // Check if guest user is allowed (paid guests are allowed, free guests are not)
     if user.is_guest() {
         if let Some(billing_client) = &state.billing_client {
@@ -1918,13 +2296,22 @@ async fn proxy_transcription(
         }
     }
 
-    // Decode base64 audio file
+    let bounded_chunking = provider_policy.retry == ProviderRetryPolicy::NoAmbiguousRetry;
+
+    // V2 moves the encoded input out of the request and drops it immediately
+    // after decoding. The v1 path deliberately retains its existing request
+    // shape and lifetime.
+    let encoded_file = bounded_chunking.then(|| std::mem::take(&mut transcription_request.file));
+    let encoded_file_for_decode = encoded_file
+        .as_deref()
+        .unwrap_or(transcription_request.file.as_str());
     let file_bytes = general_purpose::STANDARD
-        .decode(&transcription_request.file)
+        .decode(encoded_file_for_decode)
         .map_err(|e| {
             error!("Failed to decode base64 audio file: {:?}", e);
             ApiError::BadRequest
         })?;
+    drop(encoded_file);
 
     // Validate file size (100MB limit as sanity check, CF already limits to 50MB)
     let file_size = file_bytes.len();
@@ -1950,92 +2337,73 @@ async fn proxy_transcription(
     let client = state.provider_client.clone();
 
     // Always split the audio (returns single chunk if no splitting needed)
-    let chunks = splitter
-        .split_audio(&file_bytes, &transcription_request.content_type)
-        .map_err(|e| {
-            error!("Failed to split audio: {}", e);
+    let chunks = if bounded_chunking {
+        splitter.split_audio_bounded(
+            file_bytes,
+            &transcription_request.content_type,
+            V2_MAX_TRANSCRIPTION_CHUNKS,
+            V2_MAX_TRANSCRIPTION_CHUNK_BYTES,
+        )
+    } else {
+        splitter.split_audio(&file_bytes, &transcription_request.content_type)
+    }
+    .map_err(|e| {
+        error!("Failed to split audio: {}", e);
+        if bounded_chunking
+            && matches!(
+                e.as_str(),
+                "WAV file requires too many bounded audio chunks"
+                    | "WAV chunks exceed bounded aggregate chunk bytes"
+                    | "Audio exceeds bounded aggregate chunk bytes"
+            )
+        {
+            ApiError::PayloadTooLarge
+        } else {
             ApiError::InternalServerError
-        })?;
+        }
+    })?;
+    // V2 admits one bounded logical response, not one full response budget per
+    // parallel audio chunk. Dividing only the bounded policy keeps aggregate
+    // provider bytes under the same 28 MiB ceiling while v1 stays unbounded.
+    let provider_policy = provider_policy.divide_bounded_response_across(chunks.len());
 
     info!("Processing {} chunk(s)", chunks.len());
 
-    // Process chunks in parallel (even if it's just one)
-    let mut futures = Vec::new();
-
-    for chunk in chunks {
-        let client = client.clone();
-        let model_name = transcription_request.model.clone();
-        let filename = transcription_request.filename.clone();
-        let content_type = transcription_request.content_type.clone();
-        let language = transcription_request.language.clone();
-        let prompt = transcription_request.prompt.clone();
-        let response_format = transcription_request.response_format.clone();
-        let temperature = transcription_request.temperature;
-        let default_proxy = default_proxy.clone();
-        let tinfoil_proxy = tinfoil_proxy.clone();
-
-        let future = async move {
-            let chunk_size = chunk.data.len();
-            info!(
-                "Processing chunk {} (size: {} bytes)",
-                chunk.index, chunk_size
-            );
-
-            let mut primary_provider = tinfoil_proxy.clone();
-            let mut fallback_provider = Some(default_proxy.clone());
-
-            if chunk_size > TINFOIL_MAX_SIZE && primary_provider.provider_name == "tinfoil" {
-                info!(
-                    "Chunk {} size {} bytes exceeds Tinfoil's 0.5MB limit, using fallback only",
-                    chunk.index, chunk_size
-                );
-
-                if let Some(fallback) = fallback_provider.take() {
-                    primary_provider = fallback;
-                } else {
-                    error!(
-                        "Chunk {} size {} bytes exceeds Tinfoil's limit and no fallback is available",
-                        chunk.index, chunk_size
-                    );
-                    return Err(ApiError::InternalServerError);
-                }
-            }
-
-            let params = TranscriptionParams {
-                audio_data: &chunk.data,
-                filename: &filename,
-                content_type: &content_type,
-                language: language.as_deref(),
-                prompt: prompt.as_deref(),
-                response_format: &response_format,
-                temperature,
-            };
-
-            match send_transcription_with_retries(
+    // Keep v1's parallel chunk dispatch unchanged. V2 processes one owned
+    // chunk and one multipart body at a time so the aggregate audio working set
+    // remains inside the gateway's provider reservation.
+    let results: Vec<Result<(usize, Value), ApiError>> = if bounded_chunking {
+        let mut results = Vec::with_capacity(chunks.len());
+        for chunk in chunks {
+            let result = transcribe_audio_chunk(
                 &client,
-                &primary_provider,
-                fallback_provider.as_ref(),
-                &model_name,
-                &params,
+                &default_proxy,
+                &tinfoil_proxy,
+                &transcription_request,
+                chunk,
+                provider_policy,
             )
-            .await
-            {
-                Ok(response) => {
-                    info!("Chunk {} transcribed successfully", chunk.index);
-                    Ok((chunk.index, response))
-                }
-                Err(err) => {
-                    error!("Chunk {} failed: {}", chunk.index, err);
-                    Err(err)
-                }
+            .await;
+            let failed = result.is_err();
+            results.push(result);
+            if failed {
+                break;
             }
-        };
-
-        futures.push(future);
-    }
-
-    // Execute all futures in parallel
-    let results: Vec<Result<(usize, Value), ApiError>> = futures::future::join_all(futures).await;
+        }
+        results
+    } else {
+        futures::future::join_all(chunks.into_iter().map(|chunk| {
+            transcribe_audio_chunk(
+                &client,
+                &default_proxy,
+                &tinfoil_proxy,
+                &transcription_request,
+                chunk,
+                provider_policy,
+            )
+        }))
+        .await
+    };
 
     // Check if all chunks succeeded
     let mut successful_results = Vec::new();
@@ -2089,17 +2457,188 @@ async fn proxy_transcription(
     // TODO: Add SQS-based billing events for transcription usage
     // Should track: audio duration/size, model used, user ID, timestamp, provider
 
-    // Encrypt and return the response
-    encrypt_response(&state, &session_id, &response).await
+    Ok(response)
 }
 
-/// Sanitize form field values to prevent HTTP header injection attacks
-/// Removes or replaces any CRLF sequences that could be used to inject headers
-fn sanitize_form_field(value: &str) -> String {
+async fn transcribe_audio_chunk(
+    client: &ProviderClient,
+    default_proxy: &ProxyConfig,
+    tinfoil_proxy: &ProxyConfig,
+    transcription_request: &TranscriptionRequest,
+    chunk: crate::web::audio_utils::AudioChunk,
+    provider_policy: UnaryProviderPolicy,
+) -> Result<(usize, Value), ApiError> {
+    let chunk_size = chunk.data.len();
+    info!(
+        "Processing chunk {} (size: {} bytes)",
+        chunk.index, chunk_size
+    );
+
+    let (primary_provider, fallback_provider) =
+        if chunk_size > TINFOIL_MAX_SIZE && tinfoil_proxy.provider_name == "tinfoil" {
+            info!(
+                "Chunk {} size {} bytes exceeds Tinfoil's 0.5MB limit, using fallback only",
+                chunk.index, chunk_size
+            );
+            (default_proxy, None)
+        } else {
+            (tinfoil_proxy, Some(default_proxy))
+        };
+
+    let params = TranscriptionParams {
+        audio_data: &chunk.data,
+        filename: &transcription_request.filename,
+        content_type: &transcription_request.content_type,
+        language: transcription_request.language.as_deref(),
+        prompt: transcription_request.prompt.as_deref(),
+        response_format: &transcription_request.response_format,
+        temperature: transcription_request.temperature,
+    };
+
+    match send_transcription_with_retries(
+        client,
+        primary_provider,
+        fallback_provider,
+        &transcription_request.model,
+        &params,
+        provider_policy,
+    )
+    .await
+    {
+        Ok(response) => {
+            info!("Chunk {} transcribed successfully", chunk.index);
+            Ok((chunk.index, response))
+        }
+        Err(err) => {
+            error!("Chunk {} failed: {}", chunk.index, err);
+            Err(err)
+        }
+    }
+}
+
+/// Execute transcription without transport encryption. V2 performs no
+/// post-send provider retry or fallback and bounds each provider JSON response
+/// before structural preflight and serde allocation.
+pub(crate) async fn openai_transcription_v2_data(
+    state: &Arc<AppState>,
+    user: &User,
+    transcription_request: TranscriptionRequest,
+) -> Result<Value, ApiError> {
+    openai_transcription_data(state, user, transcription_request, UnaryProviderPolicy::V2).await
+}
+
+/// Count and append form values after removing CRLF without allocating an
+/// intermediate sanitized copy. This matters when an optional transcription
+/// prompt consumes most of the bounded logical request.
+fn sanitized_form_field_bytes(value: &str) -> usize {
     value
-        .chars()
-        .filter(|c| !matches!(c, '\r' | '\n'))
-        .collect()
+        .as_bytes()
+        .iter()
+        .filter(|byte| !matches!(byte, b'\r' | b'\n'))
+        .count()
+}
+
+fn extend_sanitized_form_field(output: &mut Vec<u8>, value: &str) {
+    let mut retained_start = 0_usize;
+    for (index, byte) in value.as_bytes().iter().enumerate() {
+        if matches!(byte, b'\r' | b'\n') {
+            output.extend_from_slice(&value.as_bytes()[retained_start..index]);
+            retained_start = index + 1;
+        }
+    }
+    output.extend_from_slice(&value.as_bytes()[retained_start..]);
+}
+
+fn sanitized_filename_bytes(value: &str) -> usize {
+    value.chars().count()
+}
+
+fn extend_sanitized_filename(output: &mut Vec<u8>, value: &str) {
+    output.extend(value.chars().map(|character| {
+        if character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-') {
+            character as u8
+        } else {
+            b'_'
+        }
+    }));
+}
+
+fn checked_byte_sum(parts: &[usize]) -> Option<usize> {
+    parts
+        .iter()
+        .try_fold(0_usize, |total, part| total.checked_add(*part))
+}
+
+fn multipart_text_field_bytes(boundary: &str, name: &str, value_bytes: usize) -> Option<usize> {
+    checked_byte_sum(&[
+        2,
+        boundary.len(),
+        2,
+        b"Content-Disposition: form-data; name=\"".len(),
+        name.len(),
+        b"\"\r\n\r\n".len(),
+        value_bytes,
+        2,
+    ])
+}
+
+struct TranscriptionMultipartLengths {
+    model_bytes: usize,
+    filename_bytes: usize,
+    content_type_bytes: usize,
+    language_bytes: Option<usize>,
+    prompt_bytes: Option<usize>,
+    response_format_bytes: usize,
+    temperature_bytes: Option<usize>,
+    audio_bytes: usize,
+}
+
+fn transcription_multipart_bytes(
+    boundary: &str,
+    lengths: &TranscriptionMultipartLengths,
+) -> Option<usize> {
+    let mut total = multipart_text_field_bytes(boundary, "model", lengths.model_bytes)?;
+    let file_part = checked_byte_sum(&[
+        2,
+        boundary.len(),
+        2,
+        b"Content-Disposition: form-data; name=\"file\"; filename=\"".len(),
+        lengths.filename_bytes,
+        b"\"\r\n".len(),
+        b"Content-Type: ".len(),
+        lengths.content_type_bytes,
+        b"\r\n\r\n".len(),
+        lengths.audio_bytes,
+        2,
+    ])?;
+    total = total.checked_add(file_part)?;
+    if let Some(language_bytes) = lengths.language_bytes {
+        total = total.checked_add(multipart_text_field_bytes(
+            boundary,
+            "language",
+            language_bytes,
+        )?)?;
+    }
+    if let Some(prompt_bytes) = lengths.prompt_bytes {
+        total = total.checked_add(multipart_text_field_bytes(
+            boundary,
+            "prompt",
+            prompt_bytes,
+        )?)?;
+    }
+    total = total.checked_add(multipart_text_field_bytes(
+        boundary,
+        "response_format",
+        lengths.response_format_bytes,
+    )?)?;
+    if let Some(temperature_bytes) = lengths.temperature_bytes {
+        total = total.checked_add(multipart_text_field_bytes(
+            boundary,
+            "temperature",
+            temperature_bytes,
+        )?)?;
+    }
+    total.checked_add(checked_byte_sum(&[2, boundary.len(), 4])?)
 }
 
 async fn send_transcription_request(
@@ -2107,75 +2646,84 @@ async fn send_transcription_request(
     provider: &ProxyConfig,
     model: &str,
     params: &TranscriptionParams<'_>,
+    response_body_policy: ProviderResponseBodyPolicy,
 ) -> Result<Value, ApiError> {
     // Build multipart form data
     let boundary = format!("----FormBoundary{}", Uuid::new_v4().simple());
-    let mut form_data = Vec::new();
+    let temperature = params.temperature.map(|value| value.to_string());
+
+    let bounded_form_bytes = match response_body_policy {
+        ProviderResponseBodyPolicy::Unbounded => None,
+        ProviderResponseBodyPolicy::Bounded { .. } => {
+            let form_bytes = transcription_multipart_bytes(
+                &boundary,
+                &TranscriptionMultipartLengths {
+                    model_bytes: sanitized_form_field_bytes(model),
+                    filename_bytes: sanitized_filename_bytes(params.filename),
+                    content_type_bytes: sanitized_form_field_bytes(params.content_type),
+                    language_bytes: params.language.map(sanitized_form_field_bytes),
+                    prompt_bytes: params.prompt.map(sanitized_form_field_bytes),
+                    response_format_bytes: sanitized_form_field_bytes(params.response_format),
+                    temperature_bytes: temperature.as_deref().map(str::len),
+                    audio_bytes: params.audio_data.len(),
+                },
+            )
+            .ok_or(ApiError::PayloadTooLarge)?;
+            if form_bytes > V2_MAX_TRANSCRIPTION_MULTIPART_BYTES {
+                return Err(ApiError::PayloadTooLarge);
+            }
+            Some(form_bytes)
+        }
+    };
+    let mut form_data = bounded_form_bytes
+        .map(Vec::with_capacity)
+        .unwrap_or_default();
 
     // Add model field (sanitized to prevent header injection)
-    let safe_model = sanitize_form_field(model);
     form_data.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
     form_data.extend_from_slice(b"Content-Disposition: form-data; name=\"model\"\r\n\r\n");
-    form_data.extend_from_slice(safe_model.as_bytes());
+    extend_sanitized_form_field(&mut form_data, model);
     form_data.extend_from_slice(b"\r\n");
 
     // Add file field with sanitized filename to prevent header injection
-    let safe_filename: String = params
-        .filename
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
-                c
-            } else {
-                '_'
-            }
-        })
-        .collect();
-
     form_data.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
-    form_data.extend_from_slice(
-        format!(
-            "Content-Disposition: form-data; name=\"file\"; filename=\"{}\"\r\n",
-            safe_filename
-        )
-        .as_bytes(),
-    );
-    let safe_content_type = sanitize_form_field(params.content_type);
-    form_data.extend_from_slice(format!("Content-Type: {}\r\n\r\n", safe_content_type).as_bytes());
+    form_data.extend_from_slice(b"Content-Disposition: form-data; name=\"file\"; filename=\"");
+    extend_sanitized_filename(&mut form_data, params.filename);
+    form_data.extend_from_slice(b"\"\r\nContent-Type: ");
+    extend_sanitized_form_field(&mut form_data, params.content_type);
+    form_data.extend_from_slice(b"\r\n\r\n");
     form_data.extend_from_slice(params.audio_data);
     form_data.extend_from_slice(b"\r\n");
 
     // Add optional fields (sanitized to prevent header injection)
-    if let Some(lang) = params.language {
-        let safe_lang = sanitize_form_field(lang);
+    if let Some(language) = params.language {
         form_data.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
         form_data.extend_from_slice(b"Content-Disposition: form-data; name=\"language\"\r\n\r\n");
-        form_data.extend_from_slice(safe_lang.as_bytes());
+        extend_sanitized_form_field(&mut form_data, language);
         form_data.extend_from_slice(b"\r\n");
     }
-    if let Some(p) = params.prompt {
-        let safe_prompt = sanitize_form_field(p);
+    if let Some(prompt) = params.prompt {
         form_data.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
         form_data.extend_from_slice(b"Content-Disposition: form-data; name=\"prompt\"\r\n\r\n");
-        form_data.extend_from_slice(safe_prompt.as_bytes());
+        extend_sanitized_form_field(&mut form_data, prompt);
         form_data.extend_from_slice(b"\r\n");
     }
-    let safe_response_format = sanitize_form_field(params.response_format);
     form_data.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
     form_data
         .extend_from_slice(b"Content-Disposition: form-data; name=\"response_format\"\r\n\r\n");
-    form_data.extend_from_slice(safe_response_format.as_bytes());
+    extend_sanitized_form_field(&mut form_data, params.response_format);
     form_data.extend_from_slice(b"\r\n");
-    if let Some(temp) = params.temperature {
+    if let Some(temperature) = temperature.as_deref() {
         form_data.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
         form_data
             .extend_from_slice(b"Content-Disposition: form-data; name=\"temperature\"\r\n\r\n");
-        form_data.extend_from_slice(temp.to_string().as_bytes());
+        form_data.extend_from_slice(temperature.as_bytes());
         form_data.extend_from_slice(b"\r\n");
     }
 
     // End boundary
     form_data.extend_from_slice(format!("--{}--\r\n", boundary).as_bytes());
+    debug_assert!(bounded_form_bytes.is_none_or(|expected| form_data.len() == expected));
 
     let content_type = format!("multipart/form-data; boundary={boundary}");
     match client
@@ -2193,9 +2741,14 @@ async fn send_transcription_request(
     {
         Ok(res) => {
             if res.is_success() {
-                let body_bytes = res.bytes().await.map_err(|e| {
-                    error!("Failed to read transcription response body: {:?}", e);
-                    ApiError::InternalServerError
+                let body_bytes = collect_provider_response_body(res, response_body_policy)
+                    .await
+                    .map_err(|error| {
+                        error!("Failed to read transcription response body: {error}");
+                        error
+                    })?;
+                preflight_provider_json(&body_bytes, response_body_policy).inspect_err(|_| {
+                    error!("Transcription provider response failed structural JSON preflight");
                 })?;
 
                 let response_json: Value = serde_json::from_slice(&body_bytes).map_err(|e| {
@@ -2206,15 +2759,16 @@ async fn send_transcription_request(
                 Ok(response_json)
             } else {
                 let status = res.status_code();
-                let body_bytes = res.bytes().await.ok();
-                let error_msg = body_bytes
-                    .map(|b| String::from_utf8_lossy(&b).to_string())
-                    .unwrap_or_else(|| status.to_string());
-
-                error!(
-                    "Provider {} returned transcription error: {} - {}",
-                    provider.provider_name, status, error_msg
-                );
+                match collect_provider_error_body_for_log(res, response_body_policy, status).await {
+                    ProviderErrorBodyForLog::Legacy(error_msg) => error!(
+                        "Provider {} returned transcription error: {} - {}",
+                        provider.provider_name, status, error_msg
+                    ),
+                    ProviderErrorBodyForLog::StatusOnly => error!(
+                        "Provider {} returned transcription error: {}",
+                        provider.provider_name, status
+                    ),
+                }
                 Err(ApiError::InternalServerError)
             }
         }
@@ -2295,6 +2849,17 @@ async fn proxy_tts(
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(tts_request): axum::Extension<TTSRequest>,
 ) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
+    let response =
+        openai_tts_data(&state, &user, tts_request, UnaryProviderPolicy::LEGACY_V1).await?;
+    encrypt_response(&state, &session_id, &response).await
+}
+
+async fn openai_tts_data(
+    state: &Arc<AppState>,
+    user: &User,
+    tts_request: TTSRequest,
+    provider_policy: UnaryProviderPolicy,
+) -> Result<Value, ApiError> {
     let prepared = prepare_tts_request(tts_request).map_err(|validation_error| {
         warn!(
             error = %validation_error,
@@ -2305,7 +2870,7 @@ async fn proxy_tts(
             _ => ApiError::BadRequest,
         }
     })?;
-    ensure_paid_tts_access(&state, &user).await?;
+    ensure_paid_tts_access(state, user).await?;
 
     let proxy_config = state.proxy_router.get_tinfoil_proxy();
     let request_body = serde_json::to_vec(&prepared.provider_payload).map_err(|e| {
@@ -2341,10 +2906,12 @@ async fn proxy_tts(
             .content_type()
             .unwrap_or("application/octet-stream")
             .to_string();
-        let body_bytes = res.bytes().await.map_err(|e| {
-            error!("Failed to read TTS response body: {:?}", e);
-            ApiError::InternalServerError
-        })?;
+        let body_bytes = collect_provider_response_body(res, provider_policy.response_body)
+            .await
+            .map_err(|error| {
+                error!("Failed to read TTS response body: {error}");
+                error
+            })?;
         Ok((body_bytes, content_type))
     })
     .await
@@ -2357,8 +2924,11 @@ async fn proxy_tts(
         ApiError::InternalServerError
     })??;
 
-    let (response_payload, is_json_response) =
-        build_tts_response_payload(&body_bytes, &response_content_type);
+    let (response_payload, is_json_response) = build_tts_response_payload_with_policy(
+        &body_bytes,
+        &response_content_type,
+        provider_policy.retry == ProviderRetryPolicy::NoAmbiguousRetry,
+    );
     if is_json_response {
         warn!(
             model = %prepared.model,
@@ -2376,8 +2946,18 @@ async fn proxy_tts(
         );
     }
 
-    // Encrypt and return the response
-    encrypt_response(&state, &session_id, &response_payload).await
+    Ok(response_payload)
+}
+
+/// Execute speech synthesis without transport encryption. The raw provider
+/// audio is capped so padded base64 plus the JSON wrapper fits the v2 logical
+/// response ceiling.
+pub(crate) async fn openai_tts_v2_data(
+    state: &Arc<AppState>,
+    user: &User,
+    tts_request: TTSRequest,
+) -> Result<Value, ApiError> {
+    openai_tts_data(state, user, tts_request, UnaryProviderPolicy::V2_TTS).await
 }
 
 async fn proxy_embeddings(
@@ -2385,9 +2965,27 @@ async fn proxy_embeddings(
     _headers: HeaderMap,
     axum::Extension(session_id): axum::Extension<TransportSession>,
     axum::Extension(user): axum::Extension<User>,
-    axum::Extension(_auth_method): axum::Extension<AuthMethod>,
+    axum::Extension(auth_method): axum::Extension<AuthMethod>,
     axum::Extension(embedding_request): axum::Extension<EmbeddingRequest>,
 ) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
+    let response = openai_embeddings_data(
+        &state,
+        &user,
+        auth_method,
+        embedding_request,
+        UnaryProviderPolicy::LEGACY_V1,
+    )
+    .await?;
+    encrypt_response(&state, &session_id, &response).await
+}
+
+async fn openai_embeddings_data(
+    state: &Arc<AppState>,
+    user: &User,
+    auth_method: AuthMethod,
+    embedding_request: EmbeddingRequest,
+    provider_policy: UnaryProviderPolicy,
+) -> Result<Value, ApiError> {
     // Check if guest user is allowed (paid guests are allowed, free guests are not)
     if user.is_guest() {
         if let Some(billing_client) = &state.billing_client {
@@ -2455,21 +3053,28 @@ async fn proxy_embeddings(
 
     if !res.is_success() {
         let status = res.status_code();
-        let body_bytes = res.bytes().await.ok();
-        let error_msg = body_bytes
-            .map(|b| String::from_utf8_lossy(&b).to_string())
-            .unwrap_or_else(|| status.to_string());
-        error!(
-            "Embeddings proxy returned non-success status: {} - {}",
-            status, error_msg
-        );
+        match collect_provider_error_body_for_log(res, provider_policy.response_body, status).await
+        {
+            ProviderErrorBodyForLog::Legacy(error_msg) => error!(
+                "Embeddings proxy returned non-success status: {} - {}",
+                status, error_msg
+            ),
+            ProviderErrorBodyForLog::StatusOnly => {
+                error!("Embeddings proxy returned non-success status: {}", status)
+            }
+        }
         return Err(ApiError::InternalServerError);
     }
 
     // Parse response
-    let body_bytes = res.bytes().await.map_err(|e| {
-        error!("Failed to read embeddings response body: {:?}", e);
-        ApiError::InternalServerError
+    let body_bytes = collect_provider_response_body(res, provider_policy.response_body)
+        .await
+        .map_err(|error| {
+            error!("Failed to read embeddings response body: {error}");
+            error
+        })?;
+    preflight_provider_json(&body_bytes, provider_policy.response_body).inspect_err(|_| {
+        error!("Embeddings provider response failed structural JSON preflight");
     })?;
 
     let response_json: Value = serde_json::from_slice(&body_bytes).map_err(|e| {
@@ -2485,16 +3090,15 @@ async fn proxy_embeddings(
             .unwrap_or(0) as i32;
 
         if prompt_tokens > 0 {
-            let billing_context =
-                BillingContext::new(_auth_method, embedding_request.model.clone());
+            let billing_context = BillingContext::new(auth_method, embedding_request.model.clone());
             let embedding_usage = CompletionUsage {
                 prompt_tokens,
                 completion_tokens: 0, // Embeddings don't have completion tokens
                 cached_prompt_tokens: None,
             };
             publish_usage_event_internal(
-                &state,
-                &user,
+                state,
+                user,
                 &billing_context,
                 embedding_usage,
                 &proxy_config.provider_name,
@@ -2503,8 +3107,25 @@ async fn proxy_embeddings(
         }
     }
 
-    // Encrypt and return the response
-    encrypt_response(&state, &session_id, &response_json).await
+    Ok(response_json)
+}
+
+/// Execute embeddings without transport encryption. Provider JSON is bounded
+/// and structurally preflighted before serde allocation.
+pub(crate) async fn openai_embeddings_v2_data(
+    state: &Arc<AppState>,
+    user: &User,
+    auth_method: AuthMethod,
+    embedding_request: EmbeddingRequest,
+) -> Result<Value, ApiError> {
+    openai_embeddings_data(
+        state,
+        user,
+        auth_method,
+        embedding_request,
+        UnaryProviderPolicy::V2,
+    )
+    .await
 }
 
 #[derive(Debug, PartialEq, Eq, thiserror::Error)]
@@ -2513,6 +3134,59 @@ enum BoundedProviderResponseBodyError {
     Read,
     #[error("provider response body exceeded the {limit_bytes}-byte limit")]
     TooLarge { limit_bytes: usize },
+}
+
+enum ProviderErrorBodyForLog {
+    Legacy(String),
+    StatusOnly,
+}
+
+async fn collect_provider_error_body_for_log(
+    response: ProviderResponse,
+    response_body_policy: ProviderResponseBodyPolicy,
+    status: u16,
+) -> ProviderErrorBodyForLog {
+    match response_body_policy.error_body() {
+        ProviderErrorBodyPolicy::LegacyBody => {
+            let error_msg = response
+                .bytes()
+                .await
+                .ok()
+                .map(|body| String::from_utf8_lossy(&body).to_string())
+                .unwrap_or_else(|| status.to_string());
+            ProviderErrorBodyForLog::Legacy(error_msg)
+        }
+        ProviderErrorBodyPolicy::StatusOnly { drain_limit_bytes } => {
+            // V2 provider errors are status-only. Consume at most a small
+            // prefix for connection hygiene without copying or retaining it,
+            // and never make provider-controlled error text loggable.
+            let _ =
+                drain_bounded_provider_response_body(response.bytes_stream(), drain_limit_bytes)
+                    .await;
+            ProviderErrorBodyForLog::StatusOnly
+        }
+    }
+}
+
+async fn collect_provider_response_body(
+    response: ProviderResponse,
+    policy: ProviderResponseBodyPolicy,
+) -> Result<bytes::Bytes, ApiError> {
+    match policy {
+        ProviderResponseBodyPolicy::Unbounded => response
+            .bytes()
+            .await
+            .map_err(|_| ApiError::InternalServerError),
+        ProviderResponseBodyPolicy::Bounded { limit_bytes, .. } => {
+            collect_bounded_provider_response_body(response.bytes_stream(), limit_bytes)
+                .await
+                .map(bytes::Bytes::from)
+                .map_err(|error| match error {
+                    BoundedProviderResponseBodyError::Read => ApiError::InternalServerError,
+                    BoundedProviderResponseBodyError::TooLarge { .. } => ApiError::PayloadTooLarge,
+                })
+        }
+    }
 }
 
 async fn collect_bounded_provider_response_body<S>(
@@ -2533,6 +3207,30 @@ where
     }
 
     Ok(body)
+}
+
+async fn drain_bounded_provider_response_body<S>(
+    mut body_stream: S,
+    limit_bytes: usize,
+) -> Result<usize, BoundedProviderResponseBodyError>
+where
+    S: futures::Stream<Item = Result<bytes::Bytes, String>> + Unpin,
+{
+    let mut drained_bytes = 0_usize;
+
+    while drained_bytes < limit_bytes {
+        let Some(chunk) = body_stream.next().await else {
+            break;
+        };
+        let chunk = chunk.map_err(|_| BoundedProviderResponseBodyError::Read)?;
+        let remaining = limit_bytes - drained_bytes;
+        drained_bytes += chunk.len().min(remaining);
+        if chunk.len() >= remaining {
+            break;
+        }
+    }
+
+    Ok(drained_bytes)
 }
 
 /// Helper function to try a provider once
@@ -2596,6 +3294,140 @@ async fn try_provider(
 mod tests {
     use super::*;
 
+    #[test]
+    fn unary_provider_policies_keep_v1_legacy_and_v2_bounded_nonretrying() {
+        assert_eq!(
+            UnaryProviderPolicy::LEGACY_V1,
+            UnaryProviderPolicy {
+                response_body: ProviderResponseBodyPolicy::Unbounded,
+                retry: ProviderRetryPolicy::LegacyV1,
+            }
+        );
+        assert_eq!(
+            UnaryProviderPolicy::V2,
+            UnaryProviderPolicy {
+                response_body: ProviderResponseBodyPolicy::Bounded {
+                    limit_bytes: V2_MAX_PROVIDER_RESPONSE_BYTES,
+                    max_json_structural_tokens: Some(V2_MAX_PROVIDER_JSON_STRUCTURAL_TOKENS,),
+                },
+                retry: ProviderRetryPolicy::NoAmbiguousRetry,
+            }
+        );
+        assert_eq!(
+            UnaryProviderPolicy::V2_TTS,
+            UnaryProviderPolicy {
+                response_body: ProviderResponseBodyPolicy::Bounded {
+                    limit_bytes: V2_MAX_TTS_PROVIDER_RESPONSE_BYTES,
+                    max_json_structural_tokens: None,
+                },
+                retry: ProviderRetryPolicy::NoAmbiguousRetry,
+            }
+        );
+        assert_eq!(
+            UnaryProviderPolicy::LEGACY_V1.response_body.error_body(),
+            ProviderErrorBodyPolicy::LegacyBody
+        );
+        assert_eq!(
+            UnaryProviderPolicy::V2.response_body.error_body(),
+            ProviderErrorBodyPolicy::StatusOnly {
+                drain_limit_bytes: MAX_BOUNDED_PROVIDER_RESPONSE_BYTES,
+            }
+        );
+    }
+
+    #[test]
+    fn v2_unary_chat_helper_accepts_only_absent_or_boolean_false_stream() {
+        assert!(ensure_nonstream_chat_completion(&json!({"stream": false})).is_ok());
+        assert!(ensure_nonstream_chat_completion(&json!({})).is_ok());
+        for rejected in [
+            json!({"stream": true}),
+            json!({"stream": null}),
+            json!({"stream": "false"}),
+            json!({"stream": 0}),
+            json!({"stream": {}}),
+            json!({"stream": []}),
+        ] {
+            assert!(ensure_nonstream_chat_completion(&rejected).is_err());
+        }
+    }
+
+    #[test]
+    fn v2_provider_json_preflight_bounds_depth_and_structure_only_for_v2() {
+        let too_deep = format!(
+            "{}0{}",
+            "[".repeat(V2_MAX_PROVIDER_JSON_DEPTH + 1),
+            "]".repeat(V2_MAX_PROVIDER_JSON_DEPTH + 1)
+        );
+        assert!(matches!(
+            preflight_provider_json(too_deep.as_bytes(), UnaryProviderPolicy::V2.response_body),
+            Err(ApiError::PayloadTooLarge)
+        ));
+        assert!(preflight_provider_json(
+            too_deep.as_bytes(),
+            UnaryProviderPolicy::LEGACY_V1.response_body
+        )
+        .is_ok());
+
+        let mut too_many_tokens =
+            String::with_capacity(V2_MAX_PROVIDER_JSON_STRUCTURAL_TOKENS.saturating_add(3));
+        too_many_tokens.push('[');
+        for index in 0..=V2_MAX_PROVIDER_JSON_STRUCTURAL_TOKENS {
+            if index > 0 {
+                too_many_tokens.push(',');
+            }
+            too_many_tokens.push('0');
+        }
+        too_many_tokens.push(']');
+        assert!(matches!(
+            preflight_provider_json(
+                too_many_tokens.as_bytes(),
+                UnaryProviderPolicy::V2.response_body
+            ),
+            Err(ApiError::PayloadTooLarge)
+        ));
+    }
+
+    #[test]
+    fn bounded_transcription_chunks_share_one_provider_response_budget() {
+        let divided = UnaryProviderPolicy::V2.divide_bounded_response_across(4);
+        let per_chunk_structural_tokens = V2_MAX_PROVIDER_JSON_STRUCTURAL_TOKENS / 4;
+        assert_eq!(
+            divided.response_body,
+            ProviderResponseBodyPolicy::Bounded {
+                limit_bytes: V2_MAX_PROVIDER_RESPONSE_BYTES / 4,
+                max_json_structural_tokens: Some(per_chunk_structural_tokens),
+            }
+        );
+        assert_eq!(divided.retry, ProviderRetryPolicy::NoAmbiguousRetry);
+
+        let numeric_array = |elements: usize| {
+            let mut json = String::with_capacity(elements.saturating_mul(2).saturating_add(1));
+            json.push('[');
+            for index in 0..elements {
+                if index > 0 {
+                    json.push(',');
+                }
+                json.push('0');
+            }
+            json.push(']');
+            json
+        };
+        let exact_limit = numeric_array(per_chunk_structural_tokens - 1);
+        assert!(preflight_provider_json(exact_limit.as_bytes(), divided.response_body).is_ok());
+        let over_limit = numeric_array(per_chunk_structural_tokens);
+        assert!(matches!(
+            preflight_provider_json(over_limit.as_bytes(), divided.response_body),
+            Err(ApiError::PayloadTooLarge)
+        ));
+
+        assert_eq!(
+            UnaryProviderPolicy::LEGACY_V1
+                .divide_bounded_response_across(4)
+                .response_body,
+            ProviderResponseBodyPolicy::Unbounded
+        );
+    }
+
     #[tokio::test]
     async fn bounded_provider_response_body_accepts_exact_limit_across_chunks() {
         let body_stream = futures::stream::iter([
@@ -2633,6 +3465,20 @@ mod tests {
         assert_eq!(
             collect_bounded_provider_response_body(body_stream, 6).await,
             Err(BoundedProviderResponseBodyError::Read)
+        );
+    }
+
+    #[tokio::test]
+    async fn bounded_provider_error_drain_stops_without_polling_past_limit() {
+        let body_stream = futures::stream::iter([
+            Ok::<_, String>(bytes::Bytes::from_static(b"abcd")),
+            Ok(bytes::Bytes::from_static(b"efgh")),
+            Err("must not be polled after the bounded prefix".to_string()),
+        ]);
+
+        assert_eq!(
+            drain_bounded_provider_response_body(body_stream, 6).await,
+            Ok(6)
         );
     }
 
@@ -2888,7 +3734,8 @@ mod tests {
     #[test]
     fn tts_binary_response_preserves_bytes_and_mime_type() {
         let audio_bytes = [b'R', b'I', b'F', b'F', 0, 0xff, b'W', b'A', b'V', b'E'];
-        let (response, is_json_response) = build_tts_response_payload(&audio_bytes, "audio/flac");
+        let (response, is_json_response) =
+            build_tts_response_payload_with_policy(&audio_bytes, "audio/flac", false);
         let decoded = general_purpose::STANDARD
             .decode(response["content_base64"].as_str().unwrap())
             .unwrap();
@@ -2902,8 +3749,11 @@ mod tests {
     fn tts_json_response_preserves_exact_bytes_and_problem_mime_type() {
         let body = br#"{ "error" : { "message" : "voice generation failed" } }"#;
 
-        let (response, is_json_response) =
-            build_tts_response_payload(body, "application/problem+json; charset=utf-8");
+        let (response, is_json_response) = build_tts_response_payload_with_policy(
+            body,
+            "application/problem+json; charset=utf-8",
+            false,
+        );
         let decoded = general_purpose::STANDARD
             .decode(response["content_base64"].as_str().unwrap())
             .unwrap();
@@ -2981,7 +3831,12 @@ mod tests {
             ("messages".to_string(), json!([])),
         ]);
 
-        apply_provider_managed_request_fields(&mut body, ProviderName::Tinfoil.as_str(), user_uuid);
+        apply_provider_managed_request_fields(
+            &mut body,
+            ProviderName::Tinfoil.as_str(),
+            user_uuid,
+            &CompletionCachePolicy::LegacyV1,
+        );
 
         assert_eq!(body.get("model"), Some(&json!("kimi-k2-6")));
         assert_eq!(body.get("messages"), Some(&json!([])));
@@ -2993,7 +3848,39 @@ mod tests {
     }
 
     #[test]
+    fn bound_v2_cache_namespace_replaces_legacy_and_client_values() {
+        let user_uuid = Uuid::from_u128(42);
+        let root = crate::provider_cache::CacheNamespaceRoot::from_bytes([0x55; 32]);
+        let namespace = crate::provider_cache::derive_tinfoil_cache_namespace(&root, user_uuid);
+        let expected = namespace.tinfoil_user_cache_secret();
+        let mut body = serde_json::Map::from_iter([
+            ("cache_salt".to_string(), json!("user-supplied")),
+            ("user_cache_secret".to_string(), json!("client-controlled")),
+        ]);
+
+        apply_provider_managed_request_fields(
+            &mut body,
+            ProviderName::Tinfoil.as_str(),
+            user_uuid,
+            &CompletionCachePolicy::BoundV2(&namespace),
+        );
+
+        assert!(!body.contains_key(PROVIDER_MANAGED_CACHE_SALT_FIELD));
+        assert_eq!(
+            body.get(PROVIDER_MANAGED_USER_CACHE_SECRET_FIELD),
+            Some(&json!(expected))
+        );
+        assert_ne!(
+            body.get(PROVIDER_MANAGED_USER_CACHE_SECRET_FIELD),
+            Some(&json!(tinfoil_user_cache_secret(user_uuid)))
+        );
+    }
+
+    #[test]
     fn strips_tinfoil_cache_fields_from_non_tinfoil_requests() {
+        let user_uuid = Uuid::from_u128(42);
+        let root = crate::provider_cache::CacheNamespaceRoot::from_bytes([0x55; 32]);
+        let namespace = crate::provider_cache::derive_tinfoil_cache_namespace(&root, user_uuid);
         let mut body = serde_json::Map::from_iter([
             ("cache_salt".to_string(), json!("user-supplied")),
             ("user_cache_secret".to_string(), json!("client-controlled")),
@@ -3002,7 +3889,8 @@ mod tests {
         apply_provider_managed_request_fields(
             &mut body,
             ProviderName::Continuum.as_str(),
-            Uuid::from_u128(42),
+            user_uuid,
+            &CompletionCachePolicy::BoundV2(&namespace),
         );
 
         assert!(!body.contains_key(PROVIDER_MANAGED_CACHE_SALT_FIELD));
@@ -3021,6 +3909,7 @@ mod tests {
             &mut body,
             ProviderName::Continuum.as_str(),
             user_uuid,
+            &CompletionCachePolicy::LegacyV1,
         );
         assert!(!body.contains_key(PROVIDER_MANAGED_CACHE_SALT_FIELD));
 

--- a/src/web/web_routes.rs
+++ b/src/web/web_routes.rs
@@ -211,8 +211,23 @@ struct WebErrorBody {
     trace_id: Option<String>,
 }
 
+/// The exact sanitized JSON body returned for a failed logical web operation.
+///
+/// Transport v1 wraps this body in an Axum response, while transport v2 can
+/// serialize the same value inside its authenticated response envelope.
+#[derive(Debug, Serialize)]
+#[serde(transparent)]
+pub(crate) struct WebRouteErrorBody(WebRouteErrorBodyKind);
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum WebRouteErrorBodyKind {
+    Web(WebErrorBody),
+    Api(crate::ErrorResponse),
+}
+
 #[derive(Debug)]
-enum WebRouteError {
+pub(crate) enum WebRouteError {
     InvalidRequest,
     ProviderUnavailable { trace_id: Option<String> },
     Api(ApiError),
@@ -224,30 +239,48 @@ impl From<ApiError> for WebRouteError {
     }
 }
 
-impl IntoResponse for WebRouteError {
-    fn into_response(self) -> Response {
+impl WebRouteError {
+    /// Split a logical failure into the status and JSON body shared by every
+    /// encrypted transport. Dynamic provider trace IDs are sanitized and
+    /// bounded before crossing the public API boundary.
+    pub(crate) fn into_logical_parts(self) -> (StatusCode, WebRouteErrorBody) {
         match self {
             Self::InvalidRequest => (
                 StatusCode::UNPROCESSABLE_ENTITY,
-                Json(WebErrorBody {
+                WebRouteErrorBody(WebRouteErrorBodyKind::Web(WebErrorBody {
                     status: StatusCode::UNPROCESSABLE_ENTITY.as_u16(),
                     code: "invalid_request",
                     message: "The web request is invalid.",
                     trace_id: None,
-                }),
-            )
-                .into_response(),
+                })),
+            ),
             Self::ProviderUnavailable { trace_id } => (
                 StatusCode::SERVICE_UNAVAILABLE,
-                Json(WebErrorBody {
+                WebRouteErrorBody(WebRouteErrorBodyKind::Web(WebErrorBody {
                     status: StatusCode::SERVICE_UNAVAILABLE.as_u16(),
                     code: "web_provider_unavailable",
                     message: "The web provider is temporarily unavailable.",
-                    trace_id,
-                }),
-            )
-                .into_response(),
+                    trace_id: trace_id
+                        .as_deref()
+                        .and_then(|trace_id| meaningful_trace_id(Some(trace_id))),
+                })),
+            ),
+            Self::Api(error) => (
+                error.status_code(),
+                WebRouteErrorBody(WebRouteErrorBodyKind::Api(error.response_body())),
+            ),
+        }
+    }
+}
+
+impl IntoResponse for WebRouteError {
+    fn into_response(self) -> Response {
+        match self {
             Self::Api(error) => error.into_response(),
+            error => {
+                let (status, body) = error.into_logical_parts();
+                (status, Json(body)).into_response()
+            }
         }
     }
 }
@@ -277,18 +310,33 @@ async fn search_web(
     Extension(user): Extension<User>,
     Extension(body): Extension<Value>,
 ) -> Result<Json<EncryptedResponse<WebSearchResponse>>, WebRouteError> {
-    let request = serde_json::from_value::<WebSearchRequest>(body)
-        .map_err(|_| WebRouteError::InvalidRequest)?;
+    let request = parse_web_search_request(body)?;
+    let response = execute_web_search(&state, &user, request).await?;
+    encrypt_response(&state, &session_id, &response)
+        .await
+        .map_err(WebRouteError::from)
+}
+
+/// Deserialize a structurally valid web-search body using the public web API's
+/// sanitized validation error contract.
+pub(crate) fn parse_web_search_request(body: Value) -> Result<WebSearchRequest, WebRouteError> {
+    serde_json::from_value::<WebSearchRequest>(body).map_err(|_| WebRouteError::InvalidRequest)
+}
+
+/// Execute a validated, authenticated web-search operation without depending
+/// on a particular encrypted transport.
+pub(crate) async fn execute_web_search(
+    state: &AppState,
+    user: &User,
+    request: WebSearchRequest,
+) -> Result<WebSearchResponse, WebRouteError> {
     let options = validate_search_request(request)?;
     let client = state.kagi_client.as_ref().ok_or_else(|| {
         warn!("Web search requested while the provider client is unavailable");
         WebRouteError::ProviderUnavailable { trace_id: None }
     })?;
-    ensure_paid_web_access(&state, &user).await?;
-    let response = execute_search(client, options).await?;
-    encrypt_response(&state, &session_id, &response)
-        .await
-        .map_err(WebRouteError::from)
+    ensure_paid_web_access(state, user).await?;
+    execute_search(client, options).await
 }
 
 async fn extract_web(
@@ -297,18 +345,33 @@ async fn extract_web(
     Extension(user): Extension<User>,
     Extension(body): Extension<Value>,
 ) -> Result<Json<EncryptedResponse<WebExtractResponse>>, WebRouteError> {
-    let request = serde_json::from_value::<WebExtractRequest>(body)
-        .map_err(|_| WebRouteError::InvalidRequest)?;
+    let request = parse_web_extract_request(body)?;
+    let response = execute_web_extract(&state, &user, request).await?;
+    encrypt_response(&state, &session_id, &response)
+        .await
+        .map_err(WebRouteError::from)
+}
+
+/// Deserialize a structurally valid web-extraction body using the public web
+/// API's sanitized validation error contract.
+pub(crate) fn parse_web_extract_request(body: Value) -> Result<WebExtractRequest, WebRouteError> {
+    serde_json::from_value::<WebExtractRequest>(body).map_err(|_| WebRouteError::InvalidRequest)
+}
+
+/// Execute a validated, authenticated web-extraction operation without
+/// depending on a particular encrypted transport.
+pub(crate) async fn execute_web_extract(
+    state: &AppState,
+    user: &User,
+    request: WebExtractRequest,
+) -> Result<WebExtractResponse, WebRouteError> {
     let (urls, timeout) = validate_extract_request(request)?;
     let client = state.kagi_client.as_ref().ok_or_else(|| {
         warn!("Web extraction requested while the provider client is unavailable");
         WebRouteError::ProviderUnavailable { trace_id: None }
     })?;
-    ensure_paid_web_access(&state, &user).await?;
-    let response = execute_extract(client, urls, timeout).await?;
-    encrypt_response(&state, &session_id, &response)
-        .await
-        .map_err(WebRouteError::from)
+    ensure_paid_web_access(state, user).await?;
+    execute_extract(client, urls, timeout).await
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -984,6 +1047,57 @@ mod tests {
             assert!(body.contains("invalid_request"));
             assert!(!body.contains("private provider diagnostic"));
         }
+    }
+
+    async fn assert_logical_error_matches_v1(
+        logical_error: WebRouteError,
+        v1_error: WebRouteError,
+    ) {
+        let (logical_status, logical_body) = logical_error.into_logical_parts();
+        let logical_body = serde_json::to_vec(&logical_body).unwrap();
+
+        let v1_response = v1_error.into_response();
+        assert_eq!(logical_status, v1_response.status());
+        let v1_body = axum::body::to_bytes(v1_response.into_body(), 8 * 1024)
+            .await
+            .unwrap();
+        assert_eq!(logical_body.as_slice(), v1_body.as_ref());
+    }
+
+    #[tokio::test]
+    async fn logical_errors_preserve_exact_v1_status_and_json_body() {
+        assert_logical_error_matches_v1(
+            WebRouteError::InvalidRequest,
+            WebRouteError::InvalidRequest,
+        )
+        .await;
+        assert_logical_error_matches_v1(
+            WebRouteError::ProviderUnavailable {
+                trace_id: Some("safe-trace".to_owned()),
+            },
+            WebRouteError::ProviderUnavailable {
+                trace_id: Some("safe-trace".to_owned()),
+            },
+        )
+        .await;
+        assert_logical_error_matches_v1(
+            WebRouteError::Api(ApiError::UsageLimitReached),
+            WebRouteError::Api(ApiError::UsageLimitReached),
+        )
+        .await;
+    }
+
+    #[test]
+    fn logical_provider_errors_bound_and_sanitize_trace_ids() {
+        let (_, body) = WebRouteError::ProviderUnavailable {
+            trace_id: Some(format!("safe<script>{}", "x".repeat(512))),
+        }
+        .into_logical_parts();
+        let body = serde_json::to_string(&body).unwrap();
+
+        assert!(!body.contains('<'));
+        assert!(!body.contains('>'));
+        assert!(body.len() < 512);
     }
 
     #[test]

--- a/testdata/transport-v2-golden-vectors.json
+++ b/testdata/transport-v2-golden-vectors.json
@@ -45,6 +45,6 @@
     "record_hex": "2425262728292a2b2c2d2e2f7f7818dab8d77e819361a2b9cb7fbccc2ba70f4bb6b751e1329622624dfa35cefb9031a6e93e608bc9777a57a7f35480ba",
     "record_base64": "JCUmJygpKissLS4vf3gY2rjXfoGTYaK5y3+8zCunD0u2t1HhMpYiYk36Nc77kDGm6T5gi8l3elen81SAug=="
   },
-  "request_without_body_json": "{\"version\":2,\"request_id\":\"ffeeddccbbaa99887766554433221100\",\"response_mode\":\"unary\",\"credential\":null,\"request\":{\"method\":\"GET\",\"path\":\"/v1/models\",\"query\":\"limit=10\",\"headers\":[{\"name\":\"x-provider-beta\",\"value_base64\":\"YmV0YQ==\"}],\"body_base64\":null}}",
-  "request_with_empty_body_json": "{\"version\":2,\"request_id\":\"ffeeddccbbaa99887766554433221100\",\"response_mode\":\"unary\",\"credential\":null,\"request\":{\"method\":\"POST\",\"path\":\"/v1/responses\",\"query\":null,\"headers\":[{\"name\":\"content-type\",\"value_base64\":\"YXBwbGljYXRpb24vanNvbg==\"}],\"body_base64\":\"\"}}"
+  "request_without_body_json": "{\"version\":2,\"request_id\":\"ffeeddccbbaa99887766554433221100\",\"response_mode\":\"unary\",\"credential\":null,\"cache_namespace_root_base64\":null,\"request\":{\"method\":\"GET\",\"path\":\"/v1/models\",\"query\":\"limit=10\",\"headers\":[{\"name\":\"x-provider-beta\",\"value_base64\":\"YmV0YQ==\"}],\"body_base64\":null}}",
+  "request_with_empty_body_json": "{\"version\":2,\"request_id\":\"ffeeddccbbaa99887766554433221100\",\"response_mode\":\"unary\",\"credential\":null,\"cache_namespace_root_base64\":null,\"request\":{\"method\":\"POST\",\"path\":\"/v1/responses\",\"query\":null,\"headers\":[{\"name\":\"content-type\",\"value_base64\":\"YXBwbGljYXRpb24vanNvbg==\"}],\"body_base64\":\"\"}}"
 }


### PR DESCRIPTION
## Summary

- add transport-neutral, v1-preserving provider seams for models, catalog, unary Chat Completions, speech, transcription, embeddings, and web search/extract
- bind existing raw API keys to immutable v2 inference sessions with live owner/key revalidation and preserved billing attribution
- derive a stable Tinfoil cache namespace from a client-random root that is revealed only inside the attested binding transition
- bound v2 provider bodies, JSON structure, WAV expansion, multipart allocation, and error draining while preserving every legacy v1 retry, logging, cache, and concurrency path
- preserve authenticated logical API error contract/code headers and reject ambiguous outer transfer framing

## Security boundaries

- exact unordered replay admission and the same held session lease precede provider dispatch and response encryption
- API keys are accepted only on the five inference routes already authorized for that credential class
- client/provider cache material is dropped after derivation; only a redacted final-drop-zeroizing namespace remains
- this PR intentionally excludes streaming, Responses inference, OAuth, and platform authority

## Validation

- exact Rust CI: format, warning-strict all-target/all-feature clippy, 596 passed / 34 expected ignored / 0 failed
- disposable PostgreSQL: all migrations, 26 AEAD/database tests, and 2 OAuth DB tests passed with no skips
- API-key joined-resolution/live-owner DB test passed
- focused suites: 41 transport application, 45 OpenAI, 8 audio, and 3 provider-cache tests passed
- current TypeScript and Rust SDK v1 smokes passed against the exact local backend for attestation, login/JWT, encrypted protected APIs, models/catalog, and valid/invalid API-key authentication

No live inference or live Tinfoil provider call was made.