### PR TITLE
Transport v2: project platform resource control

### DIFF
--- a/.agents/skills/validate-opensecret/scripts/disposable_db_tests.sh
+++ b/.agents/skills/validate-opensecret/scripts/disposable_db_tests.sh
@@ -90,8 +90,8 @@ cleanup() {
   rm -rf -- "$workdir"
 
   if [ "$status" -eq 0 ] && [ "$tests_passed" -eq 1 ]; then
-    printf 'Disposable-DB evidence: %s AEAD/database tests and %s OAuth database tests passed; no tests skipped; temporary cluster removed.\n' \
-      "$aead_count" "$oauth_count"
+    printf 'Disposable-DB evidence: %s AEAD/database tests, %s OAuth database tests, and %s platform-resource database tests passed; no tests skipped; temporary cluster removed.\n' \
+      "$aead_count" "$oauth_count" "$platform_resource_count"
   fi
   exit "$status"
 }
@@ -177,6 +177,13 @@ oauth_count="$(awk '/^web::oauth_routes::tests::db_.*: test$/ { count++ }
   END { print count + 0 }' "$workdir/oauth-tests.list")"
 test "$oauth_count" -gt 0
 
+cargo test --locked --all-features \
+  transport_v2::platform_resources::tests::database_ \
+  -- --ignored --list | tee "$workdir/platform-resource-tests.list"
+platform_resource_count="$(awk '/^transport_v2::platform_resources::tests::database_.*: test$/ { count++ }
+  END { print count + 0 }' "$workdir/platform-resource-tests.list")"
+test "$platform_resource_count" -gt 0
+
 cargo test --locked --all-features aead_db_tamper_tests \
   -- --ignored --test-threads=1 --nocapture 2>&1 | tee "$workdir/aead-tests.log"
 if grep -qi 'skipping:' "$workdir/aead-tests.log"; then
@@ -194,6 +201,17 @@ if grep -qi 'skipping:' "$workdir/oauth-tests.log"; then
 fi
 grep -Eq "test result: ok\\. ${oauth_count} passed; 0 failed; 0 ignored;" \
   "$workdir/oauth-tests.log"
+
+cargo test --locked --all-features \
+  transport_v2::platform_resources::tests::database_ \
+  -- --ignored --test-threads=1 --nocapture 2>&1 |
+  tee "$workdir/platform-resource-tests.log"
+if grep -qi 'skipping:' "$workdir/platform-resource-tests.log"; then
+  printf 'Platform-resource database test output contained a skip marker\n' >&2
+  exit 1
+fi
+grep -Eq "test result: ok\\. ${platform_resource_count} passed; 0 failed; 0 ignored;" \
+  "$workdir/platform-resource-tests.log"
 
 assert_database_identity
 assert_migration_count

--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -616,6 +616,62 @@ organization, project, membership, invite, secret, and settings control plane.
 Those operations require live role checks and v2-only bounded database output;
 they are deliberately separated from principal establishment.
 
+### 8.8 Platform resource control
+
+Every platform resource request requires the immutable platform authority on
+the admitting v2 session. The logical request carries no credential, cache
+namespace, or query. GET and DELETE operations, plus invite acceptance, carry
+no logical headers or body. POST, PATCH, and PUT resource operations carry one
+nonempty JSON body and exactly one logical JSON content-type header. The
+gateway claims the request ID before any read or mutation and encrypts the
+logical result through the same held session lease.
+
+Transport v2 projects the complete currently implemented control plane:
+
+| Resource | Read authority | Mutation authority |
+| --- | --- | --- |
+| `/platform/me` and `/platform/orgs` | current platform user; organization lists contain only memberships | any platform user may create an organization and becomes Owner; only Owner deletes it |
+| organization projects | any organization member | Owner or Admin creates, updates, and deletes |
+| project secret metadata | any organization member; values are never returned or loaded by a metadata read | Owner or Admin upserts and deletes |
+| project email and OAuth settings | any organization member | Owner or Admin updates |
+| organization memberships | any organization member | Owner changes roles or removes members; the final Owner cannot be demoted or removed |
+| organization invites | Owner or Admin lists and deletes; the exact recipient may read its invite | Owner or Admin creates non-Owner invites; only Owner creates an Owner invite |
+| `/platform/accept_invite/{code}` | exact bound recipient | unused, unexpired invite is consumed atomically with membership creation |
+
+Every operation rechecks that the platform-user row still exists. Organization
+roles are never cached in session state: reads recheck live membership, and a
+write checks authority in the same transaction as its mutation. Project paths
+also prove that the selected project belongs to the selected organization.
+Membership changes serialize the actor, target, and final-Owner invariant.
+Invite acceptance locks and revalidates the invite before consuming it.
+
+V2 closes two demonstrated invitation elevation paths without changing the
+transport-v1 contract. An Admin cannot issue an Owner invite. Accepting an
+Owner invite additionally requires a currently verified platform email, so an
+account registered under a visible pending recipient address cannot claim
+ownership before proving mailbox control. During v1 coexistence, an authorized
+legacy Admin can still use the unchanged v1 invitation behavior; global closure
+therefore requires eventual v1 platform-control retirement or a separately
+approved v1 security correction.
+
+Database-controlled platform output uses a v2-only bounded storage projection.
+Reads measure length and count in a repeatable-read snapshot before loading
+variable strings or JSON, use narrow columns, and fail with encrypted 413
+rather than truncating. Collections have a 65,536-row sentinel and must also
+fit the 28 MiB logical-response ceiling. Secret listing and deletion never load
+the encrypted secret value. Operations whose logical success depends on stored
+variable data obtain the larger stored-output working-set reservation before
+the replay claim and database dispatch.
+
+Response status and JSON shape otherwise remain the current application
+contract: every success is 200, delete operations retain their message object,
+secret creation remains an upsert, absent email settings remain 404, absent
+OAuth settings return the disabled default, and the SDK-only push-settings
+stubs are not treated as backend routes. V2 also applies the already-declared
+project-update and invite-request validators that their v1 handlers omit; this
+prevents a v2 write from creating stored values outside the bounded v2 read
+contract while leaving the v1 handlers unchanged.
+
 ## 9. First-party and third-party tokens
 
 Transport v2 removes first-party JWTs from steady-state OpenSecret request

--- a/src/transport_v2/application.rs
+++ b/src/transport_v2/application.rs
@@ -11,7 +11,9 @@ use std::time::Instant;
 use axum::extract::Query;
 use axum::http::{header, HeaderMap, HeaderName, HeaderValue, StatusCode, Uri};
 use axum::response::IntoResponse;
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use chrono::{DateTime, Utc};
+use secp256k1::SecretKey;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -20,12 +22,14 @@ use zeroize::{Zeroize, Zeroizing};
 
 use crate::bounded_json::BoundedJsonBuffer;
 use crate::db::DBError;
+use crate::email::send_platform_invite_email;
 use crate::encrypt::{decrypt_with_key, encrypt_with_key};
 use crate::jwt::{
     issue_transport_v2_platform_tokens, issue_transport_v2_user_tokens,
     validate_transport_v2_platform_resumption, validate_transport_v2_user_resumption, AuthContext,
 };
 use crate::kv::StoreError;
+use crate::models::project_settings::{EmailSettings, OAuthSettings};
 use crate::models::responses::{ConversationProjectFilter, NewConversation, ResponseStatus};
 use crate::provider_cache::{
     derive_tinfoil_cache_namespace, CacheNamespaceRoot, DerivedCacheNamespace,
@@ -46,6 +50,11 @@ use crate::web::openai::{
     EmbeddingRequest, TTSRequest, TranscriptionRequest,
 };
 use crate::web::openai_auth::AuthMethod as OpenAiAuthMethod;
+use crate::web::platform::common::{
+    CreateInviteRequest, CreateOrgRequest, CreateProjectRequest, CreateSecretRequest,
+    UpdateEmailSettingsRequest, UpdateMembershipRequest, UpdateOAuthSettingsRequest,
+    UpdateProjectRequest,
+};
 use crate::web::platform::login_routes::{
     authenticate_platform_login, platform_logout_data, platform_password_reset_confirm_data,
     platform_password_reset_request_data, register_platform_user_data, verify_platform_email_data,
@@ -113,11 +122,13 @@ use crate::{
 use super::envelope::{
     decode_canonical_api_key_name_path, decode_canonical_conversation_path,
     decode_canonical_conversation_project_path, decode_canonical_instruction_path,
-    decode_canonical_kv_item_path, decode_canonical_platform_verify_email_path,
-    decode_canonical_response_path, decode_canonical_verify_email_path, ConversationItemPath,
-    Credential, EncodedBytes, EnvelopeLimits, HeaderField, InstructionItemPath, LogicalMethod,
+    decode_canonical_kv_item_path, decode_canonical_platform_resource_path,
+    decode_canonical_platform_verify_email_path, decode_canonical_response_path,
+    decode_canonical_verify_email_path, ConversationItemPath, Credential, EncodedBytes,
+    EnvelopeLimits, HeaderField, InstructionItemPath, LogicalMethod, PlatformResourcePath,
     RequestEnvelope, RequestId, ResponseItemPath, ResponseMode,
 };
+use super::platform_resources::{self, PlatformResourceError, PlatformResourceKind};
 use super::session::{
     AuthenticationReservation, AuthenticationStartError, AuthorityState, BoundAuthority,
     BoundPrincipal,
@@ -220,6 +231,10 @@ pub(crate) enum UserOperation {
         authority: BoundPlatformAuthority,
         body: SensitiveBytes,
     },
+    PlatformControl {
+        authority: BoundPlatformAuthority,
+        operation: PlatformControlOperation,
+    },
     Logout {
         body: SensitiveBytes,
     },
@@ -235,6 +250,119 @@ pub(crate) enum UserOperation {
         authority: InferenceAuthority,
         operation: InferenceOperation,
     },
+}
+
+pub(crate) enum PlatformControlOperation {
+    GetMe,
+    CreateOrganization {
+        body: SensitiveBytes,
+    },
+    ListOrganizations,
+    DeleteOrganization {
+        org_id: uuid::Uuid,
+    },
+    CreateProject {
+        org_id: uuid::Uuid,
+        body: SensitiveBytes,
+    },
+    ListProjects {
+        org_id: uuid::Uuid,
+    },
+    GetProject {
+        org_id: uuid::Uuid,
+        project_id: uuid::Uuid,
+    },
+    UpdateProject {
+        org_id: uuid::Uuid,
+        project_id: uuid::Uuid,
+        body: SensitiveBytes,
+    },
+    DeleteProject {
+        org_id: uuid::Uuid,
+        project_id: uuid::Uuid,
+    },
+    CreateSecret {
+        org_id: uuid::Uuid,
+        project_id: uuid::Uuid,
+        body: SensitiveBytes,
+    },
+    ListSecrets {
+        org_id: uuid::Uuid,
+        project_id: uuid::Uuid,
+    },
+    DeleteSecret {
+        org_id: uuid::Uuid,
+        project_id: uuid::Uuid,
+        key_name: Zeroizing<String>,
+    },
+    GetEmailSettings {
+        org_id: uuid::Uuid,
+        project_id: uuid::Uuid,
+    },
+    UpdateEmailSettings {
+        org_id: uuid::Uuid,
+        project_id: uuid::Uuid,
+        body: SensitiveBytes,
+    },
+    GetOAuthSettings {
+        org_id: uuid::Uuid,
+        project_id: uuid::Uuid,
+    },
+    UpdateOAuthSettings {
+        org_id: uuid::Uuid,
+        project_id: uuid::Uuid,
+        body: SensitiveBytes,
+    },
+    ListMemberships {
+        org_id: uuid::Uuid,
+    },
+    UpdateMembership {
+        org_id: uuid::Uuid,
+        user_id: uuid::Uuid,
+        body: SensitiveBytes,
+    },
+    DeleteMembership {
+        org_id: uuid::Uuid,
+        user_id: uuid::Uuid,
+    },
+    CreateInvite {
+        org_id: uuid::Uuid,
+        body: SensitiveBytes,
+    },
+    ListInvites {
+        org_id: uuid::Uuid,
+    },
+    GetInvite {
+        org_id: uuid::Uuid,
+        invite_code: uuid::Uuid,
+    },
+    DeleteInvite {
+        org_id: uuid::Uuid,
+        invite_code: uuid::Uuid,
+    },
+    AcceptInvite {
+        invite_code: uuid::Uuid,
+    },
+}
+
+impl PlatformControlOperation {
+    const fn requires_stored_output_reservation(&self) -> bool {
+        matches!(
+            self,
+            Self::GetMe
+                | Self::ListOrganizations
+                | Self::ListProjects { .. }
+                | Self::GetProject { .. }
+                | Self::UpdateProject { .. }
+                | Self::ListSecrets { .. }
+                | Self::GetEmailSettings { .. }
+                | Self::GetOAuthSettings { .. }
+                | Self::ListMemberships { .. }
+                | Self::UpdateMembership { .. }
+                | Self::ListInvites { .. }
+                | Self::GetInvite { .. }
+        )
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -493,6 +621,10 @@ impl UserOperation {
                     | ProtectedUserOperation::CancelStoredResponse { .. },
                 ..
             }
+        ) || matches!(
+            self,
+            Self::PlatformControl { operation, .. }
+                if operation.requires_stored_output_reservation()
         )
     }
 
@@ -503,6 +635,7 @@ impl UserOperation {
             | Self::PlatformLogout { .. }
             | Self::PlatformChangePassword { .. } => SessionEffect::Close,
             Self::Protected { operation, .. } => operation.session_effect_on_success(),
+            Self::PlatformControl { .. } => SessionEffect::Retain,
             Self::Inference { .. } => SessionEffect::Retain,
             _ => SessionEffect::Retain,
         }
@@ -839,6 +972,10 @@ pub(crate) fn prepare_user_operation(
         PlatformLogout,
         PlatformRequestVerification,
         PlatformChangePassword,
+        PlatformMe,
+        CreatePlatformOrganization,
+        ListPlatformOrganizations,
+        PlatformResource,
         GetUser,
         RequestVerification,
         GetPrivateKey,
@@ -924,6 +1061,14 @@ pub(crate) fn prepare_user_operation(
                 return rejected_bad_request();
             }
         };
+    let platform_resource_path =
+        match decode_canonical_platform_resource_path(request.method, &request.path) {
+            Ok(path) => path,
+            Err(_) => {
+                request.path.zeroize();
+                return rejected_bad_request();
+            }
+        };
     let conversation_project_id =
         match decode_canonical_conversation_project_path(request.method, &request.path) {
             Ok(project_id) => project_id,
@@ -985,6 +1130,9 @@ pub(crate) fn prepare_user_operation(
             Some(Route::PlatformRequestVerification)
         }
         (LogicalMethod::Post, "/platform/change-password") => Some(Route::PlatformChangePassword),
+        (LogicalMethod::Get, "/platform/me") => Some(Route::PlatformMe),
+        (LogicalMethod::Post, "/platform/orgs") => Some(Route::CreatePlatformOrganization),
+        (LogicalMethod::Get, "/platform/orgs") => Some(Route::ListPlatformOrganizations),
         (LogicalMethod::Get, "/protected/user") => Some(Route::GetUser),
         (LogicalMethod::Post, "/protected/request_verification") => {
             Some(Route::RequestVerification)
@@ -1107,12 +1255,14 @@ pub(crate) fn prepare_user_operation(
         (LogicalMethod::Post, _) if matches!(response_path, Some(ResponseItemPath::Cancel(_))) => {
             Some(Route::CancelStoredResponse)
         }
+        (_, _) if platform_resource_path.is_some() => Some(Route::PlatformResource),
         _ => None,
     };
     if kv_key.is_some()
         || api_key_name.is_some()
         || verification_code.is_some()
         || platform_verification_code.is_some()
+        || platform_resource_path.is_some()
         || conversation_project_id.is_some()
         || instruction_path.is_some()
         || conversation_path.is_some()
@@ -1509,6 +1659,234 @@ pub(crate) fn prepare_user_operation(
                 Err(rejection) => return OperationPreparation::Rejected(rejection),
             };
             OperationPreparation::Ready(UserOperation::PlatformRequestVerification { authority })
+        }
+        Route::PlatformMe
+        | Route::CreatePlatformOrganization
+        | Route::ListPlatformOrganizations
+        | Route::PlatformResource => {
+            if credential.is_some() || request.query.is_some() {
+                return rejected_bad_request();
+            }
+
+            let requires_body = matches!(route, Route::CreatePlatformOrganization)
+                || matches!(
+                    (&platform_resource_path, request.method),
+                    (
+                        Some(
+                            PlatformResourcePath::Projects(_)
+                                | PlatformResourcePath::Secrets { .. }
+                                | PlatformResourcePath::Invites(_)
+                        ),
+                        LogicalMethod::Post
+                    ) | (
+                        Some(
+                            PlatformResourcePath::Project { .. }
+                                | PlatformResourcePath::Membership { .. }
+                        ),
+                        LogicalMethod::Patch
+                    ) | (
+                        Some(
+                            PlatformResourcePath::EmailSettings { .. }
+                                | PlatformResourcePath::OAuthSettings { .. }
+                        ),
+                        LogicalMethod::Put
+                    )
+                );
+
+            let body = if requires_body {
+                if !has_exact_json_content_type(&request.headers)
+                    || request
+                        .body_base64
+                        .as_ref()
+                        .is_none_or(EncodedBytes::is_empty)
+                {
+                    return rejected_bad_request();
+                }
+                Some(Zeroizing::new(
+                    request
+                        .body_base64
+                        .take()
+                        .expect("validated platform resource body")
+                        .into_bytes(),
+                ))
+            } else {
+                if !request.headers.is_empty() || request.body_base64.is_some() {
+                    return rejected_bad_request();
+                }
+                None
+            };
+
+            let authority = match bound_platform_authority(authority) {
+                Ok(authority) => authority,
+                Err(rejection) => return OperationPreparation::Rejected(rejection),
+            };
+            let operation = match (route, platform_resource_path, request.method) {
+                (Route::PlatformMe, None, LogicalMethod::Get) => PlatformControlOperation::GetMe,
+                (Route::CreatePlatformOrganization, None, LogicalMethod::Post) => {
+                    PlatformControlOperation::CreateOrganization {
+                        body: body.expect("organization creation requires a body"),
+                    }
+                }
+                (Route::ListPlatformOrganizations, None, LogicalMethod::Get) => {
+                    PlatformControlOperation::ListOrganizations
+                }
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::Organization(org_id)),
+                    LogicalMethod::Delete,
+                ) => PlatformControlOperation::DeleteOrganization { org_id },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::Projects(org_id)),
+                    LogicalMethod::Post,
+                ) => PlatformControlOperation::CreateProject {
+                    org_id,
+                    body: body.expect("project creation requires a body"),
+                },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::Projects(org_id)),
+                    LogicalMethod::Get,
+                ) => PlatformControlOperation::ListProjects { org_id },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::Project { org_id, project_id }),
+                    LogicalMethod::Get,
+                ) => PlatformControlOperation::GetProject { org_id, project_id },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::Project { org_id, project_id }),
+                    LogicalMethod::Patch,
+                ) => PlatformControlOperation::UpdateProject {
+                    org_id,
+                    project_id,
+                    body: body.expect("project update requires a body"),
+                },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::Project { org_id, project_id }),
+                    LogicalMethod::Delete,
+                ) => PlatformControlOperation::DeleteProject { org_id, project_id },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::Secrets { org_id, project_id }),
+                    LogicalMethod::Post,
+                ) => PlatformControlOperation::CreateSecret {
+                    org_id,
+                    project_id,
+                    body: body.expect("secret creation requires a body"),
+                },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::Secrets { org_id, project_id }),
+                    LogicalMethod::Get,
+                ) => PlatformControlOperation::ListSecrets { org_id, project_id },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::Secret {
+                        org_id,
+                        project_id,
+                        key_name,
+                    }),
+                    LogicalMethod::Delete,
+                ) => PlatformControlOperation::DeleteSecret {
+                    org_id,
+                    project_id,
+                    key_name,
+                },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::EmailSettings { org_id, project_id }),
+                    LogicalMethod::Get,
+                ) => PlatformControlOperation::GetEmailSettings { org_id, project_id },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::EmailSettings { org_id, project_id }),
+                    LogicalMethod::Put,
+                ) => PlatformControlOperation::UpdateEmailSettings {
+                    org_id,
+                    project_id,
+                    body: body.expect("email settings update requires a body"),
+                },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::OAuthSettings { org_id, project_id }),
+                    LogicalMethod::Get,
+                ) => PlatformControlOperation::GetOAuthSettings { org_id, project_id },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::OAuthSettings { org_id, project_id }),
+                    LogicalMethod::Put,
+                ) => PlatformControlOperation::UpdateOAuthSettings {
+                    org_id,
+                    project_id,
+                    body: body.expect("OAuth settings update requires a body"),
+                },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::Memberships(org_id)),
+                    LogicalMethod::Get,
+                ) => PlatformControlOperation::ListMemberships { org_id },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::Membership { org_id, user_id }),
+                    LogicalMethod::Patch,
+                ) => PlatformControlOperation::UpdateMembership {
+                    org_id,
+                    user_id,
+                    body: body.expect("membership update requires a body"),
+                },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::Membership { org_id, user_id }),
+                    LogicalMethod::Delete,
+                ) => PlatformControlOperation::DeleteMembership { org_id, user_id },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::Invites(org_id)),
+                    LogicalMethod::Post,
+                ) => PlatformControlOperation::CreateInvite {
+                    org_id,
+                    body: body.expect("invite creation requires a body"),
+                },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::Invites(org_id)),
+                    LogicalMethod::Get,
+                ) => PlatformControlOperation::ListInvites { org_id },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::Invite {
+                        org_id,
+                        invite_code,
+                    }),
+                    LogicalMethod::Get,
+                ) => PlatformControlOperation::GetInvite {
+                    org_id,
+                    invite_code,
+                },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::Invite {
+                        org_id,
+                        invite_code,
+                    }),
+                    LogicalMethod::Delete,
+                ) => PlatformControlOperation::DeleteInvite {
+                    org_id,
+                    invite_code,
+                },
+                (
+                    Route::PlatformResource,
+                    Some(PlatformResourcePath::AcceptInvite(invite_code)),
+                    LogicalMethod::Post,
+                ) => PlatformControlOperation::AcceptInvite { invite_code },
+                _ => return rejected_bad_request(),
+            };
+            OperationPreparation::Ready(UserOperation::PlatformControl {
+                authority,
+                operation,
+            })
         }
         Route::VerifyEmail => {
             if credential.is_some()
@@ -2808,6 +3186,10 @@ pub(crate) async fn execute_user_operation(
             };
             ApplicationOutcome::success(response, session_effect_on_success)
         }
