### PR TITLE
Transport v2: bind user OAuth to attested sessions

### DIFF
--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -487,7 +487,52 @@ client while preventing the parent/operator, which sees neither the root
 plaintext nor the enclave-held derivation result, from computing it from a
 UUID.
 
-### 8.5 Unary inference projection
+### 8.5 Session-bound user OAuth
+
+Transport v2 admits exactly seven user OAuth operations:
+
+| Logical operation | Authority before request | Cache namespace root | Success effect |
+| --- | --- | --- | --- |
+| `POST /auth/github` | anonymous | null | retain anonymous session |
+| `POST /auth/google` | anonymous | null | retain anonymous session |
+| `POST /auth/apple` | anonymous | null | retain anonymous session |
+| `POST /auth/github/callback` | anonymous | required | bind verified user |
+| `POST /auth/google/callback` | anonymous | required | bind verified user |
+| `POST /auth/apple/callback` | anonymous | required | bind verified user |
+| `POST /auth/apple/native` | anonymous | required | bind verified user |
+
+Every operation is unary, carries one non-empty JSON body, and rejects logical
+query fields, generic credentials, or additional logical headers. Initiation
+accepts the existing `{client_id}` shape; existing ignored SDK compatibility
+fields remain tolerated by the application decoder. Callback and native
+success use the same transport-v2 token issuance and immutable user-binding
+path as password login. V2 applies bounded JSON-shape and credential-field
+limits before decoding state or calling an external provider, and callback or
+native operations reserve provider-output working-set capacity before replay
+claim or dispatch.
+
+The public OAuth `state` encoding remains compatible. Its server-side entry is
+additionally tagged as either `LegacyV1` or `TransportV2(session_id)`. A v2
+callback must match both the stored state and the exact attested session that
+initiated the redirect. A v1 callback, or a callback on another v2 session,
+fails without consuming the legitimate continuation. Successful matching is
+still atomic and one-time.
+
+The gateway reserves the anonymous session's authentication transition before
+callback state consumption, provider exchange, or database work. A failed
+callback releases that reservation back to anonymous. A verified callback
+commits the user authority only after its complete logical success response has
+been constructed. The gateway then encrypts it through the same held session
+lease that authenticated the callback request; encryption failure closes the
+newly bound session through the normal gateway rule.
+
+OAuth transport keys are never moved between clients. If the initiating v2
+session is lost or expires while the browser is away, the client establishes a
+new anonymous session and restarts OAuth. It cannot replay the old callback on
+the replacement session. Transport-v1 state storage, callbacks, token issuance,
+and encrypted-body routes retain their existing behavior during migration.
+
+### 8.6 Unary inference projection
 
 The initial unary-inference layer admits exactly these logical operations:
 
@@ -757,7 +802,7 @@ capability PRs. Each PR targets the branch immediately below it:
 8. **Conversations, items, and stored response control**: bounded encrypted
    storage operations and response cancellation/deletion.
 9. **Unary providers and API-key binding**: the exact unary route table in
