### PR TITLE
Transport v2: bind platform authentication and lifecycle

### DIFF
--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -567,6 +567,55 @@ error bodies never enter enclave logs. These are v2-only admission rules;
 transport v1 retains its existing limits, concurrency, retry behavior, error
 logging, and provider-cache derivation.
 
+### 8.7 Password recovery and platform authentication lifecycle
+
+Transport v2 completes the anonymous password-recovery paths needed by a
+v2-only SDK and establishes a distinct platform authority before projecting
+the larger organization control plane:
+
+| Logical operation | Authority before request | Generic credential | Success effect |
+| --- | --- | --- | --- |
+| `POST /password-reset/request` | anonymous | none | retain anonymous |
+| `POST /password-reset/confirm` | anonymous | none | retain anonymous |
+| `POST /platform/login` | anonymous | none | bind platform user |
+| `POST /platform/register` | anonymous | none | bind platform user |
+| `POST /platform/refresh` | anonymous | platform resumption | bind platform user |
+| `GET /platform/verify-email/{code}` | anonymous or same-kind platform binding | none | retain authority |
+| `POST /platform/password-reset/request` | anonymous | none | retain anonymous |
+| `POST /platform/password-reset/confirm` | anonymous | none | retain anonymous |
+| `POST /platform/logout` | bound platform user | none | close exact session |
+| `POST /platform/request_verification` | bound platform user | none | retain binding |
+| `POST /platform/change-password` | bound platform user | none | close exact session |
+
+Except for refresh, bodyful operations retain their existing logical JSON
+shapes. Platform refresh carries no logical body or header: its v2-only
+resumption secret is the envelope credential. Every platform transition
+requires `cache_namespace_root_base64: null`; a platform session never obtains
+a provider-cache namespace.
+
+Platform access-descriptor and resumption tokens use distinct platform
+audiences and `pk = platform`. Legacy platform JWTs, user-v2 credentials,
+access descriptors, wrong-signature tokens, and wrong-purpose tokens cannot
+resume a platform session. Successful login, registration, or resumption
+constructs the complete logical response before atomically committing
+`Bound(Platform { platform_user_id })`; the gateway then encrypts that response
+through the same held session lease. The binding's authentication deadline is
+the access-descriptor expiry capped by the session's absolute expiry.
+
+Every bound platform account operation reloads the exact platform user. A
+deleted platform user produces an authenticated unauthorized response and
+closes the session; transient database failure retains the otherwise valid
+session. Logout intentionally preserves current behavior: it closes this
+transport session but does not globally revoke resumption credentials. A
+successful password change also closes this session. Global credential epochs
+and all-device logout remain separate application-authentication work, not an
+implicit transport promise.
+
+The following stack layer projects `/platform/me` and the complete
+organization, project, membership, invite, secret, and settings control plane.
+Those operations require live role checks and v2-only bounded database output;
+they are deliberately separated from principal establishment.
+
 ## 9. First-party and third-party tokens
 
 Transport v2 removes first-party JWTs from steady-state OpenSecret request
@@ -589,6 +638,11 @@ first-party audiences. Resumption validates the expected v2 audience, token
 kind, principal kind and identity, project/authentication context where
 applicable, issue/expiry times, and active credential state; an audience match
 alone is never sufficient.
+
+User and platform credentials occupy separate v2 domains. Platform credentials
+carry no user project or seed-wrap authentication context; platform resumption
+instead revalidates that exact platform-user row before binding. Neither kind
+can be parsed as or substituted for the other.
 
 These credentials remain bearer secrets if stolen from the client. Transport
 v2 protects them from the parent/network threat; it does not claim to protect a
@@ -779,7 +833,7 @@ encryption, bodyless, and SSE behavior. Client cutover proves:
 
 ## 14. Planned pull-request stack
 
-The implementation is intentionally consolidated into at most fourteen
+The implementation is intentionally consolidated into at most fifteen
 capability PRs. Each PR targets the branch immediately below it:
 
 1. **Protocol and v1-neutral seam**: freeze the contract and introduce shared
@@ -806,13 +860,17 @@ capability PRs. Each PR targets the branch immediately below it:
    revalidation, and client-random Tinfoil cache namespaces.
 10. **Session-bound user OAuth**: bind OAuth continuation to its originating
     v2 session without exposing credentials outside ciphertext.
-11. **Platform v2 end to end**: platform authentication and authorization with
-    live organization checks.
-12. **Authenticated streaming**: ordered, request-bound records and an
+11. **Platform authentication and account lifecycle**: distinct platform-v2
+    credentials, immutable platform-session binding, password recovery, email
+    verification, logout, and password change.
+12. **Platform resource control**: bounded `/platform/me` and complete
+    organization, project, membership, invite, secret, and settings projection
+    with live role checks.
+13. **Authenticated streaming**: ordered, request-bound records and an
     authenticated terminal event while preserving caller-visible streaming.
-13. **Dormant TypeScript and Rust SDK engines**: shared vectors and private v2
+14. **Dormant TypeScript and Rust SDK engines**: shared vectors and private v2
     session/transport implementations that public calls do not yet select.
-14. **Atomic v2 cutover and packaging**: switch new SDK majors to v2-only,
+15. **Atomic v2 cutover and packaging**: switch new SDK majors to v2-only,
     update Maple and maple-proxy dependencies, and run compatibility/release
     rehearsal. Publication and deployment remain separately authorized.
 