+        UserOperation::PlatformControl {
+            authority,
+            operation,
+        } => execute_platform_control_operation(&app_state, authority, operation).await,
         UserOperation::VerifyEmail { code } => {
             debug_assert!(authentication.is_none());
             let response = match verify_email_data(&app_state, code)
@@ -2961,6 +3343,421 @@ pub(crate) async fn execute_user_operation(
                 monotonic_now,
             )
             .await
+        }
+    }
+}
+
+async fn execute_platform_control_operation(
+    app_state: &AppState,
+    authority: BoundPlatformAuthority,
+    operation: PlatformControlOperation,
+) -> ApplicationOutcome {
+    macro_rules! resource_value {
+        ($future:expr) => {
+            match $future.await {
+                Ok(value) => value,
+                Err(error) => return platform_resource_error_outcome(error),
+            }
+        };
+    }
+
+    macro_rules! json_response {
+        ($value:expr) => {
+            match LogicalUnaryResponse::json(StatusCode::OK, &$value) {
+                Ok(response) => response,
+                Err(error) => return ApplicationOutcome::error(error),
+            }
+        };
+    }
+
+    let pool = app_state.db.get_pool();
+    let actor_id = authority.platform_user_id;
+    let logical_body_limit = EnvelopeLimits::DEFAULT.logical_body_bytes;
+    let response = match operation {
+        PlatformControlOperation::GetMe => {
+            let value = resource_value!(platform_resources::get_me(
+                pool,
+                actor_id,
+                logical_body_limit
+            ));
+            json_response!(value)
+        }
+        PlatformControlOperation::CreateOrganization { body } => {
+            let request = match parse_json_body::<CreateOrgRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            if request.validate().is_err() {
+                return ApplicationOutcome::error(ApiError::BadRequest);
+            }
+            let value =
+                resource_value!(platform_resources::create_org(pool, actor_id, request.name));
+            json_response!(value)
+        }
+        PlatformControlOperation::ListOrganizations => {
+            let value = resource_value!(platform_resources::list_orgs(
+                pool,
+                actor_id,
+                logical_body_limit
+            ));
+            json_response!(value)
+        }
+        PlatformControlOperation::DeleteOrganization { org_id } => {
+            resource_value!(platform_resources::delete_org(pool, actor_id, org_id));
+            json_response!(serde_json::json!({
+                "message": "Organization deleted successfully"
+            }))
+        }
+        PlatformControlOperation::CreateProject { org_id, body } => {
+            let request = match parse_json_body::<CreateProjectRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            if request.validate().is_err() {
+                return ApplicationOutcome::error(ApiError::BadRequest);
+            }
+            let value = resource_value!(platform_resources::create_project(
+                pool,
+                actor_id,
+                org_id,
+                request.name,
+                request.description,
+            ));
+            json_response!(value)
+        }
+        PlatformControlOperation::ListProjects { org_id } => {
+            let value = resource_value!(platform_resources::list_projects(
+                pool,
+                actor_id,
+                org_id,
+                logical_body_limit,
+            ));
+            json_response!(value)
+        }
+        PlatformControlOperation::GetProject { org_id, project_id } => {
+            let value = resource_value!(platform_resources::get_project(
+                pool,
+                actor_id,
+                org_id,
+                project_id,
+                logical_body_limit,
+            ));
+            json_response!(value)
+        }
+        PlatformControlOperation::UpdateProject {
+            org_id,
+            project_id,
+            body,
+        } => {
+            let request = match parse_json_body::<UpdateProjectRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            if request.validate().is_err() {
+                return ApplicationOutcome::error(ApiError::BadRequest);
+            }
+            let value = resource_value!(platform_resources::update_project(
+                pool,
+                actor_id,
+                org_id,
+                project_id,
+                request.name,
+                request.description,
+                request.status,
+                logical_body_limit,
+            ));
+            json_response!(value)
+        }
+        PlatformControlOperation::DeleteProject { org_id, project_id } => {
+            resource_value!(platform_resources::delete_project(
+                pool, actor_id, org_id, project_id
+            ));
+            json_response!(serde_json::json!({
+                "message": "Project deleted successfully"
+            }))
+        }
+        PlatformControlOperation::CreateSecret {
+            org_id,
+            project_id,
+            body,
+        } => {
+            let mut request = match parse_json_body::<CreateSecretRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            if request.validate().is_err() {
+                request.secret.zeroize();
+                return ApplicationOutcome::error(ApiError::BadRequest);
+            }
+            let encoded_secret = Zeroizing::new(std::mem::take(&mut request.secret));
+            let secret_bytes = match STANDARD.decode(encoded_secret.as_bytes()) {
+                Ok(secret) => Zeroizing::new(secret),
+                Err(_) => return ApplicationOutcome::error(ApiError::BadRequest),
+            };
+            let enclave_key = match SecretKey::from_slice(&app_state.enclave_key) {
+                Ok(key) => key,
+                Err(_) => return ApplicationOutcome::error(ApiError::InternalServerError),
+            };
+            let encrypted_secret =
+                Zeroizing::new(encrypt_with_key(&enclave_key, &secret_bytes).await);
+            let value = resource_value!(platform_resources::create_secret(
+                pool,
+                actor_id,
+                org_id,
+                project_id,
+                request.key_name,
+                &encrypted_secret,
+            ));
+            json_response!(value)
+        }
+        PlatformControlOperation::ListSecrets { org_id, project_id } => {
+            let value = resource_value!(platform_resources::list_secrets(
+                pool,
+                actor_id,
+                org_id,
+                project_id,
+                logical_body_limit,
+            ));
+            json_response!(value)
+        }
+        PlatformControlOperation::DeleteSecret {
+            org_id,
+            project_id,
+            key_name,
+        } => {
+            resource_value!(platform_resources::delete_secret(
+                pool, actor_id, org_id, project_id, &key_name,
+            ));
+            json_response!(serde_json::json!({
+                "message": "Secret deleted successfully"
+            }))
+        }
+        PlatformControlOperation::GetEmailSettings { org_id, project_id } => {
+            let value = resource_value!(platform_resources::get_email_settings(
+                pool,
+                actor_id,
+                org_id,
+                project_id,
+                logical_body_limit,
+            ));
+            json_response!(value)
+        }
+        PlatformControlOperation::UpdateEmailSettings {
+            org_id,
+            project_id,
+            body,
+        } => {
+            let request = match parse_json_body::<UpdateEmailSettingsRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            if request.validate().is_err() {
+                return ApplicationOutcome::error(ApiError::BadRequest);
+            }
+            let settings = EmailSettings {
+                provider: request.provider,
+                send_from: request.send_from,
+                email_verification_url: request.email_verification_url,
+            };
+            let value = resource_value!(platform_resources::update_email_settings(
+                pool, actor_id, org_id, project_id, settings,
+            ));
+            json_response!(value)
+        }
+        PlatformControlOperation::GetOAuthSettings { org_id, project_id } => {
+            let value = resource_value!(platform_resources::get_oauth_settings(
+                pool,
+                actor_id,
+                org_id,
+                project_id,
+                logical_body_limit,
+            ));
+            json_response!(value)
+        }
+        PlatformControlOperation::UpdateOAuthSettings {
+            org_id,
+            project_id,
+            body,
+        } => {
+            let request = match parse_json_body::<UpdateOAuthSettingsRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            if request.validate().is_err()
+                || (request.google_oauth_enabled && request.google_oauth_settings.is_none())
+                || (request.github_oauth_enabled && request.github_oauth_settings.is_none())
+                || (request.apple_oauth_enabled && request.apple_oauth_settings.is_none())
+            {
+                return ApplicationOutcome::error(ApiError::BadRequest);
+            }
+            let settings = OAuthSettings {
+                google_oauth_enabled: request.google_oauth_enabled,
+                github_oauth_enabled: request.github_oauth_enabled,
+                apple_oauth_enabled: request.apple_oauth_enabled,
+                google_oauth_settings: request.google_oauth_settings,
+                github_oauth_settings: request.github_oauth_settings,
+                apple_oauth_settings: request.apple_oauth_settings,
+            };
+            let value = resource_value!(platform_resources::update_oauth_settings(
+                pool, actor_id, org_id, project_id, settings,
+            ));
+            json_response!(value)
+        }
+        PlatformControlOperation::ListMemberships { org_id } => {
+            let value = resource_value!(platform_resources::list_memberships(
+                pool,
+                actor_id,
+                org_id,
+                logical_body_limit,
+            ));
+            json_response!(value)
+        }
+        PlatformControlOperation::UpdateMembership {
+            org_id,
+            user_id,
+            body,
+        } => {
+            let request = match parse_json_body::<UpdateMembershipRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            let value = resource_value!(platform_resources::update_membership(
+                pool,
+                actor_id,
+                org_id,
+                user_id,
+                request.role,
+                logical_body_limit,
+            ));
+            json_response!(value)
+        }
+        PlatformControlOperation::DeleteMembership { org_id, user_id } => {
+            resource_value!(platform_resources::delete_membership(
+                pool, actor_id, org_id, user_id,
+            ));
+            json_response!(serde_json::json!({
+                "message": "Membership deleted successfully"
+            }))
+        }
+        PlatformControlOperation::CreateInvite { org_id, body } => {
+            let request = match parse_json_body::<CreateInviteRequest>(body) {
+                Ok(request) => request,
+                Err(error) => return ApplicationOutcome::error(error),
+            };
+            if request.validate().is_err() {
+                return ApplicationOutcome::error(ApiError::BadRequest);
+            }
+            let created = match platform_resources::create_invite(
+                pool,
+                actor_id,
+                org_id,
+                request.email,
+                request.role,
+                logical_body_limit,
+            )
+            .await
+            {
+                Ok(created) => created,
+                Err(PlatformResourceError::NotFound(PlatformResourceKind::Organization)) => {
+                    return ApplicationOutcome::error(ApiError::BadRequest);
+                }
+                Err(error) => return platform_resource_error_outcome(error),
+            };
+            let response = json_response!(created.response);
+            let dispatch = created.dispatch;
+            let app_mode = app_state.app_mode.clone();
+            let resend_api_key = app_state.resend_api_key.clone();
+            tokio::spawn(async move {
+                if send_platform_invite_email(
+                    app_mode,
+                    resend_api_key,
+                    dispatch.email,
+                    dispatch.organization_name,
+                    dispatch.invite_code,
+                    dispatch.organization_id,
+                )
+                .await
+                .is_err()
+                {
+                    tracing::error!("Failed to send platform invitation email");
+                }
+            });
+            response
+        }
+        PlatformControlOperation::ListInvites { org_id } => {
+            let value = resource_value!(platform_resources::list_invites(
+                pool,
+                actor_id,
+                org_id,
+                logical_body_limit,
+            ));
+            json_response!(value)
+        }
+        PlatformControlOperation::GetInvite {
+            org_id,
+            invite_code,
+        } => {
+            let value = resource_value!(platform_resources::get_invite(
+                pool,
+                actor_id,
+                org_id,
+                invite_code,
+                logical_body_limit,
+            ));
+            json_response!(value)
+        }
+        PlatformControlOperation::DeleteInvite {
+            org_id,
+            invite_code,
+        } => {
+            resource_value!(platform_resources::delete_invite(
+                pool,
+                actor_id,
+                org_id,
+                invite_code,
+            ));
+            json_response!(serde_json::json!({
+                "message": "Invite deleted successfully"
+            }))
+        }
+        PlatformControlOperation::AcceptInvite { invite_code } => {
+            resource_value!(platform_resources::accept_invite(
+                pool,
+                actor_id,
+                invite_code,
+                logical_body_limit,
+            ));
+            json_response!(serde_json::json!({
+                "message": "Invite accepted successfully"
+            }))
+        }
+    };
+
+    ApplicationOutcome::success(response, SessionEffect::Retain)
+}
+
+fn platform_resource_error_outcome(error: PlatformResourceError) -> ApplicationOutcome {
+    match error {
+        PlatformResourceError::NotFound(PlatformResourceKind::Actor) => {
+            ApplicationOutcome::closing_error(ApiError::Unauthorized)
+        }
+        PlatformResourceError::NotFound(_) => ApplicationOutcome::error(ApiError::NotFound),
+        PlatformResourceError::Unauthorized | PlatformResourceError::VerifiedEmailRequired => {
+            ApplicationOutcome::error(ApiError::Unauthorized)
+        }
+        PlatformResourceError::Validation
+        | PlatformResourceError::Conflict
+        | PlatformResourceError::LastOwner
+        | PlatformResourceError::InviteAlreadyUsed
+        | PlatformResourceError::InviteExpired => ApplicationOutcome::error(ApiError::BadRequest),
+        PlatformResourceError::OutputTooLarge => {
+            ApplicationOutcome::error(ApiError::PayloadTooLarge)
+        }
+        PlatformResourceError::InconsistentSnapshot
+        | PlatformResourceError::Connection
+        | PlatformResourceError::Database(_) => {
+            tracing::error!("Failed to execute bounded platform resource operation");
+            ApplicationOutcome::error(ApiError::InternalServerError)
         }
     }
 }
