### PR TITLE
Make GLM 5.2 the default Powerful model

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ use crate::encrypt::{
 };
 use crate::jwt::validate_platform_jwt;
 use crate::login_routes::RegisterCredentials;
-use crate::model_config::{ModelAliasTargets, ModelPlan, PaidModelAliasOverrides};
 use crate::models::account_deletion::{AccountDeletionError, NewAccountDeletionRequest};
 use crate::models::email_verification::{EmailVerificationError, NewEmailVerification};
 use crate::models::oauth::{NewUserOAuthConnection, OAuthError};
@@ -149,7 +148,6 @@ const BILLING_SERVER_URL_NAME: &str = "billing_server_url";
 const KAGI_API_KEY_NAME: &str = "kagi_api_key";
 const OS_FLAGS_API_KEY_NAME: &str = "os_flags_api_key";
 const OS_FLAGS_BASE_URL_NAME: &str = "os_flags_base_url";
-const MODEL_ALIAS_FLAGS_TIMEOUT_SECS: u64 = 5;
 const PROVIDER_ROUTING_FLAGS_TIMEOUT_SECS: u64 = 5;
 const BILLING_ACCESS_TIMEOUT_SECS: u64 = 5;
 const MAX_ATTESTATION_NONCE_BYTES: usize = 512;
@@ -1250,52 +1248,6 @@ impl AppState {
                 None
             }
         }