-   section 8.5, one-time encrypted API-key authority transition, live key-owner
+   section 8.6, one-time encrypted API-key authority transition, live key-owner
    revalidation, and client-random Tinfoil cache namespaces.
 10. **Session-bound user OAuth**: bind OAuth continuation to its originating
     v2 session without exposing credentials outside ciphertext.

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -44,7 +44,20 @@ struct OAuthStateStoreInner {
 #[derive(Debug)]
 struct StoredOAuthState {
     state: OAuthState,
+    binding: OAuthStateBinding,
     expires_at: Instant,
+}
+
+/// Server-only continuation binding for an OAuth authorization round trip.
+///
+/// V1 keeps its existing bearer-independent state semantics. V2 additionally
+/// binds the one-time state to the attested transport session that initiated
+/// the redirect, so copied callback parameters cannot authenticate a different
+/// session and a v1 callback cannot downgrade a v2 continuation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OAuthStateBinding {
+    LegacyV1,
+    TransportV2(Uuid),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
@@ -70,13 +83,46 @@ impl OAuthStateStore {
         csrf_token: &str,
         state: OAuthState,
     ) -> Result<(), OAuthStateCapacityError> {
-        self.store_at(csrf_token, state, Instant::now()).await
+        self.store_with_binding(
+            csrf_token,
+            state,
+            OAuthStateBinding::LegacyV1,
+            Instant::now(),
+        )
+        .await
     }
 
+    async fn store_for_session(
+        &self,
+        csrf_token: &str,
+        state: OAuthState,
+        session_id: Uuid,
+    ) -> Result<(), OAuthStateCapacityError> {
+        self.store_with_binding(
+            csrf_token,
+            state,
+            OAuthStateBinding::TransportV2(session_id),
+            Instant::now(),
+        )
+        .await
+    }
+
+    #[cfg(test)]
     async fn store_at(
         &self,
         csrf_token: &str,
         state: OAuthState,
+        now: Instant,
+    ) -> Result<(), OAuthStateCapacityError> {
+        self.store_with_binding(csrf_token, state, OAuthStateBinding::LegacyV1, now)
+            .await
+    }
+
+    async fn store_with_binding(
+        &self,
+        csrf_token: &str,
+        state: OAuthState,
+        binding: OAuthStateBinding,
         now: Instant,
     ) -> Result<(), OAuthStateCapacityError> {
         let mut inner = self.inner.lock().await;
@@ -92,6 +138,7 @@ impl OAuthStateStore {
             csrf_token.to_string(),
             StoredOAuthState {
                 state,
+                binding,
                 expires_at: now
                     .checked_add(self.ttl)
                     .expect("OAuth state TTL must fit in Instant"),
@@ -101,10 +148,31 @@ impl OAuthStateStore {
     }
 
     async fn consume(&self, state: &OAuthState) -> bool {
-        self.consume_at(state, Instant::now()).await
+        self.consume_with_binding(state, OAuthStateBinding::LegacyV1, Instant::now())
+            .await
     }
 
+    async fn consume_for_session(&self, state: &OAuthState, session_id: Uuid) -> bool {
+        self.consume_with_binding(
+            state,
+            OAuthStateBinding::TransportV2(session_id),
+            Instant::now(),
+        )
+        .await
+    }
+
+    #[cfg(test)]
     async fn consume_at(&self, state: &OAuthState, now: Instant) -> bool {
+        self.consume_with_binding(state, OAuthStateBinding::LegacyV1, now)
+            .await
+    }
+
+    async fn consume_with_binding(
+        &self,
+        state: &OAuthState,
+        binding: OAuthStateBinding,
+        now: Instant,
+    ) -> bool {
         let mut inner = self.inner.lock().await;
         inner
             .entries
@@ -113,7 +181,9 @@ impl OAuthStateStore {
         let matches = inner
             .entries
             .get(&state.csrf_token)
-            .is_some_and(|stored_state| stored_state.state == *state);
+            .is_some_and(|stored_state| {
+                stored_state.state == *state && stored_state.binding == binding
+            });
         if matches {
             inner.entries.remove(&state.csrf_token);
         }
@@ -198,6 +268,27 @@ impl GithubProvider {
 
     pub async fn consume_state(&self, state: &OAuthState) -> bool {
         self.state_store.consume(state).await
+    }
+
+    pub(crate) async fn store_state_for_session(
+        &self,
+        csrf_token: &str,
+        state: OAuthState,
+        session_id: Uuid,
+    ) -> Result<(), OAuthStateCapacityError> {
+        self.state_store
+            .store_for_session(csrf_token, state, session_id)
+            .await
+    }
+
+    pub(crate) async fn consume_state_for_session(
+        &self,
+        state: &OAuthState,
+        session_id: Uuid,
+    ) -> bool {
+        self.state_store
+            .consume_for_session(state, session_id)
+            .await
     }
 
     async fn ensure_provider_exists(
@@ -303,6 +394,27 @@ impl GoogleProvider {
 
     pub async fn consume_state(&self, state: &OAuthState) -> bool {
         self.state_store.consume(state).await
+    }
+
+    pub(crate) async fn store_state_for_session(
+        &self,
+        csrf_token: &str,
+        state: OAuthState,
+        session_id: Uuid,
+    ) -> Result<(), OAuthStateCapacityError> {
+        self.state_store
+            .store_for_session(csrf_token, state, session_id)
+            .await
+    }
+
+    pub(crate) async fn consume_state_for_session(
+        &self,
+        state: &OAuthState,
+        session_id: Uuid,
+    ) -> bool {
+        self.state_store
+            .consume_for_session(state, session_id)
+            .await
     }
 
     async fn ensure_provider_exists(
@@ -415,6 +527,27 @@ impl AppleProvider {
         self.state_store.consume(state).await
     }
 
+    pub(crate) async fn store_state_for_session(
+        &self,
+        csrf_token: &str,
+        state: OAuthState,
+        session_id: Uuid,
+    ) -> Result<(), OAuthStateCapacityError> {
+        self.state_store
+            .store_for_session(csrf_token, state, session_id)
+            .await
+    }
+
+    pub(crate) async fn consume_state_for_session(
+        &self,
+        state: &OAuthState,
+        session_id: Uuid,
+    ) -> bool {
+        self.state_store
+            .consume_for_session(state, session_id)
+            .await
+    }
+
     async fn ensure_provider_exists(
         &self,
         db: Arc<dyn DBConnection + Send + Sync>,
@@ -468,6 +601,13 @@ pub trait OAuthProvider: Send + Sync + 'static {
         state: OAuthState,
     ) -> Result<(), OAuthStateCapacityError>;
     async fn consume_state(&self, state: &OAuthState) -> bool;
+    async fn store_state_for_session(
+        &self,
+        csrf_token: &str,
+        state: OAuthState,
+        session_id: Uuid,
+    ) -> Result<(), OAuthStateCapacityError>;
+    async fn consume_state_for_session(&self, state: &OAuthState, session_id: Uuid) -> bool;
     async fn build_client(
         &self,
         client_id: String,
@@ -518,6 +658,20 @@ impl OAuthProvider for GithubProvider {
         self.consume_state(state).await
     }
 
+    async fn store_state_for_session(
+        &self,
+        csrf_token: &str,
+        state: OAuthState,
+        session_id: Uuid,
+    ) -> Result<(), OAuthStateCapacityError> {
+        self.store_state_for_session(csrf_token, state, session_id)
+            .await
+    }
+
+    async fn consume_state_for_session(&self, state: &OAuthState, session_id: Uuid) -> bool {
+        self.consume_state_for_session(state, session_id).await
+    }
+
     async fn build_client(
         &self,
         client_id: String,
@@ -551,6 +705,20 @@ impl OAuthProvider for GoogleProvider {
         self.consume_state(state).await
     }
 
+    async fn store_state_for_session(
+        &self,
+        csrf_token: &str,
+        state: OAuthState,
+        session_id: Uuid,
+    ) -> Result<(), OAuthStateCapacityError> {
+        self.store_state_for_session(csrf_token, state, session_id)
+            .await
+    }
+
+    async fn consume_state_for_session(&self, state: &OAuthState, session_id: Uuid) -> bool {
+        self.consume_state_for_session(state, session_id).await
+    }
+
     async fn build_client(
         &self,
         client_id: String,
@@ -582,6 +750,20 @@ impl OAuthProvider for AppleProvider {
 
     async fn consume_state(&self, state: &OAuthState) -> bool {
         self.consume_state(state).await
+    }
+
+    async fn store_state_for_session(
+        &self,
+        csrf_token: &str,
+        state: OAuthState,
+        session_id: Uuid,
+    ) -> Result<(), OAuthStateCapacityError> {
+        self.store_state_for_session(csrf_token, state, session_id)
+            .await
+    }
+
+    async fn consume_state_for_session(&self, state: &OAuthState, session_id: Uuid) -> bool {
+        self.consume_state_for_session(state, session_id).await
     }
 
     async fn build_client(
@@ -714,6 +896,61 @@ mod tests {
 
         assert!(!store.consume_at(&mismatched, now).await);
         assert!(store.consume_at(&valid, now).await);
+    }
+
+    #[tokio::test]
+    async fn oauth_state_protocol_and_v2_session_binding_are_non_consuming_on_mismatch() {
+        let store = OAuthStateStore::with_limits(Duration::from_secs(60), 2);
+        let now = Instant::now();
+        let v2_state = state("v2-state", 1);
+        let initiating_session = Uuid::from_u128(10);
+        let other_session = Uuid::from_u128(11);
+
+        store
+            .store_with_binding(
+                &v2_state.csrf_token,
+                v2_state.clone(),
+                OAuthStateBinding::TransportV2(initiating_session),
+                now,
+            )
+            .await
+            .unwrap();
+
+        assert!(!store.consume_at(&v2_state, now).await);
+        assert!(
+            !store
+                .consume_with_binding(
+                    &v2_state,
+                    OAuthStateBinding::TransportV2(other_session),
+                    now,
+                )
+                .await
+        );
+        assert!(
+            store
+                .consume_with_binding(
+                    &v2_state,
+                    OAuthStateBinding::TransportV2(initiating_session),
+                    now,
+                )
+                .await
+        );
+
+        let v1_state = state("v1-state", 2);
+        store
+            .store_at(&v1_state.csrf_token, v1_state.clone(), now)
+            .await
+            .unwrap();
+        assert!(
+            !store
+                .consume_with_binding(
+                    &v1_state,
+                    OAuthStateBinding::TransportV2(initiating_session),
+                    now,
+                )
+                .await
+        );
+        assert!(store.consume_at(&v1_state, now).await);
     }
 
     #[tokio::test]

--- a/src/security_invariants.rs
+++ b/src/security_invariants.rs
@@ -681,8 +681,10 @@ fn oauth_login_uses_verified_project_scoped_subject_and_pre_token_unwrap() {
     let shared_oauth_body =
         extract_function_body(&contents, "async fn find_or_create_user_from_oauth");
     let authenticated_body = extract_function_body(&contents, "fn authenticated_oauth_user");
-    let apple_native_body =
+    let apple_native_handler =
         extract_function_body(&contents, "pub async fn handle_apple_native_signin");
+    let apple_native_body =
+        extract_function_body(&contents, "pub(crate) async fn apple_native_authenticate");
 
     for required_pattern in [
         "get_project_user_oauth_connection_by_provider_subject(",
@@ -713,14 +715,28 @@ fn oauth_login_uses_verified_project_scoped_subject_and_pre_token_unwrap() {
         "apple_provider.id",
         "&verified_user_id",
         "project.id",
-        "update_provider_connection(&app_state, &connection, &access_token)",
-        "authenticated_oauth_user(&app_state, user, \"apple\", &verified_user_id)",
+        "update_provider_connection(app_state, &connection, &access_token)",
+        "authenticated_oauth_user(app_state, user, \"apple\", &verified_user_id)",
     ] {
         assert!(
             apple_native_body.contains(required_pattern),
             "Apple native OAuth flow must contain `{required_pattern}`"
         );
     }
+
+    let authenticate = apple_native_handler
+        .find("apple_native_authenticate(")
+        .expect("Apple native v1 handler must authenticate before issuing tokens");
+    let issue_tokens = apple_native_handler
+        .find("oauth_callback_response(")
+        .expect("Apple native v1 handler must issue legacy tokens");
+    let encrypt = apple_native_handler
+        .find("encrypt_response(")
+        .expect("Apple native v1 handler must encrypt its token response");
+    assert!(
+        authenticate < issue_tokens && issue_tokens < encrypt,
+        "Apple native v1 handler must authenticate, issue legacy tokens, and then encrypt"
+    );
 }
 
 #[test]

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -32,6 +32,10 @@ use crate::web::login_routes::{
     authenticate_login, logout_data, register_and_authenticate, verify_email_data, AuthResponse,
     Credentials, LogoutRequest, RefreshResponse, RegisterCredentials,
 };
+use crate::web::oauth_routes::{
+    apple_native_authenticate, initiate_oauth_data, oauth_callback_authenticate,
+    AppleNativeSignInRequest, OAuthAuthRequest, OAuthCallbackRequest,
+};
 use crate::web::openai::{
     openai_embeddings_v2_data, openai_model_catalog_data, openai_models_v2_data,
     openai_nonstream_chat_completion_v2_data, openai_transcription_v2_data, openai_tts_v2_data,
@@ -118,6 +122,10 @@ const MAX_V2_KV_LIST_ROWS: usize = 65_536;
 const MAX_V2_API_KEY_LIST_ROWS: usize = 65_536;
 const MAX_CONVERSATION_JSON_DEPTH: usize = 64;
 const MAX_CONVERSATION_JSON_STRUCTURAL_TOKENS: usize = 131_072;
+const MAX_OAUTH_STATE_BYTES: usize = 4 * 1024;
+const MAX_OAUTH_CODE_BYTES: usize = 16 * 1024;
+const MAX_APPLE_IDENTITY_TOKEN_BYTES: usize = 64 * 1024;
+const MAX_APPLE_OPTIONAL_FIELD_BYTES: usize = 4 * 1024;
 
 type SensitiveBytes = Zeroizing<Vec<u8>>;
 
@@ -146,6 +154,19 @@ pub(crate) enum UserOperation {
         credential: SensitiveBytes,
         cache_namespace_root: CacheNamespaceRoot,
     },
+    OAuthInitiate {
+        provider: OAuthProviderName,
+        body: SensitiveBytes,
+    },
+    OAuthCallback {
+        provider: OAuthProviderName,
+        body: SensitiveBytes,
+        cache_namespace_root: CacheNamespaceRoot,
+    },
+    AppleNativeOAuth {
+        body: SensitiveBytes,
+        cache_namespace_root: CacheNamespaceRoot,
+    },
     VerifyEmail {
         code: uuid::Uuid,
     },
@@ -164,6 +185,23 @@ pub(crate) enum UserOperation {
         authority: InferenceAuthority,
         operation: InferenceOperation,
     },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum OAuthProviderName {
+    Github,
+    Google,
+    Apple,
+}
+
+impl OAuthProviderName {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Github => "github",
+            Self::Google => "google",
+            Self::Apple => "apple",
+        }
+    }
 }
 
 pub(crate) enum InferenceOperation {
@@ -358,6 +396,8 @@ impl UserOperation {
             Self::Login { .. }
                 | Self::Register { .. }
                 | Self::Resume { .. }
+                | Self::OAuthCallback { .. }
+                | Self::AppleNativeOAuth { .. }
                 | Self::Inference {
                     authority: InferenceAuthority::AuthenticateApiKey { .. },
                     ..
@@ -366,7 +406,10 @@ impl UserOperation {
     }
 
     pub(crate) const fn requires_provider_output_reservation(&self) -> bool {
-        matches!(self, Self::Inference { .. })
+        matches!(
+            self,
+            Self::Inference { .. } | Self::OAuthCallback { .. } | Self::AppleNativeOAuth { .. }
+        )
     }
 
     pub(crate) const fn requires_stored_output_reservation(&self) -> bool {
@@ -716,6 +759,13 @@ pub(crate) fn prepare_user_operation(
         Login,
         Register,
         Resume,
+        GithubOAuthInitiate,
+        GithubOAuthCallback,
+        GoogleOAuthInitiate,
+        GoogleOAuthCallback,
+        AppleOAuthInitiate,
+        AppleOAuthCallback,
+        AppleNativeOAuth,
         VerifyEmail,
         GetUser,
         RequestVerification,
@@ -828,6 +878,13 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Post, "/login") => Some(Route::Login),
         (LogicalMethod::Post, "/register") => Some(Route::Register),
         (LogicalMethod::Post, "/refresh") => Some(Route::Resume),
+        (LogicalMethod::Post, "/auth/github") => Some(Route::GithubOAuthInitiate),
+        (LogicalMethod::Post, "/auth/github/callback") => Some(Route::GithubOAuthCallback),
+        (LogicalMethod::Post, "/auth/google") => Some(Route::GoogleOAuthInitiate),
+        (LogicalMethod::Post, "/auth/google/callback") => Some(Route::GoogleOAuthCallback),
+        (LogicalMethod::Post, "/auth/apple") => Some(Route::AppleOAuthInitiate),
+        (LogicalMethod::Post, "/auth/apple/callback") => Some(Route::AppleOAuthCallback),
+        (LogicalMethod::Post, "/auth/apple/native") => Some(Route::AppleNativeOAuth),
         (LogicalMethod::Get, _) if verification_code.is_some() => Some(Route::VerifyEmail),
         (LogicalMethod::Get, "/protected/user") => Some(Route::GetUser),
         (LogicalMethod::Post, "/protected/request_verification") => {
@@ -977,6 +1034,10 @@ pub(crate) fn prepare_user_operation(
             Route::Login
                 | Route::Register
                 | Route::Resume
+                | Route::GithubOAuthCallback
+                | Route::GoogleOAuthCallback
+                | Route::AppleOAuthCallback
+                | Route::AppleNativeOAuth
                 | Route::ModelCatalog
                 | Route::ChatCompletions
                 | Route::TextToSpeech
@@ -1054,6 +1115,123 @@ pub(crate) fn prepare_user_operation(
                 credential: Zeroizing::new(value_base64.into_bytes()),
                 cache_namespace_root,
             })
+        }
+        Route::GithubOAuthInitiate | Route::GoogleOAuthInitiate | Route::AppleOAuthInitiate => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            match authority {
+                AuthorityState::Anonymous => {}
+                AuthorityState::Bound(_) => {
+                    return OperationPreparation::Rejected(authentication_start_error(
+                        AuthenticationStartError::AlreadyBound,
+                    ));
+                }
+                AuthorityState::Authenticating(_) => {
+                    return OperationPreparation::Rejected(authentication_start_error(
+                        AuthenticationStartError::AuthenticationInProgress,
+                    ));
+                }
+                AuthorityState::Closing => {
+                    return OperationPreparation::Rejected(authentication_start_error(
+                        AuthenticationStartError::Closing,
+                    ));
+                }
+            }
+            let provider = match route {
+                Route::GithubOAuthInitiate => OAuthProviderName::Github,
+                Route::GoogleOAuthInitiate => OAuthProviderName::Google,
+                Route::AppleOAuthInitiate => OAuthProviderName::Apple,
+                _ => unreachable!("OAuth initiation route group is exhaustive"),
+            };
+            OperationPreparation::Ready(UserOperation::OAuthInitiate {
+                provider,
+                body: Zeroizing::new(
+                    request
+                        .body_base64
+                        .expect("validated OAuth initiation body")
+                        .into_bytes(),
+                ),
+            })
+        }
+        Route::GithubOAuthCallback
+        | Route::GoogleOAuthCallback
+        | Route::AppleOAuthCallback
+        | Route::AppleNativeOAuth => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            match authority {
+                AuthorityState::Anonymous => {}
+                AuthorityState::Bound(_) => {
+                    return OperationPreparation::Rejected(authentication_start_error(
+                        AuthenticationStartError::AlreadyBound,
+                    ));
+                }
+                AuthorityState::Authenticating(_) => {
+                    return OperationPreparation::Rejected(authentication_start_error(
+                        AuthenticationStartError::AuthenticationInProgress,
+                    ));
+                }
+                AuthorityState::Closing => {
+                    return OperationPreparation::Rejected(authentication_start_error(
+                        AuthenticationStartError::Closing,
+                    ));
+                }
+            }
+            let Some(cache_namespace_root) = cache_namespace_root_base64 else {
+                return rejected_bad_request();
+            };
+            let body = Zeroizing::new(
+                request
+                    .body_base64
+                    .expect("validated OAuth callback body")
+                    .into_bytes(),
+            );
+            match route {
+                Route::GithubOAuthCallback => {
+                    OperationPreparation::Ready(UserOperation::OAuthCallback {
+                        provider: OAuthProviderName::Github,
+                        body,
+                        cache_namespace_root,
+                    })
+                }
+                Route::GoogleOAuthCallback => {
+                    OperationPreparation::Ready(UserOperation::OAuthCallback {
+                        provider: OAuthProviderName::Google,
+                        body,
+                        cache_namespace_root,
+                    })
+                }
+                Route::AppleOAuthCallback => {
+                    OperationPreparation::Ready(UserOperation::OAuthCallback {
+                        provider: OAuthProviderName::Apple,
+                        body,
+                        cache_namespace_root,
+                    })
+                }
+                Route::AppleNativeOAuth => {
+                    OperationPreparation::Ready(UserOperation::AppleNativeOAuth {
+                        body,
+                        cache_namespace_root,
+                    })
+                }
+                _ => unreachable!("OAuth callback route group is exhaustive"),
+            }
         }
         Route::VerifyEmail => {
             if credential.is_some()
@@ -2048,6 +2226,84 @@ pub(crate) async fn execute_user_operation(
                 authentication.expect("resumption requires authentication reservation"),
                 monotonic_now,
                 UserAuthResponseKind::Refresh,
+                cache_namespace_root,
+            )
+        }
+        UserOperation::OAuthInitiate { provider, body } => {
+            debug_assert!(authentication.is_none());
+            let request = match parse_provider_json_body::<OAuthAuthRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            let response = match initiate_oauth_data(
+                &app_state,
+                request,
+                provider.as_str(),
+                Some(lease.state().session_id()),
+            )
+            .await
+            .and_then(|value| LogicalUnaryResponse::json(StatusCode::OK, &value))
+            {
+                Ok(response) => response,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            ApplicationOutcome::success(response, SessionEffect::Retain)
+        }
+        UserOperation::OAuthCallback {
+            provider,
+            body,
+            cache_namespace_root,
+        } => {
+            let request = match parse_provider_json_body::<OAuthCallbackRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            if let Err(error) = validate_oauth_callback_request(&request) {
+                return ApplicationOutcome::error(error);
+            }
+            let verified = match oauth_callback_authenticate(
+                &app_state,
+                request,
+                provider.as_str(),
+                Some(lease.state().session_id()),
+            )
+            .await
+            {
+                Ok(verified) => verified,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            finish_user_binding(
+                &app_state,
+                &lease,
+                verified,
+                authentication.expect("OAuth callback requires authentication reservation"),
+                monotonic_now,
+                UserAuthResponseKind::Login,
+                cache_namespace_root,
+            )
+        }
+        UserOperation::AppleNativeOAuth {
+            body,
+            cache_namespace_root,
+        } => {
+            let request = match parse_provider_json_body::<AppleNativeSignInRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            if let Err(error) = validate_apple_native_request(&request) {
+                return ApplicationOutcome::error(error);
+            }
+            let verified = match apple_native_authenticate(&app_state, request).await {
+                Ok(verified) => verified,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            finish_user_binding(
+                &app_state,
+                &lease,
+                verified,
+                authentication.expect("Apple native OAuth requires authentication reservation"),
+                monotonic_now,
+                UserAuthResponseKind::Login,
                 cache_namespace_root,
             )
         }
@@ -4045,6 +4301,36 @@ fn parse_provider_json_body<T: DeserializeOwned>(body: SensitiveBytes) -> Result
         Err(JsonShapeError::TooLarge) => Err(ApiError::PayloadTooLarge),
         Err(JsonShapeError::Malformed) => Err(ApiError::BadRequest),
     }
+}
+
+fn validate_oauth_callback_request(request: &OAuthCallbackRequest) -> Result<(), ApiError> {
+    if request.code.is_empty() || request.state.is_empty() {
+        return Err(ApiError::BadRequest);
+    }
+    if request.code.len() > MAX_OAUTH_CODE_BYTES || request.state.len() > MAX_OAUTH_STATE_BYTES {
+        return Err(ApiError::PayloadTooLarge);
+    }
+    Ok(())
+}
+
+fn validate_apple_native_request(request: &AppleNativeSignInRequest) -> Result<(), ApiError> {
+    let oversized_optional_field = [
+        request.user_identifier.as_deref(),
+        request.email.as_deref(),
+        request.given_name.as_deref(),
+        request.family_name.as_deref(),
+        request.nonce.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .any(|value| value.len() > MAX_APPLE_OPTIONAL_FIELD_BYTES);
+    if request.identity_token.is_empty() {
+        return Err(ApiError::BadRequest);
+    }
+    if request.identity_token.len() > MAX_APPLE_IDENTITY_TOKEN_BYTES || oversized_optional_field {
+        return Err(ApiError::PayloadTooLarge);
+    }
+    Ok(())
 }
 
 fn parse_logical_query<T: DeserializeOwned>(query: Option<String>) -> Result<T, ApiError> {
@@ -6635,6 +6921,204 @@ mod tests {
             OperationPreparation::Unsupported => panic!("expected a classified rejection"),
             OperationPreparation::Ready(_) => panic!("expected the request to be rejected"),
         }
+    }
+
+    fn oauth_envelope(path: &str, body: &[u8], with_cache_root: bool) -> RequestEnvelope {
+        let mut request = envelope(LogicalMethod::Post, path, json_header(), Some(body), None);
+        if with_cache_root {
+            request.cache_namespace_root_base64 = Some(CacheNamespaceRoot::from_bytes([0xa5; 32]));
+        }
+        request
+    }
+
+    #[test]
+    fn exact_seven_route_oauth_matrix_is_session_bound_at_callback() {
+        let initiate_body =
+            br#"{"client_id":"00000000-0000-0000-0000-000000000000","invite_code":"ignored"}"#;
+        for (path, expected_provider) in [
+            ("/auth/github", OAuthProviderName::Github),
+            ("/auth/google", OAuthProviderName::Google),
+            ("/auth/apple", OAuthProviderName::Apple),
+        ] {
+            let OperationPreparation::Ready(operation) = prepare_user_operation(
+                oauth_envelope(path, initiate_body, false),
+                AuthorityState::Anonymous,
+            ) else {
+                panic!("OAuth initiation route {path} must be admitted");
+            };
+            assert!(matches!(
+                &operation,
+                UserOperation::OAuthInitiate { provider, .. }
+                    if *provider == expected_provider
+            ));
+            assert!(!operation.requires_authentication_transition());
+            assert!(!operation.requires_provider_output_reservation());
+        }
+
+        let callback_body = br#"{"code":"code","state":"state"}"#;
+        for (path, expected_provider) in [
+            ("/auth/github/callback", OAuthProviderName::Github),
+            ("/auth/google/callback", OAuthProviderName::Google),
+            ("/auth/apple/callback", OAuthProviderName::Apple),
+        ] {
+            let OperationPreparation::Ready(operation) = prepare_user_operation(
+                oauth_envelope(path, callback_body, true),
+                AuthorityState::Anonymous,
+            ) else {
+                panic!("OAuth callback route {path} must be admitted");
+            };
+            assert!(matches!(
+                &operation,
+                UserOperation::OAuthCallback { provider, .. }
+                    if *provider == expected_provider
+            ));
+            assert!(operation.requires_authentication_transition());
+            assert!(operation.requires_provider_output_reservation());
+        }
+
+        let native_body =
+            br#"{"identity_token":"token","client_id":"00000000-0000-0000-0000-000000000000"}"#;
+        let OperationPreparation::Ready(operation) = prepare_user_operation(
+            oauth_envelope("/auth/apple/native", native_body, true),
+            AuthorityState::Anonymous,
+        ) else {
+            panic!("Apple native OAuth route must be admitted");
+        };
+        assert!(matches!(&operation, UserOperation::AppleNativeOAuth { .. }));
+        assert!(operation.requires_authentication_transition());
+        assert!(operation.requires_provider_output_reservation());
+
+        assert!(serde_json::from_slice::<OAuthAuthRequest>(initiate_body).is_ok());
+    }
+
+    #[test]
+    fn oauth_projection_rejects_transplants_and_noncanonical_shapes() {
+        let callback_body = br#"{"code":"code","state":"state"}"#;
+        let initiation_body = br#"{"client_id":"00000000-0000-0000-0000-000000000000"}"#;
+
+        assert_eq!(
+            rejected_status(prepare_user_operation(
+                oauth_envelope("/auth/github/callback", callback_body, false),
+                AuthorityState::Anonymous,
+            )),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            rejected_status(prepare_user_operation(
+                oauth_envelope("/auth/github", initiation_body, true),
+                AuthorityState::Anonymous,
+            )),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            rejected_status(prepare_user_operation(
+                oauth_envelope("/auth/github", initiation_body, false),
+                bound_user_authority(),
+            )),
+            StatusCode::CONFLICT
+        );
+        assert_eq!(
+            rejected_status(prepare_user_operation(
+                oauth_envelope("/auth/github/callback", callback_body, true),
+                bound_user_authority(),
+            )),
+            StatusCode::CONFLICT
+        );
+
+        let mut with_query = oauth_envelope("/auth/google/callback", callback_body, true);
+        with_query.request.query = Some("next=elsewhere".to_owned());
+        assert_eq!(
+            rejected_status(prepare_user_operation(
+                with_query,
+                AuthorityState::Anonymous
+            )),
+            StatusCode::BAD_REQUEST
+        );
+
+        let mut with_credential = oauth_envelope("/auth/apple/native", callback_body, true);
+        with_credential.credential = Some(Credential::Resumption {
+            value_base64: EncodedBytes::from_bytes(b"copied".to_vec()),
+        });
+        assert_eq!(
+            rejected_status(prepare_user_operation(
+                with_credential,
+                AuthorityState::Anonymous
+            )),
+            StatusCode::BAD_REQUEST
+        );
+
+        let mut streaming = oauth_envelope("/auth/apple/callback", callback_body, true);
+        streaming.response_mode = ResponseMode::Stream;
+        assert_eq!(
+            rejected_status(prepare_user_operation(streaming, AuthorityState::Anonymous)),
+            StatusCode::BAD_REQUEST
+        );
+
+        let trailing_slash = oauth_envelope("/auth/github/", initiation_body, false);
+        assert!(matches!(
+            prepare_user_operation(trailing_slash, AuthorityState::Anonymous),
+            OperationPreparation::Unsupported
+        ));
+        let wrong_method = envelope(LogicalMethod::Get, "/auth/github", Vec::new(), None, None);
+        assert!(matches!(
+            prepare_user_operation(wrong_method, AuthorityState::Anonymous),
+            OperationPreparation::Unsupported
+        ));
+    }
+
+    #[test]
+    fn oauth_callback_controlled_fields_are_bounded_before_provider_work() {
+        let valid_callback = OAuthCallbackRequest {
+            code: "code".to_owned(),
+            state: "state".to_owned(),
+        };
+        assert!(validate_oauth_callback_request(&valid_callback).is_ok());
+        assert!(matches!(
+            validate_oauth_callback_request(&OAuthCallbackRequest {
+                code: String::new(),
+                state: "state".to_owned(),
+            }),
+            Err(ApiError::BadRequest)
+        ));
+        assert!(matches!(
+            validate_oauth_callback_request(&OAuthCallbackRequest {
+                code: "code".to_owned(),
+                state: "s".repeat(MAX_OAUTH_STATE_BYTES + 1),
+            }),
+            Err(ApiError::PayloadTooLarge)
+        ));
+
+        let valid_native = AppleNativeSignInRequest {
+            identity_token: "token".to_owned(),
+            user_identifier: None,
+            email: None,
+            given_name: None,
+            family_name: None,
+            client_id: uuid::Uuid::nil(),
+            nonce: None,
+        };
+        assert!(validate_apple_native_request(&valid_native).is_ok());
+        assert!(matches!(
+            validate_apple_native_request(&AppleNativeSignInRequest {
+                identity_token: String::new(),
+                ..valid_native.clone()
+            }),
+            Err(ApiError::BadRequest)
+        ));
+        assert!(matches!(
+            validate_apple_native_request(&AppleNativeSignInRequest {
+                identity_token: "t".repeat(MAX_APPLE_IDENTITY_TOKEN_BYTES + 1),
+                ..valid_native.clone()
+            }),
+            Err(ApiError::PayloadTooLarge)
+        ));
+        assert!(matches!(
+            validate_apple_native_request(&AppleNativeSignInRequest {
+                nonce: Some("n".repeat(MAX_APPLE_OPTIONAL_FIELD_BYTES + 1)),
+                ..valid_native
+            }),
+            Err(ApiError::PayloadTooLarge)
+        ));
     }
 
     #[test]

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -3,7 +3,7 @@ pub mod audio_utils;
 pub mod encryption_middleware;
 mod health_routes;
 pub mod login_routes;
-mod oauth_routes;
+pub(crate) mod oauth_routes;
 pub(crate) mod openai;
 pub mod openai_auth;
 pub mod platform;

--- a/src/web/oauth_routes.rs
+++ b/src/web/oauth_routes.rs
@@ -15,12 +15,12 @@ use crate::GoogleProvider;
 use crate::{decrypt_with_key, private_key::generate_twelve_word_seed};
 use crate::{encrypt, DBError};
 use crate::{
-    jwt::{AuthContext, NewToken, TokenType},
+    jwt::{NewToken, TokenType},
     models::{
         project_settings::OAuthProviderSettings,
         users::{NewUser, User},
     },
-    ApiError, AppState,
+    ApiError, AppState, VerifiedUserAuthentication,
 };
 use axum::{
     extract::{Extension, State},
@@ -128,11 +128,6 @@ pub struct OAuthCallbackResponse {
     email: String,
     access_token: String,
     refresh_token: String,
-}
-
-struct AuthenticatedOAuthUser {
-    user: User,
-    auth_context: AuthContext,
 }
 
 #[derive(Deserialize, Clone)]
@@ -426,6 +421,16 @@ pub async fn initiate_oauth(
     Extension(session_id): Extension<TransportSession>,
     provider_name: &str,
 ) -> Result<Json<EncryptedResponse<OAuthOAuthCallbackResponse>>, ApiError> {
+    let response = initiate_oauth_data(&app_state, auth_request, provider_name, None).await?;
+    encrypt_response(&app_state, &session_id, &response).await
+}
+
+pub(crate) async fn initiate_oauth_data(
+    app_state: &Arc<AppState>,
+    auth_request: OAuthAuthRequest,
+    provider_name: &str,
+    v2_session_id: Option<Uuid>,
+) -> Result<OAuthOAuthCallbackResponse, ApiError> {
     // Get project
     let project = app_state
         .db
@@ -433,7 +438,7 @@ pub async fn initiate_oauth(
         .map_err(|_| ApiError::BadRequest)?;
 
     // Get OAuth client for this project
-    let oauth_client = get_project_oauth_client(&app_state, project.id, provider_name).await?;
+    let oauth_client = get_project_oauth_client(app_state, project.id, provider_name).await?;
 
     // Get the OAuth provider
     let oauth_provider = app_state
@@ -454,10 +459,19 @@ pub async fn initiate_oauth(
     };
 
     // Store the complete state in the provider
-    oauth_provider
-        .store_state(csrf_token.secret(), state.clone())
-        .await
-        .map_err(|_| ApiError::TooManyRequests)?;
+    match v2_session_id {
+        Some(session_id) => {
+            oauth_provider
+                .store_state_for_session(csrf_token.secret(), state.clone(), session_id)
+                .await
+        }
+        None => {
+            oauth_provider
+                .store_state(csrf_token.secret(), state.clone())
+                .await
+        }
+    }
+    .map_err(|_| ApiError::TooManyRequests)?;
 
     let state_json = serde_json::to_string(&state).map_err(|_| ApiError::InternalServerError)?;
     let state_base64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(state_json);
@@ -465,11 +479,10 @@ pub async fn initiate_oauth(
     // Replace the CSRF token in the URL with our encoded state
     let auth_url = initial_url.replace(csrf_token.secret(), &state_base64);
 
-    let response = OAuthOAuthCallbackResponse {
+    Ok(OAuthOAuthCallbackResponse {
         auth_url,
         state: state_base64,
-    };
-    encrypt_response(&app_state, &session_id, &response).await
+    })
 }
 
 pub async fn oauth_callback(
@@ -484,6 +497,18 @@ pub async fn oauth_callback(
     );
     debug!("Received state: {}", callback_request.state);
 
+    let authenticated_user =
+        oauth_callback_authenticate(&app_state, callback_request, provider_name, None).await?;
+    let auth_response = oauth_callback_response(&app_state, &authenticated_user)?;
+    encrypt_response(&app_state, &session_id, &auth_response).await
+}
+
+pub(crate) async fn oauth_callback_authenticate(
+    app_state: &Arc<AppState>,
+    callback_request: OAuthCallbackRequest,
+    provider_name: &str,
+    v2_session_id: Option<Uuid>,
+) -> Result<VerifiedUserAuthentication, ApiError> {
     // Decode and parse the state
     let state_json = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .decode(&callback_request.state)
@@ -509,7 +534,14 @@ pub async fn oauth_callback(
 
     // Validate and atomically consume the complete state so a successful match is one-time.
     // A mismatched state is left in the store for the legitimate callback.
-    let is_valid = oauth_provider.consume_state(&state).await;
+    let is_valid = match v2_session_id {
+        Some(session_id) => {
+            oauth_provider
+                .consume_state_for_session(&state, session_id)
+                .await
+        }
+        None => oauth_provider.consume_state(&state).await,
+    };
 
     if !is_valid {
         error!("Invalid state in {} callback", provider_name);
@@ -530,7 +562,7 @@ pub async fn oauth_callback(
         })?;
 
     // Get OAuth client for this project
-    let oauth_client = get_project_oauth_client(&app_state, project.id, provider_name).await?;
+    let oauth_client = get_project_oauth_client(app_state, project.id, provider_name).await?;
 
     // Exchange the code for an access token
     debug!(
@@ -785,7 +817,7 @@ pub async fn oauth_callback(
             };
 
             find_or_create_user_from_oauth(
-                &app_state,
+                app_state,
                 github_user.email.clone(),
                 github_user.id.to_string(),
                 "github",
@@ -814,7 +846,7 @@ pub async fn oauth_callback(
             };
 
             find_or_create_user_from_oauth(
-                &app_state,
+                app_state,
                 Some(google_user.email.clone()),
                 google_user.sub.clone(),
                 "google",
@@ -869,7 +901,7 @@ pub async fn oauth_callback(
             })?;
 
             // Verify the token just like we do for native sign-in
-            let apple_user = match fetch_apple_user(&app_state, &id_token, &client_id).await {
+            let apple_user = match fetch_apple_user(app_state, &id_token, &client_id).await {
                 Ok(user) => {
                     debug!("Successfully verified Apple ID token");
                     user
@@ -888,7 +920,7 @@ pub async fn oauth_callback(
                 .unwrap_or_else(|| "".to_string());
 
             find_or_create_user_from_oauth(
-                &app_state,
+                app_state,
                 apple_user.email.clone(),
                 sub,
                 "apple",
@@ -904,8 +936,7 @@ pub async fn oauth_callback(
         }
     };
 
-    let auth_response = oauth_callback_response(&app_state, &authenticated_user)?;
-    encrypt_response(&app_state, &session_id, &auth_response).await
+    Ok(authenticated_user)
 }
 
 async fn fetch_github_user(
@@ -1104,7 +1135,7 @@ fn authenticated_oauth_user(
     user: User,
     provider_name: &str,
     provider_user_id: &str,
-) -> Result<AuthenticatedOAuthUser, ApiError> {
+) -> Result<VerifiedUserAuthentication, ApiError> {
     let auth_context = app_state
         .oauth_auth_context_for_user(&user, provider_name, provider_user_id)
         .map_err(|e| {
@@ -1119,12 +1150,12 @@ fn authenticated_oauth_user(
             ApiError::Unauthorized
         })?;
 
-    Ok(AuthenticatedOAuthUser { user, auth_context })
+    Ok(VerifiedUserAuthentication { user, auth_context })
 }
 
 fn oauth_callback_response(
     app_state: &AppState,
-    authenticated_user: &AuthenticatedOAuthUser,
+    authenticated_user: &VerifiedUserAuthentication,
 ) -> Result<OAuthCallbackResponse, ApiError> {
     let access_token = NewToken::new_with_auth_context(
         &authenticated_user.user,
@@ -1167,7 +1198,7 @@ async fn find_or_create_user_from_oauth(
     access_token: String,
     user_name: Option<String>,
     project_id: i32,
-) -> Result<AuthenticatedOAuthUser, ApiError> {
+) -> Result<VerifiedUserAuthentication, ApiError> {
     let provider = app_state
         .db
         .get_oauth_provider_by_name(provider_name)
@@ -1285,6 +1316,15 @@ pub async fn handle_apple_native_signin(
 ) -> Result<Json<EncryptedResponse<OAuthCallbackResponse>>, ApiError> {
     debug!("Handling Apple native sign-in");
 
+    let authenticated_user = apple_native_authenticate(&app_state, request).await?;
+    let auth_response = oauth_callback_response(&app_state, &authenticated_user)?;
+    encrypt_response(&app_state, &session_id, &auth_response).await
+}
+
+pub(crate) async fn apple_native_authenticate(
+    app_state: &Arc<AppState>,
+    request: AppleNativeSignInRequest,
+) -> Result<VerifiedUserAuthentication, ApiError> {
     // Get project
     let project = app_state
         .db
@@ -1379,14 +1419,13 @@ pub async fn handle_apple_native_signin(
             return Err(ApiError::Unauthorized);
         }
 
-        update_provider_connection(&app_state, &connection, &access_token).await?;
+        update_provider_connection(app_state, &connection, &access_token).await?;
 
         let authenticated_user =
-            authenticated_oauth_user(&app_state, user, "apple", &verified_user_id)?;
-        let auth_response = oauth_callback_response(&app_state, &authenticated_user)?;
+            authenticated_oauth_user(app_state, user, "apple", &verified_user_id)?;
 
         debug!("Apple sign-in successful for existing user");
-        return encrypt_response(&app_state, &session_id, &auth_response).await;
+        return Ok(authenticated_user);
     }
 
     // If we get here, user doesn't exist - need to create new user
@@ -1441,7 +1480,7 @@ pub async fn handle_apple_native_signin(
 
     // Create the new user
     let authenticated_user = find_or_create_user_from_oauth(
-        &app_state,
+        app_state,
         Some(email),
         verified_user_id,
         "apple",
@@ -1451,10 +1490,8 @@ pub async fn handle_apple_native_signin(
     )
     .await?;
 
-    let auth_response = oauth_callback_response(&app_state, &authenticated_user)?;
-
     debug!("Apple native sign-in successful for new user");
-    encrypt_response(&app_state, &session_id, &auth_response).await
+    Ok(authenticated_user)
 }
 
 async fn update_provider_connection(


### PR DESCRIPTION
## Summary

- preserve every existing `/v1` GitHub, Google, and Apple OAuth route while extracting transport-neutral authentication helpers
- tag stored OAuth continuation state as `LegacyV1` or `TransportV2(session_id)` so a copied callback cannot bind a different attested session or cross protocol versions
- project exactly seven OAuth operations through the v2 envelope, with callback/native authentication reservations, client-random cache namespace roots, bounded provider work, and the existing v2 user-binding/token path

## Security properties

- wrong-session and v1/v2 state mismatches fail without consuming the legitimate continuation
- callback/native reserve authority transition and provider working-set capacity before state consumption, provider exchange, or database work
- successful callback responses are encrypted through the same held session lease; failure after binding closes the session
- callback-controlled state, code, Apple token, and optional fields are bounded only in v2 before decode or external work
- losing the initiating v2 session requires restarting OAuth; transport keys are never transferred

## Compatibility

- `/v1` state, provider flow, token issuance, encryption, and response shapes remain unchanged
- initiation continues to tolerate existing ignored SDK compatibility fields
- no database migration and no SDK cutover in this PR

## Validation

- exact Rust CI parity: fmt, warning-strict all-target/all-feature clippy, 600 passed / 34 expected ignored / 0 failed
- disposable PostgreSQL: all migrations, 26 AEAD/database tests, and 2 OAuth database tests passed with no skips
- focused OAuth state, route matrix, field-bound, and security-invariant tests passed
- old TypeScript SDK: v1 signup/login/user-data and encrypt/decrypt passed
- old Rust SDK: v1 models and catalog passed
- no live OAuth provider or paid inference call was made

Stacked on #332.