@@ -7730,6 +8527,230 @@ mod tests {
             uuid::Uuid::from_bytes([0xa4; 16]),
             Instant::now() + std::time::Duration::from_secs(60),
         ))
+    }
+
+    #[test]
+    fn complete_platform_control_matrix_is_exactly_session_bound() {
+        let org = "123e4567-e89b-12d3-a456-426614174000";
+        let project = "223e4567-e89b-12d3-a456-426614174000";
+        let user = "323e4567-e89b-12d3-a456-426614174000";
+        let invite = "423e4567-e89b-12d3-a456-426614174000";
+        let cases = [
+            (LogicalMethod::Get, "/platform/me".to_owned(), false, true),
+            (
+                LogicalMethod::Post,
+                "/platform/orgs".to_owned(),
+                true,
+                false,
+            ),
+            (LogicalMethod::Get, "/platform/orgs".to_owned(), false, true),
+            (
+                LogicalMethod::Delete,
+                format!("/platform/orgs/{org}"),
+                false,
+                false,
+            ),
+            (
+                LogicalMethod::Post,
+                format!("/platform/orgs/{org}/projects"),
+                true,
+                false,
+            ),
+            (
+                LogicalMethod::Get,
+                format!("/platform/orgs/{org}/projects"),
+                false,
+                true,
+            ),
+            (
+                LogicalMethod::Get,
+                format!("/platform/orgs/{org}/projects/{project}"),
+                false,
+                true,
+            ),
+            (
+                LogicalMethod::Patch,
+                format!("/platform/orgs/{org}/projects/{project}"),
+                true,
+                true,
+            ),
+            (
+                LogicalMethod::Delete,
+                format!("/platform/orgs/{org}/projects/{project}"),
+                false,
+                false,
+            ),
+            (
+                LogicalMethod::Post,
+                format!("/platform/orgs/{org}/projects/{project}/secrets"),
+                true,
+                false,
+            ),
+            (
+                LogicalMethod::Get,
+                format!("/platform/orgs/{org}/projects/{project}/secrets"),
+                false,
+                true,
+            ),
+            (
+                LogicalMethod::Delete,
+                format!("/platform/orgs/{org}/projects/{project}/secrets/API_KEY"),
+                false,
+                false,
+            ),
+            (
+                LogicalMethod::Get,
+                format!("/platform/orgs/{org}/projects/{project}/settings/email"),
+                false,
+                true,
+            ),
+            (
+                LogicalMethod::Put,
+                format!("/platform/orgs/{org}/projects/{project}/settings/email"),
+                true,
+                false,
+            ),
+            (
+                LogicalMethod::Get,
+                format!("/platform/orgs/{org}/projects/{project}/settings/oauth"),
+                false,
+                true,
+            ),
+            (
+                LogicalMethod::Put,
+                format!("/platform/orgs/{org}/projects/{project}/settings/oauth"),
+                true,
+                false,
+            ),
+            (
+                LogicalMethod::Get,
+                format!("/platform/orgs/{org}/memberships"),
+                false,
+                true,
+            ),
+            (
+                LogicalMethod::Patch,
+                format!("/platform/orgs/{org}/memberships/{user}"),
+                true,
+                true,
+            ),
+            (
+                LogicalMethod::Delete,
+                format!("/platform/orgs/{org}/memberships/{user}"),
+                false,
+                false,
+            ),
+            (
+                LogicalMethod::Post,
+                format!("/platform/orgs/{org}/invites"),
+                true,
+                false,
+            ),
+            (
+                LogicalMethod::Get,
+                format!("/platform/orgs/{org}/invites"),
+                false,
+                true,
+            ),
+            (
+                LogicalMethod::Get,
+                format!("/platform/orgs/{org}/invites/{invite}"),
+                false,
+                true,
+            ),
+            (
+                LogicalMethod::Delete,
+                format!("/platform/orgs/{org}/invites/{invite}"),
+                false,
+                false,
+            ),
+            (
+                LogicalMethod::Post,
+                format!("/platform/accept_invite/{invite}"),
+                false,
+                false,
+            ),
+        ];
+
+        assert_eq!(cases.len(), 24);
+        for (method, path, has_body, requires_stored_output) in cases {
+            let preparation = prepare_user_operation(
+                envelope(
+                    method,
+                    &path,
+                    has_body.then(json_header).unwrap_or_default(),
+                    has_body.then_some(b"{}".as_slice()),
+                    None,
+                ),
+                bound_platform_authority(),
+            );
+            let OperationPreparation::Ready(operation) = preparation else {
+                panic!("platform control route was not admitted: {method:?} {path}");
+            };
+            assert!(matches!(&operation, UserOperation::PlatformControl { .. }));
+            assert_eq!(
+                operation.requires_stored_output_reservation(),
+                requires_stored_output,
+                "{method:?} {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn platform_control_rejects_authority_and_request_transplants() {
+        let exact = || envelope(LogicalMethod::Get, "/platform/me", Vec::new(), None, None);
+        for authority in [
+            AuthorityState::Anonymous,
+            bound_user_authority(),
+            bound_api_key_authority(),
+        ] {
+            assert_eq!(
+                rejected_status(prepare_user_operation(exact(), authority)),
+                StatusCode::UNAUTHORIZED
+            );
+        }
+
+        let mut with_query = exact();
+        with_query.request.query = Some("transplanted=true".to_owned());
+        assert_eq!(
+            rejected_status(prepare_user_operation(
+                with_query,
+                bound_platform_authority()
+            )),
+            StatusCode::BAD_REQUEST
+        );
+
+        let mut with_body = exact();
+        with_body.request.body_base64 = Some(EncodedBytes::from_bytes(b"{}".to_vec()));
+        assert_eq!(
+            rejected_status(prepare_user_operation(
+                with_body,
+                bound_platform_authority()
+            )),
+            StatusCode::BAD_REQUEST
+        );
+
+        let mut with_header = exact();
+        with_header.request.headers = json_header();
+        assert_eq!(
+            rejected_status(prepare_user_operation(
+                with_header,
+                bound_platform_authority()
+            )),
+            StatusCode::BAD_REQUEST
+        );
+
+        let mut with_credential = exact();
+        with_credential.credential = Some(Credential::Resumption {
+            value_base64: EncodedBytes::from_bytes(b"transplanted".to_vec()),
+        });
+        assert_eq!(
+            rejected_status(prepare_user_operation(
+                with_credential,
+                bound_platform_authority()
+            )),
+            StatusCode::BAD_REQUEST
+        );
     }
 
     fn inference_kind(operation: &InferenceOperation) -> &'static str {

--- a/src/transport_v2/envelope.rs
+++ b/src/transport_v2/envelope.rs
@@ -378,6 +378,8 @@ const KV_ITEM_PATH_PREFIX: &str = "/protected/kv/";
 const API_KEY_ITEM_PATH_PREFIX: &str = "/protected/api-keys/";
 const VERIFY_EMAIL_PATH_PREFIX: &str = "/verify-email/";
 const PLATFORM_VERIFY_EMAIL_PATH_PREFIX: &str = "/platform/verify-email/";
+const PLATFORM_ORG_PATH_PREFIX: &str = "/platform/orgs/";
+const PLATFORM_ACCEPT_INVITE_PATH_PREFIX: &str = "/platform/accept_invite/";
 const CONVERSATION_PROJECT_ITEM_PATH_PREFIX: &str = "/v1/conversation-projects/";
 const CONVERSATION_ITEM_PATH_PREFIX: &str = "/v1/conversations/";
 const INSTRUCTION_ITEM_PATH_PREFIX: &str = "/v1/instructions/";
@@ -405,6 +407,44 @@ pub(crate) enum ResponseItemPath {
     Cancel(Uuid),
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum PlatformResourcePath {
+    Organization(Uuid),
+    Projects(Uuid),
+    Project {
+        org_id: Uuid,
+        project_id: Uuid,
+    },
+    Secrets {
+        org_id: Uuid,
+        project_id: Uuid,
+    },
+    Secret {
+        org_id: Uuid,
+        project_id: Uuid,
+        key_name: Zeroizing<String>,
+    },
+    EmailSettings {
+        org_id: Uuid,
+        project_id: Uuid,
+    },
+    OAuthSettings {
+        org_id: Uuid,
+        project_id: Uuid,
+    },
+    Memberships(Uuid),
+    Membership {
+        org_id: Uuid,
+        user_id: Uuid,
+    },
+    Invites(Uuid),
+    Invite {
+        org_id: Uuid,
+        invite_code: Uuid,
+    },
+    AcceptInvite(Uuid),
+}
+
 fn validate_logical_path(
     method: LogicalMethod,
     path: &str,
@@ -421,6 +461,9 @@ fn validate_logical_path(
         return Ok(());
     }
     if decode_canonical_platform_verify_email_path(method, path)?.is_some() {
+        return Ok(());
+    }
+    if decode_canonical_platform_resource_path(method, path)?.is_some() {
         return Ok(());
     }
     if decode_canonical_conversation_project_path(method, path)?.is_some() {
@@ -538,6 +581,140 @@ pub(crate) fn decode_canonical_platform_verify_email_path(
         ));
     }
     Ok(Some(code))
+}
+
+/// Decodes the dynamic platform control-plane paths admitted by transport v2.
+///
+/// UUIDs have one lowercase-hyphenated spelling. Project-secret names use the
+/// released `[A-Za-z0-9_]+` route contract directly; unlike general opaque
+/// paths, an underscore is literal because existing TypeScript clients place
+/// it in the URL without percent encoding.
+pub(crate) fn decode_canonical_platform_resource_path(
+    method: LogicalMethod,
+    path: &str,
+) -> Result<Option<PlatformResourcePath>, EnvelopeError> {
+    if let Some(code) = path.strip_prefix(PLATFORM_ACCEPT_INVITE_PATH_PREFIX) {
+        if method != LogicalMethod::Post {
+            return Ok(None);
+        }
+        return decode_canonical_uuid_segment(
+            code,
+            "platform invite code must use lowercase hyphenated UUID spelling",
+        )
+        .map(PlatformResourcePath::AcceptInvite)
+        .map(Some);
+    }
+
+    let Some(suffix) = path.strip_prefix(PLATFORM_ORG_PATH_PREFIX) else {
+        return Ok(None);
+    };
+    let mut segments = suffix.split('/');
+    let org = segments.next().unwrap_or_default();
+    let org_id = decode_canonical_uuid_segment(
+        org,
+        "platform organization ID must use lowercase hyphenated UUID spelling",
+    )?;
+    let remainder = segments.collect::<Vec<_>>();
+
+    let decoded = match remainder.as_slice() {
+        [] if method == LogicalMethod::Delete => PlatformResourcePath::Organization(org_id),
+        ["projects"] if matches!(method, LogicalMethod::Get | LogicalMethod::Post) => {
+            PlatformResourcePath::Projects(org_id)
+        }
+        ["projects", project]
+            if matches!(
+                method,
+                LogicalMethod::Get | LogicalMethod::Patch | LogicalMethod::Delete
+            ) =>
+        {
+            PlatformResourcePath::Project {
+                org_id,
+                project_id: decode_canonical_uuid_segment(
+                    project,
+                    "platform project ID must use lowercase hyphenated UUID spelling",
+                )?,
+            }
+        }
+        ["projects", project, "secrets"]
+            if matches!(method, LogicalMethod::Get | LogicalMethod::Post) =>
+        {
+            PlatformResourcePath::Secrets {
+                org_id,
+                project_id: decode_canonical_uuid_segment(
+                    project,
+                    "platform project ID must use lowercase hyphenated UUID spelling",
+                )?,
+            }
+        }
+        ["projects", project, "secrets", key_name] if method == LogicalMethod::Delete => {
+            if key_name.is_empty()
+                || key_name.len() > 50
+                || !key_name
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+            {
+                return Err(EnvelopeError::InvalidPath(
+                    "platform secret name violates the route contract",
+                ));
+            }
+            PlatformResourcePath::Secret {
+                org_id,
+                project_id: decode_canonical_uuid_segment(
+                    project,
+                    "platform project ID must use lowercase hyphenated UUID spelling",
+                )?,
+                key_name: Zeroizing::new((*key_name).to_owned()),
+            }
+        }
+        ["projects", project, "settings", "email"]
+            if matches!(method, LogicalMethod::Get | LogicalMethod::Put) =>
+        {
+            PlatformResourcePath::EmailSettings {
+                org_id,
+                project_id: decode_canonical_uuid_segment(
+                    project,
+                    "platform project ID must use lowercase hyphenated UUID spelling",
+                )?,
+            }
+        }
+        ["projects", project, "settings", "oauth"]
+            if matches!(method, LogicalMethod::Get | LogicalMethod::Put) =>
+        {
+            PlatformResourcePath::OAuthSettings {
+                org_id,
+                project_id: decode_canonical_uuid_segment(
+                    project,
+                    "platform project ID must use lowercase hyphenated UUID spelling",
+                )?,
+            }
+        }
+        ["memberships"] if method == LogicalMethod::Get => {
+            PlatformResourcePath::Memberships(org_id)
+        }
+        ["memberships", user] if matches!(method, LogicalMethod::Patch | LogicalMethod::Delete) => {
+            PlatformResourcePath::Membership {
+                org_id,
+                user_id: decode_canonical_uuid_segment(
+                    user,
+                    "platform membership user ID must use lowercase hyphenated UUID spelling",
+                )?,
+            }
+        }
+        ["invites"] if matches!(method, LogicalMethod::Get | LogicalMethod::Post) => {
+            PlatformResourcePath::Invites(org_id)
+        }
+        ["invites", invite] if matches!(method, LogicalMethod::Get | LogicalMethod::Delete) => {
+            PlatformResourcePath::Invite {
+                org_id,
+                invite_code: decode_canonical_uuid_segment(
+                    invite,
+                    "platform invite code must use lowercase hyphenated UUID spelling",
+                )?,
+            }
+        }
+        _ => return Ok(None),
+    };
+    Ok(Some(decoded))
 }
 
 /// Decodes the canonical UUID segment used by one conversation-project item.
@@ -1581,6 +1758,157 @@ mod tests {
                 "{invalid}"
             );
         }
+    }
+
+    #[test]
+    fn platform_resource_paths_have_one_canonical_route_spelling() {
+        let org = Uuid::parse_str("123e4567-e89b-12d3-a456-426614174000").unwrap();
+        let project = Uuid::parse_str("223e4567-e89b-12d3-a456-426614174000").unwrap();
+        let user = Uuid::parse_str("323e4567-e89b-12d3-a456-426614174000").unwrap();
+        let invite = Uuid::parse_str("423e4567-e89b-12d3-a456-426614174000").unwrap();
+
+        for (method, path, expected) in [
+            (
+                LogicalMethod::Delete,
+                format!("/platform/orgs/{org}"),
+                PlatformResourcePath::Organization(org),
+            ),
+            (
+                LogicalMethod::Get,
+                format!("/platform/orgs/{org}/projects"),
+                PlatformResourcePath::Projects(org),
+            ),
+            (
+                LogicalMethod::Patch,
+                format!("/platform/orgs/{org}/projects/{project}"),
+                PlatformResourcePath::Project {
+                    org_id: org,
+                    project_id: project,
+                },
+            ),
+            (
+                LogicalMethod::Post,
+                format!("/platform/orgs/{org}/projects/{project}/secrets"),
+                PlatformResourcePath::Secrets {
+                    org_id: org,
+                    project_id: project,
+                },
+            ),
+            (
+                LogicalMethod::Delete,
+                format!("/platform/orgs/{org}/projects/{project}/secrets/API_KEY_2"),
+                PlatformResourcePath::Secret {
+                    org_id: org,
+                    project_id: project,
+                    key_name: Zeroizing::new("API_KEY_2".to_owned()),
+                },
+            ),
+            (
+                LogicalMethod::Get,
+                format!("/platform/orgs/{org}/projects/{project}/settings/email"),
+                PlatformResourcePath::EmailSettings {
+                    org_id: org,
+                    project_id: project,
+                },
+            ),
+            (
+                LogicalMethod::Put,
+                format!("/platform/orgs/{org}/projects/{project}/settings/oauth"),
+                PlatformResourcePath::OAuthSettings {
+                    org_id: org,
+                    project_id: project,
+                },
+            ),
+            (
+                LogicalMethod::Get,
+                format!("/platform/orgs/{org}/memberships"),
+                PlatformResourcePath::Memberships(org),
+            ),
+            (
+                LogicalMethod::Delete,
+                format!("/platform/orgs/{org}/memberships/{user}"),
+                PlatformResourcePath::Membership {
+                    org_id: org,
+                    user_id: user,
+                },
+            ),
+            (
+                LogicalMethod::Post,
+                format!("/platform/orgs/{org}/invites"),
+                PlatformResourcePath::Invites(org),
+            ),
+            (
+                LogicalMethod::Get,
+                format!("/platform/orgs/{org}/invites/{invite}"),
+                PlatformResourcePath::Invite {
+                    org_id: org,
+                    invite_code: invite,
+                },
+            ),
+            (
+                LogicalMethod::Post,
+                format!("/platform/accept_invite/{invite}"),
+                PlatformResourcePath::AcceptInvite(invite),
+            ),
+        ] {
+            assert_eq!(
+                decode_canonical_platform_resource_path(method, &path).unwrap(),
+                Some(expected),
+                "{method:?} {path}"
+            );
+            validate_logical_path(method, &path, &EnvelopeLimits::default()).unwrap();
+        }
+    }
+
+    #[test]
+    fn platform_resource_paths_reject_aliases_and_route_transplants() {
+        let canonical_org = "123e4567-e89b-12d3-a456-426614174000";
+        let canonical_project = "223e4567-e89b-12d3-a456-426614174000";
+        for (method, invalid) in [
+            (
+                LogicalMethod::Get,
+                format!("/platform/orgs/{}/projects", canonical_org.to_uppercase()),
+            ),
+            (
+                LogicalMethod::Get,
+                format!("/platform/orgs/{canonical_org}/projects/{canonical_project}/"),
+            ),
+            (
+                LogicalMethod::Delete,
+                format!("/platform/orgs/{canonical_org}/projects/{canonical_project}/secrets/a-b"),
+            ),
+            (
+                LogicalMethod::Delete,
+                format!(
+                    "/platform/orgs/{canonical_org}/projects/{canonical_project}/secrets/a%5Fb"
+                ),
+            ),
+            (
+                LogicalMethod::Post,
+                "/platform/accept_invite/423E4567-E89B-12D3-A456-426614174000".to_owned(),
+            ),
+        ] {
+            assert!(
+                !matches!(
+                    decode_canonical_platform_resource_path(method, &invalid),
+                    Ok(Some(_))
+                ),
+                "{method:?} {invalid}"
+            );
+        }
+
+        assert!(decode_canonical_platform_resource_path(
+            LogicalMethod::Post,
+            &format!("/platform/orgs/{canonical_org}/memberships")
+        )
+        .unwrap()
+        .is_none());
+        assert!(decode_canonical_platform_resource_path(
+            LogicalMethod::Get,
+            "/platform/accept_invite/423e4567-e89b-12d3-a456-426614174000"
+        )
+        .unwrap()
+        .is_none());
     }
 
     #[test]