--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -2,7 +2,10 @@ use crate::{
     db::{setup_db, DBError},
     encrypt::{encrypt_key_deterministic, encrypt_with_key},
     generate_reset_hash,
-    jwt::{issue_transport_v2_user_tokens, validate_transport_v2_user_resumption},
+    jwt::{
+        issue_transport_v2_platform_tokens, issue_transport_v2_user_tokens,
+        validate_transport_v2_platform_resumption, validate_transport_v2_user_resumption,
+    },
     login_routes::RegisterCredentials,
     models::{
         account_deletion::NewAccountDeletionRequest,
@@ -10,6 +13,7 @@ use crate::{
         oauth::NewUserOAuthConnection,
         org_projects::OrgProject,
         password_reset::NewPasswordResetRequest,
+        platform_users::NewPlatformUser,
         responses::{
             NewAssistantMessage, NewConversation, NewConversationProject, NewReasoningItem,
             NewResponse, NewToolCall, NewToolOutput, NewUserInstruction, NewUserMessage,
@@ -18,8 +22,8 @@ use crate::{
         schema::{
             account_deletion_requests, assistant_messages, conversation_projects,
             conversation_summaries, conversations, org_projects, password_reset_requests,
-            reasoning_items, responses, tool_calls, tool_outputs, user_instructions, user_messages,
-            user_oauth_connections, user_seed_wrappings,
+            platform_users, reasoning_items, responses, tool_calls, tool_outputs,
+            user_instructions, user_messages, user_oauth_connections, user_seed_wrappings,
         },
         user_api_keys::{NewUserApiKey, UserApiKey, UserApiKeyError},
         user_kv::{NewUserKV, UserKV},
@@ -41,6 +45,39 @@ use uuid::Uuid;
 
 fn test_credential(label: &str) -> &'static str {
     Box::leak(format!("aead-test-credential-{label}").into_boxed_str())
+}
+
+#[tokio::test]
+#[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+async fn db_platform_v2_resumption_revalidates_live_platform_user() {
+    let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+        eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+        return;
+    };
+
+    let app_state = build_local_test_app_state(database_url).await;
+    let marker = Uuid::new_v4();
+    let platform_user = app_state
+        .db
+        .create_platform_user(NewPlatformUser::new(
+            format!("transport-v2-platform-{marker}@example.com"),
+            Some(vec![0x41; 32]),
+        ))
+        .expect("platform user should be created");
+    let issued = issue_transport_v2_platform_tokens(&platform_user, &app_state)
+        .expect("platform v2 credentials should issue");
+    let resumed = validate_transport_v2_platform_resumption(&issued.resumption_token, &app_state)
+        .expect("live platform principal should resume");
+    assert_eq!(resumed.uuid, platform_user.uuid);
+
+    let mut connection = app_state.db.get_pool().get().expect("database connection");
+    diesel::delete(platform_users::table.filter(platform_users::id.eq(platform_user.id)))
+        .execute(&mut connection)
+        .expect("platform test user should be deleted");
+    assert!(
+        validate_transport_v2_platform_resumption(&issued.resumption_token, &app_state).is_err(),
+        "deleted platform principals must not resume"
+    );
 }
 
 #[tokio::test]

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -37,6 +37,10 @@ pub(crate) const TRANSPORT_V2_USER_ACCESS_AUDIENCE: &str =
     "urn:opensecret:internal:transport-v2:user:access-descriptor";
 pub(crate) const TRANSPORT_V2_USER_RESUMPTION_AUDIENCE: &str =
     "urn:opensecret:internal:transport-v2:user:resumption";
+pub(crate) const TRANSPORT_V2_PLATFORM_ACCESS_AUDIENCE: &str =
+    "urn:opensecret:internal:transport-v2:platform:access-descriptor";
+pub(crate) const TRANSPORT_V2_PLATFORM_RESUMPTION_AUDIENCE: &str =
+    "urn:opensecret:internal:transport-v2:platform:resumption";
 const TRANSPORT_V2_TOKEN_ISSUER: &str = "urn:opensecret:transport-v2";
 const TRANSPORT_V2_TOKEN_VERSION: u8 = 2;
 
@@ -190,6 +194,7 @@ enum TransportV2TokenKind {
 #[serde(rename_all = "snake_case")]
 enum TransportV2PrincipalKind {
     User,
+    Platform,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -210,7 +215,23 @@ struct TransportV2UserClaims {
     auth_binding: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct TransportV2PlatformClaims {
+    sub: String,
+    iss: String,
+    aud: String,
+    tv: u8,
+    tk: TransportV2TokenKind,
+    pk: TransportV2PrincipalKind,
+}
+
 pub(crate) struct IssuedTransportV2UserTokens {
+    pub(crate) access_token: String,
+    pub(crate) resumption_token: String,
+    pub(crate) access_expires_at: DateTime<Utc>,
+}
+
+pub(crate) struct IssuedTransportV2PlatformTokens {
     pub(crate) access_token: String,
     pub(crate) resumption_token: String,
     pub(crate) access_expires_at: DateTime<Utc>,
@@ -219,13 +240,15 @@ pub(crate) struct IssuedTransportV2UserTokens {
 impl TokenType {
     pub fn validate_third_party_audience(aud: &str) -> Result<(), ApiError> {
         // Validate third party audience can't use our internal audience types
-        const RESERVED_AUDIENCES: [&str; 6] = [
+        const RESERVED_AUDIENCES: [&str; 8] = [
             USER_ACCESS,
             USER_REFRESH,
             PLATFORM_ACCESS,
             PLATFORM_REFRESH,
             TRANSPORT_V2_USER_ACCESS_AUDIENCE,
             TRANSPORT_V2_USER_RESUMPTION_AUDIENCE,
+            TRANSPORT_V2_PLATFORM_ACCESS_AUDIENCE,
+            TRANSPORT_V2_PLATFORM_RESUMPTION_AUDIENCE,
         ];
 
         // 1. Check for reserved audiences
@@ -681,6 +704,67 @@ fn issue_transport_v2_user_token(
     Ok((token, expiration))
 }
 
+pub(crate) fn issue_transport_v2_platform_tokens(
+    platform_user: &PlatformUser,
+    app_state: &AppState,
+) -> Result<IssuedTransportV2PlatformTokens, ApiError> {
+    let (access_token, access_expires_at) = issue_transport_v2_platform_token(
+        platform_user,
+        app_state,
+        TransportV2TokenKind::AccessDescriptor,
+        TRANSPORT_V2_PLATFORM_ACCESS_AUDIENCE,
+        Duration::minutes(app_state.config.access_token_maxage),
+    )?;
+    let (resumption_token, _) = issue_transport_v2_platform_token(
+        platform_user,
+        app_state,
+        TransportV2TokenKind::Resumption,
+        TRANSPORT_V2_PLATFORM_RESUMPTION_AUDIENCE,
+        Duration::days(app_state.config.refresh_token_maxage),
+    )?;
+
+    Ok(IssuedTransportV2PlatformTokens {
+        access_token,
+        resumption_token,
+        access_expires_at,
+    })
+}
+
+fn issue_transport_v2_platform_token(
+    platform_user: &PlatformUser,
+    app_state: &AppState,
+    token_kind: TransportV2TokenKind,
+    audience: &str,
+    duration: Duration,
+) -> Result<(String, DateTime<Utc>), ApiError> {
+    let custom_claims = TransportV2PlatformClaims {
+        sub: platform_user.uuid.to_string(),
+        iss: TRANSPORT_V2_TOKEN_ISSUER.to_owned(),
+        aud: audience.to_owned(),
+        tv: TRANSPORT_V2_TOKEN_VERSION,
+        tk: token_kind,
+        pk: TransportV2PrincipalKind::Platform,
+    };
+
+    let issued_at = Utc::now() - Duration::minutes(1);
+    let expiration = issued_at + duration;
+    let mut claims = Claims::new(custom_claims);
+    claims.issued_at = Some(issued_at);
+    claims.not_before = Some(issued_at);
+    claims.expiration = Some(expiration);
+
+    let header = Header::empty().with_token_type("JWT");
+    let es256k = Es256k::<Sha256>::new(app_state.config.jwt_keys.secp.clone());
+    let token = es256k
+        .token(&header, &claims, &app_state.config.jwt_keys.signing_key)
+        .map_err(|error| {
+            tracing::error!("Error creating transport-v2 platform token: {:?}", error);
+            ApiError::InternalServerError
+        })?;
+
+    Ok((token, expiration))
+}
+
 pub(crate) fn validate_transport_v2_user_resumption(
     original_token: &str,
     data: &AppState,
@@ -696,6 +780,65 @@ pub(crate) fn validate_transport_v2_user_resumption(
     };
 
     Ok(VerifiedUserAuthentication { user, auth_context })
+}
+
+pub(crate) fn validate_transport_v2_platform_resumption(
+    original_token: &str,
+    data: &AppState,
+) -> Result<PlatformUser, ApiError> {
+    let claims =
+        validate_transport_v2_platform_resumption_claims(original_token, &data.config.jwt_keys)?;
+    let platform_user_id = Uuid::parse_str(&claims.sub).map_err(|_| ApiError::InvalidJwt)?;
+    data.db
+        .get_platform_user_by_uuid(platform_user_id)
+        .map_err(|error| match error {
+            DBError::PlatformUserNotFound => ApiError::InvalidJwt,
+            _ => {
+                tracing::error!(
+                    "Failed to load transport-v2 platform resumption principal: {:?}",
+                    error
+                );
+                ApiError::InternalServerError
+            }
+        })
+}
+
+fn validate_transport_v2_platform_resumption_claims(
+    original_token: &str,
+    jwt_keys: &JwtKeys,
+) -> Result<TransportV2PlatformClaims, ApiError> {
+    let parsed_token = UntrustedToken::new(original_token).map_err(|error| {
+        tracing::error!(
+            "Failed to parse transport-v2 platform resumption token: {:?}",
+            error
+        );
+        ApiError::InvalidJwt
+    })?;
+    let es256k = Es256k::<Sha256>::new(jwt_keys.secp.clone());
+    let public_key = jwt_keys.public_key();
+    let token: Token<TransportV2PlatformClaims> = es256k
+        .validator(&public_key)
+        .validate(&parsed_token)
+        .map_err(|error| {
+            tracing::debug!(
+                "Transport-v2 platform resumption signature validation failed: {:?}",
+                error
+            );
+            ApiError::InvalidJwt
+        })?;
+    let claims = token.claims();
+
+    if claims.custom.iss != TRANSPORT_V2_TOKEN_ISSUER
+        || claims.custom.aud != TRANSPORT_V2_PLATFORM_RESUMPTION_AUDIENCE
+        || claims.custom.tv != TRANSPORT_V2_TOKEN_VERSION
+        || claims.custom.tk != TransportV2TokenKind::Resumption
+        || claims.custom.pk != TransportV2PrincipalKind::Platform
+    {
+        return Err(ApiError::InvalidJwt);
+    }
+
+    validate_transport_v2_token_times(claims, "platform")?;
+    Ok(claims.custom.clone())
 }
 
 fn validate_transport_v2_user_resumption_claims(
@@ -729,12 +872,22 @@ fn validate_transport_v2_user_resumption_claims(
         return Err(ApiError::InvalidJwt);
     }
 
+    validate_transport_v2_token_times(claims, "user")?;
+
+    Ok(claims.custom.clone())
+}
+
+fn validate_transport_v2_token_times<T>(
+    claims: &Claims<T>,
+    principal_label: &'static str,
+) -> Result<(), ApiError> {
     let time_options = TimeOptions::default();
     claims
         .validate_expiration(&time_options)
         .and_then(|claims| claims.validate_maturity(&time_options))
         .map_err(|error| {
             tracing::error!(
+                principal = principal_label,
                 "Transport-v2 resumption time validation failed: {:?}",
                 error
             );
@@ -751,8 +904,7 @@ fn validate_transport_v2_user_resumption_claims(
     {
         return Err(ApiError::InvalidJwt);
     }
-
-    Ok(claims.custom.clone())
+    Ok(())
 }
 
 fn transport_v2_auth_context(claims: &TransportV2UserClaims) -> Result<AuthContext, ApiError> {
@@ -1124,6 +1276,34 @@ mod tests {
         )
     }
 
+    fn transport_v2_platform_test_claims(
+        token_kind: TransportV2TokenKind,
+        audience: &str,
+    ) -> TransportV2PlatformClaims {
+        TransportV2PlatformClaims {
+            sub: Uuid::nil().to_string(),
+            iss: TRANSPORT_V2_TOKEN_ISSUER.to_owned(),
+            aud: audience.to_owned(),
+            tv: TRANSPORT_V2_TOKEN_VERSION,
+            tk: token_kind,
+            pk: TransportV2PrincipalKind::Platform,
+        }
+    }
+
+    fn valid_transport_v2_platform_resumption(keys: &JwtKeys) -> String {
+        let now = Utc::now();
+        signed_transport_v2_test_token(
+            keys,
+            transport_v2_platform_test_claims(
+                TransportV2TokenKind::Resumption,
+                TRANSPORT_V2_PLATFORM_RESUMPTION_AUDIENCE,
+            ),
+            Some(now - Duration::minutes(2)),
+            Some(now - Duration::minutes(2)),
+            Some(now + Duration::minutes(5)),
+        )
+    }
+
     #[test]
     fn expired_user_access_token_is_recoverable_only_after_signature_and_audience_validation() {
         let trusted_keys = test_keys(1);
@@ -1375,6 +1555,132 @@ mod tests {
             assert!(matches!(
                 TokenType::validate_third_party_audience(audience),
                 Err(ApiError::BadRequest)
+            ));
+        }
+    }
+
+    #[test]
+    fn transport_v2_platform_tokens_are_separate_from_user_and_v1_domains() {
+        let keys = test_keys(10);
+        let now = Utc::now();
+        let resumption = valid_transport_v2_platform_resumption(&keys);
+        assert!(validate_transport_v2_platform_resumption_claims(&resumption, &keys).is_ok());
+        assert!(matches!(
+            validate_transport_v2_user_resumption_claims(&resumption, &keys),
+            Err(ApiError::InvalidJwt)
+        ));
+        for audience in [PLATFORM_ACCESS, PLATFORM_REFRESH] {
+            assert!(matches!(
+                validate_token_with_keys(&resumption, &keys, audience),
+                Err(ApiError::InvalidJwt)
+            ));
+        }
+
+        let descriptor = signed_transport_v2_test_token(
+            &keys,
+            transport_v2_platform_test_claims(
+                TransportV2TokenKind::AccessDescriptor,
+                TRANSPORT_V2_PLATFORM_ACCESS_AUDIENCE,
+            ),
+            Some(now - Duration::minutes(2)),
+            Some(now - Duration::minutes(2)),
+            Some(now + Duration::minutes(5)),
+        );
+        assert!(matches!(
+            validate_transport_v2_platform_resumption_claims(&descriptor, &keys),
+            Err(ApiError::InvalidJwt)
+        ));
+
+        let user_resumption = valid_transport_v2_resumption(&keys);
+        assert!(matches!(
+            validate_transport_v2_platform_resumption_claims(&user_resumption, &keys),
+            Err(ApiError::InvalidJwt)
+        ));
+
+        let legacy = signed_test_token(&keys, PLATFORM_REFRESH, Some(now + Duration::minutes(5)));
+        assert!(matches!(
+            validate_transport_v2_platform_resumption_claims(&legacy, &keys),
+            Err(ApiError::InvalidJwt)
+        ));
+
+        for audience in [
+            TRANSPORT_V2_PLATFORM_ACCESS_AUDIENCE,
+            TRANSPORT_V2_PLATFORM_RESUMPTION_AUDIENCE,
+        ] {
+            assert!(matches!(
+                TokenType::validate_third_party_audience(audience),
+                Err(ApiError::BadRequest)
+            ));
+        }
+    }
+
+    #[test]
+    fn transport_v2_platform_resumption_rejects_wrong_identity_purpose_and_time() {
+        let keys = test_keys(11);
+        let now = Utc::now();
+        let sign = |claims: TransportV2PlatformClaims,
+                    issued_at: Option<DateTime<Utc>>,
+                    not_before: Option<DateTime<Utc>>,
+                    expiration: Option<DateTime<Utc>>| {
+            signed_transport_v2_test_token(&keys, claims, issued_at, not_before, expiration)
+        };
+        let valid_claims = || {
+            transport_v2_platform_test_claims(
+                TransportV2TokenKind::Resumption,
+                TRANSPORT_V2_PLATFORM_RESUMPTION_AUDIENCE,
+            )
+        };
+
+        let mut wrong_issuer = valid_claims();
+        wrong_issuer.iss = "urn:attacker".to_owned();
+        let mut wrong_audience = valid_claims();
+        wrong_audience.aud = TRANSPORT_V2_PLATFORM_ACCESS_AUDIENCE.to_owned();
+        let mut wrong_version = valid_claims();
+        wrong_version.tv += 1;
+        let mut wrong_kind = valid_claims();
+        wrong_kind.tk = TransportV2TokenKind::AccessDescriptor;
+        let mut wrong_principal = valid_claims();
+        wrong_principal.pk = TransportV2PrincipalKind::User;
+
+        for claims in [
+            wrong_issuer,
+            wrong_audience,
+            wrong_version,
+            wrong_kind,
+            wrong_principal,
+        ] {
+            let token = sign(
+                claims,
+                Some(now - Duration::minutes(2)),
+                Some(now - Duration::minutes(2)),
+                Some(now + Duration::minutes(5)),
+            );
+            assert!(matches!(
+                validate_transport_v2_platform_resumption_claims(&token, &keys),
+                Err(ApiError::InvalidJwt)
+            ));
+        }
+
+        let invalid_times = [
+            (None, Some(now), Some(now + Duration::minutes(5))),
+            (Some(now), None, Some(now + Duration::minutes(5))),
+            (Some(now), Some(now), None),
+            (
+                Some(now - Duration::minutes(10)),
+                Some(now - Duration::minutes(10)),
+                Some(now - Duration::minutes(5)),
+            ),
+            (
+                Some(now + Duration::minutes(10)),
+                Some(now + Duration::minutes(10)),
+                Some(now + Duration::minutes(15)),
+            ),
+        ];
+        for (issued_at, not_before, expiration) in invalid_times {
+            let token = sign(valid_claims(), issued_at, not_before, expiration);
+            assert!(matches!(
+                validate_transport_v2_platform_resumption_claims(&token, &keys),
+                Err(ApiError::InvalidJwt)
             ));
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1697,7 +1697,7 @@ impl AppState {
 
         let encrypted_pw = encrypt_with_key(&secret_key, password_hash.as_bytes()).await;
 
-        tracing::debug!("registering new user: {:?}", creds.email);
+        tracing::debug!("registering new password-backed user");
 
         // Generate private key for new user
         let user_seed_words = generate_twelve_word_seed(self.aws_credential_manager.clone())
@@ -1713,7 +1713,7 @@ impl AppState {
             user_seed_words.as_bytes(),
         )?;
 
-        tracing::info!("registered new user: {:?} {:?}", user.email, user.uuid);
+        tracing::info!(user_uuid = %user.uuid, "registered new user");
 
         Ok(user)
     }
@@ -2200,7 +2200,7 @@ impl AppState {
             Err(DBError::UserNotFound) => {
                 // User doesn't exist, but we don't want to reveal this information
                 // So we'll just log it and return as if everything was successful
-                debug!("Password reset requested for non-existent email: {}", email);
+                debug!("Password reset requested for a non-existent email address");
             }
             Err(e) => {
                 // For other errors, we should still log them but not expose them to the user
@@ -2374,10 +2374,7 @@ impl AppState {
             Ok(None) => {
                 // User doesn't exist, but we don't want to reveal this information
                 // So we'll just log it and return as if everything was successful
-                debug!(
-                    "Password reset requested for non-existent platform email: {}",
-                    email
-                );
+                debug!("Platform password reset requested for a non-existent email address");
             }
             Err(e) => {
                 // For other errors, we should still log them but not expose them to the user
@@ -2735,7 +2732,7 @@ impl AppState {
         let platform_user = match self.db.get_platform_user_by_email(email)? {
             Some(user) => user,
             None => {
-                warn!("Could not find platform user by email: {email}");
+                warn!("Could not find platform user for email login");
                 return Ok(None);
             }
         };

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -15,12 +15,15 @@ use chrono::{DateTime, Utc};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
+use validator::Validate;
 use zeroize::{Zeroize, Zeroizing};
 
 use crate::bounded_json::BoundedJsonBuffer;
+use crate::db::DBError;
 use crate::encrypt::{decrypt_with_key, encrypt_with_key};
 use crate::jwt::{
-    issue_transport_v2_user_tokens, validate_transport_v2_user_resumption, AuthContext,
+    issue_transport_v2_platform_tokens, issue_transport_v2_user_tokens,
+    validate_transport_v2_platform_resumption, validate_transport_v2_user_resumption, AuthContext,
 };
 use crate::kv::StoreError;
 use crate::models::responses::{ConversationProjectFilter, NewConversation, ResponseStatus};
@@ -29,8 +32,9 @@ use crate::provider_cache::{
 };
 use crate::tokens::count_tokens;
 use crate::web::login_routes::{
-    authenticate_login, logout_data, register_and_authenticate, verify_email_data, AuthResponse,
-    Credentials, LogoutRequest, RefreshResponse, RegisterCredentials,
+    authenticate_login, logout_data, password_reset_confirm_data, password_reset_request_data,
+    register_and_authenticate, verify_email_data, AuthResponse, Credentials, LogoutRequest,
+    PasswordResetConfirmPayload, PasswordResetRequestPayload, RefreshResponse, RegisterCredentials,
 };
 use crate::web::oauth_routes::{
     apple_native_authenticate, initiate_oauth_data, oauth_callback_authenticate,
@@ -42,6 +46,17 @@ use crate::web::openai::{
     EmbeddingRequest, TTSRequest, TranscriptionRequest,
 };
 use crate::web::openai_auth::AuthMethod as OpenAiAuthMethod;
+use crate::web::platform::login_routes::{
+    authenticate_platform_login, platform_logout_data, platform_password_reset_confirm_data,
+    platform_password_reset_request_data, register_platform_user_data, verify_platform_email_data,
+    PlatformAuthResponse, PlatformLoginRequest, PlatformLogoutRequest,
+    PlatformPasswordResetConfirmPayload, PlatformPasswordResetRequestPayload,
+    PlatformRefreshResponse, PlatformRegisterRequest,
+};
+use crate::web::platform::me_routes::{
+    platform_change_password_data, request_platform_verification_data,
+    PlatformChangePasswordRequest,
+};
 use crate::web::protected_routes::{
     confirm_account_deletion_data, create_api_key_data, decrypt_data_value, delete_all_kv_values,
     delete_api_key_by_name, delete_kv_value, encrypt_data_value, initiate_account_deletion_data,
@@ -98,10 +113,10 @@ use crate::{
 use super::envelope::{
     decode_canonical_api_key_name_path, decode_canonical_conversation_path,
     decode_canonical_conversation_project_path, decode_canonical_instruction_path,
-    decode_canonical_kv_item_path, decode_canonical_response_path,
-    decode_canonical_verify_email_path, ConversationItemPath, Credential, EncodedBytes,
-    EnvelopeLimits, HeaderField, InstructionItemPath, LogicalMethod, RequestEnvelope, RequestId,
-    ResponseItemPath, ResponseMode,
+    decode_canonical_kv_item_path, decode_canonical_platform_verify_email_path,
+    decode_canonical_response_path, decode_canonical_verify_email_path, ConversationItemPath,
+    Credential, EncodedBytes, EnvelopeLimits, HeaderField, InstructionItemPath, LogicalMethod,
+    RequestEnvelope, RequestId, ResponseItemPath, ResponseMode,
 };
 use super::session::{
     AuthenticationReservation, AuthenticationStartError, AuthorityState, BoundAuthority,
@@ -167,8 +182,43 @@ pub(crate) enum UserOperation {
         body: SensitiveBytes,
         cache_namespace_root: CacheNamespaceRoot,
     },
+    UserPasswordResetRequest {
+        body: SensitiveBytes,
+    },
+    UserPasswordResetConfirm {
+        body: SensitiveBytes,
+    },
     VerifyEmail {
         code: uuid::Uuid,
+    },
+    PlatformLogin {
+        body: SensitiveBytes,
+    },
+    PlatformRegister {
+        body: SensitiveBytes,
+    },
+    PlatformResume {
+        credential: SensitiveBytes,
+    },
+    PlatformVerifyEmail {
+        code: uuid::Uuid,
+    },
+    PlatformPasswordResetRequest {
+        body: SensitiveBytes,
+    },
+    PlatformPasswordResetConfirm {
+        body: SensitiveBytes,
+    },
+    PlatformLogout {
+        authority: BoundPlatformAuthority,
+        body: SensitiveBytes,
+    },
+    PlatformRequestVerification {
+        authority: BoundPlatformAuthority,
+    },
+    PlatformChangePassword {
+        authority: BoundPlatformAuthority,
+        body: SensitiveBytes,
     },
     Logout {
         body: SensitiveBytes,
@@ -389,6 +439,11 @@ pub(crate) struct BoundUserAuthority {
     cache_namespace: DerivedCacheNamespace,
 }
 
+#[derive(Clone)]
+pub(crate) struct BoundPlatformAuthority {
+    platform_user_id: uuid::Uuid,
+}
+
 impl UserOperation {
     pub(crate) const fn requires_authentication_transition(&self) -> bool {
         matches!(
@@ -398,6 +453,9 @@ impl UserOperation {
                 | Self::Resume { .. }
                 | Self::OAuthCallback { .. }
                 | Self::AppleNativeOAuth { .. }
+                | Self::PlatformLogin { .. }
+                | Self::PlatformRegister { .. }
+                | Self::PlatformResume { .. }
                 | Self::Inference {
                     authority: InferenceAuthority::AuthenticateApiKey { .. },
                     ..
@@ -440,7 +498,10 @@ impl UserOperation {
 
     const fn session_effect_on_success(&self) -> SessionEffect {
         match self {
-            Self::Logout { .. } | Self::ChangePassword { .. } => SessionEffect::Close,
+            Self::Logout { .. }
+            | Self::ChangePassword { .. }
+            | Self::PlatformLogout { .. }
+            | Self::PlatformChangePassword { .. } => SessionEffect::Close,
             Self::Protected { operation, .. } => operation.session_effect_on_success(),
             Self::Inference { .. } => SessionEffect::Retain,
             _ => SessionEffect::Retain,
@@ -766,7 +827,18 @@ pub(crate) fn prepare_user_operation(
         AppleOAuthInitiate,
         AppleOAuthCallback,
         AppleNativeOAuth,
+        UserPasswordResetRequest,
+        UserPasswordResetConfirm,
         VerifyEmail,
+        PlatformLogin,
+        PlatformRegister,
+        PlatformResume,
+        PlatformVerifyEmail,
+        PlatformPasswordResetRequest,
+        PlatformPasswordResetConfirm,
+        PlatformLogout,
+        PlatformRequestVerification,
+        PlatformChangePassword,
         GetUser,
         RequestVerification,
         GetPrivateKey,
@@ -844,6 +916,14 @@ pub(crate) fn prepare_user_operation(
             return rejected_bad_request();
         }
     };
+    let platform_verification_code =
+        match decode_canonical_platform_verify_email_path(request.method, &request.path) {
+            Ok(code) => code,
+            Err(_) => {
+                request.path.zeroize();
+                return rejected_bad_request();
+            }
+        };
     let conversation_project_id =
         match decode_canonical_conversation_project_path(request.method, &request.path) {
             Ok(project_id) => project_id,
@@ -885,7 +965,26 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Post, "/auth/apple") => Some(Route::AppleOAuthInitiate),
         (LogicalMethod::Post, "/auth/apple/callback") => Some(Route::AppleOAuthCallback),
         (LogicalMethod::Post, "/auth/apple/native") => Some(Route::AppleNativeOAuth),
+        (LogicalMethod::Post, "/password-reset/request") => Some(Route::UserPasswordResetRequest),
+        (LogicalMethod::Post, "/password-reset/confirm") => Some(Route::UserPasswordResetConfirm),
         (LogicalMethod::Get, _) if verification_code.is_some() => Some(Route::VerifyEmail),
+        (LogicalMethod::Post, "/platform/login") => Some(Route::PlatformLogin),
+        (LogicalMethod::Post, "/platform/register") => Some(Route::PlatformRegister),
+        (LogicalMethod::Post, "/platform/refresh") => Some(Route::PlatformResume),
+        (LogicalMethod::Get, _) if platform_verification_code.is_some() => {
+            Some(Route::PlatformVerifyEmail)
+        }
+        (LogicalMethod::Post, "/platform/password-reset/request") => {
+            Some(Route::PlatformPasswordResetRequest)
+        }
+        (LogicalMethod::Post, "/platform/password-reset/confirm") => {
+            Some(Route::PlatformPasswordResetConfirm)
+        }
+        (LogicalMethod::Post, "/platform/logout") => Some(Route::PlatformLogout),
+        (LogicalMethod::Post, "/platform/request_verification") => {
+            Some(Route::PlatformRequestVerification)
+        }
+        (LogicalMethod::Post, "/platform/change-password") => Some(Route::PlatformChangePassword),
         (LogicalMethod::Get, "/protected/user") => Some(Route::GetUser),
         (LogicalMethod::Post, "/protected/request_verification") => {
             Some(Route::RequestVerification)
@@ -1013,6 +1112,7 @@ pub(crate) fn prepare_user_operation(
     if kv_key.is_some()
         || api_key_name.is_some()
         || verification_code.is_some()
+        || platform_verification_code.is_some()
         || conversation_project_id.is_some()
         || instruction_path.is_some()
         || conversation_path.is_some()
@@ -1233,6 +1333,183 @@ pub(crate) fn prepare_user_operation(
                 _ => unreachable!("OAuth callback route group is exhaustive"),
             }
         }
+        Route::UserPasswordResetRequest | Route::UserPasswordResetConfirm => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            if !matches!(authority, AuthorityState::Anonymous) {
+                return OperationPreparation::Rejected(authentication_required_response());
+            }
+            let body = Zeroizing::new(
+                request
+                    .body_base64
+                    .expect("validated password-reset body")
+                    .into_bytes(),
+            );
+            if matches!(route, Route::UserPasswordResetRequest) {
+                OperationPreparation::Ready(UserOperation::UserPasswordResetRequest { body })
+            } else {
+                OperationPreparation::Ready(UserOperation::UserPasswordResetConfirm { body })
+            }
+        }
+        Route::PlatformLogin | Route::PlatformRegister => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            if !matches!(authority, AuthorityState::Anonymous) {
+                return OperationPreparation::Rejected(authentication_start_error(
+                    AuthenticationStartError::AlreadyBound,
+                ));
+            }
+            let body = Zeroizing::new(
+                request
+                    .body_base64
+                    .expect("validated platform authentication body")
+                    .into_bytes(),
+            );
+            if matches!(route, Route::PlatformLogin) {
+                OperationPreparation::Ready(UserOperation::PlatformLogin { body })
+            } else {
+                OperationPreparation::Ready(UserOperation::PlatformRegister { body })
+            }
+        }
+        Route::PlatformResume => {
+            if request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            if !matches!(authority, AuthorityState::Anonymous) {
+                return OperationPreparation::Rejected(authentication_start_error(
+                    AuthenticationStartError::AlreadyBound,
+                ));
+            }
+            let Some(Credential::Resumption { value_base64 }) = credential else {
+                return rejected_bad_request();
+            };
+            if value_base64.is_empty() {
+                return rejected_bad_request();
+            }
+            OperationPreparation::Ready(UserOperation::PlatformResume {
+                credential: Zeroizing::new(value_base64.into_bytes()),
+            })
+        }
+        Route::PlatformVerifyEmail => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            match authority {
+                AuthorityState::Anonymous => {}
+                AuthorityState::Bound(bound)
+                    if matches!(bound.principal(), BoundPrincipal::Platform { .. }) => {}
+                AuthorityState::Bound(_) => {
+                    return OperationPreparation::Rejected(authentication_required_response());
+                }
+                AuthorityState::Authenticating(_) => {
+                    return OperationPreparation::Rejected(authentication_start_error(
+                        AuthenticationStartError::AuthenticationInProgress,
+                    ));
+                }
+                AuthorityState::Closing => {
+                    return OperationPreparation::Rejected(authentication_start_error(
+                        AuthenticationStartError::Closing,
+                    ));
+                }
+            }
+            OperationPreparation::Ready(UserOperation::PlatformVerifyEmail {
+                code: platform_verification_code
+                    .expect("classified platform verification route must have a code"),
+            })
+        }
+        Route::PlatformPasswordResetRequest | Route::PlatformPasswordResetConfirm => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            if !matches!(authority, AuthorityState::Anonymous) {
+                return OperationPreparation::Rejected(authentication_required_response());
+            }
+            let body = Zeroizing::new(
+                request
+                    .body_base64
+                    .expect("validated platform password-reset body")
+                    .into_bytes(),
+            );
+            if matches!(route, Route::PlatformPasswordResetRequest) {
+                OperationPreparation::Ready(UserOperation::PlatformPasswordResetRequest { body })
+            } else {
+                OperationPreparation::Ready(UserOperation::PlatformPasswordResetConfirm { body })
+            }
+        }
+        Route::PlatformLogout | Route::PlatformChangePassword => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !has_exact_json_content_type(&request.headers)
+                || request
+                    .body_base64
+                    .as_ref()
+                    .is_none_or(EncodedBytes::is_empty)
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_platform_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
+            };
+            let body = Zeroizing::new(
+                request
+                    .body_base64
+                    .expect("validated platform account body")
+                    .into_bytes(),
+            );
+            if matches!(route, Route::PlatformLogout) {
+                OperationPreparation::Ready(UserOperation::PlatformLogout { authority, body })
+            } else {
+                OperationPreparation::Ready(UserOperation::PlatformChangePassword {
+                    authority,
+                    body,
+                })
+            }
+        }
+        Route::PlatformRequestVerification => {
+            if credential.is_some()
+                || request.query.is_some()
+                || !request.headers.is_empty()
+                || request.body_base64.is_some()
+            {
+                return rejected_bad_request();
+            }
+            let authority = match bound_platform_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
+            };
+            OperationPreparation::Ready(UserOperation::PlatformRequestVerification { authority })
+        }
         Route::VerifyEmail => {
             if credential.is_some()
                 || request.query.is_some()
@@ -1242,7 +1519,12 @@ pub(crate) fn prepare_user_operation(
                 return rejected_bad_request();
             }
             match authority {
-                AuthorityState::Anonymous | AuthorityState::Bound(_) => {}
+                AuthorityState::Anonymous => {}
+                AuthorityState::Bound(bound)
+                    if matches!(bound.principal(), BoundPrincipal::User { .. }) => {}
+                AuthorityState::Bound(_) => {
+                    return OperationPreparation::Rejected(authentication_required_response());
+                }
                 AuthorityState::Authenticating(_) => {
                     return OperationPreparation::Rejected(authentication_start_error(
                         AuthenticationStartError::AuthenticationInProgress,
@@ -1911,7 +2193,15 @@ pub(crate) fn prepare_user_operation(
                 return rejected_bad_request();
             }
             match authority {
-                AuthorityState::Anonymous | AuthorityState::Bound(_) => {}
+                AuthorityState::Anonymous => {}
+                AuthorityState::Bound(bound)
+                    if matches!(
+                        bound.principal(),
+                        BoundPrincipal::User { .. } | BoundPrincipal::ApiKey { .. }
+                    ) => {}
+                AuthorityState::Bound(_) => {
+                    return OperationPreparation::Rejected(authentication_required_response());
+                }
                 AuthorityState::Authenticating(_) => {
                     return OperationPreparation::Rejected(authentication_start_error(
                         AuthenticationStartError::AuthenticationInProgress,
@@ -2049,6 +2339,20 @@ fn bound_user_authority(
         project_id: *project_id,
         auth_context: auth_context.clone(),
         cache_namespace: cache_namespace.clone(),
+    })
+}
+
+fn bound_platform_authority(
+    authority: AuthorityState,
+) -> Result<BoundPlatformAuthority, LogicalUnaryResponse> {
+    let AuthorityState::Bound(bound) = authority else {
+        return Err(authentication_required_response());
+    };
+    let BoundPrincipal::Platform { platform_user_id } = bound.principal() else {
+        return Err(authentication_required_response());
+    };
+    Ok(BoundPlatformAuthority {
+        platform_user_id: *platform_user_id,
     })
 }
 
@@ -2306,6 +2610,203 @@ pub(crate) async fn execute_user_operation(
                 UserAuthResponseKind::Login,
                 cache_namespace_root,
             )
+        }
+        UserOperation::UserPasswordResetRequest { body } => {
+            debug_assert!(authentication.is_none());
+            let request = match parse_json_body::<PasswordResetRequestPayload>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            let response = match password_reset_request_data(&app_state, request)
+                .await
+                .and_then(|value| LogicalUnaryResponse::json(StatusCode::OK, &value))
+            {
+                Ok(response) => response,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            ApplicationOutcome::success(response, SessionEffect::Retain)
+        }
+        UserOperation::UserPasswordResetConfirm { body } => {
+            debug_assert!(authentication.is_none());
+            let request = match parse_json_body::<PasswordResetConfirmPayload>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            let response = match password_reset_confirm_data(&app_state, request)
+                .await
+                .and_then(|value| LogicalUnaryResponse::json(StatusCode::OK, &value))
+            {
+                Ok(response) => response,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            ApplicationOutcome::success(response, SessionEffect::Retain)
+        }
+        UserOperation::PlatformLogin { body } => {
+            let request = match parse_json_body::<PlatformLoginRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            if request.validate().is_err() {
+                return ApplicationOutcome::error(ApiError::BadRequest);
+            }
+            let platform_user =
+                match authenticate_platform_login(Arc::clone(&app_state), request).await {
+                    Ok(platform_user) => platform_user,
+                    Err(error) => return ApplicationOutcome::error(error),
+                };
+            finish_platform_binding(
+                &app_state,
+                &lease,
+                platform_user,
+                authentication.expect("platform login requires authentication reservation"),
+                monotonic_now,
+                PlatformAuthResponseKind::Login,
+            )
+        }
+        UserOperation::PlatformRegister { body } => {
+            let request = match parse_json_body::<PlatformRegisterRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            if request.validate().is_err() {
+                return ApplicationOutcome::error(ApiError::BadRequest);
+            }
+            let platform_user =
+                match register_platform_user_data(Arc::clone(&app_state), request).await {
+                    Ok(platform_user) => platform_user,
+                    Err(error) => return ApplicationOutcome::error(error),
+                };
+            finish_platform_binding(
+                &app_state,
+                &lease,
+                platform_user,
+                authentication.expect("platform registration requires authentication reservation"),
+                monotonic_now,
+                PlatformAuthResponseKind::Login,
+            )
+        }
+        UserOperation::PlatformResume { mut credential } => {
+            let bytes = std::mem::take(&mut *credential);
+            let credential = match String::from_utf8(bytes) {
+                Ok(credential) => Zeroizing::new(credential),
+                Err(error) => {
+                    let mut bytes = error.into_bytes();
+                    bytes.zeroize();
+                    return ApplicationOutcome::error(ApiError::InvalidJwt);
+                }
+            };
+            let platform_user =
+                match validate_transport_v2_platform_resumption(&credential, &app_state) {
+                    Ok(platform_user) => platform_user,
+                    Err(error) => return ApplicationOutcome::error(error),
+                };
+            finish_platform_binding(
+                &app_state,
+                &lease,
+                platform_user,
+                authentication.expect("platform resumption requires authentication reservation"),
+                monotonic_now,
+                PlatformAuthResponseKind::Refresh,
+            )
+        }
+        UserOperation::PlatformVerifyEmail { code } => {
+            debug_assert!(authentication.is_none());
+            let response = match verify_platform_email_data(&app_state, code)
+                .and_then(|value| LogicalUnaryResponse::json(StatusCode::OK, &value))
+            {
+                Ok(response) => response,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            ApplicationOutcome::success(response, SessionEffect::Retain)
+        }
+        UserOperation::PlatformPasswordResetRequest { body } => {
+            debug_assert!(authentication.is_none());
+            let request = match parse_json_body::<PlatformPasswordResetRequestPayload>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            if request.validate().is_err() {
+                return ApplicationOutcome::error(ApiError::BadRequest);
+            }
+            let response = match platform_password_reset_request_data(&app_state, request)
+                .await
+                .and_then(|value| LogicalUnaryResponse::json(StatusCode::OK, &value))
+            {
+                Ok(response) => response,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            ApplicationOutcome::success(response, SessionEffect::Retain)
+        }
+        UserOperation::PlatformPasswordResetConfirm { body } => {
+            debug_assert!(authentication.is_none());
+            let request = match parse_json_body::<PlatformPasswordResetConfirmPayload>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            if request.validate().is_err() {
+                return ApplicationOutcome::error(ApiError::BadRequest);
+            }
+            let response = match platform_password_reset_confirm_data(&app_state, request)
+                .await
+                .and_then(|value| LogicalUnaryResponse::json(StatusCode::OK, &value))
+            {
+                Ok(response) => response,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            ApplicationOutcome::success(response, SessionEffect::Retain)
+        }
+        UserOperation::PlatformLogout { authority, body } => {
+            debug_assert!(authentication.is_none());
+            if let Err(outcome) = revalidate_bound_platform_user(&app_state, &authority) {
+                return outcome;
+            }
+            let request = match parse_json_body::<PlatformLogoutRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            let response =
+                match LogicalUnaryResponse::json(StatusCode::OK, &platform_logout_data(request)) {
+                    Ok(response) => response,
+                    Err(error) => return ApplicationOutcome::error(error),
+                };
+            ApplicationOutcome::success(response, session_effect_on_success)
+        }
+        UserOperation::PlatformRequestVerification { authority } => {
+            debug_assert!(authentication.is_none());
+            let platform_user = match revalidate_bound_platform_user(&app_state, &authority) {
+                Ok(platform_user) => platform_user,
+                Err(outcome) => return outcome,
+            };
+            let response = match request_platform_verification_data(&app_state, &platform_user)
+                .await
+                .and_then(|value| LogicalUnaryResponse::json(StatusCode::OK, &value))
+            {
+                Ok(response) => response,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            ApplicationOutcome::success(response, SessionEffect::Retain)
+        }
+        UserOperation::PlatformChangePassword { authority, body } => {
+            debug_assert!(authentication.is_none());
+            let platform_user = match revalidate_bound_platform_user(&app_state, &authority) {
+                Ok(platform_user) => platform_user,
+                Err(outcome) => return outcome,
+            };
+            let request = match parse_json_body::<PlatformChangePasswordRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            if request.validate().is_err() {
+                return ApplicationOutcome::error(ApiError::BadRequest);
+            }
+            let response = match platform_change_password_data(&app_state, &platform_user, request)
+                .await
+                .and_then(|value| LogicalUnaryResponse::json(StatusCode::OK, &value))
+            {
+                Ok(response) => response,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            ApplicationOutcome::success(response, session_effect_on_success)
         }
         UserOperation::VerifyEmail { code } => {
             debug_assert!(authentication.is_none());
@@ -2720,6 +3221,27 @@ fn bound_user_error_outcome(
     } else {
         ApplicationOutcome::error(error)
     }
+}
+
+fn revalidate_bound_platform_user(
+    app_state: &AppState,
+    authority: &BoundPlatformAuthority,
+) -> Result<crate::models::platform_users::PlatformUser, ApplicationOutcome> {
+    app_state
+        .db
+        .get_platform_user_by_uuid(authority.platform_user_id)
+        .map_err(|error| match error {
+            DBError::PlatformUserNotFound => {
+                ApplicationOutcome::closing_error(ApiError::Unauthorized)
+            }
+            _ => {
+                tracing::error!(
+                    platform_user_id = %authority.platform_user_id,
+                    "Failed to revalidate bound platform user: {error:?}"
+                );
+                ApplicationOutcome::error(ApiError::InternalServerError)
+            }
+        })
 }
 
 async fn execute_protected_user_operation(
@@ -4367,6 +4889,78 @@ enum UserAuthResponseKind {
     Refresh,
 }
 
+enum PlatformAuthResponseKind {
+    Login,
+    Refresh,
+}
+
+fn finish_platform_binding(
+    app_state: &AppState,
+    lease: &V2SessionLease,
+    platform_user: crate::models::platform_users::PlatformUser,
+    authentication: AuthenticationReservation,
+    monotonic_now: Instant,
+    response_kind: PlatformAuthResponseKind,
+) -> ApplicationOutcome {
+    let issued = match issue_transport_v2_platform_tokens(&platform_user, app_state) {
+        Ok(issued) => issued,
+        Err(error) => return ApplicationOutcome::error(error),
+    };
+    let authentication_expires_at = match monotonic_authentication_expiry(
+        issued.access_expires_at,
+        monotonic_now,
+        lease.state().absolute_expires_at(),
+    ) {
+        Ok(expiry) => expiry,
+        Err(error) => return ApplicationOutcome::error(error),
+    };
+
+    let mut access_token = issued.access_token;
+    let mut resumption_token = issued.resumption_token;
+    let response = match response_kind {
+        PlatformAuthResponseKind::Login => {
+            let mut value = PlatformAuthResponse {
+                id: platform_user.uuid,
+                email: platform_user.email.clone(),
+                name: platform_user.name.clone(),
+                access_token: access_token.clone(),
+                refresh_token: resumption_token.clone(),
+            };
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value);
+            value.access_token.zeroize();
+            value.refresh_token.zeroize();
+            response
+        }
+        PlatformAuthResponseKind::Refresh => {
+            let mut value = PlatformRefreshResponse {
+                access_token: access_token.clone(),
+                refresh_token: resumption_token.clone(),
+            };
+            let response = LogicalUnaryResponse::json(StatusCode::OK, &value);
+            value.access_token.zeroize();
+            value.refresh_token.zeroize();
+            response
+        }
+    };
+    access_token.zeroize();
+    resumption_token.zeroize();
+    let response = match response {
+        Ok(response) => response,
+        Err(error) => return ApplicationOutcome::error(error),
+    };
+
+    if authentication
+        .commit_at(
+            BoundAuthority::platform(platform_user.uuid, authentication_expires_at),
+            monotonic_now,
+        )
+        .is_err()
+    {
+        return ApplicationOutcome::error(ApiError::InternalServerError);
+    }
+    ApplicationOutcome::success(response, SessionEffect::NewlyBound)
+}
+
 fn finish_user_binding(
     app_state: &AppState,
     lease: &V2SessionLease,
@@ -4713,6 +5307,235 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn exact_password_reset_and_platform_lifecycle_contracts_are_admitted() {
+        for (path, expected_request) in [
+            ("/password-reset/request", true),
+            ("/password-reset/confirm", false),
+        ] {
+            let prepared = prepare_user_operation(
+                envelope(LogicalMethod::Post, path, json_header(), Some(b"{}"), None),
+                AuthorityState::Anonymous,
+            );
+            assert!(matches!(
+                (expected_request, prepared),
+                (
+                    true,
+                    OperationPreparation::Ready(UserOperation::UserPasswordResetRequest { .. })
+                ) | (
+                    false,
+                    OperationPreparation::Ready(UserOperation::UserPasswordResetConfirm { .. })
+                )
+            ));
+        }
+
+        for (path, expected_login) in [("/platform/login", true), ("/platform/register", false)] {
+            let prepared = prepare_user_operation(
+                envelope(LogicalMethod::Post, path, json_header(), Some(b"{}"), None),
+                AuthorityState::Anonymous,
+            );
+            assert!(matches!(
+                (expected_login, prepared),
+                (
+                    true,
+                    OperationPreparation::Ready(UserOperation::PlatformLogin { .. })
+                ) | (
+                    false,
+                    OperationPreparation::Ready(UserOperation::PlatformRegister { .. })
+                )
+            ));
+        }
+
+        let mut resume = envelope(
+            LogicalMethod::Post,
+            "/platform/refresh",
+            Vec::new(),
+            None,
+            Some(Credential::Resumption {
+                value_base64: EncodedBytes::from_bytes(b"platform-resumption".to_vec()),
+            }),
+        );
+        resume.cache_namespace_root_base64 = None;
+        assert!(matches!(
+            prepare_user_operation(resume, AuthorityState::Anonymous),
+            OperationPreparation::Ready(UserOperation::PlatformResume { .. })
+        ));
+
+        let verification_path = "/platform/verify-email/123e4567-e89b-12d3-a456-426614174000";
+        for authority in [AuthorityState::Anonymous, bound_platform_authority()] {
+            assert!(matches!(
+                prepare_user_operation(
+                    envelope(
+                        LogicalMethod::Get,
+                        verification_path,
+                        Vec::new(),
+                        None,
+                        None,
+                    ),
+                    authority,
+                ),
+                OperationPreparation::Ready(UserOperation::PlatformVerifyEmail { .. })
+            ));
+        }
+
+        for (path, expected_request) in [
+            ("/platform/password-reset/request", true),
+            ("/platform/password-reset/confirm", false),
+        ] {
+            let prepared = prepare_user_operation(
+                envelope(LogicalMethod::Post, path, json_header(), Some(b"{}"), None),
+                AuthorityState::Anonymous,
+            );
+            assert!(matches!(
+                (expected_request, prepared),
+                (
+                    true,
+                    OperationPreparation::Ready(UserOperation::PlatformPasswordResetRequest { .. })
+                ) | (
+                    false,
+                    OperationPreparation::Ready(UserOperation::PlatformPasswordResetConfirm { .. })
+                )
+            ));
+        }
+
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Post,
+                    "/platform/logout",
+                    json_header(),
+                    Some(b"{}"),
+                    None,
+                ),
+                bound_platform_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::PlatformLogout { .. })
+        ));
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Post,
+                    "/platform/request_verification",
+                    Vec::new(),
+                    None,
+                    None,
+                ),
+                bound_platform_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::PlatformRequestVerification { .. })
+        ));
+        assert!(matches!(
+            prepare_user_operation(
+                envelope(
+                    LogicalMethod::Post,
+                    "/platform/change-password",
+                    json_header(),
+                    Some(b"{}"),
+                    None,
+                ),
+                bound_platform_authority(),
+            ),
+            OperationPreparation::Ready(UserOperation::PlatformChangePassword { .. })
+        ));
+    }
+
+    #[test]
+    fn platform_lifecycle_rejects_wrong_authority_and_transplanted_metadata() {
+        for path in [
+            "/platform/logout",
+            "/platform/request_verification",
+            "/platform/change-password",
+        ] {
+            let bodyful = path != "/platform/request_verification";
+            let request = envelope(
+                LogicalMethod::Post,
+                path,
+                if bodyful { json_header() } else { Vec::new() },
+                bodyful.then_some(b"{}".as_slice()),
+                None,
+            );
+            for authority in [AuthorityState::Anonymous, bound_user_authority()] {
+                assert!(matches!(
+                    prepare_user_operation(request.clone(), authority),
+                    OperationPreparation::Rejected(response)
+                        if response.status == StatusCode::UNAUTHORIZED
+                ));
+            }
+
+            let mut transplanted = request;
+            transplanted.request.query = Some("admin=true".to_owned());
+            assert!(matches!(
+                prepare_user_operation(transplanted, bound_platform_authority()),
+                OperationPreparation::Rejected(response)
+                    if response.status == StatusCode::BAD_REQUEST
+            ));
+        }
+
+        let platform_login = envelope(
+            LogicalMethod::Post,
+            "/platform/login",
+            json_header(),
+            Some(b"{}"),
+            None,
+        );
+        assert!(matches!(
+            prepare_user_operation(platform_login, bound_platform_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::CONFLICT
+        ));
+
+        let platform_verification = envelope(
+            LogicalMethod::Get,
+            "/platform/verify-email/123e4567-e89b-12d3-a456-426614174000",
+            Vec::new(),
+            None,
+            None,
+        );
+        assert!(matches!(
+            prepare_user_operation(platform_verification, bound_user_authority()),
+            OperationPreparation::Rejected(response)
+                if response.status == StatusCode::UNAUTHORIZED
+        ));
+    }
+
+    #[test]
+    fn platform_authentication_and_terminal_session_effects_are_classified() {
+        for operation in [
+            UserOperation::PlatformLogin {
+                body: Zeroizing::new(Vec::new()),
+            },
+            UserOperation::PlatformRegister {
+                body: Zeroizing::new(Vec::new()),
+            },
+            UserOperation::PlatformResume {
+                credential: Zeroizing::new(Vec::new()),
+            },
+        ] {
+            assert!(operation.requires_authentication_transition());
+            assert_eq!(operation.session_effect_on_success(), SessionEffect::Retain);
+        }
+
+        let authority = BoundPlatformAuthority {
+            platform_user_id: uuid::Uuid::nil(),
+        };
+        assert_eq!(
+            UserOperation::PlatformLogout {
+                authority: authority.clone(),
+                body: Zeroizing::new(Vec::new()),
+            }
+            .session_effect_on_success(),
+            SessionEffect::Close
+        );
+        assert_eq!(
+            UserOperation::PlatformChangePassword {
+                authority,
+                body: Zeroizing::new(Vec::new()),
+            }
+            .session_effect_on_success(),
+            SessionEffect::Close
+        );
     }
 
     #[test]
@@ -5119,6 +5942,13 @@ mod tests {
                 OperationPreparation::Ready(UserOperation::VerifyEmail { code })
                     if code == uuid::Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").unwrap()
             ));
+        }
+
+        for authority in [bound_api_key_authority(), bound_platform_authority()] {
+            assert_eq!(
+                rejected_status(prepare_user_operation(request(), authority)),
+                StatusCode::UNAUTHORIZED
+            );
         }
 
         assert!(matches!(
@@ -7355,6 +8185,14 @@ mod tests {
                 bound_user_authority(),
             )),
             StatusCode::BAD_REQUEST
+        );
+
+        assert_eq!(
+            rejected_status(prepare_user_operation(
+                envelope(LogicalMethod::Get, "/v1/models", Vec::new(), None, None),
+                bound_platform_authority(),
+            )),
+            StatusCode::UNAUTHORIZED
         );
     }
 

--- a/src/transport_v2/envelope.rs
+++ b/src/transport_v2/envelope.rs
@@ -377,6 +377,7 @@ impl LogicalRequest {
 const KV_ITEM_PATH_PREFIX: &str = "/protected/kv/";
 const API_KEY_ITEM_PATH_PREFIX: &str = "/protected/api-keys/";
 const VERIFY_EMAIL_PATH_PREFIX: &str = "/verify-email/";
+const PLATFORM_VERIFY_EMAIL_PATH_PREFIX: &str = "/platform/verify-email/";
 const CONVERSATION_PROJECT_ITEM_PATH_PREFIX: &str = "/v1/conversation-projects/";
 const CONVERSATION_ITEM_PATH_PREFIX: &str = "/v1/conversations/";
 const INSTRUCTION_ITEM_PATH_PREFIX: &str = "/v1/instructions/";
@@ -417,6 +418,9 @@ fn validate_logical_path(
         return Ok(());
     }
     if decode_canonical_verify_email_path(method, path)?.is_some() {
+        return Ok(());
+    }
+    if decode_canonical_platform_verify_email_path(method, path)?.is_some() {
         return Ok(());
     }
     if decode_canonical_conversation_project_path(method, path)?.is_some() {
@@ -508,6 +512,29 @@ pub(crate) fn decode_canonical_verify_email_path(
     if code.hyphenated().to_string() != segment {
         return Err(EnvelopeError::InvalidPath(
             "email verification code must use lowercase hyphenated UUID spelling",
+        ));
+    }
+    Ok(Some(code))
+}
+
+/// Decodes the canonical UUID credential admitted by platform email
+/// verification without changing the more permissive transport-v1 parser.
+pub(crate) fn decode_canonical_platform_verify_email_path(
+    method: LogicalMethod,
+    path: &str,
+) -> Result<Option<Uuid>, EnvelopeError> {
+    if method != LogicalMethod::Get {
+        return Ok(None);
+    }
+    let Some(segment) = path.strip_prefix(PLATFORM_VERIFY_EMAIL_PATH_PREFIX) else {
+        return Ok(None);
+    };
+    let code = Uuid::parse_str(segment).map_err(|_| {
+        EnvelopeError::InvalidPath("platform email verification code must be a canonical UUID")
+    })?;
+    if code.hyphenated().to_string() != segment {
+        return Err(EnvelopeError::InvalidPath(
+            "platform email verification code must use lowercase hyphenated UUID spelling",
         ));
     }
     Ok(Some(code))
@@ -1517,6 +1544,36 @@ mod tests {
             "/verify-email/123e4567%2De89b%2D12d3%2Da456%2D426614174000",
             "/verify-email/123e4567-e89b-12d3-a456-426614174000/extra",
             "/verify-email/not-a-uuid",
+        ] {
+            assert!(
+                validate_logical_path(LogicalMethod::Get, invalid, &EnvelopeLimits::default())
+                    .is_err(),
+                "{invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn platform_email_verification_path_uses_one_canonical_uuid_spelling() {
+        let encoded = "123e4567-e89b-12d3-a456-426614174000";
+        let path = format!("{PLATFORM_VERIFY_EMAIL_PATH_PREFIX}{encoded}");
+        assert_eq!(
+            decode_canonical_platform_verify_email_path(LogicalMethod::Get, &path).unwrap(),
+            Some(Uuid::parse_str(encoded).unwrap())
+        );
+        validate_logical_path(LogicalMethod::Get, &path, &EnvelopeLimits::default()).unwrap();
+
+        assert!(
+            decode_canonical_platform_verify_email_path(LogicalMethod::Post, &path)
+                .unwrap()
+                .is_none()
+        );
+        for invalid in [
+            "/platform/verify-email/",
+            "/platform/verify-email/123E4567-E89B-12D3-A456-426614174000",
+            "/platform/verify-email/123e4567e89b12d3a456426614174000",
+            "/platform/verify-email/123e4567-e89b-12d3-a456-426614174000/extra",
+            "/platform/verify-email/not-a-uuid",
         ] {
             assert!(
                 validate_logical_path(LogicalMethod::Get, invalid, &EnvelopeLimits::default())

--- a/src/web/login_routes.rs
+++ b/src/web/login_routes.rs
@@ -444,6 +444,14 @@ pub async fn password_reset_request(
     Extension(payload): Extension<PasswordResetRequestPayload>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+    let response = password_reset_request_data(&data, payload).await?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn password_reset_request_data(
+    data: &Arc<AppState>,
+    payload: PasswordResetRequestPayload,
+) -> Result<serde_json::Value, ApiError> {
     // Get project by client_id
     let project = data
         .db
@@ -459,7 +467,7 @@ pub async fn password_reset_request(
                 let response = json!({
                     "message": "If an account with that email exists, we have sent a password reset link."
                 });
-                return encrypt_response(&data, &session_id, &response).await;
+                return Ok(response);
             }
         }
         Err(DBError::UserNotFound) => {
@@ -467,7 +475,7 @@ pub async fn password_reset_request(
             let response = json!({
                 "message": "If an account with that email exists, we have sent a password reset link."
             });
-            return encrypt_response(&data, &session_id, &response).await;
+            return Ok(response);
         }
         Err(e) => {
             error!("Error in password reset request: {:?}", e);
@@ -487,8 +495,7 @@ pub async fn password_reset_request(
     let response = json!({
         "message": "If an account with that email exists, we have sent a password reset link."
     });
-    let result = encrypt_response(&data, &session_id, &response).await;
-    result
+    Ok(response)
 }
 
 pub async fn password_reset_confirm(
@@ -496,6 +503,14 @@ pub async fn password_reset_confirm(
     Extension(payload): Extension<PasswordResetConfirmPayload>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+    let response = password_reset_confirm_data(&data, payload).await?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn password_reset_confirm_data(
+    data: &Arc<AppState>,
+    payload: PasswordResetConfirmPayload,
+) -> Result<serde_json::Value, ApiError> {
     // Get project by client_id
     let project = data
         .db
@@ -539,6 +554,5 @@ pub async fn password_reset_confirm(
     let response = json!({
         "message": "Password reset successful. You can now log in with your new password."
     });
-    let result = encrypt_response(&data, &session_id, &response).await;
-    result
+    Ok(response)
 }

--- a/src/web/login_routes.rs
+++ b/src/web/login_routes.rs
@@ -169,7 +169,7 @@ pub(crate) async fn authenticate_login(
             match data.db.get_user_by_email(email.clone(), project.id) {
                 Ok(user) => user,
                 Err(DBError::UserNotFound) => {
-                    error!("User not found by email: {email}");
+                    error!("User not found for email login");
                     return Err(ApiError::InvalidUsernameOrPassword);
                 }
                 Err(e) => {

--- a/src/web/platform/login_routes.rs
+++ b/src/web/platform/login_routes.rs
@@ -2,8 +2,9 @@ use crate::{
     email::send_platform_verification_email,
     jwt::{NewToken, TokenType, PLATFORM_REFRESH},
     models::{
-        org_memberships::OrgRole, platform_email_verification::NewPlatformEmailVerification,
-        platform_users::NewPlatformUser,
+        org_memberships::OrgRole,
+        platform_email_verification::NewPlatformEmailVerification,
+        platform_users::{NewPlatformUser, PlatformUser},
     },
     web::encryption_middleware::{
         decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
@@ -203,36 +204,22 @@ pub async fn login_platform_user(
         return Err(ApiError::BadRequest);
     }
 
-    let auth_response = login_internal_platform(data.clone(), login_request).await?;
+    let platform_user = authenticate_platform_login(data.clone(), login_request).await?;
+    let auth_response = v1_platform_auth_response(&data, platform_user)?;
     let result = encrypt_response(&data, &session_id, &auth_response).await;
     result
 }
 
-async fn login_internal_platform(
+pub(crate) async fn authenticate_platform_login(
     data: Arc<AppState>,
     login_request: PlatformLoginRequest,
-) -> Result<PlatformAuthResponse, ApiError> {
+) -> Result<PlatformUser, ApiError> {
     // Authenticate the platform user
     match data
         .authenticate_platform_user(&login_request.email, login_request.password)
         .await
     {
-        Ok(Some(platform_user)) => {
-            // Generate tokens
-            let access_token =
-                NewToken::new_for_platform_user(&platform_user, TokenType::Access, &data)?;
-            let refresh_token =
-                NewToken::new_for_platform_user(&platform_user, TokenType::Refresh, &data)?;
-
-            let auth_response = PlatformAuthResponse {
-                id: platform_user.uuid,
-                email: platform_user.email,
-                name: platform_user.name,
-                access_token: access_token.token,
-                refresh_token: refresh_token.token,
-            };
-            Ok(auth_response)
-        }
+        Ok(Some(platform_user)) => Ok(platform_user),
         Ok(None) => {
             error!("Invalid login attempt for platform user");
             Err(ApiError::InvalidUsernameOrPassword)
@@ -242,6 +229,22 @@ async fn login_internal_platform(
             Err(ApiError::InternalServerError)
         }
     }
+}
+
+fn v1_platform_auth_response(
+    data: &AppState,
+    platform_user: PlatformUser,
+) -> Result<PlatformAuthResponse, ApiError> {
+    let access_token = NewToken::new_for_platform_user(&platform_user, TokenType::Access, data)?;
+    let refresh_token = NewToken::new_for_platform_user(&platform_user, TokenType::Refresh, data)?;
+
+    Ok(PlatformAuthResponse {
+        id: platform_user.uuid,
+        email: platform_user.email,
+        name: platform_user.name,
+        access_token: access_token.token,
+        refresh_token: refresh_token.token,
+    })
 }
 
 pub async fn register_platform_user(
@@ -255,6 +258,17 @@ pub async fn register_platform_user(
         return Err(ApiError::BadRequest);
     }
 
+    let platform_user = register_platform_user_data(data.clone(), register_request).await?;
+    let response = v1_platform_auth_response(&data, platform_user)?;
+
+    let result = encrypt_response(&data, &session_id, &response).await;
+    result
+}
+
+pub(crate) async fn register_platform_user_data(
+    data: Arc<AppState>,
+    register_request: PlatformRegisterRequest,
+) -> Result<PlatformUser, ApiError> {
     // Check if user already exists
     if data
         .db
@@ -333,20 +347,7 @@ pub async fn register_platform_user(
         }
     });
 
-    // Generate tokens
-    let access_token = NewToken::new_for_platform_user(&platform_user, TokenType::Access, &data)?;
-    let refresh_token = NewToken::new_for_platform_user(&platform_user, TokenType::Refresh, &data)?;
-
-    let response = PlatformAuthResponse {
-        id: platform_user.uuid,
-        email: platform_user.email,
-        name: platform_user.name,
-        access_token: access_token.token,
-        refresh_token: refresh_token.token,
-    };
-
-    let result = encrypt_response(&data, &session_id, &response).await;
-    result
+    Ok(platform_user)
 }
 
 pub async fn refresh_platform_token(
@@ -387,6 +388,14 @@ pub async fn verify_platform_email(
     Path(code): Path<Uuid>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+    let response = verify_platform_email_data(&data, code)?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) fn verify_platform_email_data(
+    data: &AppState,
+    code: Uuid,
+) -> Result<serde_json::Value, ApiError> {
     // Retrieve the verification record using the code
     let verification = match data.db.get_platform_email_verification_by_code(code) {
         Ok(verification) => verification,
@@ -405,7 +414,7 @@ pub async fn verify_platform_email(
         let response = json!({
             "message": "Email already verified"
         });
-        return encrypt_response(&data, &session_id, &response).await;
+        return Ok(response);
     }
 
     // Check if verification is expired
@@ -428,8 +437,7 @@ pub async fn verify_platform_email(
         "message": "Email verified successfully"
     });
 
-    let result = encrypt_response(&data, &session_id, &response).await;
-    result
+    Ok(response)
 }
 
 pub async fn logout_platform_user(
@@ -439,11 +447,15 @@ pub async fn logout_platform_user(
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     info!("Platform logout request received");
 
-    // TODO: Implement token invalidation logic here when needed
-    drop(logout_request.refresh_token);
-    let response = json!({ "message": "Logged out successfully" });
+    let response = platform_logout_data(logout_request);
     let result = encrypt_response(&data, &session_id, &response).await;
     result
+}
+
+pub(crate) fn platform_logout_data(logout_request: PlatformLogoutRequest) -> serde_json::Value {
+    // TODO: Implement token invalidation logic here when needed
+    drop(logout_request.refresh_token);
+    json!({ "message": "Logged out successfully" })
 }
 
 pub async fn platform_password_reset_request(
@@ -457,6 +469,14 @@ pub async fn platform_password_reset_request(
         return Err(ApiError::BadRequest);
     }
 
+    let response = platform_password_reset_request_data(&data, payload).await?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn platform_password_reset_request_data(
+    data: &Arc<AppState>,
+    payload: PlatformPasswordResetRequestPayload,
+) -> Result<serde_json::Value, ApiError> {
     // Check if user exists and is not an OAuth-only user
     match data.db.get_platform_user_by_email(&payload.email) {
         Ok(Some(user)) => {
@@ -466,7 +486,7 @@ pub async fn platform_password_reset_request(
                 let response = json!({
                     "message": "If an account with that email exists, we have sent a password reset link."
                 });
-                return encrypt_response(&data, &session_id, &response).await;
+                return Ok(response);
             }
         }
         Ok(None) => {
@@ -474,7 +494,7 @@ pub async fn platform_password_reset_request(
             let response = json!({
                 "message": "If an account with that email exists, we have sent a password reset link."
             });
-            return encrypt_response(&data, &session_id, &response).await;
+            return Ok(response);
         }
         Err(e) => {
             error!("Error in platform password reset request: {:?}", e);
@@ -494,8 +514,7 @@ pub async fn platform_password_reset_request(
     let response = json!({
         "message": "If an account with that email exists, we have sent a password reset link."
     });
-    let result = encrypt_response(&data, &session_id, &response).await;
-    result
+    Ok(response)
 }
 
 pub async fn platform_password_reset_confirm(
@@ -509,6 +528,14 @@ pub async fn platform_password_reset_confirm(
         return Err(ApiError::BadRequest);
     }
 
+    let response = platform_password_reset_confirm_data(&data, payload).await?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn platform_password_reset_confirm_data(
+    data: &Arc<AppState>,
+    payload: PlatformPasswordResetConfirmPayload,
+) -> Result<serde_json::Value, ApiError> {
     // Check if user exists and is not an OAuth-only user
     match data.db.get_platform_user_by_email(&payload.email) {
         Ok(Some(user)) => {
@@ -546,6 +573,5 @@ pub async fn platform_password_reset_confirm(
         "message": "Password reset successful. You can now log in with your new password."
     });
 
-    let result = encrypt_response(&data, &session_id, &response).await;
-    result
+    Ok(response)
 }

--- a/src/web/platform/me_routes.rs
+++ b/src/web/platform/me_routes.rs
@@ -133,6 +133,14 @@ async fn request_platform_verification(
     Extension(platform_user): Extension<PlatformUser>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+    let response = request_platform_verification_data(&data, &platform_user).await?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn request_platform_verification_data(
+    data: &Arc<AppState>,
+    platform_user: &PlatformUser,
+) -> Result<serde_json::Value, ApiError> {
     // Check if the user is already verified
     match data
         .db
@@ -141,7 +149,7 @@ async fn request_platform_verification(
         Ok(verification) => {
             if verification.is_verified {
                 let response = json!({ "error": "User is already verified" });
-                return encrypt_response(&data, &session_id, &response).await;
+                return Ok(response);
             }
             // Delete the old verification
             if let Err(e) = data.db.delete_platform_email_verification(&verification) {
@@ -193,8 +201,7 @@ async fn request_platform_verification(
         }
     });
 
-    let response = json!({ "message": "New verification code sent successfully" });
-    encrypt_response(&data, &session_id, &response).await
+    Ok(json!({ "message": "New verification code sent successfully" }))
 }
 
 pub async fn platform_change_password(
@@ -209,6 +216,15 @@ pub async fn platform_change_password(
         return Err(ApiError::BadRequest);
     }
 
+    let response = platform_change_password_data(&data, &platform_user, change_request).await?;
+    encrypt_response(&data, &session_id, &response).await
+}
+
+pub(crate) async fn platform_change_password_data(
+    data: &Arc<AppState>,
+    platform_user: &PlatformUser,
+    change_request: PlatformChangePasswordRequest,
+) -> Result<serde_json::Value, ApiError> {
     // Check if user is an OAuth-only user
     if platform_user.password_enc.is_none() {
         error!("OAuth-only platform user attempted to change password");
@@ -223,13 +239,10 @@ pub async fn platform_change_password(
         Ok(Some(authenticated_user)) if authenticated_user.uuid == platform_user.uuid => {
             // Current password is correct, proceed with password change
             match data
-                .update_platform_user_password(&platform_user, change_request.new_password)
+                .update_platform_user_password(platform_user, change_request.new_password)
                 .await
             {
-                Ok(()) => {
-                    let response = json!({ "message": "Password changed successfully" });
-                    encrypt_response(&data, &session_id, &response).await
-                }
+                Ok(()) => Ok(json!({ "message": "Password changed successfully" })),
                 Err(e) => {
                     error!("Error changing platform user password: {:?}", e);
                     Err(ApiError::InternalServerError)

--- a/src/web/platform/mod.rs
+++ b/src/web/platform/mod.rs
@@ -1,7 +1,7 @@
 pub mod common;
 mod invite_routes;
-mod login_routes;
-mod me_routes;
+pub(crate) mod login_routes;
+pub(crate) mod me_routes;
 mod membership_routes;
 pub mod org_routes;
 mod project_routes;


### PR DESCRIPTION
## Scope

This capability layer adds transport-v2 platform authentication and account lifecycle while preserving every existing `/v1` route and response contract.

- Extracts transport-neutral user and platform lifecycle helpers while retaining the existing v1 validation, side effects, legacy JWT issuance, response shapes, statuses, and encrypted-body wrappers.
- Adds v2 user password-reset request and confirmation.
- Adds v2 platform login, registration, resumption, email verification, password-reset request and confirmation, logout, verification resend, and password change.
- Leaves `/platform/me` and the platform organization/project/member/invite/secret/settings control plane for the next stacked PR.

## Security properties

- Platform access descriptors and resumption credentials use separate issuer, audience, purpose, and principal domains from user-v2, platform-v1, and third-party JWTs.
- Login, registration, and resumption atomically bind an anonymous attested session to one live platform user; platform sessions never receive a provider-cache namespace.
- Bound platform operations reload the exact live user before dispatch.
- Logout and successful password change close the exact admitting session before the reserved logical response is encrypted through the same held lease.
- Exact replay IDs are claimed before authentication transition or application dispatch.
- User and platform email-verification capabilities reject cross-principal transplantation.
- Platform authority is rejected from inference operations, including the public models route.
- Authentication-path logs no longer expose submitted email addresses to the forwarding parent.

Global all-device credential revocation remains intentionally out of scope. Logout, password change, and reset do not invalidate other already-issued sessions or resumption credentials; that requires a future platform authentication epoch.

## Compatibility proof

- Source review confirmed unchanged v1 validation, token issuance, response construction, and encryption order.
- The existing TypeScript SDK completed platform registration, login, refresh, logout, and a protected `/platform/me` read against the committed backend.
- Post-restart backend logs contained no email, password, JWT, refresh-token, or reset-code material from that flow.

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo test --locked --all-features`: 606 passed, 35 ignored, 0 failed
- Disposable PostgreSQL suite: 27 AEAD/database tests and 2 OAuth database tests passed with no skips
- Two focused independent reviews found no remaining material issue after the principal-isolation and documentation fixes

Stacked on #333.