-    }
-
-    /// Resolve the automatic model aliases for this user's plan. The paid alias
-    /// override defaults off on missing configuration, a missing flag, service
-    /// failure, or timeout. Free plans never apply the override.
-    pub(crate) async fn model_alias_targets(
-        &self,
-        user_uuid: Uuid,
-        model_plan: ModelPlan,
-    ) -> ModelAliasTargets {
-        if !model_plan.is_paid() {
-            return ModelAliasTargets::for_plan(model_plan);
-        }
-
-        let Some(client) = &self.os_flags_client else {
-            trace!(
-                "os-flags client not configured; using default paid model aliases (user_uuid={})",
-                user_uuid
-            );
-            return ModelAliasTargets::for_plan(model_plan);
-        };
-
-        let overrides = match tokio::time::timeout(
-            Duration::from_secs(MODEL_ALIAS_FLAGS_TIMEOUT_SECS),
-            client.get_user_flags(user_uuid, Some(os_flags::PAID_MODEL_ALIAS_FLAG_KEYS)),
-        )
-        .await
-        {
-            Ok(Ok(response)) => PaidModelAliasOverrides::from_flag_values(&response.flags),
-            Ok(Err(e)) => {
-                warn!(
-                    "os-flags paid model alias check failed (user_uuid={}): {}; using default aliases",
-                    user_uuid, e
-                );
-                PaidModelAliasOverrides::default()
-            }
-            Err(_) => {
-                warn!(
-                    "os-flags paid model alias check timed out after {}s (user_uuid={}); using default aliases",
-                    MODEL_ALIAS_FLAGS_TIMEOUT_SECS, user_uuid
-                );
-                PaidModelAliasOverrides::default()
-            }
-        };
-
-        ModelAliasTargets::for_plan_with_overrides(model_plan, overrides)
     }
 
     fn password_login_identifier_for_user(user: &User) -> (PasswordLoginIdentifierKind, String) {

--- a/src/model_config.rs
+++ b/src/model_config.rs
@@ -1,8 +1,6 @@
 //! Central model-specific configuration and public model catalog.
 
-use crate::os_flags::PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY;
 use serde_json::{json, Value};
-use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ModelConfig {
@@ -103,21 +101,16 @@ pub(crate) struct ModelAliasTargets {
     powerful: &'static str,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct PaidModelAliasOverrides {
-    powerful_kimi_k3: bool,
-}
-
 pub const DEFAULT_CONTEXT_WINDOW: usize = 64_000;
 pub const DEFAULT_TEMPERATURE: f32 = 0.7;
 pub const DEFAULT_TOP_P: f32 = 1.0;
 pub const AUTO_QUICK_MODEL_ID: &str = "auto:quick";
 pub const AUTO_POWERFUL_MODEL_ID: &str = "auto:powerful";
 pub const QUICK_MODEL_ID: &str = "gpt-oss-120b";
-pub const POWERFUL_MODEL_ID: &str = "kimi-k2-6";
+pub const GLM_5_2_MODEL_ID: &str = "glm-5-2";
+pub const POWERFUL_MODEL_ID: &str = GLM_5_2_MODEL_ID;
 pub const KIMI_K3_MODEL_ID: &str = "kimi-k3";
 pub const DEEPSEEK_V4_FLASH_MODEL_ID: &str = "deepseek-v4-flash";
-pub const GLM_5_2_MODEL_ID: &str = "glm-5-2";
 
 const FREE_MODEL_ALIAS_TARGETS: ModelAliasTargets = ModelAliasTargets {
     quick: QUICK_MODEL_ID,
@@ -399,23 +392,6 @@ impl ModelAliasTargets {
         }
     }
 
-    pub(crate) const fn for_plan_with_overrides(
-        plan: ModelPlan,
-        overrides: PaidModelAliasOverrides,
-    ) -> Self {
-        match plan {
-            ModelPlan::Free => FREE_MODEL_ALIAS_TARGETS,
-            ModelPlan::Paid => Self {
-                quick: PAID_MODEL_ALIAS_TARGETS.quick,
-                powerful: if overrides.powerful_kimi_k3 {
-                    KIMI_K3_MODEL_ID
-                } else {
-                    PAID_MODEL_ALIAS_TARGETS.powerful
-                },
-            },
-        }
-    }
-
     pub(crate) fn resolve(self, model: &str) -> &str {
         match model {
             AUTO_QUICK_MODEL_ID => self.quick,
@@ -429,17 +405,6 @@ impl ModelAliasTargets {
             AUTO_QUICK_MODEL_ID => Some(self.quick),
             AUTO_POWERFUL_MODEL_ID => Some(self.powerful),
             _ => None,
-        }
-    }
-}
-
-impl PaidModelAliasOverrides {
-    pub(crate) fn from_flag_values(flags: &HashMap<String, bool>) -> Self {
-        Self {
-            powerful_kimi_k3: flags
-                .get(PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY)
-                .copied()
-                .unwrap_or(false),
         }
     }
 }
@@ -650,10 +615,6 @@ const MODEL_ALIAS_ENTRIES: &[ModelAliasEntry] = &[
 
 fn alias_target(model: &str) -> Option<&'static str> {
     ModelAliasTargets::default().target_for(model)
-}
-
-pub(crate) fn model_alias_requires_flag_lookup(model: &str) -> bool {
-    model == AUTO_POWERFUL_MODEL_ID
 }
 
 fn model_entry(model: &str) -> Option<ModelConfigEntry> {
@@ -920,6 +881,10 @@ mod tests {
             model_reasoning_history_strategy("glm-5-2"),
             Some(ReasoningHistoryStrategy::GlmClearThinking)
         );
+        assert_eq!(
+            model_reasoning_history_strategy(AUTO_POWERFUL_MODEL_ID),
+            Some(ReasoningHistoryStrategy::GlmClearThinking)
+        );
         assert_eq!(model_reasoning_history_strategy("gemma4-31b"), None);
     }
 
@@ -1001,68 +966,24 @@ mod tests {
 
     #[test]
     fn test_model_alias_targets_are_selected_by_plan() {
+        assert_eq!(POWERFUL_MODEL_ID, GLM_5_2_MODEL_ID);
+
         let free = ModelAliasTargets::for_plan(ModelPlan::Free);
         assert_eq!(free.resolve(AUTO_QUICK_MODEL_ID), QUICK_MODEL_ID);
-        assert_eq!(free.resolve(AUTO_POWERFUL_MODEL_ID), POWERFUL_MODEL_ID);
+        assert_eq!(free.resolve(AUTO_POWERFUL_MODEL_ID), GLM_5_2_MODEL_ID);
 
         let paid = ModelAliasTargets::for_plan(ModelPlan::Paid);
         assert_eq!(
             paid.resolve(AUTO_QUICK_MODEL_ID),
             DEEPSEEK_V4_FLASH_MODEL_ID
         );
-        assert_eq!(paid.resolve(AUTO_POWERFUL_MODEL_ID), POWERFUL_MODEL_ID);
-        assert_eq!(paid.resolve("glm-5-2"), "glm-5-2");
+        assert_eq!(paid.resolve(AUTO_POWERFUL_MODEL_ID), GLM_5_2_MODEL_ID);
+        assert_eq!(paid.resolve(KIMI_K3_MODEL_ID), KIMI_K3_MODEL_ID);
     }
 
     #[test]
-    fn test_paid_powerful_kimi_k3_alias_override_is_plan_gated_and_default_off() {
-        for powerful_enabled in [false, true] {
-            let flags = HashMap::from([(
-                PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY.to_string(),
-                powerful_enabled,
-            )]);
-            let overrides = PaidModelAliasOverrides::from_flag_values(&flags);
-
-            let free = ModelAliasTargets::for_plan_with_overrides(ModelPlan::Free, overrides);
-            assert_eq!(free.resolve(AUTO_QUICK_MODEL_ID), QUICK_MODEL_ID);
-            assert_eq!(free.resolve(AUTO_POWERFUL_MODEL_ID), POWERFUL_MODEL_ID);
-
-            let paid = ModelAliasTargets::for_plan_with_overrides(ModelPlan::Paid, overrides);
-            assert_eq!(
-                paid.resolve(AUTO_QUICK_MODEL_ID),
-                DEEPSEEK_V4_FLASH_MODEL_ID
-            );
-            assert_eq!(
-                paid.resolve(AUTO_POWERFUL_MODEL_ID),
-                if powerful_enabled {
-                    KIMI_K3_MODEL_ID
-                } else {
-                    POWERFUL_MODEL_ID
-                }
-            );
-        }
-
-        assert_eq!(
-            PaidModelAliasOverrides::from_flag_values(&HashMap::new()),
-            PaidModelAliasOverrides::default()
-        );
-        assert_eq!(
-            PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY,
-            "model-alias.paid.powerful.kimi-k3"
-        );
-        assert_eq!(
-            crate::os_flags::PAID_MODEL_ALIAS_FLAG_KEYS,
-            &[PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY]
-        );
-    }
-
-    #[test]
-    fn test_catalog_alias_metadata_tracks_paid_override_targets() {
-        let flags = HashMap::from([(PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY.to_string(), true)]);
-        let targets = ModelAliasTargets::for_plan_with_overrides(
-            ModelPlan::Paid,
-            PaidModelAliasOverrides::from_flag_values(&flags),
-        );
+    fn test_catalog_alias_metadata_tracks_paid_targets() {
+        let targets = ModelAliasTargets::for_plan(ModelPlan::Paid);
         let catalog = model_catalog_response(targets);
         let aliases = catalog["aliases"].as_array().expect("aliases");
         let quick = aliases
@@ -1077,9 +998,9 @@ mod tests {
         assert_eq!(quick["target_model"], DEEPSEEK_V4_FLASH_MODEL_ID);
         assert_eq!(quick["access"], "pro");
         assert_eq!(quick["capabilities"]["vision"], false);
-        assert_eq!(powerful["target_model"], KIMI_K3_MODEL_ID);
+        assert_eq!(powerful["target_model"], GLM_5_2_MODEL_ID);
         assert_eq!(powerful["access"], "pro");
-        assert_eq!(powerful["capabilities"]["vision"], true);
+        assert_eq!(powerful["capabilities"]["vision"], false);
     }
 
     #[test]
@@ -1152,24 +1073,6 @@ mod tests {
     }
 
     #[test]
-    fn test_only_powerful_alias_requires_flag_lookup() {
-        assert!(model_alias_requires_flag_lookup(AUTO_POWERFUL_MODEL_ID));
-        for model in [
-            AUTO_QUICK_MODEL_ID,
-            QUICK_MODEL_ID,
-            POWERFUL_MODEL_ID,
-            "kimi-k3",
-            DEEPSEEK_V4_FLASH_MODEL_ID,
-            GLM_5_2_MODEL_ID,
-        ] {
-            assert!(
-                !model_alias_requires_flag_lookup(model),
-                "direct/static model should not require flags: {model}"
-            );
-        }
-    }
-
-    #[test]
     fn test_openai_models_includes_api_only_models() {
         let response = openai_models_response();
         let data = response["data"].as_array().expect("models data");
@@ -1192,16 +1095,13 @@ mod tests {
     }
 
     #[test]
-    fn test_catalog_advertises_kimi_through_continuum() {
+    fn test_catalog_keeps_kimi_k2_6_selectable_through_continuum() {
         let catalog = model_catalog_response(ModelAliasTargets::default());
-        let kimi = catalog_model(&catalog, POWERFUL_MODEL_ID);
+        let kimi = catalog_model(&catalog, "kimi-k2-6");
 
         assert_eq!(kimi["provider"], "continuum");
         assert_eq!(kimi["provider_id"], "kimi-k2.6");
-        assert_eq!(
-            resolve_completion_model_id(POWERFUL_MODEL_ID),
-            Some(POWERFUL_MODEL_ID)
-        );
+        assert_eq!(resolve_completion_model_id("kimi-k2-6"), Some("kimi-k2-6"));
     }
 
     #[test]

--- a/src/os_flags.rs
+++ b/src/os_flags.rs
@@ -16,8 +16,6 @@ const USER_FLAGS_CACHE_TTL: Duration = Duration::from_secs(10 * 60);
 #[allow(dead_code)]
 pub const AGENT_FEATURE_FLAG_KEY: &str = "agent";
 pub const GLM_5_2_CONTINUUM_FLAG_KEY: &str = "provider-routing.glm-5-2.continuum";
-pub const PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY: &str = "model-alias.paid.powerful.kimi-k3";
-pub const PAID_MODEL_ALIAS_FLAG_KEYS: &[&str] = &[PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY];
 
 #[derive(Debug, thiserror::Error)]
 pub enum OsFlagsError {

--- a/src/provider_routing.rs
+++ b/src/provider_routing.rs
@@ -468,6 +468,12 @@ mod tests {
             Some(GLM_5_2_CONTINUUM_FLAG_KEY)
         );
         assert_eq!(
+            router.continuum_flag_key_for_completion_model(
+                crate::model_config::AUTO_POWERFUL_MODEL_ID
+            ),
+            Some(GLM_5_2_CONTINUUM_FLAG_KEY)
+        );
+        assert_eq!(
             router.continuum_flag_key_for_completion_model("kimi-k2-6"),
             None
         );
@@ -572,7 +578,7 @@ mod tests {
     }
 
     #[test]
-    fn test_auto_powerful_uses_kimi_route_table() {
+    fn test_auto_powerful_uses_glm_route_table() {
         let router = ProviderRouter::default();
         let proxy_router = proxy_router_with_both_providers();
 
@@ -584,10 +590,15 @@ mod tests {
             )
             .expect("route");
 
-        assert_eq!(selected.proxy.provider_name, "continuum");
-        assert_eq!(selected.public_model_id, "kimi-k2-6");
-        assert_eq!(selected.provider_model_id, "kimi-k2.6");
-        assert_eq!(selected.response_model_id, "kimi-k2-6");
+        assert_eq!(selected.proxy.provider_name, "tinfoil");
+        assert_eq!(selected.public_model_id, GLM_5_2_MODEL_ID);
+        assert_eq!(selected.provider_model_id, GLM_5_2_MODEL_ID);
+        assert_eq!(selected.response_model_id, GLM_5_2_MODEL_ID);
+        assert_eq!(selected.bucket, None);
+        assert_eq!(
+            selected.selection_source,
+            ProviderSelectionSource::DefaultProvider
+        );
     }
 
     #[test]

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -1,6 +1,5 @@
 use crate::model_config::{
-    model_alias_requires_flag_lookup, model_catalog_response, openai_models_response,
-    ModelAliasTargets, ModelPlan,
+    model_catalog_response, openai_models_response, ModelAliasTargets, ModelPlan,
 };
 use crate::models::token_usage::NewTokenUsage;
 use crate::models::users::User;
@@ -790,11 +789,7 @@ async fn proxy_openai(
         })?
         .to_string();
 
-    let alias_targets = if model_alias_requires_flag_lookup(&requested_model_name) {
-        state.model_alias_targets(user.uuid, model_plan).await
-    } else {
-        ModelAliasTargets::for_plan(model_plan)
-    };
+    let alias_targets = ModelAliasTargets::for_plan(model_plan);
     let model_name = alias_targets.resolve(&requested_model_name).to_string();
     if requested_model_name != model_name {
         debug!(
@@ -1782,7 +1777,7 @@ async fn proxy_model_catalog(
     let model_plan = ModelPlan::from_is_paid(
         billing_access.is_some_and(crate::billing::ChatBillingAccess::is_paid),
     );
-    let alias_targets = state.model_alias_targets(user.uuid, model_plan).await;
+    let alias_targets = ModelAliasTargets::for_plan(model_plan);
     let catalog_response = model_catalog_response(alias_targets);
     encrypt_response(&state, &session_id, &catalog_response).await
 }

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -7,9 +7,8 @@ use crate::{
     encrypt::{decrypt_content, decrypt_string, encrypt_with_key},
     jwt::AuthContext,
     model_config::{
-        model_alias_requires_flag_lookup, model_config, model_reasoning_history_strategy,
-        resolve_public_model_id, ModelAliasTargets, ModelPlan, ReasoningHistoryStrategy,
-        ResponsesModelConfig, SamplingConfig,
+        model_config, model_reasoning_history_strategy, resolve_public_model_id, ModelAliasTargets,
+        ModelPlan, ReasoningHistoryStrategy, ResponsesModelConfig, SamplingConfig,
     },
     models::responses::{
         NewToolCall, NewToolOutput, NewUserMessage, ResponseStatus, ResponsesError,
@@ -417,7 +416,6 @@ mod tests {
     use axum::{routing::get, Json, Router};
     use chrono::{TimeZone, Utc};
     use serde_json::json;
-    use std::collections::HashMap;
     use tokio::{
         net::TcpListener,
         sync::{broadcast, mpsc},
@@ -957,17 +955,15 @@ mod tests {
             &[json!({"role": "user", "content": "hello"})],
             false,
         );
+        assert_eq!(auto_request["model"], crate::model_config::GLM_5_2_MODEL_ID);
         assert_eq!(
-            auto_request["chat_template_kwargs"]["preserve_thinking"],
-            true
+            auto_request["chat_template_kwargs"]["clear_thinking"],
+            false
         );
+        assert!(auto_request["chat_template_kwargs"]
+            .get("preserve_thinking")
+            .is_none());
 
-        let overrides =
-            crate::model_config::PaidModelAliasOverrides::from_flag_values(&HashMap::from([(
-                crate::os_flags::PAID_POWERFUL_KIMI_K3_ALIAS_FLAG_KEY.to_string(),
-                true,
-            )]));
-        let targets = ModelAliasTargets::for_plan_with_overrides(ModelPlan::Paid, overrides);
         let paid_quick =
             responses_request_for_model(targets.resolve(crate::model_config::AUTO_QUICK_MODEL_ID));
         let paid_quick_request = build_model_turn_request(
@@ -980,26 +976,6 @@ mod tests {
             crate::model_config::DEEPSEEK_V4_FLASH_MODEL_ID
         );
         assert!(paid_quick_request.get("chat_template_kwargs").is_none());
-
-        let paid_powerful = responses_request_for_model(
-            targets.resolve(crate::model_config::AUTO_POWERFUL_MODEL_ID),
-        );
-        let paid_powerful_request = build_model_turn_request(
-            &paid_powerful,
-            &[json!({"role": "user", "content": "hello"})],
-            false,
-        );
-        assert_eq!(
-            paid_powerful_request["model"],
-            crate::model_config::KIMI_K3_MODEL_ID
-        );
-        assert_eq!(
-            paid_powerful_request["chat_template_kwargs"]["preserve_thinking"],
-            true
-        );
-        assert!(paid_powerful_request["chat_template_kwargs"]
-            .get("clear_thinking")
-            .is_none());
     }
 
     #[test]
@@ -3800,11 +3776,7 @@ async fn create_response_stream(
         );
         return Err(ApiError::Unauthorized);
     }
-    let alias_targets = if model_alias_requires_flag_lookup(&requested_model) {
-        state.model_alias_targets(user.uuid, model_plan).await
-    } else {
-        ModelAliasTargets::for_plan(model_plan)
-    };
+    let alias_targets = ModelAliasTargets::for_plan(model_plan);
     let selected_model = alias_targets.resolve(&requested_model).to_string();
     let completion_provider = state.proxy_router.get_completion_proxy();
     let resolved_model = resolve_responses_model(


### PR DESCRIPTION
## Summary

- point the static `auto:powerful` alias at `glm-5-2`; existing Pro access enforcement continues to deny Free users
- remove the paid Kimi K3 Powerful alias flag and the per-request alias flag lookup/fallback path
- keep Kimi K3 and Kimi K2.6 available for direct paid-user selection
- preserve the separate `provider-routing.glm-5-2.continuum` control so GLM provider routing continues independently

## Validation

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo clippy --locked --all-targets --all-features -- -D warnings`
- focused model catalog/alias, entitlement, Responses template, and provider-routing tests (38 passed)
- `RUSTFLAGS='-D warnings' cargo test --locked --all-features` (431 passed, 20 ignored)

Local service smoke and GUI validation were intentionally out of scope for this configuration-only routing change.