--- a/src/transport_v2/mod.rs
+++ b/src/transport_v2/mod.rs
@@ -10,6 +10,7 @@ mod application;
 mod crypto;
 mod envelope;
 mod gateway;
+pub(crate) mod platform_resources;
 mod session;
 mod session_cache;
 pub(crate) mod stored_conversations;

--- a/src/transport_v2/platform_resources.rs
+++ b/src/transport_v2/platform_resources.rs
@@ -1,0 +1,2179 @@
+//! Bounded, transport-v2-only persistence for the platform control plane.
+//!
+//! Transport v1 deliberately keeps using its existing handlers and model
+//! loaders. This module gives transport v2 a narrower boundary: every stored
+//! response is measured before database-controlled strings or JSON are loaded,
+//! list reads have an independent row cap, and mutations revalidate the live
+//! platform actor and organization role inside the committing transaction.
+
+use chrono::{DateTime, Duration, Utc};
+use diesel::dsl::{count_star, sql};
+use diesel::prelude::*;
+use diesel::sql_types::{BigInt, Integer};
+use diesel::{Connection, OptionalExtension};
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::models::org_memberships::OrgRole;
+use crate::models::project_settings::{EmailSettings, OAuthSettings, SettingCategory};
+use crate::models::schema::{
+    invite_codes, org_memberships, org_project_secrets, org_projects, orgs,
+    platform_email_verifications, platform_users, project_settings,
+};
+use crate::web::platform::common::{
+    DetailedInviteResponse, InviteResponse, MeResponse, MembershipResponse, OrgResponse,
+    PlatformUserResponse, ProjectResponse, SecretResponse,
+};
+
+type Pool = diesel::r2d2::Pool<diesel::r2d2::ConnectionManager<PgConnection>>;
+
+/// Platform lists are intentionally unpaginated for compatibility. This cap
+/// prevents a database attacker from turning that contract into an unbounded
+/// metadata allocation even when all stored strings are tiny.
+pub(crate) const MAX_PLATFORM_RESOURCE_ROWS: usize = 65_536;
+
+const ACCOUNTED_BYTES_PER_LIST_ROW: usize = 256;
+// The shared v1 validators bound these fields to 50 Unicode scalar values,
+// not 50 bytes. Four bytes per scalar is therefore the exact UTF-8 ceiling
+// for values that existing clients can legitimately store.
+const MAX_ORG_NAME_BYTES: usize = 50 * 4;
+const MAX_PROJECT_NAME_BYTES: usize = 50 * 4;
+const MAX_PROJECT_DESCRIPTION_BYTES: usize = 255 * 4;
+const MAX_PLATFORM_NAME_BYTES: usize = 50 * 4;
+const MAX_EMAIL_BYTES: usize = 255 * 4;
+const MAX_SECRET_KEY_BYTES: usize = 50;
+const MAX_SETTINGS_JSON_BYTES: usize = 64 * 1024;
+const MEMBERSHIP_ROLE_RANK_SQL: &str = "CASE org_memberships.role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 WHEN 'developer' THEN 2 WHEN 'viewer' THEN 3 ELSE -1 END";
+const INVITE_ROLE_RANK_SQL: &str = "CASE invite_codes.role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 WHEN 'developer' THEN 2 WHEN 'viewer' THEN 3 ELSE -1 END";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PlatformResourceKind {
+    Actor,
+    Organization,
+    Project,
+    Secret,
+    EmailSettings,
+    Membership,
+    Invite,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum PlatformResourceError {
+    #[error("{0:?} not found")]
+    NotFound(PlatformResourceKind),
+    #[error("the bound platform actor is not authorized for this operation")]
+    Unauthorized,
+    #[error("the request violates the platform resource contract")]
+    Validation,
+    #[error("the requested platform resource conflicts with existing state")]
+    Conflict,
+    #[error("the last organization owner cannot be removed or demoted")]
+    LastOwner,
+    #[error("the invite has already been used")]
+    InviteAlreadyUsed,
+    #[error("the invite has expired")]
+    InviteExpired,
+    #[error("an owner invitation requires a verified recipient email")]
+    VerifiedEmailRequired,
+    #[error("stored platform output exceeds the logical response limit")]
+    OutputTooLarge,
+    #[error("stored platform state violates its bounded representation")]
+    InconsistentSnapshot,
+    #[error("database connection unavailable")]
+    Connection,
+    #[error("database error: {0}")]
+    Database(#[from] diesel::result::Error),
+}
+
+pub(crate) struct CreatedInvite {
+    pub(crate) response: InviteResponse,
+    pub(crate) dispatch: InviteEmailDispatch,
+}
+
+pub(crate) struct InviteEmailDispatch {
+    pub(crate) email: String,
+    pub(crate) organization_name: String,
+    pub(crate) organization_id: Uuid,
+    pub(crate) invite_code: Uuid,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StrictRole {
+    Owner,
+    Admin,
+    Developer,
+    Viewer,
+}
+
+impl StrictRole {
+    fn from_rank(rank: i32) -> Result<Self, PlatformResourceError> {
+        match rank {
+            0 => Ok(Self::Owner),
+            1 => Ok(Self::Admin),
+            2 => Ok(Self::Developer),
+            3 => Ok(Self::Viewer),
+            _ => Err(PlatformResourceError::InconsistentSnapshot),
+        }
+    }
+
+    fn from_org_role(role: &OrgRole) -> Self {
+        match role {
+            OrgRole::Owner => Self::Owner,
+            OrgRole::Admin => Self::Admin,
+            OrgRole::Developer => Self::Developer,
+            OrgRole::Viewer => Self::Viewer,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Owner => "owner",
+            Self::Admin => "admin",
+            Self::Developer => "developer",
+            Self::Viewer => "viewer",
+        }
+    }
+
+    fn can_read(self) -> bool {
+        matches!(
+            self,
+            Self::Owner | Self::Admin | Self::Developer | Self::Viewer
+        )
+    }
+
+    fn can_administer(self) -> bool {
+        matches!(self, Self::Owner | Self::Admin)
+    }
+
+    fn is_owner(self) -> bool {
+        self == Self::Owner
+    }
+}
+
+fn checked_length(length: i64) -> Result<usize, PlatformResourceError> {
+    usize::try_from(length).map_err(|_| PlatformResourceError::InconsistentSnapshot)
+}
+
+fn checked_optional_length(length: Option<i64>) -> Result<Option<usize>, PlatformResourceError> {
+    length.map(checked_length).transpose()
+}
+
+fn account_bytes(
+    total: &mut usize,
+    bytes: usize,
+    logical_body_limit: usize,
+) -> Result<(), PlatformResourceError> {
+    *total = total
+        .checked_add(bytes)
+        .ok_or(PlatformResourceError::OutputTooLarge)?;
+    if *total > logical_body_limit {
+        return Err(PlatformResourceError::OutputTooLarge);
+    }
+    Ok(())
+}
+
+fn validate_list_aggregate(
+    row_count: i64,
+    aggregate_string_bytes: Option<i64>,
+    maximum_field_bytes: Option<i64>,
+    field_limit: usize,
+    logical_body_limit: usize,
+) -> Result<(usize, usize), PlatformResourceError> {
+    let rows = checked_length(row_count)?;
+    if rows > MAX_PLATFORM_RESOURCE_ROWS {
+        return Err(PlatformResourceError::OutputTooLarge);
+    }
+    let aggregate = checked_optional_length(aggregate_string_bytes)?.unwrap_or(0);
+    let maximum = checked_optional_length(maximum_field_bytes)?.unwrap_or(0);
+    if maximum > field_limit {
+        return Err(PlatformResourceError::InconsistentSnapshot);
+    }
+    let mut total = rows
+        .checked_mul(ACCOUNTED_BYTES_PER_LIST_ROW)
+        .ok_or(PlatformResourceError::OutputTooLarge)?;
+    account_bytes(&mut total, aggregate, logical_body_limit)?;
+    Ok((rows, aggregate))
+}
+
+fn validate_single_output(
+    lengths: impl IntoIterator<Item = (i64, usize)>,
+    logical_body_limit: usize,
+) -> Result<Vec<usize>, PlatformResourceError> {
+    let mut total = ACCOUNTED_BYTES_PER_LIST_ROW;
+    let mut expected = Vec::new();
+    for (length, maximum) in lengths {
+        let length = checked_length(length)?;
+        if length > maximum {
+            return Err(PlatformResourceError::InconsistentSnapshot);
+        }
+        account_bytes(&mut total, length, logical_body_limit)?;
+        expected.push(length);
+    }
+    Ok(expected)
+}
+
+fn get_connection(
+    pool: &Pool,
+) -> Result<
+    diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<PgConnection>>,
+    PlatformResourceError,
+> {
+    pool.get().map_err(|_| PlatformResourceError::Connection)
+}
+
+fn ensure_live_actor(
+    conn: &mut PgConnection,
+    actor_id: Uuid,
+) -> Result<i32, PlatformResourceError> {
+    platform_users::table
+        .filter(platform_users::uuid.eq(actor_id))
+        .select(platform_users::id)
+        .first::<i32>(conn)
+        .optional()?
+        .ok_or(PlatformResourceError::NotFound(PlatformResourceKind::Actor))
+}
+
+fn lock_live_actor(conn: &mut PgConnection, actor_id: Uuid) -> Result<i32, PlatformResourceError> {
+    platform_users::table
+        .filter(platform_users::uuid.eq(actor_id))
+        .select(platform_users::id)
+        .for_update()
+        .first::<i32>(conn)
+        .optional()?
+        .ok_or(PlatformResourceError::NotFound(PlatformResourceKind::Actor))
+}
+
+fn find_org(conn: &mut PgConnection, org_uuid: Uuid) -> Result<i32, PlatformResourceError> {
+    orgs::table
+        .filter(orgs::uuid.eq(org_uuid))
+        .select(orgs::id)
+        .first::<i32>(conn)
+        .optional()?
+        .ok_or(PlatformResourceError::NotFound(
+            PlatformResourceKind::Organization,
+        ))
+}
+
+fn lock_org(conn: &mut PgConnection, org_uuid: Uuid) -> Result<i32, PlatformResourceError> {
+    orgs::table
+        .filter(orgs::uuid.eq(org_uuid))
+        .select(orgs::id)
+        .for_update()
+        .first::<i32>(conn)
+        .optional()?
+        .ok_or(PlatformResourceError::NotFound(
+            PlatformResourceKind::Organization,
+        ))
+}
+
+fn decode_role_flags(
+    owner: bool,
+    admin: bool,
+    developer: bool,
+    viewer: bool,
+) -> Result<StrictRole, PlatformResourceError> {
+    match (owner, admin, developer, viewer) {
+        (true, false, false, false) => Ok(StrictRole::Owner),
+        (false, true, false, false) => Ok(StrictRole::Admin),
+        (false, false, true, false) => Ok(StrictRole::Developer),
+        (false, false, false, true) => Ok(StrictRole::Viewer),
+        _ => Err(PlatformResourceError::InconsistentSnapshot),
+    }
+}
+
+fn membership_role(
+    conn: &mut PgConnection,
+    actor_id: Uuid,
+    org_id: i32,
+) -> Result<StrictRole, PlatformResourceError> {
+    let flags = org_memberships::table
+        .filter(org_memberships::platform_user_id.eq(actor_id))
+        .filter(org_memberships::org_id.eq(org_id))
+        .select((
+            org_memberships::role.eq(StrictRole::Owner.as_str()),
+            org_memberships::role.eq(StrictRole::Admin.as_str()),
+            org_memberships::role.eq(StrictRole::Developer.as_str()),
+            org_memberships::role.eq(StrictRole::Viewer.as_str()),
+        ))
+        .first::<(bool, bool, bool, bool)>(conn)
+        .optional()?
+        .ok_or(PlatformResourceError::Unauthorized)?;
+    decode_role_flags(flags.0, flags.1, flags.2, flags.3)
+}
+
+fn locked_membership_role(
+    conn: &mut PgConnection,
+    actor_id: Uuid,
+    org_id: i32,
+) -> Result<StrictRole, PlatformResourceError> {
+    let flags = org_memberships::table
+        .filter(org_memberships::platform_user_id.eq(actor_id))
+        .filter(org_memberships::org_id.eq(org_id))
+        .select((
+            org_memberships::role.eq(StrictRole::Owner.as_str()),
+            org_memberships::role.eq(StrictRole::Admin.as_str()),
+            org_memberships::role.eq(StrictRole::Developer.as_str()),
+            org_memberships::role.eq(StrictRole::Viewer.as_str()),
+        ))
+        .for_update()
+        .first::<(bool, bool, bool, bool)>(conn)
+        .optional()?
+        .ok_or(PlatformResourceError::Unauthorized)?;
+    decode_role_flags(flags.0, flags.1, flags.2, flags.3)
+}
+
+fn require_read(role: StrictRole) -> Result<(), PlatformResourceError> {
+    if role.can_read() {
+        Ok(())
+    } else {
+        Err(PlatformResourceError::Unauthorized)
+    }
+}
+
+fn require_admin(role: StrictRole) -> Result<(), PlatformResourceError> {
+    if role.can_administer() {
+        Ok(())
+    } else {
+        Err(PlatformResourceError::Unauthorized)
+    }
+}
+
+fn require_owner(role: StrictRole) -> Result<(), PlatformResourceError> {
+    if role.is_owner() {
+        Ok(())
+    } else {
+        Err(PlatformResourceError::Unauthorized)
+    }
+}
+
+fn find_project(
+    conn: &mut PgConnection,
+    org_id: i32,
+    project_uuid: Uuid,
+) -> Result<i32, PlatformResourceError> {
+    org_projects::table
+        .filter(org_projects::org_id.eq(org_id))
+        .filter(org_projects::uuid.eq(project_uuid))
+        .select(org_projects::id)
+        .first::<i32>(conn)
+        .optional()?
+        .ok_or(PlatformResourceError::NotFound(
+            PlatformResourceKind::Project,
+        ))
+}
+
+fn lock_project(
+    conn: &mut PgConnection,
+    org_id: i32,
+    project_uuid: Uuid,
+) -> Result<i32, PlatformResourceError> {
+    org_projects::table
+        .filter(org_projects::org_id.eq(org_id))
+        .filter(org_projects::uuid.eq(project_uuid))
+        .select(org_projects::id)
+        .for_update()
+        .first::<i32>(conn)
+        .optional()?
+        .ok_or(PlatformResourceError::NotFound(
+            PlatformResourceKind::Project,
+        ))
+}
+
+fn map_unique_conflict(error: diesel::result::Error) -> PlatformResourceError {
+    if matches!(
+        error,
+        diesel::result::Error::DatabaseError(diesel::result::DatabaseErrorKind::UniqueViolation, _)
+    ) {
+        PlatformResourceError::Conflict
+    } else {
+        PlatformResourceError::Database(error)
+    }
+}
+
+fn load_orgs_for_actor(
+    conn: &mut PgConnection,
+    actor_id: Uuid,
+    logical_body_limit: usize,
+) -> Result<Vec<OrgResponse>, PlatformResourceError> {
+    let (count, total_name_bytes, max_name_bytes, invalid_roles) = org_memberships::table
+        .inner_join(orgs::table.on(orgs::id.eq(org_memberships::org_id)))
+        .filter(org_memberships::platform_user_id.eq(actor_id))
+        .select((
+            count_star(),
+            sql::<diesel::sql_types::Nullable<BigInt>>(
+                "SUM(octet_length(orgs.name)::bigint)::bigint",
+            ),
+            sql::<diesel::sql_types::Nullable<BigInt>>(
+                "MAX(octet_length(orgs.name)::bigint)::bigint",
+            ),
+            sql::<diesel::sql_types::Nullable<BigInt>>(
+                "SUM(CASE WHEN org_memberships.role IN ('owner','admin','developer','viewer') THEN 0 ELSE 1 END)::bigint",
+            ),
+        ))
+        .first::<(i64, Option<i64>, Option<i64>, Option<i64>)>(conn)?;
+    if invalid_roles.unwrap_or(0) != 0 {
+        return Err(PlatformResourceError::InconsistentSnapshot);
+    }
+    let (expected_rows, expected_name_bytes) = validate_list_aggregate(
+        count,
+        total_name_bytes,
+        max_name_bytes,
+        MAX_ORG_NAME_BYTES,
+        logical_body_limit,
+    )?;
+
+    let rows = org_memberships::table
+        .inner_join(orgs::table.on(orgs::id.eq(org_memberships::org_id)))
+        .filter(org_memberships::platform_user_id.eq(actor_id))
+        .order(orgs::id.asc())
+        .select((orgs::uuid, orgs::name))
+        .load::<(Uuid, String)>(conn)?;
+    let actual_name_bytes = rows.iter().try_fold(0_usize, |total, (_, name)| {
+        if name.len() > MAX_ORG_NAME_BYTES {
+            return Err(PlatformResourceError::InconsistentSnapshot);
+        }
+        total
+            .checked_add(name.len())
+            .ok_or(PlatformResourceError::InconsistentSnapshot)
+    })?;
+    if rows.len() != expected_rows || actual_name_bytes != expected_name_bytes {
+        return Err(PlatformResourceError::InconsistentSnapshot);
+    }
+    Ok(rows
+        .into_iter()
+        .map(|(id, name)| OrgResponse { id, name })
+        .collect())
+}
+
+pub(crate) async fn get_me(
+    pool: &Pool,
+    actor_id: Uuid,
+    logical_body_limit: usize,
+) -> Result<MeResponse, PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, PlatformResourceError, _>(|conn| {
+            let measurement = platform_users::table
+                .filter(platform_users::uuid.eq(actor_id))
+                .select((
+                    platform_users::id,
+                    sql::<BigInt>("octet_length(platform_users.email::text)::bigint"),
+                    sql::<diesel::sql_types::Nullable<BigInt>>(
+                        "octet_length(platform_users.name)::bigint",
+                    ),
+                    platform_users::created_at,
+                    platform_users::updated_at,
+                ))
+                .first::<(i32, i64, Option<i64>, DateTime<Utc>, DateTime<Utc>)>(conn)
+                .optional()?
+                .ok_or(PlatformResourceError::NotFound(PlatformResourceKind::Actor))?;
+
+            let mut lengths = vec![(measurement.1, MAX_EMAIL_BYTES)];
+            if let Some(name_length) = measurement.2 {
+                lengths.push((name_length, MAX_PLATFORM_NAME_BYTES));
+            }
+            let expected = validate_single_output(lengths, logical_body_limit)?;
+            let (email, name) = platform_users::table
+                .filter(platform_users::id.eq(measurement.0))
+                .select((platform_users::email, platform_users::name))
+                .first::<(String, Option<String>)>(conn)?;
+            if email.len() != expected[0]
+                || name.as_ref().map(String::len) != expected.get(1).copied()
+            {
+                return Err(PlatformResourceError::InconsistentSnapshot);
+            }
+
+            let email_verified = platform_email_verifications::table
+                .filter(platform_email_verifications::platform_user_id.eq(actor_id))
+                .filter(platform_email_verifications::is_verified.eq(true))
+                .select(platform_email_verifications::id)
+                .first::<i32>(conn)
+                .optional()?
+                .is_some();
+            let actor_bytes = ACCOUNTED_BYTES_PER_LIST_ROW
+                .checked_add(email.len())
+                .and_then(|total| total.checked_add(name.as_ref().map_or(0, String::len)))
+                .ok_or(PlatformResourceError::OutputTooLarge)?;
+            let remaining_body_limit = logical_body_limit
+                .checked_sub(actor_bytes)
+                .ok_or(PlatformResourceError::OutputTooLarge)?;
+            let organizations = load_orgs_for_actor(conn, actor_id, remaining_body_limit)?;
+
+            Ok(MeResponse {
+                user: PlatformUserResponse {
+                    id: actor_id,
+                    email,
+                    name,
+                    email_verified,
+                    created_at: measurement.3,
+                    updated_at: measurement.4,
+                },
+                organizations,
+            })
+        })
+}
+
+pub(crate) async fn create_org(
+    pool: &Pool,
+    actor_id: Uuid,
+    name: String,
+) -> Result<OrgResponse, PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.transaction::<_, PlatformResourceError, _>(|conn| {
+        lock_live_actor(conn, actor_id)?;
+        let org = diesel::insert_into(orgs::table)
+            .values(orgs::name.eq(&name))
+            .returning((orgs::id, orgs::uuid))
+            .get_result::<(i32, Uuid)>(conn)
+            .map_err(map_unique_conflict)?;
+        diesel::insert_into(org_memberships::table)
+            .values((
+                org_memberships::platform_user_id.eq(actor_id),
+                org_memberships::org_id.eq(org.0),
+                org_memberships::role.eq(StrictRole::Owner.as_str()),
+            ))
+            .execute(conn)
+            .map_err(map_unique_conflict)?;
+        Ok(OrgResponse { id: org.1, name })
+    })
+}
+
+pub(crate) async fn list_orgs(
+    pool: &Pool,
+    actor_id: Uuid,
+    logical_body_limit: usize,
+) -> Result<Vec<OrgResponse>, PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, PlatformResourceError, _>(|conn| {
+            ensure_live_actor(conn, actor_id)?;
+            load_orgs_for_actor(conn, actor_id, logical_body_limit)
+        })
+}
+
+pub(crate) async fn delete_org(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+) -> Result<(), PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.transaction::<_, PlatformResourceError, _>(|conn| {
+        lock_live_actor(conn, actor_id)?;
+        let org_id = lock_org(conn, org_uuid)?;
+        require_owner(locked_membership_role(conn, actor_id, org_id)?)?;
+        let deleted = diesel::delete(orgs::table.filter(orgs::id.eq(org_id))).execute(conn)?;
+        if deleted == 1 {
+            Ok(())
+        } else {
+            Err(PlatformResourceError::NotFound(
+                PlatformResourceKind::Organization,
+            ))
+        }
+    })
+}
+
+pub(crate) async fn create_project(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    name: String,
+    description: Option<String>,
+) -> Result<ProjectResponse, PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.transaction::<_, PlatformResourceError, _>(|conn| {
+        lock_live_actor(conn, actor_id)?;
+        let org_id = lock_org(conn, org_uuid)?;
+        require_admin(locked_membership_role(conn, actor_id, org_id)?)?;
+        let description = Some(description.unwrap_or_default());
+        let row = diesel::insert_into(org_projects::table)
+            .values((
+                org_projects::org_id.eq(org_id),
+                org_projects::name.eq(&name),
+                org_projects::description.eq(&description),
+                org_projects::status.eq("active"),
+            ))
+            .returning((
+                org_projects::uuid,
+                org_projects::client_id,
+                org_projects::created_at,
+            ))
+            .get_result::<(Uuid, Uuid, DateTime<Utc>)>(conn)
+            .map_err(map_unique_conflict)?;
+        Ok(ProjectResponse {
+            id: row.0,
+            client_id: row.1,
+            name,
+            description,
+            status: "active".to_string(),
+            created_at: row.2,
+        })
+    })
+}
+
+fn status_from_rank(rank: i32) -> Result<&'static str, PlatformResourceError> {
+    match rank {
+        0 => Ok("active"),
+        1 => Ok("inactive"),
+        2 => Ok("suspended"),
+        _ => Err(PlatformResourceError::InconsistentSnapshot),
+    }
+}
+
+fn load_project_response(
+    conn: &mut PgConnection,
+    project_id: i32,
+    logical_body_limit: usize,
+) -> Result<ProjectResponse, PlatformResourceError> {
+    let measurement = org_projects::table
+        .filter(org_projects::id.eq(project_id))
+        .select((
+            sql::<BigInt>("octet_length(org_projects.name)::bigint"),
+            sql::<diesel::sql_types::Nullable<BigInt>>(
+                "octet_length(org_projects.description)::bigint",
+            ),
+            sql::<Integer>(
+                "CASE org_projects.status WHEN 'active' THEN 0 WHEN 'inactive' THEN 1 WHEN 'suspended' THEN 2 ELSE -1 END",
+            ),
+        ))
+        .first::<(i64, Option<i64>, i32)>(conn)
+        .optional()?
+        .ok_or(PlatformResourceError::NotFound(
+            PlatformResourceKind::Project,
+        ))?;
+    let mut lengths = vec![(measurement.0, MAX_PROJECT_NAME_BYTES)];
+    if let Some(description_length) = measurement.1 {
+        lengths.push((description_length, MAX_PROJECT_DESCRIPTION_BYTES));
+    }
+    let expected = validate_single_output(lengths, logical_body_limit)?;
+    let row = org_projects::table
+        .filter(org_projects::id.eq(project_id))
+        .select((
+            org_projects::uuid,
+            org_projects::client_id,
+            org_projects::name,
+            org_projects::description,
+            sql::<Integer>(
+                "CASE org_projects.status WHEN 'active' THEN 0 WHEN 'inactive' THEN 1 WHEN 'suspended' THEN 2 ELSE -1 END",
+            ),
+            org_projects::created_at,
+        ))
+        .first::<(Uuid, Uuid, String, Option<String>, i32, DateTime<Utc>)>(conn)?;
+    if row.2.len() != expected[0] || row.3.as_ref().map(String::len) != expected.get(1).copied() {
+        return Err(PlatformResourceError::InconsistentSnapshot);
+    }
+    Ok(ProjectResponse {
+        id: row.0,
+        client_id: row.1,
+        name: row.2,
+        description: row.3,
+        status: status_from_rank(row.4)?.to_string(),
+        created_at: row.5,
+    })
+}
+
+pub(crate) async fn list_projects(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    logical_body_limit: usize,
+) -> Result<Vec<ProjectResponse>, PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, PlatformResourceError, _>(|conn| {
+            ensure_live_actor(conn, actor_id)?;
+            let org_id = find_org(conn, org_uuid)?;
+            require_read(membership_role(conn, actor_id, org_id)?)?;
+            let (count, total, maximum_name, maximum_description, invalid_statuses) =
+                org_projects::table
+                .filter(org_projects::org_id.eq(org_id))
+                .select((
+                    count_star(),
+                    sql::<diesel::sql_types::Nullable<BigInt>>(
+                        "SUM(octet_length(name)::bigint + COALESCE(octet_length(description)::bigint, 0))::bigint",
+                    ),
+                    sql::<diesel::sql_types::Nullable<BigInt>>(
+                        "MAX(octet_length(name)::bigint)::bigint",
+                    ),
+                    sql::<diesel::sql_types::Nullable<BigInt>>(
+                        "MAX(COALESCE(octet_length(description)::bigint, 0))::bigint",
+                    ),
+                    sql::<diesel::sql_types::Nullable<BigInt>>(
+                        "SUM(CASE WHEN status IN ('active','inactive','suspended') THEN 0 ELSE 1 END)::bigint",
+                    ),
+                ))
+                .first::<(i64, Option<i64>, Option<i64>, Option<i64>, Option<i64>)>(conn)?;
+            if invalid_statuses.unwrap_or(0) != 0 {
+                return Err(PlatformResourceError::InconsistentSnapshot);
+            }
+            if checked_optional_length(maximum_description)?.unwrap_or(0)
+                > MAX_PROJECT_DESCRIPTION_BYTES
+            {
+                return Err(PlatformResourceError::InconsistentSnapshot);
+            }
+            let (expected_rows, expected_bytes) = validate_list_aggregate(
+                count,
+                total,
+                maximum_name,
+                MAX_PROJECT_NAME_BYTES,
+                logical_body_limit,
+            )?;
+            let rows = org_projects::table
+                .filter(org_projects::org_id.eq(org_id))
+                .order(org_projects::id.asc())
+                .select((
+                    org_projects::uuid,
+                    org_projects::client_id,
+                    org_projects::name,
+                    org_projects::description,
+                    sql::<Integer>(
+                        "CASE status WHEN 'active' THEN 0 WHEN 'inactive' THEN 1 WHEN 'suspended' THEN 2 ELSE -1 END",
+                    ),
+                    org_projects::created_at,
+                ))
+                .load::<(Uuid, Uuid, String, Option<String>, i32, DateTime<Utc>)>(conn)?;
+            let actual_bytes = rows.iter().try_fold(0_usize, |total, row| {
+                if row.2.len() > MAX_PROJECT_NAME_BYTES
+                    || row.3.as_ref().is_some_and(|value| value.len() > MAX_PROJECT_DESCRIPTION_BYTES)
+                {
+                    return Err(PlatformResourceError::InconsistentSnapshot);
+                }
+                status_from_rank(row.4)?;
+                total
+                    .checked_add(row.2.len())
+                    .and_then(|total| total.checked_add(row.3.as_ref().map_or(0, String::len)))
+                    .ok_or(PlatformResourceError::InconsistentSnapshot)
+            })?;
+            if rows.len() != expected_rows || actual_bytes != expected_bytes {
+                return Err(PlatformResourceError::InconsistentSnapshot);
+            }
+            rows.into_iter()
+                .map(|row| {
+                    Ok(ProjectResponse {
+                        id: row.0,
+                        client_id: row.1,
+                        name: row.2,
+                        description: row.3,
+                        status: status_from_rank(row.4)?.to_string(),
+                        created_at: row.5,
+                    })
+                })
+                .collect()
+        })
+}
+
+pub(crate) async fn get_project(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    project_uuid: Uuid,
+    logical_body_limit: usize,
+) -> Result<ProjectResponse, PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, PlatformResourceError, _>(|conn| {
+            ensure_live_actor(conn, actor_id)?;
+            let org_id = find_org(conn, org_uuid)?;
+            require_read(membership_role(conn, actor_id, org_id)?)?;
+            let project_id = find_project(conn, org_id, project_uuid)?;
+            load_project_response(conn, project_id, logical_body_limit)
+        })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn update_project(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    project_uuid: Uuid,
+    name: Option<String>,
+    description: Option<String>,
+    status: Option<String>,
+    logical_body_limit: usize,
+) -> Result<ProjectResponse, PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.transaction::<_, PlatformResourceError, _>(|conn| {
+        lock_live_actor(conn, actor_id)?;
+        let org_id = lock_org(conn, org_uuid)?;
+        require_admin(locked_membership_role(conn, actor_id, org_id)?)?;
+        let project_id = lock_project(conn, org_id, project_uuid)?;
+        let current = load_project_response(conn, project_id, logical_body_limit)?;
+        let final_name = name.unwrap_or(current.name);
+        let final_description = description.or(current.description);
+        let final_status = status.unwrap_or(current.status);
+        let updated = diesel::update(org_projects::table.filter(org_projects::id.eq(project_id)))
+            .set((
+                org_projects::name.eq(&final_name),
+                org_projects::description.eq(&final_description),
+                org_projects::status.eq(&final_status),
+                org_projects::updated_at.eq(diesel::dsl::now),
+            ))
+            .execute(conn)
+            .map_err(map_unique_conflict)?;
+        if updated != 1 {
+            return Err(PlatformResourceError::NotFound(
+                PlatformResourceKind::Project,
+            ));
+        }
+        Ok(ProjectResponse {
+            id: current.id,
+            client_id: current.client_id,
+            name: final_name,
+            description: final_description,
+            status: final_status,
+            created_at: current.created_at,
+        })
+    })
+}
+
+pub(crate) async fn delete_project(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    project_uuid: Uuid,
+) -> Result<(), PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.transaction::<_, PlatformResourceError, _>(|conn| {
+        lock_live_actor(conn, actor_id)?;
+        let org_id = lock_org(conn, org_uuid)?;
+        require_admin(locked_membership_role(conn, actor_id, org_id)?)?;
+        let project_id = lock_project(conn, org_id, project_uuid)?;
+        let deleted = diesel::delete(org_projects::table.filter(org_projects::id.eq(project_id)))
+            .execute(conn)?;
+        if deleted == 1 {
+            Ok(())
+        } else {
+            Err(PlatformResourceError::NotFound(
+                PlatformResourceKind::Project,
+            ))
+        }
+    })
+}
+
+pub(crate) async fn create_secret(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    project_uuid: Uuid,
+    key_name: String,
+    encrypted_secret: &[u8],
+) -> Result<SecretResponse, PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.transaction::<_, PlatformResourceError, _>(|conn| {
+        lock_live_actor(conn, actor_id)?;
+        let org_id = lock_org(conn, org_uuid)?;
+        require_admin(locked_membership_role(conn, actor_id, org_id)?)?;
+        let project_id = lock_project(conn, org_id, project_uuid)?;
+        let timestamps = diesel::insert_into(org_project_secrets::table)
+            .values((
+                org_project_secrets::project_id.eq(project_id),
+                org_project_secrets::key_name.eq(&key_name),
+                org_project_secrets::secret_enc.eq(encrypted_secret),
+            ))
+            .on_conflict((
+                org_project_secrets::project_id,
+                org_project_secrets::key_name,
+            ))
+            .do_update()
+            .set(org_project_secrets::secret_enc.eq(encrypted_secret))
+            .returning((
+                org_project_secrets::created_at,
+                org_project_secrets::updated_at,
+            ))
+            .get_result::<(DateTime<Utc>, DateTime<Utc>)>(conn)?;
+        Ok(SecretResponse {
+            key_name,
+            created_at: timestamps.0,
+            updated_at: timestamps.1,
+        })
+    })
+}
+
+pub(crate) async fn list_secrets(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    project_uuid: Uuid,
+    logical_body_limit: usize,
+) -> Result<Vec<SecretResponse>, PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, PlatformResourceError, _>(|conn| {
+            ensure_live_actor(conn, actor_id)?;
+            let org_id = find_org(conn, org_uuid)?;
+            require_read(membership_role(conn, actor_id, org_id)?)?;
+            let project_id = find_project(conn, org_id, project_uuid)?;
+            let (count, total, maximum) = org_project_secrets::table
+                .filter(org_project_secrets::project_id.eq(project_id))
+                .select((
+                    count_star(),
+                    sql::<diesel::sql_types::Nullable<BigInt>>(
+                        "SUM(octet_length(key_name)::bigint)::bigint",
+                    ),
+                    sql::<diesel::sql_types::Nullable<BigInt>>(
+                        "MAX(octet_length(key_name)::bigint)::bigint",
+                    ),
+                ))
+                .first::<(i64, Option<i64>, Option<i64>)>(conn)?;
+            let (expected_rows, expected_bytes) = validate_list_aggregate(
+                count,
+                total,
+                maximum,
+                MAX_SECRET_KEY_BYTES,
+                logical_body_limit,
+            )?;
+            let rows = org_project_secrets::table
+                .filter(org_project_secrets::project_id.eq(project_id))
+                .order(org_project_secrets::id.asc())
+                .select((
+                    org_project_secrets::key_name,
+                    org_project_secrets::created_at,
+                    org_project_secrets::updated_at,
+                ))
+                .load::<(String, DateTime<Utc>, DateTime<Utc>)>(conn)?;
+            let actual_bytes = rows.iter().try_fold(0_usize, |total, row| {
+                if row.0.len() > MAX_SECRET_KEY_BYTES {
+                    return Err(PlatformResourceError::InconsistentSnapshot);
+                }
+                total
+                    .checked_add(row.0.len())
+                    .ok_or(PlatformResourceError::InconsistentSnapshot)
+            })?;
+            if rows.len() != expected_rows || actual_bytes != expected_bytes {
+                return Err(PlatformResourceError::InconsistentSnapshot);
+            }
+            Ok(rows
+                .into_iter()
+                .map(|row| SecretResponse {
+                    key_name: row.0,
+                    created_at: row.1,
+                    updated_at: row.2,
+                })
+                .collect())
+        })
+}
+
+pub(crate) async fn delete_secret(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    project_uuid: Uuid,
+    key_name: &str,
+) -> Result<(), PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.transaction::<_, PlatformResourceError, _>(|conn| {
+        lock_live_actor(conn, actor_id)?;
+        let org_id = lock_org(conn, org_uuid)?;
+        require_admin(locked_membership_role(conn, actor_id, org_id)?)?;
+        let project_id = lock_project(conn, org_id, project_uuid)?;
+        let deleted = diesel::delete(
+            org_project_secrets::table
+                .filter(org_project_secrets::project_id.eq(project_id))
+                .filter(org_project_secrets::key_name.eq(key_name)),
+        )
+        .execute(conn)?;
+        if deleted == 1 {
+            Ok(())
+        } else {
+            Err(PlatformResourceError::NotFound(
+                PlatformResourceKind::Secret,
+            ))
+        }
+    })
+}
+
+fn load_settings_json(
+    conn: &mut PgConnection,
+    project_id: i32,
+    category: SettingCategory,
+    logical_body_limit: usize,
+) -> Result<Option<Value>, PlatformResourceError> {
+    let category_name = category.as_str();
+    let measured = project_settings::table
+        .filter(project_settings::project_id.eq(project_id))
+        .filter(project_settings::category.eq(category_name))
+        .select(sql::<BigInt>(
+            "octet_length(project_settings.settings::text)::bigint",
+        ))
+        .first::<i64>(conn)
+        .optional()?;
+    let Some(measured) = measured else {
+        return Ok(None);
+    };
+    let expected =
+        validate_single_output([(measured, MAX_SETTINGS_JSON_BYTES)], logical_body_limit)?[0];
+    let value = project_settings::table
+        .filter(project_settings::project_id.eq(project_id))
+        .filter(project_settings::category.eq(category_name))
+        .select(project_settings::settings)
+        .first::<Value>(conn)?;
+    let encoded =
+        serde_json::to_vec(&value).map_err(|_| PlatformResourceError::InconsistentSnapshot)?;
+    if encoded.len() > expected || encoded.len() > MAX_SETTINGS_JSON_BYTES {
+        return Err(PlatformResourceError::InconsistentSnapshot);
+    }
+    Ok(Some(value))
+}
+
+fn serialize_bounded_settings<T: serde::Serialize>(
+    settings: &T,
+) -> Result<Value, PlatformResourceError> {
+    let value = serde_json::to_value(settings).map_err(|_| PlatformResourceError::Validation)?;
+    let encoded = serde_json::to_vec(&value).map_err(|_| PlatformResourceError::Validation)?;
+    if encoded.len() > MAX_SETTINGS_JSON_BYTES {
+        return Err(PlatformResourceError::Validation);
+    }
+    Ok(value)
+}
+
+fn authorize_project_read(
+    conn: &mut PgConnection,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    project_uuid: Uuid,
+) -> Result<i32, PlatformResourceError> {
+    ensure_live_actor(conn, actor_id)?;
+    let org_id = find_org(conn, org_uuid)?;
+    require_read(membership_role(conn, actor_id, org_id)?)?;
+    find_project(conn, org_id, project_uuid)
+}
+
+fn authorize_project_write(
+    conn: &mut PgConnection,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    project_uuid: Uuid,
+) -> Result<i32, PlatformResourceError> {
+    lock_live_actor(conn, actor_id)?;
+    let org_id = lock_org(conn, org_uuid)?;
+    require_admin(locked_membership_role(conn, actor_id, org_id)?)?;
+    lock_project(conn, org_id, project_uuid)
+}
+
+pub(crate) async fn get_email_settings(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    project_uuid: Uuid,
+    logical_body_limit: usize,
+) -> Result<EmailSettings, PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, PlatformResourceError, _>(|conn| {
+            let project_id = authorize_project_read(conn, actor_id, org_uuid, project_uuid)?;
+            let value =
+                load_settings_json(conn, project_id, SettingCategory::Email, logical_body_limit)?
+                    .ok_or(PlatformResourceError::NotFound(
+                    PlatformResourceKind::EmailSettings,
+                ))?;
+            serde_json::from_value(value).map_err(|_| PlatformResourceError::InconsistentSnapshot)
+        })
+}
+
+pub(crate) async fn update_email_settings(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    project_uuid: Uuid,
+    settings: EmailSettings,
+) -> Result<EmailSettings, PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.transaction::<_, PlatformResourceError, _>(|conn| {
+        let project_id = authorize_project_write(conn, actor_id, org_uuid, project_uuid)?;
+        let value = serialize_bounded_settings(&settings)?;
+        diesel::insert_into(project_settings::table)
+            .values((
+                project_settings::project_id.eq(project_id),
+                project_settings::category.eq(SettingCategory::Email.as_str()),
+                project_settings::settings.eq(value),
+            ))
+            .on_conflict((project_settings::project_id, project_settings::category))
+            .do_update()
+            .set(
+                project_settings::settings.eq(diesel::upsert::excluded(project_settings::settings)),
+            )
+            .execute(conn)?;
+        Ok(settings)
+    })
+}
+
+pub(crate) async fn get_oauth_settings(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    project_uuid: Uuid,
+    logical_body_limit: usize,
+) -> Result<OAuthSettings, PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, PlatformResourceError, _>(|conn| {
+            let project_id = authorize_project_read(conn, actor_id, org_uuid, project_uuid)?;
+            let Some(value) =
+                load_settings_json(conn, project_id, SettingCategory::OAuth, logical_body_limit)?
+            else {
+                return Ok(OAuthSettings::default());
+            };
+            serde_json::from_value(value).map_err(|_| PlatformResourceError::InconsistentSnapshot)
+        })
+}
+
+pub(crate) async fn update_oauth_settings(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    project_uuid: Uuid,
+    settings: OAuthSettings,
+) -> Result<OAuthSettings, PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.transaction::<_, PlatformResourceError, _>(|conn| {
+        let project_id = authorize_project_write(conn, actor_id, org_uuid, project_uuid)?;
+        let value = serialize_bounded_settings(&settings)?;
+        diesel::insert_into(project_settings::table)
+            .values((
+                project_settings::project_id.eq(project_id),
+                project_settings::category.eq(SettingCategory::OAuth.as_str()),
+                project_settings::settings.eq(value),
+            ))
+            .on_conflict((project_settings::project_id, project_settings::category))
+            .do_update()
+            .set(
+                project_settings::settings.eq(diesel::upsert::excluded(project_settings::settings)),
+            )
+            .execute(conn)?;
+        Ok(settings)
+    })
+}
+
+pub(crate) async fn list_memberships(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    logical_body_limit: usize,
+) -> Result<Vec<MembershipResponse>, PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, PlatformResourceError, _>(|conn| {
+            ensure_live_actor(conn, actor_id)?;
+            let org_id = find_org(conn, org_uuid)?;
+            require_read(membership_role(conn, actor_id, org_id)?)?;
+            let (count, total, maximum, invalid_roles) = org_memberships::table
+                .inner_join(
+                    platform_users::table
+                        .on(platform_users::uuid.eq(org_memberships::platform_user_id)),
+                )
+                .filter(org_memberships::org_id.eq(org_id))
+                .select((
+                    count_star(),
+                    sql::<diesel::sql_types::Nullable<BigInt>>(
+                        "SUM(COALESCE(octet_length(platform_users.name)::bigint, 0))::bigint",
+                    ),
+                    sql::<diesel::sql_types::Nullable<BigInt>>(
+                        "MAX(COALESCE(octet_length(platform_users.name)::bigint, 0))::bigint",
+                    ),
+                    sql::<diesel::sql_types::Nullable<BigInt>>(
+                        "SUM(CASE WHEN org_memberships.role IN ('owner','admin','developer','viewer') THEN 0 ELSE 1 END)::bigint",
+                    ),
+                ))
+                .first::<(i64, Option<i64>, Option<i64>, Option<i64>)>(conn)?;
+            if invalid_roles.unwrap_or(0) != 0 {
+                return Err(PlatformResourceError::InconsistentSnapshot);
+            }
+            let (expected_rows, expected_bytes) = validate_list_aggregate(
+                count,
+                total,
+                maximum,
+                MAX_PLATFORM_NAME_BYTES,
+                logical_body_limit,
+            )?;
+            let rows = org_memberships::table
+                .inner_join(
+                    platform_users::table
+                        .on(platform_users::uuid.eq(org_memberships::platform_user_id)),
+                )
+                .filter(org_memberships::org_id.eq(org_id))
+                .order(org_memberships::id.asc())
+                .select((
+                    org_memberships::platform_user_id,
+                    sql::<Integer>(MEMBERSHIP_ROLE_RANK_SQL),
+                    platform_users::name,
+                ))
+                .load::<(Uuid, i32, Option<String>)>(conn)?;
+            let actual_bytes = rows.iter().try_fold(0_usize, |total, row| {
+                StrictRole::from_rank(row.1)?;
+                if row.2.as_ref().is_some_and(|name| name.len() > MAX_PLATFORM_NAME_BYTES) {
+                    return Err(PlatformResourceError::InconsistentSnapshot);
+                }
+                total
+                    .checked_add(row.2.as_ref().map_or(0, String::len))
+                    .ok_or(PlatformResourceError::InconsistentSnapshot)
+            })?;
+            if rows.len() != expected_rows || actual_bytes != expected_bytes {
+                return Err(PlatformResourceError::InconsistentSnapshot);
+            }
+            rows.into_iter()
+                .map(|row| {
+                    Ok(MembershipResponse {
+                        user_id: row.0,
+                        role: StrictRole::from_rank(row.1)?.as_str().to_string(),
+                        name: row.2,
+                    })
+                })
+                .collect()
+        })
+}
+
+#[derive(QueryableByName)]
+struct OwnerCount {
+    #[diesel(sql_type = BigInt)]
+    count: i64,
+}
+
+fn lock_and_count_owners(
+    conn: &mut PgConnection,
+    org_id: i32,
+) -> Result<i64, PlatformResourceError> {
+    diesel::sql_query(
+        "SELECT COUNT(*)::bigint AS count FROM (\
+         SELECT id FROM org_memberships \
+         WHERE org_id = $1 AND role = 'owner' FOR UPDATE\
+         ) AS locked_owners",
+    )
+    .bind::<Integer, _>(org_id)
+    .get_result::<OwnerCount>(conn)
+    .map(|row| row.count)
+    .map_err(PlatformResourceError::Database)
+}
+
+fn lock_target_membership(
+    conn: &mut PgConnection,
+    org_id: i32,
+    user_id: Uuid,
+) -> Result<(i32, StrictRole), PlatformResourceError> {
+    let row = org_memberships::table
+        .filter(org_memberships::org_id.eq(org_id))
+        .filter(org_memberships::platform_user_id.eq(user_id))
+        .select((
+            org_memberships::id,
+            org_memberships::role.eq(StrictRole::Owner.as_str()),
+            org_memberships::role.eq(StrictRole::Admin.as_str()),
+            org_memberships::role.eq(StrictRole::Developer.as_str()),
+            org_memberships::role.eq(StrictRole::Viewer.as_str()),
+        ))
+        .for_update()
+        .first::<(i32, bool, bool, bool, bool)>(conn)
+        .optional()?
+        .ok_or(PlatformResourceError::NotFound(
+            PlatformResourceKind::Membership,
+        ))?;
+    Ok((row.0, decode_role_flags(row.1, row.2, row.3, row.4)?))
+}
+
+fn load_bounded_platform_name(
+    conn: &mut PgConnection,
+    user_id: Uuid,
+    logical_body_limit: usize,
+) -> Result<Option<String>, PlatformResourceError> {
+    let length = platform_users::table
+        .filter(platform_users::uuid.eq(user_id))
+        .select(sql::<diesel::sql_types::Nullable<BigInt>>(
+            "octet_length(platform_users.name)::bigint",
+        ))
+        .first::<Option<i64>>(conn)
+        .optional()?
+        .ok_or(PlatformResourceError::NotFound(
+            PlatformResourceKind::Membership,
+        ))?;
+    let expected = if let Some(length) = length {
+        Some(validate_single_output([(length, MAX_PLATFORM_NAME_BYTES)], logical_body_limit)?[0])
+    } else {
+        None
+    };
+    let expected_database_length = expected
+        .map(i64::try_from)
+        .transpose()
+        .map_err(|_| PlatformResourceError::InconsistentSnapshot)?;
+    let name = platform_users::table
+        .filter(platform_users::uuid.eq(user_id))
+        // Do not materialize a concurrently enlarged value. The nullable
+        // length predicate keeps the second statement safe under READ
+        // COMMITTED without adding an arbitrary target-user row lock to the
+        // organization mutation lock order.
+        .filter(
+            sql::<diesel::sql_types::Nullable<BigInt>>("octet_length(platform_users.name)::bigint")
+                .is_not_distinct_from(expected_database_length),
+        )
+        .select(platform_users::name)
+        .first::<Option<String>>(conn)
+        .optional()?
+        .ok_or(PlatformResourceError::InconsistentSnapshot)?;
+    if name.as_ref().map(String::len) != expected {
+        return Err(PlatformResourceError::InconsistentSnapshot);
+    }
+    Ok(name)
+}
+
+pub(crate) async fn update_membership(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    target_user_id: Uuid,
+    new_role: OrgRole,
+    logical_body_limit: usize,
+) -> Result<MembershipResponse, PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.transaction::<_, PlatformResourceError, _>(|conn| {
+        lock_live_actor(conn, actor_id)?;
+        let org_id = lock_org(conn, org_uuid)?;
+        require_owner(locked_membership_role(conn, actor_id, org_id)?)?;
+        let (membership_id, old_role) = lock_target_membership(conn, org_id, target_user_id)?;
+        let new_role = StrictRole::from_org_role(&new_role);
+        if old_role.is_owner() && !new_role.is_owner() && lock_and_count_owners(conn, org_id)? <= 1
+        {
+            return Err(PlatformResourceError::LastOwner);
+        }
+        let updated =
+            diesel::update(org_memberships::table.filter(org_memberships::id.eq(membership_id)))
+                .set((
+                    org_memberships::role.eq(new_role.as_str()),
+                    org_memberships::updated_at.eq(diesel::dsl::now),
+                ))
+                .execute(conn)?;
+        if updated != 1 {
+            return Err(PlatformResourceError::NotFound(
+                PlatformResourceKind::Membership,
+            ));
+        }
+        let name = load_bounded_platform_name(conn, target_user_id, logical_body_limit)?;
+        Ok(MembershipResponse {
+            user_id: target_user_id,
+            role: new_role.as_str().to_string(),
+            name,
+        })
+    })
+}
+
+pub(crate) async fn delete_membership(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    target_user_id: Uuid,
+) -> Result<(), PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.transaction::<_, PlatformResourceError, _>(|conn| {
+        lock_live_actor(conn, actor_id)?;
+        let org_id = lock_org(conn, org_uuid)?;
+        require_owner(locked_membership_role(conn, actor_id, org_id)?)?;
+        let (membership_id, target_role) = lock_target_membership(conn, org_id, target_user_id)?;
+        if target_role.is_owner() && lock_and_count_owners(conn, org_id)? <= 1 {
+            return Err(PlatformResourceError::LastOwner);
+        }
+        let deleted =
+            diesel::delete(org_memberships::table.filter(org_memberships::id.eq(membership_id)))
+                .execute(conn)?;
+        if deleted == 1 {
+            Ok(())
+        } else {
+            Err(PlatformResourceError::NotFound(
+                PlatformResourceKind::Membership,
+            ))
+        }
+    })
+}
+
+fn load_bounded_org_name(
+    conn: &mut PgConnection,
+    org_id: i32,
+    logical_body_limit: usize,
+) -> Result<(Uuid, String), PlatformResourceError> {
+    let measurement = orgs::table
+        .filter(orgs::id.eq(org_id))
+        .select((orgs::uuid, sql::<BigInt>("octet_length(orgs.name)::bigint")))
+        .first::<(Uuid, i64)>(conn)
+        .optional()?
+        .ok_or(PlatformResourceError::NotFound(
+            PlatformResourceKind::Organization,
+        ))?;
+    let expected =
+        validate_single_output([(measurement.1, MAX_ORG_NAME_BYTES)], logical_body_limit)?[0];
+    let name = orgs::table
+        .filter(orgs::id.eq(org_id))
+        .select(orgs::name)
+        .first::<String>(conn)?;
+    if name.len() != expected {
+        return Err(PlatformResourceError::InconsistentSnapshot);
+    }
+    Ok((measurement.0, name))
+}
+
+pub(crate) async fn create_invite(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    email: String,
+    invite_role: OrgRole,
+    logical_body_limit: usize,
+) -> Result<CreatedInvite, PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.transaction::<_, PlatformResourceError, _>(|conn| {
+        lock_live_actor(conn, actor_id)?;
+        let org_id = lock_org(conn, org_uuid)?;
+        let actor_role = locked_membership_role(conn, actor_id, org_id)?;
+        require_admin(actor_role)?;
+        let invite_role = StrictRole::from_org_role(&invite_role);
+        if invite_role.is_owner() && !actor_role.is_owner() {
+            return Err(PlatformResourceError::Unauthorized);
+        }
+        let (organization_id, organization_name) =
+            load_bounded_org_name(conn, org_id, logical_body_limit)?;
+        let code = Uuid::new_v4();
+        let expires_at = Utc::now() + Duration::hours(24);
+        let row = diesel::insert_into(invite_codes::table)
+            .values((
+                invite_codes::code.eq(code),
+                invite_codes::org_id.eq(org_id),
+                invite_codes::email.eq(&email),
+                invite_codes::role.eq(invite_role.as_str()),
+                invite_codes::expires_at.eq(expires_at),
+            ))
+            .returning((
+                invite_codes::used,
+                invite_codes::created_at,
+                invite_codes::updated_at,
+            ))
+            .get_result::<(bool, DateTime<Utc>, DateTime<Utc>)>(conn)
+            .map_err(map_unique_conflict)?;
+        Ok(CreatedInvite {
+            response: InviteResponse {
+                code,
+                email: email.clone(),
+                role: invite_role.as_str().to_string(),
+                used: row.0,
+                expires_at,
+                created_at: row.1,
+                updated_at: row.2,
+            },
+            dispatch: InviteEmailDispatch {
+                email,
+                organization_name,
+                organization_id,
+                invite_code: code,
+            },
+        })
+    })
+}
+
+type InviteRow = (
+    Uuid,
+    String,
+    i32,
+    bool,
+    DateTime<Utc>,
+    DateTime<Utc>,
+    DateTime<Utc>,
+);
+
+fn invite_response(row: InviteRow) -> Result<InviteResponse, PlatformResourceError> {
+    Ok(InviteResponse {
+        code: row.0,
+        email: row.1,
+        role: StrictRole::from_rank(row.2)?.as_str().to_string(),
+        used: row.3,
+        expires_at: row.4,
+        created_at: row.5,
+        updated_at: row.6,
+    })
+}
+
+pub(crate) async fn list_invites(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    logical_body_limit: usize,
+) -> Result<Vec<InviteResponse>, PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, PlatformResourceError, _>(|conn| {
+            ensure_live_actor(conn, actor_id)?;
+            let org_id = find_org(conn, org_uuid)?;
+            require_admin(membership_role(conn, actor_id, org_id)?)?;
+            let now = Utc::now();
+            let (count, total, maximum, invalid_roles) = invite_codes::table
+                .filter(invite_codes::org_id.eq(org_id))
+                .filter(invite_codes::used.eq(false))
+                .filter(invite_codes::expires_at.gt(now))
+                .select((
+                    count_star(),
+                    sql::<diesel::sql_types::Nullable<BigInt>>(
+                        "SUM(octet_length(email)::bigint)::bigint",
+                    ),
+                    sql::<diesel::sql_types::Nullable<BigInt>>(
+                        "MAX(octet_length(email)::bigint)::bigint",
+                    ),
+                    sql::<diesel::sql_types::Nullable<BigInt>>(
+                        "SUM(CASE WHEN role IN ('owner','admin','developer','viewer') THEN 0 ELSE 1 END)::bigint",
+                    ),
+                ))
+                .first::<(i64, Option<i64>, Option<i64>, Option<i64>)>(conn)?;
+            if invalid_roles.unwrap_or(0) != 0 {
+                return Err(PlatformResourceError::InconsistentSnapshot);
+            }
+            let (expected_rows, expected_bytes) = validate_list_aggregate(
+                count,
+                total,
+                maximum,
+                MAX_EMAIL_BYTES,
+                logical_body_limit,
+            )?;
+            let rows = invite_codes::table
+                .filter(invite_codes::org_id.eq(org_id))
+                .filter(invite_codes::used.eq(false))
+                .filter(invite_codes::expires_at.gt(now))
+                .order(invite_codes::id.asc())
+                .select((
+                    invite_codes::code,
+                    invite_codes::email,
+                    sql::<Integer>(INVITE_ROLE_RANK_SQL),
+                    invite_codes::used,
+                    invite_codes::expires_at,
+                    invite_codes::created_at,
+                    invite_codes::updated_at,
+                ))
+                .load::<InviteRow>(conn)?;
+            let actual_bytes = rows.iter().try_fold(0_usize, |total, row| {
+                StrictRole::from_rank(row.2)?;
+                if row.1.len() > MAX_EMAIL_BYTES {
+                    return Err(PlatformResourceError::InconsistentSnapshot);
+                }
+                total
+                    .checked_add(row.1.len())
+                    .ok_or(PlatformResourceError::InconsistentSnapshot)
+            })?;
+            if rows.len() != expected_rows || actual_bytes != expected_bytes {
+                return Err(PlatformResourceError::InconsistentSnapshot);
+            }
+            rows.into_iter().map(invite_response).collect()
+        })
+}
+
+pub(crate) async fn get_invite(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    invite_code: Uuid,
+    logical_body_limit: usize,
+) -> Result<DetailedInviteResponse, PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.build_transaction()
+        .read_only()
+        .repeatable_read()
+        .run::<_, PlatformResourceError, _>(|conn| {
+            ensure_live_actor(conn, actor_id)?;
+            let org_id = find_org(conn, org_uuid)?;
+            let org = load_bounded_org_name(conn, org_id, logical_body_limit)?;
+            let measurement = invite_codes::table
+                .filter(invite_codes::org_id.eq(org_id))
+                .filter(invite_codes::code.eq(invite_code))
+                .select((
+                    invite_codes::id,
+                    sql::<BigInt>("octet_length(invite_codes.email)::bigint"),
+                    sql::<Integer>(INVITE_ROLE_RANK_SQL),
+                ))
+                .first::<(i32, i64, i32)>(conn)
+                .optional()?
+                .ok_or(PlatformResourceError::NotFound(
+                    PlatformResourceKind::Invite,
+                ))?;
+            let expected_email =
+                validate_single_output([(measurement.1, MAX_EMAIL_BYTES)], logical_body_limit)?[0];
+            StrictRole::from_rank(measurement.2)?;
+            let actor_email_length = platform_users::table
+                .filter(platform_users::uuid.eq(actor_id))
+                .select(sql::<BigInt>(
+                    "octet_length(platform_users.email::text)::bigint",
+                ))
+                .first::<i64>(conn)?;
+            let expected_actor_email = validate_single_output(
+                [(actor_email_length, MAX_EMAIL_BYTES)],
+                logical_body_limit,
+            )?[0];
+            let actor_email = platform_users::table
+                .filter(platform_users::uuid.eq(actor_id))
+                .select(platform_users::email)
+                .first::<String>(conn)?;
+            if actor_email.len() != expected_actor_email {
+                return Err(PlatformResourceError::InconsistentSnapshot);
+            }
+            let row = invite_codes::table
+                .filter(invite_codes::id.eq(measurement.0))
+                .select((
+                    invite_codes::code,
+                    invite_codes::email,
+                    sql::<Integer>(INVITE_ROLE_RANK_SQL),
+                    invite_codes::used,
+                    invite_codes::expires_at,
+                    invite_codes::created_at,
+                    invite_codes::updated_at,
+                ))
+                .first::<InviteRow>(conn)?;
+            if row.1.len() != expected_email || row.2 != measurement.2 {
+                return Err(PlatformResourceError::InconsistentSnapshot);
+            }
+            let is_admin = match membership_role(conn, actor_id, org_id) {
+                Ok(role) => role.can_administer(),
+                Err(PlatformResourceError::Unauthorized) => false,
+                Err(error) => return Err(error),
+            };
+            if actor_email != row.1 && !is_admin {
+                return Err(PlatformResourceError::Unauthorized);
+            }
+            Ok(DetailedInviteResponse {
+                code: row.0,
+                email: row.1,
+                role: StrictRole::from_rank(row.2)?.as_str().to_string(),
+                used: row.3,
+                expires_at: row.4,
+                created_at: row.5,
+                updated_at: row.6,
+                organization_name: org.1,
+            })
+        })
+}
+
+pub(crate) async fn delete_invite(
+    pool: &Pool,
+    actor_id: Uuid,
+    org_uuid: Uuid,
+    invite_code: Uuid,
+) -> Result<(), PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.transaction::<_, PlatformResourceError, _>(|conn| {
+        lock_live_actor(conn, actor_id)?;
+        let org_id = lock_org(conn, org_uuid)?;
+        require_admin(locked_membership_role(conn, actor_id, org_id)?)?;
+        let deleted = diesel::delete(
+            invite_codes::table
+                .filter(invite_codes::org_id.eq(org_id))
+                .filter(invite_codes::code.eq(invite_code)),
+        )
+        .execute(conn)?;
+        if deleted == 1 {
+            Ok(())
+        } else {
+            Err(PlatformResourceError::NotFound(
+                PlatformResourceKind::Invite,
+            ))
+        }
+    })
+}
+
+pub(crate) async fn accept_invite(
+    pool: &Pool,
+    actor_id: Uuid,
+    invite_code: Uuid,
+    logical_body_limit: usize,
+) -> Result<(), PlatformResourceError> {
+    let mut conn = get_connection(pool)?;
+    conn.transaction::<_, PlatformResourceError, _>(|conn| {
+        lock_live_actor(conn, actor_id)?;
+        let actor_measurement = platform_users::table
+            .filter(platform_users::uuid.eq(actor_id))
+            .select(sql::<BigInt>(
+                "octet_length(platform_users.email::text)::bigint",
+            ))
+            .first::<i64>(conn)?;
+        let expected_actor_email =
+            validate_single_output([(actor_measurement, MAX_EMAIL_BYTES)], logical_body_limit)?[0];
+        let actor_email = platform_users::table
+            .filter(platform_users::uuid.eq(actor_id))
+            .select(platform_users::email)
+            .first::<String>(conn)?;
+        if actor_email.len() != expected_actor_email {
+            return Err(PlatformResourceError::InconsistentSnapshot);
+        }
+
+        // Preserve the mutation lock order used by organization-scoped
+        // operations: actor -> organization -> child row. Reading the fixed
+        // internal ID first is safe; the locked invite is re-scoped to that
+        // same organization before any authorization state is consumed.
+        let invite_org_id = invite_codes::table
+            .filter(invite_codes::code.eq(invite_code))
+            .select(invite_codes::org_id)
+            .first::<i32>(conn)
+            .optional()?
+            .ok_or(PlatformResourceError::NotFound(
+                PlatformResourceKind::Invite,
+            ))?;
+        orgs::table
+            .filter(orgs::id.eq(invite_org_id))
+            .select(orgs::id)
+            .for_update()
+            .first::<i32>(conn)
+            .optional()?
+            .ok_or(PlatformResourceError::NotFound(
+                PlatformResourceKind::Invite,
+            ))?;
+        let measurement = invite_codes::table
+            .filter(invite_codes::code.eq(invite_code))
+            .filter(invite_codes::org_id.eq(invite_org_id))
+            .select((
+                invite_codes::id,
+                invite_codes::org_id,
+                sql::<BigInt>("octet_length(invite_codes.email)::bigint"),
+                sql::<Integer>(INVITE_ROLE_RANK_SQL),
+                invite_codes::used,
+                invite_codes::expires_at,
+            ))
+            .for_update()
+            .first::<(i32, i32, i64, i32, bool, DateTime<Utc>)>(conn)
+            .optional()?
+            .ok_or(PlatformResourceError::NotFound(
+                PlatformResourceKind::Invite,
+            ))?;
+        let expected_invite_email =
+            validate_single_output([(measurement.2, MAX_EMAIL_BYTES)], logical_body_limit)?[0];
+        let invite_role = StrictRole::from_rank(measurement.3)?;
+        if measurement.4 {
+            return Err(PlatformResourceError::InviteAlreadyUsed);
+        }
+        if measurement.5 < Utc::now() {
+            return Err(PlatformResourceError::InviteExpired);
+        }
+        let invite_email = invite_codes::table
+            .filter(invite_codes::id.eq(measurement.0))
+            .select(invite_codes::email)
+            .first::<String>(conn)?;
+        if invite_email.len() != expected_invite_email {
+            return Err(PlatformResourceError::InconsistentSnapshot);
+        }
+        if invite_email != actor_email {
+            return Err(PlatformResourceError::Unauthorized);
+        }
+        if invite_role.is_owner() {
+            let verified = platform_email_verifications::table
+                .filter(platform_email_verifications::platform_user_id.eq(actor_id))
+                .filter(platform_email_verifications::is_verified.eq(true))
+                .select(platform_email_verifications::id)
+                .first::<i32>(conn)
+                .optional()?
+                .is_some();
+            if !verified {
+                return Err(PlatformResourceError::VerifiedEmailRequired);
+            }
+        }
+
+        diesel::insert_into(org_memberships::table)
+            .values((
+                org_memberships::platform_user_id.eq(actor_id),
+                org_memberships::org_id.eq(measurement.1),
+                org_memberships::role.eq(invite_role.as_str()),
+            ))
+            .execute(conn)
+            .map_err(map_unique_conflict)?;
+        let updated = diesel::update(
+            invite_codes::table
+                .filter(invite_codes::id.eq(measurement.0))
+                .filter(invite_codes::used.eq(false)),
+        )
+        .set((
+            invite_codes::used.eq(true),
+            invite_codes::updated_at.eq(diesel::dsl::now),
+        ))
+        .execute(conn)?;
+        if updated != 1 {
+            return Err(PlatformResourceError::InviteAlreadyUsed);
+        }
+        Ok(())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        accept_invite, create_invite, create_org, create_project, list_invites, list_memberships,
+        list_secrets, update_membership, validate_list_aggregate, PlatformResourceError, Pool,
+        StrictRole, MAX_ORG_NAME_BYTES, MAX_PLATFORM_RESOURCE_ROWS, MAX_PROJECT_NAME_BYTES,
+    };
+    use crate::models::org_memberships::OrgRole;
+    use crate::models::platform_users::NewPlatformUser;
+    use crate::models::schema::{
+        invite_codes, org_memberships, org_project_secrets, org_projects, orgs,
+        platform_email_verifications, platform_users,
+    };
+    use crate::web::platform::common::CreateOrgRequest;
+    use chrono::{Duration, Utc};
+    use diesel::prelude::*;
+    use diesel::r2d2::ConnectionManager;
+    use uuid::Uuid;
+    use validator::Validate;
+
+    struct TestActor {
+        id: Uuid,
+        email: String,
+    }
+
+    struct PlatformFixture {
+        pool: Pool,
+        actors: Vec<Uuid>,
+        organizations: Vec<Uuid>,
+    }
+
+    impl PlatformFixture {
+        fn new(pool: Pool) -> Self {
+            Self {
+                pool,
+                actors: Vec::new(),
+                organizations: Vec::new(),
+            }
+        }
+
+        fn actor(&mut self, label: &str) -> TestActor {
+            let marker = Uuid::new_v4();
+            let email = format!("platform-v2-{label}-{marker}@example.com");
+            let mut conn = self.pool.get().expect("test database connection");
+            let user = NewPlatformUser::new(email.clone(), None)
+                .with_name(format!("{label}-{marker}"))
+                .insert(&mut conn)
+                .expect("test platform user should insert");
+            self.actors.push(user.uuid);
+            TestActor {
+                id: user.uuid,
+                email,
+            }
+        }
+
+        fn track_org(&mut self, org_id: Uuid) {
+            self.organizations.push(org_id);
+        }
+
+        fn org_internal_id(&self, org_uuid: Uuid) -> i32 {
+            let mut conn = self.pool.get().expect("test database connection");
+            orgs::table
+                .filter(orgs::uuid.eq(org_uuid))
+                .select(orgs::id)
+                .first(&mut conn)
+                .expect("test organization should exist")
+        }
+
+        fn add_member(&self, org_uuid: Uuid, actor_id: Uuid, role: StrictRole) {
+            let org_id = self.org_internal_id(org_uuid);
+            let mut conn = self.pool.get().expect("test database connection");
+            diesel::insert_into(org_memberships::table)
+                .values((
+                    org_memberships::platform_user_id.eq(actor_id),
+                    org_memberships::org_id.eq(org_id),
+                    org_memberships::role.eq(role.as_str()),
+                ))
+                .execute(&mut conn)
+                .expect("test membership should insert");
+        }
+    }
+
+    impl Drop for PlatformFixture {
+        fn drop(&mut self) {
+            let Ok(mut conn) = self.pool.get() else {
+                return;
+            };
+            let _ = diesel::delete(
+                platform_email_verifications::table
+                    .filter(platform_email_verifications::platform_user_id.eq_any(&self.actors)),
+            )
+            .execute(&mut conn);
+            let _ = diesel::delete(orgs::table.filter(orgs::uuid.eq_any(&self.organizations)))
+                .execute(&mut conn);
+            let _ = diesel::delete(
+                platform_users::table.filter(platform_users::uuid.eq_any(&self.actors)),
+            )
+            .execute(&mut conn);
+        }
+    }
+
+    fn disposable_pool() -> Option<Pool> {
+        let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+            eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+            return None;
+        };
+        let manager = ConnectionManager::<PgConnection>::new(database_url);
+        Some(
+            diesel::r2d2::Pool::builder()
+                .max_size(6)
+                .build(manager)
+                .expect("connect to disposable migrated PostgreSQL"),
+        )
+    }
+
+    #[test]
+    fn aggregate_bounds_reject_row_field_and_logical_overflow() {
+        assert_eq!(
+            validate_list_aggregate(2, Some(10), Some(7), 8, 1_024)
+                .expect("small aggregate should fit"),
+            (2, 10)
+        );
+        assert!(matches!(
+            validate_list_aggregate(
+                i64::try_from(MAX_PLATFORM_RESOURCE_ROWS + 1).unwrap(),
+                Some(0),
+                Some(0),
+                8,
+                usize::MAX,
+            ),
+            Err(PlatformResourceError::OutputTooLarge)
+        ));
+        assert!(matches!(
+            validate_list_aggregate(1, Some(9), Some(9), 8, 1_024),
+            Err(PlatformResourceError::InconsistentSnapshot)
+        ));
+        assert!(matches!(
+            validate_list_aggregate(4, Some(1), Some(1), 8, 1_024),
+            Err(PlatformResourceError::OutputTooLarge)
+        ));
+    }
+
+    #[test]
+    fn name_bounds_cover_unicode_whitespace_accepted_by_shared_validation() {
+        let name = format!("A{}B", "\u{2003}".repeat(48));
+        assert_eq!(name.chars().count(), 50);
+        assert!(CreateOrgRequest { name: name.clone() }.validate().is_ok());
+        assert!(name.len() > 50);
+        assert!(name.len() <= MAX_ORG_NAME_BYTES);
+        assert!(name.len() <= MAX_PROJECT_NAME_BYTES);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+    async fn database_secret_metadata_is_bounded_owner_scoped_and_ciphertext_free() {
+        let Some(pool) = disposable_pool() else {
+            return;
+        };
+        let mut fixture = PlatformFixture::new(pool.clone());
+        let owner = fixture.actor("secret-owner");
+        let outsider = fixture.actor("secret-outsider");
+        let org = create_org(&pool, owner.id, "Secret Metadata Org".to_string())
+            .await
+            .expect("owner should create organization");
+        fixture.track_org(org.id);
+        let project = create_project(
+            &pool,
+            owner.id,
+            org.id,
+            "Secret Metadata Project".to_string(),
+            None,
+        )
+        .await
+        .expect("owner should create project");
+
+        let mut conn = pool.get().expect("test database connection");
+        let project_id = org_projects::table
+            .filter(org_projects::uuid.eq(project.id))
+            .select(org_projects::id)
+            .first::<i32>(&mut conn)
+            .expect("test project should exist");
+        diesel::insert_into(org_project_secrets::table)
+            .values((
+                org_project_secrets::project_id.eq(project_id),
+                org_project_secrets::key_name.eq("SAFE_KEY"),
+                // A metadata list with a tiny response budget must not load or
+                // account this large ciphertext column.
+                org_project_secrets::secret_enc.eq(vec![7_u8; 2 * 1024 * 1024]),
+            ))
+            .execute(&mut conn)
+            .expect("test secret should insert");
+        drop(conn);
+
+        let listed = list_secrets(&pool, owner.id, org.id, project.id, 1_024)
+            .await
+            .expect("bounded metadata should not touch ciphertext");
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].key_name, "SAFE_KEY");
+        assert!(matches!(
+            list_secrets(&pool, outsider.id, org.id, project.id, 1_024).await,
+            Err(PlatformResourceError::Unauthorized)
+        ));
+
+        let mut conn = pool.get().expect("test database connection");
+        diesel::update(
+            org_project_secrets::table
+                .filter(org_project_secrets::project_id.eq(project_id))
+                .filter(org_project_secrets::key_name.eq("SAFE_KEY")),
+        )
+        .set(org_project_secrets::key_name.eq("X".repeat(51)))
+        .execute(&mut conn)
+        .expect("test database tamper should update key name");
+        drop(conn);
+        assert!(matches!(
+            list_secrets(&pool, owner.id, org.id, project.id, 1_024).await,
+            Err(PlatformResourceError::InconsistentSnapshot)
+        ));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+    async fn database_role_checks_and_last_owner_transition_are_transactional() {
+        let Some(pool) = disposable_pool() else {
+            return;
+        };
+        let mut fixture = PlatformFixture::new(pool.clone());
+        let owner = fixture.actor("rbac-owner");
+        let viewer = fixture.actor("rbac-viewer");
+        let org = create_org(&pool, owner.id, "RBAC Org".to_string())
+            .await
+            .expect("owner should create organization");
+        fixture.track_org(org.id);
+        fixture.add_member(org.id, viewer.id, StrictRole::Viewer);
+
+        let mut conn = pool.get().expect("test database connection");
+        diesel::update(platform_users::table.filter(platform_users::uuid.eq(viewer.id)))
+            .set(platform_users::name.eq(Option::<String>::None))
+            .execute(&mut conn)
+            .expect("test target should support an absent optional name");
+        drop(conn);
+
+        assert!(matches!(
+            create_project(
+                &pool,
+                viewer.id,
+                org.id,
+                "Unauthorized Project".to_string(),
+                None,
+            )
+            .await,
+            Err(PlatformResourceError::Unauthorized)
+        ));
+        assert!(matches!(
+            update_membership(&pool, owner.id, org.id, owner.id, OrgRole::Admin, 4_096,).await,
+            Err(PlatformResourceError::LastOwner)
+        ));
+
+        let promoted = update_membership(&pool, owner.id, org.id, viewer.id, OrgRole::Owner, 4_096)
+            .await
+            .expect("owner should promote a second owner");
+        assert_eq!(promoted.role, "owner");
+        assert!(promoted.name.is_none());
+        let demoted = update_membership(&pool, owner.id, org.id, owner.id, OrgRole::Admin, 4_096)
+            .await
+            .expect("one of two owners may be demoted");
+        assert_eq!(demoted.role, "admin");
+        let memberships = list_memberships(&pool, viewer.id, org.id, 4_096)
+            .await
+            .expect("remaining owner should list memberships");
+        assert_eq!(memberships.len(), 2);
+        assert!(memberships
+            .iter()
+            .any(|membership| membership.user_id == viewer.id && membership.role == "owner"));
+    }
+
+    #[tokio::test]
+    #[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+    async fn database_owner_invites_require_owner_issuer_and_verified_atomic_acceptance() {
+        let Some(pool) = disposable_pool() else {
+            return;
+        };
+        let mut fixture = PlatformFixture::new(pool.clone());
+        let owner = fixture.actor("invite-owner");
+        let admin = fixture.actor("invite-admin");
+        let recipient = fixture.actor("invite-recipient");
+        let org = create_org(&pool, owner.id, "Owner Invite Org".to_string())
+            .await
+            .expect("owner should create organization");
+        fixture.track_org(org.id);
+        fixture.add_member(org.id, admin.id, StrictRole::Admin);
+
+        assert!(matches!(
+            create_invite(
+                &pool,
+                admin.id,
+                org.id,
+                recipient.email.clone(),
+                OrgRole::Owner,
+                4_096,
+            )
+            .await,
+            Err(PlatformResourceError::Unauthorized)
+        ));
+        let created = create_invite(
+            &pool,
+            owner.id,
+            org.id,
+            recipient.email.clone(),
+            OrgRole::Owner,
+            4_096,
+        )
+        .await
+        .expect("owner should issue owner invite");
+        let code = created.response.code;
+        let active = list_invites(&pool, admin.id, org.id, 4_096)
+            .await
+            .expect("admin should list active invites");
+        assert!(active.iter().any(|invite| invite.code == code));
+
+        assert!(matches!(
+            accept_invite(&pool, recipient.id, code, 4_096).await,
+            Err(PlatformResourceError::VerifiedEmailRequired)
+        ));
+        let org_id = fixture.org_internal_id(org.id);
+        let mut conn = pool.get().expect("test database connection");
+        let membership_count = org_memberships::table
+            .filter(org_memberships::org_id.eq(org_id))
+            .filter(org_memberships::platform_user_id.eq(recipient.id))
+            .count()
+            .get_result::<i64>(&mut conn)
+            .expect("membership count should load");
+        let used = invite_codes::table
+            .filter(invite_codes::code.eq(code))
+            .select(invite_codes::used)
+            .first::<bool>(&mut conn)
+            .expect("invite should exist");
+        assert_eq!(membership_count, 0);
+        assert!(!used);
+
+        diesel::insert_into(platform_email_verifications::table)
+            .values((
+                platform_email_verifications::platform_user_id.eq(recipient.id),
+                platform_email_verifications::verification_code.eq(Uuid::new_v4()),
+                platform_email_verifications::is_verified.eq(true),
+                platform_email_verifications::expires_at.eq(Utc::now() + Duration::hours(1)),
+            ))
+            .execute(&mut conn)
+            .expect("verified email marker should insert");
+        drop(conn);
+
+        accept_invite(&pool, recipient.id, code, 4_096)
+            .await
+            .expect("verified recipient should atomically accept owner invite");
+        let mut conn = pool.get().expect("test database connection");
+        let role = org_memberships::table
+            .filter(org_memberships::org_id.eq(org_id))
+            .filter(org_memberships::platform_user_id.eq(recipient.id))
+            .select(org_memberships::role)
+            .first::<String>(&mut conn)
+            .expect("accepted membership should exist");
+        let used = invite_codes::table
+            .filter(invite_codes::code.eq(code))
+            .select(invite_codes::used)
+            .first::<bool>(&mut conn)
+            .expect("accepted invite should exist");
+        assert_eq!(role, "owner");
+        assert!(used);
+        drop(conn);
+        assert!(matches!(
+            accept_invite(&pool, recipient.id, code, 4_096).await,
+            Err(PlatformResourceError::InviteAlreadyUsed)
+        ));
+    }
+}

