### PR TITLE
Limit GLM 5.2 context to 256K

### DIFF
--- a/src/model_config.rs
+++ b/src/model_config.rs
@@ -582,7 +582,7 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
         true,
         false,
         50,
-        384_000,
+        256_000,
     ),
     ModelConfigEntry::new(
         DEEPSEEK_V4_FLASH_MODEL_ID,
@@ -849,7 +849,7 @@ mod tests {
         assert_eq!(model_context_window("gpt-oss-safeguard-120b"), 131_000);
         assert_eq!(model_context_window("kimi-k2-6"), 256_000);
         assert_eq!(model_context_window("gemma4-31b"), 256_000);
-        assert_eq!(model_context_window("glm-5-2"), 384_000);
+        assert_eq!(model_context_window("glm-5-2"), 256_000);
         assert_eq!(model_context_window("kimi-k3"), 256_000);
         assert_eq!(model_context_window("deepseek-v4-flash"), 800_000);
         assert_eq!(model_context_window(AUTO_QUICK_MODEL_ID), 128_000);

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -51,7 +51,7 @@ mod tests {
         assert_eq!(model_max_ctx("gpt-oss-safeguard-120b"), 131_000);
         assert_eq!(model_max_ctx("kimi-k2-6"), 256_000);
         assert_eq!(model_max_ctx("gemma4-31b"), 256_000);
-        assert_eq!(model_max_ctx("glm-5-2"), 384_000);
+        assert_eq!(model_max_ctx("glm-5-2"), 256_000);
         assert_eq!(model_max_ctx("kimi-k3"), 256_000);
         assert_eq!(model_max_ctx("deepseek-v4-flash"), 800_000);
         assert_eq!(model_max_ctx("auto:quick"), 128_000);

--- a/src/web/responses/context_builder.rs
+++ b/src/web/responses/context_builder.rs
@@ -1002,6 +1002,11 @@ fn normalize_tool_call_ids_for_kimi(messages: &mut [Value]) {
 mod tests {
     use super::*;
 
+    #[test]
+    fn test_glm_5_2_prompt_budget_reserves_response_and_safety_tokens() {
+        assert_eq!(prompt_token_budget("glm-5-2"), 256_000 - 4096 - 500);
+    }
+
     // Helper to create a ChatMsg
     fn create_chat_msg(role: &'static str, content: &str, tokens: Option<usize>) -> ChatMsg {
         use crate::web::responses::MessageContent;


### PR DESCRIPTION
## Summary

- limit the shared GLM 5.2 context window to 256,000 tokens so both Tinfoil and Continuum routes use the same application-level ceiling
- preserve the existing Responses reserve of 4,096 output tokens plus the 500-token safety buffer, yielding a 251,404-token prompt budget
- update model/token lookup coverage and add a focused assertion for the buffered GLM prompt budget

## Testing

- `git diff --check`
- Rust CI: format, Clippy, and full test suite passed
- CodeQL and Rust supply-chain checks passed
- development reproducible EIF build passed; production build is intentionally skipped for pull requests

The focused local test command could not complete because the VM had 109 MiB free and compilation stopped with `No space left on device` before tests ran. The pull request CI completed the executable validation successfully.