--- a/src/web/oauth_routes.rs
+++ b/src/web/oauth_routes.rs
@@ -1635,6 +1635,10 @@ mod tests {
         );
 
         let _ = app_state.db.delete_user(&user);
+        drop(app_state);
+        // Let the test-only database pool finish retiring its libpq worker
+        // before this one-test runtime tears down linked GSS thread state.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
 
     #[tokio::test]
@@ -1711,6 +1715,9 @@ mod tests {
             .expect("new OAuth auth context should unwrap the committed seed wrap");
 
         let _ = app_state.db.delete_user(&authenticated_user.user);
+        drop(app_state);
+        // See the same-email OAuth database test above.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
 
     async fn build_local_test_app_state(database_url: String) -> AppState {


### PR DESCRIPTION
## Summary

- project all 24 platform organization, project, secret, settings, membership, and invite operations through the authenticated transport-v2 envelope
- keep authority immutable to the session-bound platform principal and preserve the existing platform RBAC and last-owner protections
- add a v2-only bounded Diesel storage seam with length-first reads, row and logical-response ceilings, and ciphertext-free secret metadata reads
- extend protocol documentation and disposable-database coverage for the complete capability

## Compatibility

- leaves all `/v1` runtime routes and response shapes unchanged
- preserves the existing TypeScript SDK platform behavior, including the omitted project-description empty-string shape
- validates the complete legacy flow with an old-v1 SDK smoke covering all 24 projected operations
- includes only a test-runtime teardown stabilization outside the v2 transport modules

## Security properties

- claims unordered replay IDs before dispatch and encrypts responses through the same held session lease
- rejects credentials in ordinary bound-session envelopes
- scopes every resource lookup and mutation through the bound platform actor and organization/project relationships
- applies bounded validation to stored output and preserves Unicode names accepted by the shared v1 validators
- prevents administrators from issuing owner invites and requires verified email before owner invite acceptance

## Validation

- `cargo fmt --all --check`
- strict locked all-target/all-feature clippy
- full suite: 612 passed, 0 failed, 38 ignored
- focused transport-v2 suite: 153 passed, 0 failed, 7 ignored
- disposable database suite: 27 AEAD/database, 2 OAuth, and 3 platform-resource tests; no skips
- legacy TypeScript SDK platform smoke: all 24 operations passed

Stacked on #334.