### PR TITLE
[routing v2 8/8] Fence half-open circuit recovery

### DIFF
--- a/src/inference/health.rs
+++ b/src/inference/health.rs
@@ -1,22 +1,22 @@
 //! Enclave-local health classification for inference routes.
 //!
-//! Stack 5 introduced this state observationally. Stack 6 consumes one coherent
-//! snapshot only for the explicit GLM 5.3 canary; every other route remains
-//! observational until its own rollout boundary.
+//! The state has a fixed registry-derived topology and is deliberately local to
+//! one enclave. Active routing reads coherent snapshots, and expired circuits
+//! are protected by fenced half-open probe leases so concurrent requests cannot
+//! create a probe herd.
 
 use super::{AttemptFailureKind, AttemptTerminal, RouteKey};
 use crate::provider_registry::{ProviderId, ProviderRegistry, RateLimitScope, PROVIDER_REGISTRY};
 use std::collections::{HashMap, VecDeque};
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 
 pub(crate) const SHADOW_HEALTH_POLICY_VERSION: &str = "routing-v2-health-shadow-v1";
 
-// These are observation-only v1 hypotheses, not active product policy. Stack 5
-// intentionally versions and exercises them against real incidents before a
-// later stack may use any disposition during route selection.
+// The identifier retains its original shadow-era name for telemetry continuity;
+// these thresholds now drive active circuit and capacity decisions.
 const ROUTE_FAILURE_WINDOW: Duration = Duration::from_secs(60);
 const ROUTE_FAILURES_TO_OPEN: u8 = 3;
 const ROUTE_OPEN_COOLDOWN: Duration = Duration::from_secs(30);
@@ -41,9 +41,19 @@ pub(crate) enum CapacityPoolKey {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ShadowDisposition {
     Healthy,
-    Watch { consecutive_failures: u8 },
-    WouldOpen { remaining: Duration },
+    Watch {
+        consecutive_failures: u8,
+    },
+    WouldOpen {
+        remaining: Duration,
+    },
     WouldProbe,
+    /// A half-open provider attempt is live. `retry_after` is only a bounded
+    /// recovery hint for callers; the lease itself has no timer and remains
+    /// live until its attempt terminalizes or its guard is dropped.
+    ProbeInFlight {
+        retry_after: Duration,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -82,6 +92,27 @@ pub(crate) struct ShadowObservationReport {
     pub(crate) mutated: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProbeRejectionReason {
+    CircuitOpen,
+    ProbeInFlight,
+    UnknownRoute,
+}
+
+/// Result of atomically checking every health gate for a selected route.
+///
+/// `Ready(None)` means no gate needs a probe. `Ready(Some(_))` owns every
+/// expired-open gate that must be probed as one composite decision. Rejections
+/// are replay-safe because this check happens before a provider attempt starts.
+#[derive(Debug)]
+pub(crate) enum ProbeClaimResult {
+    Ready(Option<ProbeLease>),
+    Rejected {
+        reason: ProbeRejectionReason,
+        retry_after: Duration,
+    },
+}
+
 #[derive(Debug, Clone, Copy)]
 struct ShadowHealthPolicy {
     route_failure_window: Duration,
@@ -103,24 +134,106 @@ impl Default for ShadowHealthPolicy {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ActiveProbe {
+    lease_id: ProbeLeaseId,
+    generation_at_claim: u64,
+}
+
 #[derive(Debug, Default)]
 struct RouteHealthState {
     failure_times: VecDeque<Instant>,
     open_until: Option<Instant>,
+    generation: u64,
+    active_probe: Option<ActiveProbe>,
 }
 
 #[derive(Debug, Default)]
 struct CapacityState {
     open_until: Option<Instant>,
+    generation: u64,
+    active_probe: Option<ActiveProbe>,
 }
 
 #[derive(Debug)]
 struct ShadowHealthInner {
     route_health: HashMap<RouteKey, RouteHealthState>,
     capacity: HashMap<CapacityPoolKey, CapacityState>,
+    next_probe_lease_id: u64,
 }
 
-/// Fixed-topology, enclave-local shadow state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct ProbeLeaseId(u64);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum ProbeGateKey {
+    RouteHealth(RouteKey),
+    Capacity(CapacityPoolKey),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProbeGateClaim {
+    gate: ProbeGateKey,
+    generation_at_claim: u64,
+}
+
+/// Non-cloneable ownership of a composite half-open probe.
+///
+/// Dropping an unresolved lease releases only matching fenced gates. It never
+/// heals a circuit, and a stale lease cannot release a newer probe.
+pub(crate) struct ProbeLease {
+    inner: Arc<Mutex<ShadowHealthInner>>,
+    route: RouteKey,
+    lease_id: ProbeLeaseId,
+    claims: Option<Box<[ProbeGateClaim]>>,
+}
+
+impl std::fmt::Debug for ProbeLease {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ProbeLease")
+            .field("route", &self.route)
+            .field("lease_id", &self.lease_id)
+            .field(
+                "claim_count",
+                &self.claims.as_ref().map_or(0, |claims| claims.len()),
+            )
+            .finish()
+    }
+}
+
+impl ProbeLease {
+    fn take_matching_claims(
+        &mut self,
+        owner: &Arc<Mutex<ShadowHealthInner>>,
+        route: &RouteKey,
+    ) -> Option<(ProbeLeaseId, Box<[ProbeGateClaim]>)> {
+        if !Arc::ptr_eq(&self.inner, owner) || &self.route != route {
+            return None;
+        }
+        self.claims.take().map(|claims| (self.lease_id, claims))
+    }
+
+    #[cfg(test)]
+    fn claim_count(&self) -> usize {
+        self.claims.as_ref().map_or(0, |claims| claims.len())
+    }
+}
+
+impl Drop for ProbeLease {
+    fn drop(&mut self) {
+        let Some(claims) = self.claims.take() else {
+            return;
+        };
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        release_probe_claims(&mut inner, self.lease_id, &claims);
+    }
+}
+
+/// Fixed-topology, enclave-local health state.
 ///
 /// Every key is pre-populated from the static provider registry. Observations
 /// for unknown routes are reported but can never grow the maps.
@@ -128,7 +241,7 @@ struct ShadowHealthInner {
 pub(crate) struct ShadowHealthState {
     policy: ShadowHealthPolicy,
     rate_limit_pools: HashMap<RouteKey, CapacityPoolKey>,
-    inner: Mutex<ShadowHealthInner>,
+    inner: Arc<Mutex<ShadowHealthInner>>,
     #[cfg(test)]
     observation_count: AtomicUsize,
 }
@@ -173,10 +286,11 @@ impl ShadowHealthState {
         Self {
             policy,
             rate_limit_pools,
-            inner: Mutex::new(ShadowHealthInner {
+            inner: Arc::new(Mutex::new(ShadowHealthInner {
                 route_health,
                 capacity,
-            }),
+                next_probe_lease_id: 0,
+            })),
             #[cfg(test)]
             observation_count: AtomicUsize::new(0),
         }
@@ -189,7 +303,28 @@ impl ShadowHealthState {
     ) -> ShadowObservationReport {
         let mut inner = self.lock();
         let now = Instant::now();
-        self.observe_terminal_locked(&mut inner, terminal, mode, now)
+        self.observe_terminal_locked(&mut inner, terminal, mode, None, now)
+    }
+
+    /// Records the terminal result of an attempt that may own a half-open
+    /// probe. The terminal health mutation and matching lease resolution occur
+    /// while holding one state lock.
+    ///
+    /// Telemetry-only recovered sub-attempts must use [`Self::observe_terminal`]
+    /// and leave the lease on the final attempt guard.
+    pub(crate) fn observe_terminal_with_probe(
+        &self,
+        terminal: &AttemptTerminal,
+        mode: ShadowObservationMode,
+        mut probe: Option<ProbeLease>,
+    ) -> ShadowObservationReport {
+        debug_assert!(
+            mode == ShadowObservationMode::Update || probe.is_none(),
+            "telemetry-only observations must not own a probe lease"
+        );
+        let mut inner = self.lock();
+        let now = Instant::now();
+        self.observe_terminal_locked(&mut inner, terminal, mode, probe.as_mut(), now)
     }
 
     pub(crate) fn snapshot(&self, route: &RouteKey) -> Option<ShadowRouteSnapshot> {
@@ -199,7 +334,7 @@ impl ShadowHealthState {
 
     /// Returns a point-in-time snapshot for every requested route while holding
     /// the state lock once. Active selection must not combine observations from
-    /// different instants when deciding whether all canary routes are open.
+    /// different instants when deciding whether candidate routes are open.
     pub(crate) fn snapshot_routes(&self, routes: &[RouteKey]) -> Option<Vec<ShadowRouteSnapshot>> {
         let inner = self.lock();
         let now = Instant::now();
@@ -209,11 +344,100 @@ impl ShadowHealthState {
             .collect()
     }
 
+    /// Atomically checks the route-health gate, deployment-capacity gate, and
+    /// registry-declared rate-limit gate for one already-selected route.
+    pub(crate) fn try_claim_probe(&self, route: &RouteKey) -> ProbeClaimResult {
+        let mut inner = self.lock();
+        self.try_claim_probe_locked(&mut inner, route, Instant::now())
+    }
+
+    fn try_claim_probe_locked(
+        &self,
+        inner: &mut ShadowHealthInner,
+        route: &RouteKey,
+        now: Instant,
+    ) -> ProbeClaimResult {
+        let Some(rate_limit_pool) = self.rate_limit_pools.get(route) else {
+            return ProbeClaimResult::Rejected {
+                reason: ProbeRejectionReason::UnknownRoute,
+                retry_after: self.policy.minimum_capacity_cooldown,
+            };
+        };
+
+        let deployment_pool = CapacityPoolKey::ProviderModel(route.clone());
+        let mut gates = Vec::with_capacity(3);
+        gates.push(ProbeGateKey::RouteHealth(route.clone()));
+        gates.push(ProbeGateKey::Capacity(deployment_pool.clone()));
+        if rate_limit_pool != &deployment_pool {
+            gates.push(ProbeGateKey::Capacity(rate_limit_pool.clone()));
+        }
+
+        let mut expired = Vec::with_capacity(gates.len());
+        let mut open_remaining = None;
+        let mut probe_in_flight = false;
+        for gate in &gates {
+            let Some(status) = probe_gate_status(inner, gate, now) else {
+                return ProbeClaimResult::Rejected {
+                    reason: ProbeRejectionReason::UnknownRoute,
+                    retry_after: self.policy.minimum_capacity_cooldown,
+                };
+            };
+            match status {
+                ProbeGateStatus::Healthy => {}
+                ProbeGateStatus::ExpiredOpen => expired.push(gate.clone()),
+                ProbeGateStatus::StillOpen { remaining } => {
+                    open_remaining = Some(
+                        open_remaining
+                            .map_or(remaining, |current: Duration| current.max(remaining)),
+                    );
+                }
+                ProbeGateStatus::ProbeInFlight => probe_in_flight = true,
+            }
+        }
+
+        if probe_in_flight {
+            return ProbeClaimResult::Rejected {
+                reason: ProbeRejectionReason::ProbeInFlight,
+                retry_after: open_remaining
+                    .unwrap_or(self.policy.minimum_capacity_cooldown)
+                    .max(self.policy.minimum_capacity_cooldown),
+            };
+        }
+        if let Some(retry_after) = open_remaining {
+            return ProbeClaimResult::Rejected {
+                reason: ProbeRejectionReason::CircuitOpen,
+                retry_after,
+            };
+        }
+        if expired.is_empty() {
+            return ProbeClaimResult::Ready(None);
+        }
+
+        let lease_id = next_probe_lease_id(inner);
+        let mut claims = Vec::with_capacity(expired.len());
+        for gate in expired {
+            let generation_at_claim = claim_probe_gate(inner, &gate, lease_id)
+                .expect("validated probe gate must remain claimable under the state lock");
+            claims.push(ProbeGateClaim {
+                gate,
+                generation_at_claim,
+            });
+        }
+
+        ProbeClaimResult::Ready(Some(ProbeLease {
+            inner: Arc::clone(&self.inner),
+            route: route.clone(),
+            lease_id,
+            claims: Some(claims.into_boxed_slice()),
+        }))
+    }
+
     fn observe_terminal_locked(
         &self,
         inner: &mut ShadowHealthInner,
         terminal: &AttemptTerminal,
         mode: ShadowObservationMode,
+        probe: Option<&mut ProbeLease>,
         now: Instant,
     ) -> ShadowObservationReport {
         #[cfg(test)]
@@ -294,9 +518,30 @@ impl ShadowHealthState {
             }
         }
 
-        let mutated = mode == ShadowObservationMode::Update && mutation != Mutation::None;
-        if mutated {
-            self.apply_mutation(inner, &route, &rate_limit_pool, mutation, now);
+        let mut mutated = mode == ShadowObservationMode::Update && mutation != Mutation::None;
+        if mode == ShadowObservationMode::Update {
+            let probe_claims =
+                probe.and_then(|probe| probe.take_matching_claims(&self.inner, &route));
+            if let Some((lease_id, claims)) = probe_claims {
+                match mutation.clone() {
+                    Mutation::Completed => {
+                        resolve_probe_success(inner, lease_id, &claims);
+                        if let Some(state) = inner.route_health.get_mut(&route) {
+                            apply_route_success(state, now);
+                        }
+                    }
+                    Mutation::None => {
+                        release_probe_claims(inner, lease_id, &claims);
+                    }
+                    mutation => {
+                        self.apply_mutation(inner, &route, mutation, now);
+                        release_probe_claims(inner, lease_id, &claims);
+                    }
+                }
+                mutated = true;
+            } else if mutated {
+                self.apply_mutation(inner, &route, mutation, now);
+            }
         }
 
         ShadowObservationReport {
@@ -314,7 +559,6 @@ impl ShadowHealthState {
         &self,
         inner: &mut ShadowHealthInner,
         route: &RouteKey,
-        rate_limit_pool: &CapacityPoolKey,
         mutation: Mutation,
         now: Instant,
     ) {
@@ -323,16 +567,8 @@ impl ShadowHealthState {
                 if let Some(state) = inner.route_health.get_mut(route) {
                     apply_route_success(state, now);
                 }
-
-                let deployment_pool = CapacityPoolKey::ProviderModel(route.clone());
-                if let Some(state) = inner.capacity.get_mut(&deployment_pool) {
-                    apply_capacity_success(state, now);
-                }
-                if rate_limit_pool != &deployment_pool {
-                    if let Some(state) = inner.capacity.get_mut(rate_limit_pool) {
-                        apply_capacity_success(state, now);
-                    }
-                }
+                // Ordinary success carries no authority to heal an opened
+                // capacity gate; only a matching probe lease can do that.
             }
             Mutation::Capacity { pool, retry_after } => {
                 if let Some(state) = inner.capacity.get_mut(&pool) {
@@ -340,6 +576,7 @@ impl ShadowHealthState {
                         .unwrap_or(self.policy.minimum_capacity_cooldown)
                         .max(self.policy.minimum_capacity_cooldown)
                         .min(self.policy.max_capacity_cooldown);
+                    advance_generation(&mut state.generation);
                     extend_open_until(&mut state.open_until, now, cooldown);
                 }
             }
@@ -361,12 +598,21 @@ impl ShadowHealthState {
         let route_health = route_health_disposition(
             inner.route_health.get(route)?,
             self.policy.route_failure_window,
+            self.policy.minimum_capacity_cooldown,
             now,
         );
         let deployment_pool = CapacityPoolKey::ProviderModel(route.clone());
-        let deployment_capacity = capacity_disposition(inner.capacity.get(&deployment_pool)?, now);
+        let deployment_capacity = capacity_disposition(
+            inner.capacity.get(&deployment_pool)?,
+            self.policy.minimum_capacity_cooldown,
+            now,
+        );
         let rate_limit_pool = self.rate_limit_pools.get(route)?;
-        let rate_limit_capacity = capacity_disposition(inner.capacity.get(rate_limit_pool)?, now);
+        let rate_limit_capacity = capacity_disposition(
+            inner.capacity.get(rate_limit_pool)?,
+            self.policy.minimum_capacity_cooldown,
+            now,
+        );
         let effective =
             strongest_disposition([route_health, deployment_capacity, rate_limit_capacity]);
 
@@ -397,7 +643,25 @@ impl ShadowHealthState {
         now: Instant,
     ) -> ShadowObservationReport {
         let mut inner = self.lock();
-        self.observe_terminal_locked(&mut inner, terminal, mode, now)
+        self.observe_terminal_locked(&mut inner, terminal, mode, None, now)
+    }
+
+    #[cfg(test)]
+    fn observe_terminal_with_probe_at(
+        &self,
+        terminal: &AttemptTerminal,
+        mode: ShadowObservationMode,
+        mut probe: Option<ProbeLease>,
+        now: Instant,
+    ) -> ShadowObservationReport {
+        let mut inner = self.lock();
+        self.observe_terminal_locked(&mut inner, terminal, mode, probe.as_mut(), now)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn try_claim_probe_at(&self, route: &RouteKey, now: Instant) -> ProbeClaimResult {
+        let mut inner = self.lock();
+        self.try_claim_probe_locked(&mut inner, route, now)
     }
 
     #[cfg(test)]
@@ -415,6 +679,178 @@ impl ShadowHealthState {
     #[cfg(test)]
     pub(crate) fn observation_count(&self) -> usize {
         self.observation_count.load(Ordering::Relaxed)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProbeGateStatus {
+    Healthy,
+    StillOpen { remaining: Duration },
+    ExpiredOpen,
+    ProbeInFlight,
+}
+
+fn probe_gate_status(
+    inner: &ShadowHealthInner,
+    gate: &ProbeGateKey,
+    now: Instant,
+) -> Option<ProbeGateStatus> {
+    let (open_until, active_probe) = match gate {
+        ProbeGateKey::RouteHealth(route) => {
+            let state = inner.route_health.get(route)?;
+            (state.open_until, state.active_probe)
+        }
+        ProbeGateKey::Capacity(pool) => {
+            let state = inner.capacity.get(pool)?;
+            (state.open_until, state.active_probe)
+        }
+    };
+
+    if active_probe.is_some() {
+        return Some(ProbeGateStatus::ProbeInFlight);
+    }
+    match open_until {
+        Some(until) if now < until => Some(ProbeGateStatus::StillOpen {
+            remaining: until.duration_since(now),
+        }),
+        Some(_) => Some(ProbeGateStatus::ExpiredOpen),
+        None => Some(ProbeGateStatus::Healthy),
+    }
+}
+
+fn next_probe_lease_id(inner: &mut ShadowHealthInner) -> ProbeLeaseId {
+    loop {
+        inner.next_probe_lease_id = inner.next_probe_lease_id.wrapping_add(1);
+        if inner.next_probe_lease_id == 0 {
+            continue;
+        }
+        let candidate = ProbeLeaseId(inner.next_probe_lease_id);
+        let in_use = inner.route_health.values().any(|state| {
+            state
+                .active_probe
+                .is_some_and(|probe| probe.lease_id == candidate)
+        }) || inner.capacity.values().any(|state| {
+            state
+                .active_probe
+                .is_some_and(|probe| probe.lease_id == candidate)
+        });
+        if !in_use {
+            return candidate;
+        }
+    }
+}
+
+fn claim_probe_gate(
+    inner: &mut ShadowHealthInner,
+    gate: &ProbeGateKey,
+    lease_id: ProbeLeaseId,
+) -> Option<u64> {
+    let (generation, active_probe) = match gate {
+        ProbeGateKey::RouteHealth(route) => {
+            let state = inner.route_health.get_mut(route)?;
+            (&mut state.generation, &mut state.active_probe)
+        }
+        ProbeGateKey::Capacity(pool) => {
+            let state = inner.capacity.get_mut(pool)?;
+            (&mut state.generation, &mut state.active_probe)
+        }
+    };
+    debug_assert!(active_probe.is_none());
+    advance_generation(generation);
+    *active_probe = Some(ActiveProbe {
+        lease_id,
+        generation_at_claim: *generation,
+    });
+    Some(*generation)
+}
+
+fn release_probe_claims(
+    inner: &mut ShadowHealthInner,
+    lease_id: ProbeLeaseId,
+    claims: &[ProbeGateClaim],
+) {
+    for claim in claims {
+        match &claim.gate {
+            ProbeGateKey::RouteHealth(route) => {
+                if let Some(state) = inner.route_health.get_mut(route) {
+                    if active_probe_matches(state.active_probe, lease_id, claim.generation_at_claim)
+                    {
+                        state.active_probe = None;
+                    }
+                }
+            }
+            ProbeGateKey::Capacity(pool) => {
+                if let Some(state) = inner.capacity.get_mut(pool) {
+                    if active_probe_matches(state.active_probe, lease_id, claim.generation_at_claim)
+                    {
+                        state.active_probe = None;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn resolve_probe_success(
+    inner: &mut ShadowHealthInner,
+    lease_id: ProbeLeaseId,
+    claims: &[ProbeGateClaim],
+) {
+    for claim in claims {
+        match &claim.gate {
+            ProbeGateKey::RouteHealth(route) => {
+                if let Some(state) = inner.route_health.get_mut(route) {
+                    let matching_active = active_probe_matches(
+                        state.active_probe,
+                        lease_id,
+                        claim.generation_at_claim,
+                    );
+                    let matches = matching_active && state.generation == claim.generation_at_claim;
+                    if matches {
+                        state.failure_times.clear();
+                        state.open_until = None;
+                        state.active_probe = None;
+                        advance_generation(&mut state.generation);
+                    } else if matching_active {
+                        state.active_probe = None;
+                    }
+                }
+            }
+            ProbeGateKey::Capacity(pool) => {
+                if let Some(state) = inner.capacity.get_mut(pool) {
+                    let matching_active = active_probe_matches(
+                        state.active_probe,
+                        lease_id,
+                        claim.generation_at_claim,
+                    );
+                    let matches = matching_active && state.generation == claim.generation_at_claim;
+                    if matches {
+                        state.open_until = None;
+                        state.active_probe = None;
+                        advance_generation(&mut state.generation);
+                    } else if matching_active {
+                        state.active_probe = None;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn active_probe_matches(
+    active_probe: Option<ActiveProbe>,
+    lease_id: ProbeLeaseId,
+    generation_at_claim: u64,
+) -> bool {
+    active_probe.is_some_and(|active| {
+        active.lease_id == lease_id && active.generation_at_claim == generation_at_claim
+    })
+}
+
+fn advance_generation(generation: &mut u64) {
+    *generation = generation.wrapping_add(1);
+    if *generation == 0 {
+        *generation = 1;
     }
 }
 
@@ -449,7 +885,11 @@ fn is_route_health_failure(kind: AttemptFailureKind) -> bool {
 }
 
 fn apply_route_failure(state: &mut RouteHealthState, policy: ShadowHealthPolicy, now: Instant) {
-    if state.open_until.is_some_and(|until| now < until) {
+    advance_generation(&mut state.generation);
+    // Any failure while an opened route is awaiting or running its half-open
+    // probe reopens the circuit from this failure time. The probe deliberately
+    // has no timeout, so the original failure window may already have elapsed.
+    if state.open_until.is_some() {
         extend_open_until(&mut state.open_until, now, policy.route_open_cooldown);
         return;
     }
@@ -475,18 +915,17 @@ fn apply_route_failure(state: &mut RouteHealthState, policy: ShadowHealthPolicy,
     }
 }
 
-fn apply_route_success(state: &mut RouteHealthState, now: Instant) {
-    if state.open_until.is_some_and(|until| now < until) {
+fn apply_route_success(state: &mut RouteHealthState, _now: Instant) {
+    // Once a route has opened, only the matching fenced half-open probe may
+    // heal it. A late success from an attempt admitted before the open must not
+    // bypass probe ownership at or after the cooldown boundary.
+    if state.open_until.is_some() {
         return;
     }
-    state.failure_times.clear();
-    state.open_until = None;
-}
-
-fn apply_capacity_success(state: &mut CapacityState, now: Instant) {
-    if state.open_until.is_some_and(|until| now >= until) {
-        state.open_until = None;
+    if !state.failure_times.is_empty() {
+        advance_generation(&mut state.generation);
     }
+    state.failure_times.clear();
 }
 
 fn extend_open_until(open_until: &mut Option<Instant>, now: Instant, cooldown: Duration) {
@@ -497,8 +936,14 @@ fn extend_open_until(open_until: &mut Option<Instant>, now: Instant, cooldown: D
 fn route_health_disposition(
     state: &RouteHealthState,
     failure_window: Duration,
+    probe_retry_after: Duration,
     now: Instant,
 ) -> ShadowDisposition {
+    if state.active_probe.is_some() {
+        return ShadowDisposition::ProbeInFlight {
+            retry_after: probe_retry_after,
+        };
+    }
     if let Some(until) = state.open_until {
         return if now < until {
             ShadowDisposition::WouldOpen {
@@ -526,7 +971,16 @@ fn route_health_disposition(
     }
 }
 
-fn capacity_disposition(state: &CapacityState, now: Instant) -> ShadowDisposition {
+fn capacity_disposition(
+    state: &CapacityState,
+    probe_retry_after: Duration,
+    now: Instant,
+) -> ShadowDisposition {
+    if state.active_probe.is_some() {
+        return ShadowDisposition::ProbeInFlight {
+            retry_after: probe_retry_after,
+        };
+    }
     match state.open_until {
         Some(until) if now < until => ShadowDisposition::WouldOpen {
             remaining: until.duration_since(now),
@@ -546,6 +1000,28 @@ fn strongest_disposition(
 
 fn stronger_disposition(left: ShadowDisposition, right: ShadowDisposition) -> ShadowDisposition {
     match (left, right) {
+        (
+            ShadowDisposition::ProbeInFlight {
+                retry_after: left_retry_after,
+            },
+            ShadowDisposition::ProbeInFlight {
+                retry_after: right_retry_after,
+            },
+        ) => ShadowDisposition::ProbeInFlight {
+            retry_after: left_retry_after.max(right_retry_after),
+        },
+        (
+            ShadowDisposition::ProbeInFlight { retry_after },
+            ShadowDisposition::WouldOpen { remaining },
+        )
+        | (
+            ShadowDisposition::WouldOpen { remaining },
+            ShadowDisposition::ProbeInFlight { retry_after },
+        ) => ShadowDisposition::ProbeInFlight {
+            retry_after: retry_after.max(remaining),
+        },
+        (left @ ShadowDisposition::ProbeInFlight { .. }, _) => left,
+        (_, right @ ShadowDisposition::ProbeInFlight { .. }) => right,
         (
             ShadowDisposition::WouldOpen {
                 remaining: left_remaining,
@@ -585,7 +1061,7 @@ mod tests {
         RouteIdentity,
     };
     use crate::provider_registry::RouteSelectionSource;
-    use std::sync::Arc;
+    use std::sync::{Arc, Barrier};
     use std::thread;
 
     fn route(provider: ProviderId, public_model: &str, provider_model: &str) -> RouteIdentity {
@@ -640,6 +1116,23 @@ mod tests {
             route_open_cooldown: Duration::from_secs(5),
             minimum_capacity_cooldown: Duration::from_secs(4),
             max_capacity_cooldown: Duration::from_secs(10),
+        }
+    }
+
+    fn expect_probe(result: ProbeClaimResult) -> ProbeLease {
+        match result {
+            ProbeClaimResult::Ready(Some(lease)) => lease,
+            other => panic!("expected probe lease, got {other:?}"),
+        }
+    }
+
+    fn open_route_at(state: &ShadowHealthState, route: &RouteIdentity, now: Instant) {
+        for _ in 0..3 {
+            state.observe_terminal_at(
+                &failed(route.clone(), AttemptFailureKind::StreamTimeout, None, None),
+                ShadowObservationMode::Update,
+                now,
+            );
         }
     }
 
@@ -927,9 +1420,11 @@ mod tests {
             ShadowDisposition::WouldProbe
         );
 
-        state.observe_terminal_at(
+        let lease = expect_probe(state.try_claim_probe_at(&key, start + Duration::from_secs(4)));
+        state.observe_terminal_with_probe_at(
             &completed(k3.clone()),
             ShadowObservationMode::Update,
+            Some(lease),
             start + Duration::from_secs(4),
         );
         assert_eq!(
@@ -969,7 +1464,7 @@ mod tests {
 
         state.observe_terminal_at(
             &failed(
-                k3,
+                k3.clone(),
                 AttemptFailureKind::CapacityRejected,
                 Some(429),
                 Some(Duration::from_secs(100)),
@@ -1077,9 +1572,11 @@ mod tests {
             ShadowDisposition::WouldProbe
         );
 
-        state.observe_terminal_at(
+        let lease = expect_probe(state.try_claim_probe_at(&key, start + Duration::from_secs(9)));
+        state.observe_terminal_with_probe_at(
             &completed(k3.clone()),
             ShadowObservationMode::Update,
+            Some(lease),
             start + Duration::from_secs(9),
         );
         assert_eq!(
@@ -1181,6 +1678,684 @@ mod tests {
     }
 
     #[test]
+    fn half_open_probe_claim_is_atomic_with_one_winner_at_the_boundary() {
+        let state = Arc::new(ShadowHealthState::with_policy(test_policy()));
+        let start = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let key = k3.route_key();
+        state.observe_terminal_at(
+            &failed(
+                k3.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(4)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+
+        let boundary = start + Duration::from_secs(4);
+        match state.try_claim_probe_at(&key, boundary - Duration::from_nanos(1)) {
+            ProbeClaimResult::Rejected {
+                reason: ProbeRejectionReason::CircuitOpen,
+                retry_after,
+            } => assert_eq!(retry_after, Duration::from_nanos(1)),
+            other => panic!("circuit must remain closed immediately before boundary: {other:?}"),
+        }
+        let barrier = Arc::new(Barrier::new(33));
+        let late_success = {
+            let state = Arc::clone(&state);
+            let barrier = Arc::clone(&barrier);
+            let terminal = completed(k3);
+            thread::spawn(move || {
+                barrier.wait();
+                state.observe_terminal_at(&terminal, ShadowObservationMode::Update, boundary)
+            })
+        };
+        let threads = (0..32)
+            .map(|_| {
+                let state = Arc::clone(&state);
+                let key = key.clone();
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    state.try_claim_probe_at(&key, boundary)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let report = late_success.join().expect("late success thread");
+        assert_eq!(report.signal, ShadowSignal::Completed);
+
+        let mut leases = Vec::new();
+        let mut rejections = 0;
+        for thread in threads {
+            match thread.join().expect("probe claim thread") {
+                ProbeClaimResult::Ready(Some(lease)) => leases.push(lease),
+                ProbeClaimResult::Rejected {
+                    reason: ProbeRejectionReason::ProbeInFlight,
+                    retry_after,
+                } => {
+                    rejections += 1;
+                    assert_eq!(retry_after, Duration::from_secs(4));
+                }
+                other => panic!("unexpected concurrent claim result: {other:?}"),
+            }
+        }
+        assert_eq!(leases.len(), 1);
+        assert_eq!(rejections, 31);
+        assert_eq!(
+            state.snapshot_at(&key, boundary).unwrap().effective,
+            ShadowDisposition::ProbeInFlight {
+                retry_after: Duration::from_secs(4)
+            }
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&key, boundary + Duration::from_secs(60 * 60))
+                .unwrap()
+                .effective,
+            ShadowDisposition::ProbeInFlight {
+                retry_after: Duration::from_secs(4)
+            }
+        );
+
+        drop(leases);
+        assert_eq!(
+            state.snapshot_at(&key, boundary).unwrap().effective,
+            ShadowDisposition::WouldProbe
+        );
+    }
+
+    #[test]
+    fn shared_continuum_account_gate_allows_one_probe_across_models() {
+        let state = Arc::new(ShadowHealthState::with_policy(test_policy()));
+        let start = Instant::now();
+        let k2 = route(ProviderId::Continuum, "kimi-k2-6", "kimi-k2.6");
+        let glm = route(ProviderId::Continuum, "glm-5-3", "glm-5.3");
+        state.observe_terminal_at(
+            &failed(
+                k2.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(4)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+
+        let boundary = start + Duration::from_secs(4);
+        let barrier = Arc::new(Barrier::new(2));
+        let threads = [k2.route_key(), glm.route_key()]
+            .into_iter()
+            .map(|key| {
+                let state = Arc::clone(&state);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    state.try_claim_probe_at(&key, boundary)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let mut leases = Vec::new();
+        let mut rejected = 0;
+        for thread in threads {
+            match thread.join().expect("shared account probe thread") {
+                ProbeClaimResult::Ready(Some(lease)) => leases.push(lease),
+                ProbeClaimResult::Rejected {
+                    reason: ProbeRejectionReason::ProbeInFlight,
+                    ..
+                } => rejected += 1,
+                other => panic!("unexpected shared account claim result: {other:?}"),
+            }
+        }
+        assert_eq!(leases.len(), 1);
+        assert_eq!(rejected, 1);
+        assert!(matches!(
+            state
+                .snapshot_at(&k2.route_key(), boundary)
+                .unwrap()
+                .rate_limit_capacity,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+        assert!(matches!(
+            state
+                .snapshot_at(&glm.route_key(), boundary)
+                .unwrap()
+                .rate_limit_capacity,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+    }
+
+    #[test]
+    fn tinfoil_glm_models_probe_independently() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let start = Instant::now();
+        let legacy = route(ProviderId::Tinfoil, "glm-5-2", "glm-5-2");
+        let base = route(ProviderId::Tinfoil, "glm-5-3", "glm-5-3");
+        let flash = route(ProviderId::Tinfoil, "glm-5-3-flash", "glm-5-3-flash");
+
+        for route in [&legacy, &base, &flash] {
+            state.observe_terminal_at(
+                &failed(
+                    route.clone(),
+                    AttemptFailureKind::CapacityRejected,
+                    Some(429),
+                    Some(Duration::from_secs(4)),
+                ),
+                ShadowObservationMode::Update,
+                start,
+            );
+        }
+
+        let boundary = start + Duration::from_secs(4);
+        let legacy_probe = expect_probe(state.try_claim_probe_at(&legacy.route_key(), boundary));
+        let base_probe = expect_probe(state.try_claim_probe_at(&base.route_key(), boundary));
+        let flash_probe = expect_probe(state.try_claim_probe_at(&flash.route_key(), boundary));
+
+        assert_eq!(legacy_probe.claim_count(), 1);
+        assert_eq!(base_probe.claim_count(), 1);
+        assert_eq!(flash_probe.claim_count(), 1);
+        assert!(matches!(
+            state
+                .snapshot_at(&legacy.route_key(), boundary)
+                .unwrap()
+                .rate_limit_capacity,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+        assert!(matches!(
+            state
+                .snapshot_at(&base.route_key(), boundary)
+                .unwrap()
+                .rate_limit_capacity,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+        assert!(matches!(
+            state
+                .snapshot_at(&flash.route_key(), boundary)
+                .unwrap()
+                .rate_limit_capacity,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+    }
+
+    #[test]
+    fn composite_probe_claims_are_all_or_none_and_deduplicate_capacity_gates() {
+        let start = Instant::now();
+        let k2 = route(ProviderId::Continuum, "kimi-k2-6", "kimi-k2.6");
+
+        let composite = ShadowHealthState::with_policy(test_policy());
+        open_route_at(&composite, &k2, start);
+        for status in [503, 429] {
+            composite.observe_terminal_at(
+                &failed(
+                    k2.clone(),
+                    AttemptFailureKind::CapacityRejected,
+                    Some(status),
+                    Some(Duration::from_secs(5)),
+                ),
+                ShadowObservationMode::Update,
+                start,
+            );
+        }
+        let boundary = start + Duration::from_secs(5);
+        let composite_lease = expect_probe(composite.try_claim_probe_at(&k2.route_key(), boundary));
+        assert_eq!(composite_lease.claim_count(), 3);
+        let snapshot = composite.snapshot_at(&k2.route_key(), boundary).unwrap();
+        assert!(matches!(
+            snapshot.route_health,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+        assert!(matches!(
+            snapshot.deployment_capacity,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+        assert!(matches!(
+            snapshot.rate_limit_capacity,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+        drop(composite_lease);
+
+        let tinfoil = ShadowHealthState::with_policy(test_policy());
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        open_route_at(&tinfoil, &k3, start);
+        tinfoil.observe_terminal_at(
+            &failed(
+                k3.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(5)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+        let deduplicated = expect_probe(tinfoil.try_claim_probe_at(&k3.route_key(), boundary));
+        assert_eq!(deduplicated.claim_count(), 2);
+        drop(deduplicated);
+
+        let blocked = ShadowHealthState::with_policy(test_policy());
+        open_route_at(&blocked, &k2, start);
+        blocked.observe_terminal_at(
+            &failed(
+                k2.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(503),
+                Some(Duration::from_secs(6)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+        match blocked.try_claim_probe_at(&k2.route_key(), boundary) {
+            ProbeClaimResult::Rejected {
+                reason: ProbeRejectionReason::CircuitOpen,
+                retry_after,
+            } => assert_eq!(retry_after, Duration::from_secs(1)),
+            other => panic!("expected all-or-none rejection, got {other:?}"),
+        }
+        let snapshot = blocked.snapshot_at(&k2.route_key(), boundary).unwrap();
+        assert_eq!(snapshot.route_health, ShadowDisposition::WouldProbe);
+        assert_eq!(
+            snapshot.deployment_capacity,
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(1)
+            }
+        );
+    }
+
+    #[test]
+    fn successful_probe_heals_claimed_gates_and_resets_route_watch() {
+        let start = Instant::now();
+        let k2 = route(ProviderId::Continuum, "kimi-k2-6", "kimi-k2.6");
+        let state = ShadowHealthState::with_policy(test_policy());
+        open_route_at(&state, &k2, start);
+        for status in [503, 429] {
+            state.observe_terminal_at(
+                &failed(
+                    k2.clone(),
+                    AttemptFailureKind::CapacityRejected,
+                    Some(status),
+                    Some(Duration::from_secs(5)),
+                ),
+                ShadowObservationMode::Update,
+                start,
+            );
+        }
+        let boundary = start + Duration::from_secs(5);
+        let lease = expect_probe(state.try_claim_probe_at(&k2.route_key(), boundary));
+        state.observe_terminal_with_probe_at(
+            &completed(k2.clone()),
+            ShadowObservationMode::Update,
+            Some(lease),
+            boundary,
+        );
+        assert_eq!(
+            state
+                .snapshot_at(&k2.route_key(), boundary)
+                .unwrap()
+                .effective,
+            ShadowDisposition::Healthy
+        );
+
+        let only_account_open = ShadowHealthState::with_policy(test_policy());
+        only_account_open.observe_terminal_at(
+            &failed(k2.clone(), AttemptFailureKind::StreamTimeout, None, None),
+            ShadowObservationMode::Update,
+            start,
+        );
+        only_account_open.observe_terminal_at(
+            &failed(
+                k2.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(4)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+        let lease = expect_probe(
+            only_account_open.try_claim_probe_at(&k2.route_key(), start + Duration::from_secs(4)),
+        );
+        assert_eq!(lease.claim_count(), 1);
+        only_account_open.observe_terminal_with_probe_at(
+            &completed(k2.clone()),
+            ShadowObservationMode::Update,
+            Some(lease),
+            start + Duration::from_secs(4),
+        );
+        assert_eq!(
+            only_account_open
+                .snapshot_at(&k2.route_key(), start + Duration::from_secs(4))
+                .unwrap()
+                .route_health,
+            ShadowDisposition::Healthy
+        );
+    }
+
+    #[test]
+    fn unleased_success_cannot_heal_an_owned_route_gate() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let start = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let key = k3.route_key();
+        open_route_at(&state, &k3, start);
+
+        let boundary = start + Duration::from_secs(5);
+        let lease = expect_probe(state.try_claim_probe_at(&key, boundary));
+        state.observe_terminal_at(
+            &completed(k3.clone()),
+            ShadowObservationMode::Update,
+            boundary,
+        );
+        assert!(matches!(
+            state.snapshot_at(&key, boundary).unwrap().route_health,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+
+        state.observe_terminal_with_probe_at(
+            &completed(k3),
+            ShadowObservationMode::Update,
+            Some(lease),
+            boundary,
+        );
+        assert_eq!(
+            state.snapshot_at(&key, boundary).unwrap().route_health,
+            ShadowDisposition::Healthy
+        );
+    }
+
+    #[test]
+    fn failed_probes_reopen_only_the_classified_route_or_capacity_gate() {
+        let start = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let route_failure = ShadowHealthState::with_policy(test_policy());
+        open_route_at(&route_failure, &k3, start);
+        let boundary = start + Duration::from_secs(5);
+        let lease = expect_probe(route_failure.try_claim_probe_at(&k3.route_key(), boundary));
+        let late_terminal = boundary + Duration::from_secs(11);
+        route_failure.observe_terminal_with_probe_at(
+            &failed(k3.clone(), AttemptFailureKind::StreamTimeout, None, None),
+            ShadowObservationMode::Update,
+            Some(lease),
+            late_terminal,
+        );
+        assert_eq!(
+            route_failure
+                .snapshot_at(&k3.route_key(), late_terminal)
+                .unwrap()
+                .route_health,
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(5)
+            }
+        );
+
+        let k2 = route(ProviderId::Continuum, "kimi-k2-6", "kimi-k2.6");
+        let glm = route(ProviderId::Continuum, "glm-5-3", "glm-5.3");
+        let account_limit = ShadowHealthState::with_policy(test_policy());
+        account_limit.observe_terminal_at(
+            &failed(
+                k2.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(4)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+        let account_boundary = start + Duration::from_secs(4);
+        let lease =
+            expect_probe(account_limit.try_claim_probe_at(&k2.route_key(), account_boundary));
+        account_limit.observe_terminal_with_probe_at(
+            &failed(
+                k2.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                None,
+            ),
+            ShadowObservationMode::Update,
+            Some(lease),
+            account_boundary,
+        );
+        assert_eq!(
+            account_limit
+                .snapshot_at(&glm.route_key(), account_boundary)
+                .unwrap()
+                .rate_limit_capacity,
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(4)
+            }
+        );
+
+        let deployment_limit = ShadowHealthState::with_policy(test_policy());
+        deployment_limit.observe_terminal_at(
+            &failed(
+                k2.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(503),
+                Some(Duration::from_secs(4)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+        let lease =
+            expect_probe(deployment_limit.try_claim_probe_at(&k2.route_key(), account_boundary));
+        deployment_limit.observe_terminal_with_probe_at(
+            &failed(
+                k2.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(503),
+                None,
+            ),
+            ShadowObservationMode::Update,
+            Some(lease),
+            account_boundary,
+        );
+        assert_eq!(
+            deployment_limit
+                .snapshot_at(&k2.route_key(), account_boundary)
+                .unwrap()
+                .deployment_capacity,
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(4)
+            }
+        );
+        assert_eq!(
+            deployment_limit
+                .snapshot_at(&glm.route_key(), account_boundary)
+                .unwrap()
+                .effective,
+            ShadowDisposition::Healthy
+        );
+    }
+
+    #[test]
+    fn neutral_terminal_and_raii_drop_release_without_healing() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let start = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let key = k3.route_key();
+        state.observe_terminal_at(
+            &failed(
+                k3.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(4)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+        let boundary = start + Duration::from_secs(4);
+        let lease = expect_probe(state.try_claim_probe_at(&key, boundary));
+        state.observe_terminal_with_probe_at(
+            &failed(k3.clone(), AttemptFailureKind::HttpStatus, Some(400), None),
+            ShadowObservationMode::Update,
+            Some(lease),
+            boundary,
+        );
+        assert_eq!(
+            state.snapshot_at(&key, boundary).unwrap().effective,
+            ShadowDisposition::WouldProbe
+        );
+
+        let lease = expect_probe(state.try_claim_probe_at(&key, boundary));
+        state.observe_terminal_at(
+            &failed(k3, AttemptFailureKind::Connect, None, None),
+            ShadowObservationMode::TelemetryOnly,
+            boundary + Duration::from_secs(30),
+        );
+        assert!(matches!(
+            state
+                .snapshot_at(&key, boundary + Duration::from_secs(30))
+                .unwrap()
+                .effective,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+        drop(lease);
+        assert_eq!(
+            state.snapshot_at(&key, boundary).unwrap().effective,
+            ShadowDisposition::WouldProbe
+        );
+    }
+
+    #[test]
+    fn stale_or_duplicate_lease_cannot_release_a_newer_probe() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let start = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let key = k3.route_key();
+        state.observe_terminal_at(
+            &failed(
+                k3,
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(4)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+        let boundary = start + Duration::from_secs(4);
+        let first = expect_probe(state.try_claim_probe_at(&key, boundary));
+        let stale_one = ProbeLease {
+            inner: Arc::clone(&first.inner),
+            route: first.route.clone(),
+            lease_id: first.lease_id,
+            claims: first.claims.clone(),
+        };
+        let stale_two = ProbeLease {
+            inner: Arc::clone(&first.inner),
+            route: first.route.clone(),
+            lease_id: first.lease_id,
+            claims: first.claims.clone(),
+        };
+        drop(first);
+
+        // Force an ID reuse to prove the gate-local generation, not merely the
+        // monotonic ID, fences stale/double release.
+        {
+            let mut inner = state.lock();
+            inner.next_probe_lease_id = stale_one.lease_id.0.wrapping_sub(1);
+        }
+
+        let newer = expect_probe(state.try_claim_probe_at(&key, boundary));
+        assert_eq!(newer.lease_id, stale_one.lease_id);
+        assert!(matches!(
+            state.snapshot_at(&key, boundary).unwrap().effective,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+        drop(stale_one);
+        drop(stale_two);
+        assert!(matches!(
+            state.snapshot_at(&key, boundary).unwrap().effective,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+        drop(newer);
+        assert_eq!(
+            state.snapshot_at(&key, boundary).unwrap().effective,
+            ShadowDisposition::WouldProbe
+        );
+    }
+
+    #[test]
+    fn unrelated_success_cannot_heal_a_gate_with_a_live_probe() {
+        let state = ShadowHealthState::with_policy(test_policy());
+        let start = Instant::now();
+        let k3 = route(ProviderId::Tinfoil, "kimi-k3", "kimi-k3");
+        let key = k3.route_key();
+        state.observe_terminal_at(
+            &failed(
+                k3.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(4)),
+            ),
+            ShadowObservationMode::Update,
+            start,
+        );
+        let boundary = start + Duration::from_secs(4);
+        let lease = expect_probe(state.try_claim_probe_at(&key, boundary));
+
+        state.observe_terminal_at(
+            &completed(k3.clone()),
+            ShadowObservationMode::Update,
+            boundary,
+        );
+        assert!(matches!(
+            state.snapshot_at(&key, boundary).unwrap().effective,
+            ShadowDisposition::ProbeInFlight { .. }
+        ));
+
+        state.observe_terminal_with_probe_at(
+            &completed(k3.clone()),
+            ShadowObservationMode::Update,
+            Some(lease),
+            boundary,
+        );
+        assert_eq!(
+            state.snapshot_at(&key, boundary).unwrap().effective,
+            ShadowDisposition::Healthy
+        );
+
+        let reopened_at = boundary + Duration::from_secs(10);
+        state.observe_terminal_at(
+            &failed(
+                k3.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                Some(Duration::from_secs(4)),
+            ),
+            ShadowObservationMode::Update,
+            reopened_at,
+        );
+        let second_boundary = reopened_at + Duration::from_secs(4);
+        let lease = expect_probe(state.try_claim_probe_at(&key, second_boundary));
+
+        // A distinct provider attempt can reopen a gate while its half-open
+        // probe is still live. Its generation fences the older probe success.
+        state.observe_terminal_at(
+            &failed(
+                k3.clone(),
+                AttemptFailureKind::CapacityRejected,
+                Some(429),
+                None,
+            ),
+            ShadowObservationMode::Update,
+            second_boundary,
+        );
+        state.observe_terminal_with_probe_at(
+            &completed(k3),
+            ShadowObservationMode::Update,
+            Some(lease),
+            second_boundary,
+        );
+        assert_eq!(
+            state.snapshot_at(&key, second_boundary).unwrap().effective,
+            ShadowDisposition::WouldOpen {
+                remaining: Duration::from_secs(4)
+            }
+        );
+    }
+
+    #[test]
     fn registry_topology_bounds_state_under_concurrent_observation() {
         let state = Arc::new(ShadowHealthState::with_policy(test_policy()));
         let cardinality = state.cardinality();
@@ -1206,6 +2381,16 @@ mod tests {
         let report = state.observe_terminal(&unknown, ShadowObservationMode::Update);
         assert_eq!(report.signal, ShadowSignal::UnknownRoute);
         assert!(!report.mutated);
+
+        for _ in 0..128 {
+            match state.try_claim_probe(&unknown.attempt().route.route_key()) {
+                ProbeClaimResult::Rejected {
+                    reason: ProbeRejectionReason::UnknownRoute,
+                    retry_after,
+                } => assert_eq!(retry_after, Duration::from_secs(4)),
+                other => panic!("unknown route must fail closed, got {other:?}"),
+            }
+        }
         assert_eq!(state.cardinality(), cardinality);
     }
 }

--- a/src/inference_planning.rs
+++ b/src/inference_planning.rs
@@ -1,15 +1,16 @@
 //! Deterministic, credential-free completion route planning.
 //!
 //! The plan describes route identity and ordered same-model candidates without
-//! naming or invoking an executable endpoint. It remains the baseline shadow
-//! planner for every model and is also reused by Stack 6 after GLM's active
-//! canary has filtered its configured providers through one health snapshot.
+//! naming or invoking an executable endpoint. Router v2 applies the configured
+//! weights after filtering providers through one health snapshot. Legacy
+//! provider flags and default-provider preferences are not planner inputs.
 
 use crate::inference::{InferenceIntent, RouteIdentity};
 use crate::provider_registry::{
     ProviderId, ProviderRegistry, RouteSelectionSource, SHADOW_ROUTING_POLICY_VERSION,
 };
 
+/// Router v1 preference, deliberately absent from Router v2 planning inputs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ProviderPreference {
     provider: ProviderId,
@@ -82,7 +83,6 @@ impl ConfiguredProviders {
 pub(crate) struct RoutePlanningInput<'a> {
     pub(crate) intent: &'a InferenceIntent,
     pub(crate) configured_providers: ConfiguredProviders,
-    pub(crate) provider_preference: Option<ProviderPreference>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -98,10 +98,6 @@ pub(crate) struct RouteCandidate {
 pub(crate) enum PlanDecision {
     FixedRoute,
     StaticBucket,
-    DefaultProvider,
-    FeatureFlagPreference,
-    PreferredProviderUnavailable,
-    DefaultProviderUnavailable,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -171,62 +167,32 @@ pub(crate) fn plan_completion_route(
         ));
     }
 
-    if let Some(preference) = input.provider_preference {
-        if let Some(route) = eligible_routes
-            .iter()
-            .find(|route| route.candidate.provider == preference.provider())
-        {
-            return Ok(build_plan(
-                route,
-                &eligible_routes,
-                preference.source(),
-                None,
-                PlanDecision::FeatureFlagPreference,
-            ));
-        }
-    }
-
-    if let Some(default_provider) = model.default_provider {
-        if let Some(route) = eligible_routes
-            .iter()
-            .find(|route| route.candidate.provider == default_provider)
-        {
-            let (source, decision) = if input.provider_preference.is_some() {
-                (
-                    RouteSelectionSource::Fallback,
-                    PlanDecision::PreferredProviderUnavailable,
-                )
-            } else {
-                (
-                    RouteSelectionSource::DefaultProvider,
-                    PlanDecision::DefaultProvider,
-                )
-            };
-            return Ok(build_plan(route, &eligible_routes, source, None, decision));
-        }
-    }
-
-    let fallback_source = if input.provider_preference.is_some() || model.default_provider.is_some()
-    {
+    // Report fallback when a configured route is unavailable, without turning
+    // a legacy default or feature flag into a preferred Router v2 provider.
+    let enabled_route_count = model
+        .routes
+        .iter()
+        .filter(|route| {
+            route.enabled
+                && route.weight > 0
+                && registry
+                    .provider(route.provider)
+                    .is_some_and(|provider| provider.enabled && provider.weight > 0)
+        })
+        .count();
+    let selection_source = if eligible_routes.len() < enabled_route_count {
         RouteSelectionSource::Fallback
     } else {
         RouteSelectionSource::StaticSplit
-    };
-    let missing_preference_decision = if input.provider_preference.is_some() {
-        Some(PlanDecision::PreferredProviderUnavailable)
-    } else if model.default_provider.is_some() {
-        Some(PlanDecision::DefaultProviderUnavailable)
-    } else {
-        None
     };
 
     if eligible_routes.len() == 1 {
         return Ok(build_plan(
             &eligible_routes[0],
             &eligible_routes,
-            fallback_source,
+            selection_source,
             None,
-            missing_preference_decision.unwrap_or(PlanDecision::FixedRoute),
+            PlanDecision::FixedRoute,
         ));
     }
 
@@ -236,9 +202,9 @@ pub(crate) fn plan_completion_route(
     Ok(build_plan(
         selected,
         &eligible_routes,
-        fallback_source,
+        selection_source,
         Some(bucket),
-        missing_preference_decision.unwrap_or(PlanDecision::StaticBucket),
+        PlanDecision::StaticBucket,
     ))
 }
 
@@ -327,7 +293,6 @@ mod tests {
             RoutePlanningInput {
                 intent: &intent,
                 configured_providers: ConfiguredProviders::all(),
-                provider_preference: None,
             },
         )
         .expect("shadow route");
@@ -337,18 +302,17 @@ mod tests {
         assert_eq!(plan.selected.provider_model_id, GLM_5_2_MODEL_ID);
         assert_eq!(plan.selected.provider, ProviderId::Tinfoil);
         assert_eq!(plan.selected.bucket, None);
-        assert_eq!(plan.decision, PlanDecision::DefaultProvider);
+        assert_eq!(plan.decision, PlanDecision::FixedRoute);
     }
 
     #[test]
-    fn alias_resolved_glm_5_3_honors_the_tinfoil_provider_preference() {
+    fn alias_resolved_glm_5_3_uses_weighted_provider_selection() {
         let intent = intent(AUTO_POWERFUL_MODEL_ID, GLM_5_3_MODEL_ID);
         let plan = plan_completion_route(
             &PROVIDER_REGISTRY,
             RoutePlanningInput {
                 intent: &intent,
                 configured_providers: ConfiguredProviders::all(),
-                provider_preference: Some(ProviderPreference::feature_flag(ProviderId::Tinfoil)),
             },
         )
         .expect("GLM 5.3 Tinfoil plan");
@@ -357,6 +321,12 @@ mod tests {
         assert_eq!(intent.public_model_id, GLM_5_3_MODEL_ID);
         assert_eq!(plan.selected.provider, ProviderId::Tinfoil);
         assert_eq!(plan.selected.provider_model_id, GLM_5_3_MODEL_ID);
+        assert_eq!(plan.selected.bucket, Some(73));
+        assert_eq!(
+            plan.selected.selection_source,
+            RouteSelectionSource::StaticSplit
+        );
+        assert_eq!(plan.decision, PlanDecision::StaticBucket);
         assert_eq!(plan.eligible_routes.len(), 2);
         assert!(plan
             .eligible_routes
@@ -370,7 +340,6 @@ mod tests {
         let input = RoutePlanningInput {
             intent: &intent,
             configured_providers: ConfiguredProviders::all(),
-            provider_preference: Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
         };
 
         let first = plan_completion_route(&PROVIDER_REGISTRY, input).expect("first plan");
@@ -395,7 +364,7 @@ mod tests {
     }
 
     #[test]
-    fn unavailable_preference_falls_back_without_authorizing_another_model() {
+    fn unavailable_provider_falls_back_without_authorizing_another_model() {
         let intent = intent(GLM_5_3_MODEL_ID, GLM_5_3_MODEL_ID);
         let configured = ConfiguredProviders::none().with_provider(ProviderId::Tinfoil);
         let plan = plan_completion_route(
@@ -403,7 +372,6 @@ mod tests {
             RoutePlanningInput {
                 intent: &intent,
                 configured_providers: configured,
-                provider_preference: Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
             },
         )
         .expect("Tinfoil fallback plan");
@@ -414,7 +382,7 @@ mod tests {
             plan.selected.selection_source,
             RouteSelectionSource::Fallback
         );
-        assert_eq!(plan.decision, PlanDecision::PreferredProviderUnavailable);
+        assert_eq!(plan.decision, PlanDecision::FixedRoute);
         assert_eq!(plan.eligible_routes.len(), 1);
     }
 
@@ -426,7 +394,6 @@ mod tests {
             RoutePlanningInput {
                 intent: &intent,
                 configured_providers: ConfiguredProviders::all(),
-                provider_preference: None,
             },
         )
         .expect("Flash route");
@@ -450,7 +417,6 @@ mod tests {
                 RoutePlanningInput {
                     intent: &unknown,
                     configured_providers: ConfiguredProviders::all(),
-                    provider_preference: None,
                 },
             ),
             Err(RoutePlanningError::UnsupportedModel(
@@ -466,7 +432,6 @@ mod tests {
                 RoutePlanningInput {
                     intent: &kimi,
                     configured_providers: tinfoil_only,
-                    provider_preference: None,
                 },
             ),
             Err(RoutePlanningError::NoEligibleRoute("kimi-k2-6".to_string()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1404,14 +1404,18 @@ impl AppState {
         }
     }
 
-    /// Resolve automatic model aliases for this user's plan. Paid overrides
-    /// default off on missing configuration, a missing flag, service failure,
-    /// or timeout. Free plans never apply paid alias overrides.
+    /// Resolve automatic aliases under the request's router policy. Router v2
+    /// uses fixed aliases without consulting legacy selector flags. Legacy paid
+    /// overrides default off on missing configuration, failure, or timeout.
     pub(crate) async fn model_alias_targets(
         &self,
         user_uuid: Uuid,
         model_plan: ModelPlan,
+        routing_mode: InferenceRoutingMode,
     ) -> ModelAliasTargets {
+        if routing_mode == InferenceRoutingMode::V2 {
+            return ModelAliasTargets::for_router_v2(model_plan);
+        }
         if !model_plan.is_paid() {
             return ModelAliasTargets::for_plan(model_plan);
         }

--- a/src/model_config.rs
+++ b/src/model_config.rs
@@ -402,6 +402,15 @@ impl ModelAliasTargets {
         }
     }
 
+    /// Router v2 uses fixed alias policy rather than legacy model-selector flags.
+    /// Resolving an alias does not grant access to its target model.
+    pub(crate) const fn for_router_v2(plan: ModelPlan) -> Self {
+        Self {
+            powerful: GLM_5_3_MODEL_ID,
+            ..Self::for_plan(plan)
+        }
+    }
+
     pub(crate) const fn for_plan_with_overrides(
         plan: ModelPlan,
         overrides: PaidModelAliasOverrides,
@@ -1094,6 +1103,82 @@ mod tests {
         );
         assert_eq!(paid.resolve(AUTO_POWERFUL_MODEL_ID), GLM_5_2_MODEL_ID);
         assert_eq!(paid.resolve(KIMI_K3_MODEL_ID), KIMI_K3_MODEL_ID);
+    }
+
+    #[test]
+    fn test_router_v2_auto_targets_use_glm_5_3_and_preserve_plan_specific_quick() {
+        for (plan, expected_quick) in [
+            (ModelPlan::Free, QUICK_MODEL_ID),
+            (ModelPlan::Paid, DEEPSEEK_V4_FLASH_MODEL_ID),
+        ] {
+            let targets = ModelAliasTargets::for_router_v2(plan);
+            assert_eq!(targets.resolve(AUTO_QUICK_MODEL_ID), expected_quick);
+            assert_eq!(targets.resolve(AUTO_POWERFUL_MODEL_ID), GLM_5_3_MODEL_ID);
+            assert_eq!(
+                resolve_public_model_id(targets.resolve(AUTO_POWERFUL_MODEL_ID)),
+                Some(GLM_5_3_MODEL_ID)
+            );
+            assert_eq!(
+                model_context_window(targets.resolve(AUTO_POWERFUL_MODEL_ID)),
+                model_context_window(GLM_5_3_MODEL_ID)
+            );
+        }
+    }
+
+    #[test]
+    fn test_router_v2_alias_policy_preserves_explicit_model_identities() {
+        for plan in [ModelPlan::Free, ModelPlan::Paid] {
+            let targets = ModelAliasTargets::for_router_v2(plan);
+            for model in enabled_api_completion_model_ids() {
+                assert_eq!(targets.resolve(model), model, "plan={plan:?}");
+                assert_eq!(resolve_public_model_id(targets.resolve(model)), Some(model));
+            }
+            assert_eq!(targets.resolve(GLM_5_2_MODEL_ID), GLM_5_2_MODEL_ID);
+            assert_eq!(
+                resolve_completion_model_id(targets.resolve(GLM_5_2_MODEL_ID)),
+                Some(GLM_5_2_MODEL_ID)
+            );
+            assert_eq!(targets.resolve("unknown-model"), "unknown-model");
+            assert_eq!(
+                resolve_public_model_id(targets.resolve("unknown-model")),
+                None
+            );
+        }
+    }
+
+    #[test]
+    fn test_router_v2_catalog_alias_metadata_matches_resolved_models() {
+        for plan in [ModelPlan::Free, ModelPlan::Paid] {
+            let targets = ModelAliasTargets::for_router_v2(plan);
+            let catalog = model_catalog_response(targets);
+            for alias in catalog["aliases"].as_array().expect("aliases") {
+                let selector = alias["id"].as_str().expect("alias ID");
+                let target = targets.resolve(selector);
+                let model = catalog_model(&catalog, target);
+                assert_eq!(alias["target_model"], target);
+                assert_eq!(alias["access"], model["access"]);
+                assert_eq!(alias["capabilities"], model["capabilities"]);
+            }
+            assert_eq!(catalog["defaults"]["quick"], AUTO_QUICK_MODEL_ID);
+            assert_eq!(catalog["defaults"]["powerful"], AUTO_POWERFUL_MODEL_ID);
+            assert!(has_model(&catalog, GLM_5_2_MODEL_ID));
+            assert!(has_model(&catalog, GLM_5_3_MODEL_ID));
+        }
+    }
+
+    #[test]
+    fn test_router_v2_auto_targets_preserve_model_entitlements() {
+        for plan in [ModelPlan::Free, ModelPlan::Paid] {
+            let targets = ModelAliasTargets::for_router_v2(plan);
+            assert!(plan.allows_model(targets.resolve(AUTO_QUICK_MODEL_ID)));
+            assert_eq!(
+                plan.allows_model(targets.resolve(AUTO_POWERFUL_MODEL_ID)),
+                plan.is_paid()
+            );
+            for model in [GLM_5_2_MODEL_ID, GLM_5_3_MODEL_ID] {
+                assert_eq!(plan.allows_model(targets.resolve(model)), plan.is_paid());
+            }
+        }
     }
 
     #[test]

--- a/src/provider_registry.rs
+++ b/src/provider_registry.rs
@@ -1,15 +1,16 @@
 //! Credential-free provider topology for completion routing.
 //!
 //! This registry is intentionally independent from executable credentials.
-//! Stack 3 introduced it in shadow mode; Stack 6 consumes it for the explicit
-//! GLM same-model provider canary while other active routes remain unchanged.
+//! Router v2 consumes its route eligibility and weights for every completion
+//! model. Legacy feature flags and default-provider preferences stay in the
+//! separate Router v1 configuration.
 
 use crate::model_config::{
     DEEPSEEK_V4_FLASH_MODEL_ID, GLM_5_2_MODEL_ID, GLM_5_3_FLASH_MODEL_ID, GLM_5_3_MODEL_ID,
     KIMI_K2_6_MODEL_ID, KIMI_K3_MODEL_ID, QUICK_MODEL_ID,
 };
 
-pub(crate) const SHADOW_ROUTING_POLICY_VERSION: &str = "routing-v2-shadow-v1";
+pub(crate) const SHADOW_ROUTING_POLICY_VERSION: &str = "routing-v2-weighted-v2";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) enum ProviderId {
@@ -67,7 +68,6 @@ pub(crate) struct ModelRouteSpec {
 pub(crate) struct CompletionModelSpec {
     pub(crate) public_model_id: &'static str,
     pub(crate) routes: &'static [ModelRouteSpec],
-    pub(crate) default_provider: Option<ProviderId>,
 }
 
 #[derive(Debug)]
@@ -213,52 +213,42 @@ const COMPLETION_MODELS: &[CompletionModelSpec] = &[
     CompletionModelSpec {
         public_model_id: QUICK_MODEL_ID,
         routes: GPT_OSS_120B_ROUTES,
-        default_provider: None,
     },
     CompletionModelSpec {
         public_model_id: "gemma4-31b",
         routes: GEMMA4_31B_ROUTES,
-        default_provider: None,
     },
     CompletionModelSpec {
         public_model_id: KIMI_K3_MODEL_ID,
         routes: KIMI_K3_ROUTES,
-        default_provider: None,
     },
     CompletionModelSpec {
         public_model_id: KIMI_K2_6_MODEL_ID,
         routes: KIMI_K2_6_ROUTES,
-        default_provider: Some(ProviderId::Continuum),
     },
     CompletionModelSpec {
         public_model_id: GLM_5_2_MODEL_ID,
         routes: GLM_5_2_ROUTES,
-        default_provider: Some(ProviderId::Tinfoil),
     },
     CompletionModelSpec {
         public_model_id: GLM_5_3_MODEL_ID,
         routes: GLM_5_3_ROUTES,
-        default_provider: Some(ProviderId::Continuum),
     },
     CompletionModelSpec {
         public_model_id: GLM_5_3_FLASH_MODEL_ID,
         routes: GLM_5_3_FLASH_ROUTES,
-        default_provider: None,
     },
     CompletionModelSpec {
         public_model_id: DEEPSEEK_V4_FLASH_MODEL_ID,
         routes: DEEPSEEK_V4_FLASH_ROUTES,
-        default_provider: None,
     },
     CompletionModelSpec {
         public_model_id: "llama3-3-70b",
         routes: LLAMA3_3_70B_ROUTES,
-        default_provider: None,
     },
     CompletionModelSpec {
         public_model_id: "gpt-oss-safeguard-120b",
         routes: GPT_OSS_SAFEGUARD_120B_ROUTES,
-        default_provider: None,
     },
 ];
 
@@ -305,13 +295,6 @@ mod tests {
                 assert!(!route.provider_model_id.trim().is_empty());
                 assert!(!route.response_model_id.trim().is_empty());
                 assert_eq!(route.response_model_id, model.public_model_id);
-            }
-
-            if let Some(default_provider) = model.default_provider {
-                assert!(model
-                    .routes
-                    .iter()
-                    .any(|route| route.provider == default_provider));
             }
         }
 

--- a/src/provider_routing.rs
+++ b/src/provider_routing.rs
@@ -328,7 +328,7 @@ impl ProviderRouter {
 
     /// Dispatch completion routing through the request-scoped implementation
     /// selected at the public inference entrypoint. The legacy implementation
-    /// stays intact while Router v2 may evolve independently.
+    /// stays intact while Router v2 ignores legacy provider preferences.
     pub(crate) fn select_completion_route_for_mode(
         &self,
         proxy_router: &ProxyRouter,
@@ -343,9 +343,7 @@ impl ProviderRouter {
                 &intent.public_model_id,
                 provider_preference,
             ),
-            InferenceRoutingMode::V2 => {
-                self.select_active_completion_route(proxy_router, intent, provider_preference)
-            }
+            InferenceRoutingMode::V2 => self.select_active_completion_route(proxy_router, intent),
         }
     }
 
@@ -358,9 +356,8 @@ impl ProviderRouter {
         &self,
         proxy_router: &ProxyRouter,
         intent: &InferenceIntent,
-        provider_preference: Option<ProviderPreference>,
     ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
-        self.select_health_aware_route(proxy_router, intent, provider_preference, &HashSet::new())
+        self.select_health_aware_route(proxy_router, intent, &HashSet::new())
     }
 
     /// Replans a not-yet-sent logical request while excluding route resources
@@ -370,17 +367,15 @@ impl ProviderRouter {
         &self,
         proxy_router: &ProxyRouter,
         intent: &InferenceIntent,
-        provider_preference: Option<ProviderPreference>,
         excluded_routes: &HashSet<RouteKey>,
     ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
-        self.select_health_aware_route(proxy_router, intent, provider_preference, excluded_routes)
+        self.select_health_aware_route(proxy_router, intent, excluded_routes)
     }
 
     pub(crate) fn shadow_completion_plan(
         &self,
         proxy_router: &ProxyRouter,
         intent: &InferenceIntent,
-        provider_preference: Option<ProviderPreference>,
     ) -> Result<RoutePlan, RoutePlanningError> {
         let configured_providers = self.registry.providers().iter().fold(
             ConfiguredProviders::none(),
@@ -398,7 +393,6 @@ impl ProviderRouter {
             RoutePlanningInput {
                 intent,
                 configured_providers,
-                provider_preference,
             },
         )
     }
@@ -407,7 +401,6 @@ impl ProviderRouter {
         &self,
         proxy_router: &ProxyRouter,
         intent: &InferenceIntent,
-        provider_preference: Option<ProviderPreference>,
         excluded_routes: &HashSet<RouteKey>,
     ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
         let model = self
@@ -496,7 +489,6 @@ impl ProviderRouter {
             RoutePlanningInput {
                 intent,
                 configured_providers: available_providers,
-                provider_preference,
             },
         )
         .map_err(provider_routing_error_from_plan)?;
@@ -831,7 +823,7 @@ mod tests {
 
     fn intent(requested_model: &str, public_model: &str) -> InferenceIntent {
         InferenceIntent::new(
-            uuid_for_bucket(73),
+            uuid_for_bucket(0),
             requested_model,
             public_model,
             ModelPlan::Paid,
@@ -921,54 +913,68 @@ mod tests {
     }
 
     #[test]
-    fn healthy_router_v2_seam_is_route_identical_to_legacy() {
+    fn router_v2_glm_weights_are_independent_of_legacy_provider_preferences() {
         let router = ProviderRouter::default();
         let proxy_router = proxy_router_with_both_providers();
-        let cases = [
-            (GLM_5_2_MODEL_ID, None),
-            (
-                GLM_5_2_MODEL_ID,
-                Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
-            ),
-            (GLM_5_3_MODEL_ID, None),
-            (
-                GLM_5_3_MODEL_ID,
-                Some(ProviderPreference::feature_flag(ProviderId::Tinfoil)),
-            ),
-            (GLM_5_3_FLASH_MODEL_ID, None),
-            ("kimi-k2-6", None),
-            ("gpt-oss-120b", None),
+        let preferences = [
+            None,
+            Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
+            Some(ProviderPreference::feature_flag(ProviderId::Tinfoil)),
         ];
 
-        for (model, preference) in cases {
-            let intent = intent(model, model);
-            let legacy = router
-                .select_completion_route_for_mode(
-                    &proxy_router,
-                    &intent,
-                    preference,
-                    InferenceRoutingMode::Legacy,
-                )
-                .expect("legacy route");
-            let v2 = router
-                .select_completion_route_for_mode(
-                    &proxy_router,
-                    &intent,
-                    preference,
-                    InferenceRoutingMode::V2,
-                )
-                .expect("v2 route");
+        for preference in preferences {
+            let mut tinfoil_count = 0;
+            let mut continuum_count = 0;
+            for bucket in 0..100 {
+                let mut intent = intent(GLM_5_3_MODEL_ID, GLM_5_3_MODEL_ID);
+                intent.account_uuid = uuid_for_bucket(bucket);
+                let legacy = router
+                    .select_completion_route_for_mode(
+                        &proxy_router,
+                        &intent,
+                        preference,
+                        InferenceRoutingMode::Legacy,
+                    )
+                    .expect("legacy GLM route");
+                let v2 = router
+                    .select_completion_route_for_mode(
+                        &proxy_router,
+                        &intent,
+                        preference,
+                        InferenceRoutingMode::V2,
+                    )
+                    .expect("weighted Router v2 GLM route");
 
-            assert_eq!(
-                legacy.proxy.provider_name, v2.proxy.provider_name,
-                "{model}"
-            );
-            assert_eq!(legacy.proxy.base_url, v2.proxy.base_url, "{model}");
-            assert_eq!(legacy.public_model_id, v2.public_model_id, "{model}");
-            assert_eq!(legacy.provider_model_id, v2.provider_model_id, "{model}");
-            assert_eq!(legacy.response_model_id, v2.response_model_id, "{model}");
-            assert_eq!(legacy.bucket, v2.bucket, "{model}");
-            assert_eq!(legacy.selection_source, v2.selection_source, "{model}");
+                // V1 retains its flag and missing-flag behavior for every account.
+                let expected_legacy = preference
+                    .map(ProviderPreference::provider)
+                    .unwrap_or(ProviderId::Continuum);
+                assert_eq!(legacy.provider, expected_legacy);
+                assert_eq!(legacy.bucket, None);
+                assert_eq!(
+                    legacy.selection_source,
+                    if preference.is_some() {
+                        RouteSelectionSource::FeatureFlag
+                    } else {
+                        RouteSelectionSource::DefaultProvider
+                    }
+                );
+
+                let (expected_v2, upstream_model) = if bucket < 30 {
+                    continuum_count += 1;
+                    (ProviderId::Continuum, "glm-5.3")
+                } else {
+                    tinfoil_count += 1;
+                    (ProviderId::Tinfoil, GLM_5_3_MODEL_ID)
+                };
+                assert_eq!(v2.provider, expected_v2, "bucket {bucket}");
+                assert_eq!(v2.provider_model_id, upstream_model);
+                assert_eq!(v2.public_model_id, GLM_5_3_MODEL_ID);
+                assert_eq!(v2.response_model_id, GLM_5_3_MODEL_ID);
+                assert_eq!(v2.bucket, Some(bucket));
+                assert_eq!(v2.selection_source, RouteSelectionSource::StaticSplit);
+            }
+            assert_eq!((tinfoil_count, continuum_count), (70, 30));
         }
     }
 
@@ -1236,31 +1242,11 @@ mod tests {
                 case.name
             );
             assert_eq!(selected.bucket, None, "{}", case.name);
-
-            let intent = InferenceIntent::new(
-                uuid_for_bucket(73),
-                case.selector,
-                resolved_model,
-                case.plan,
-                InferenceSurface::ChatCompletions,
-                WorkloadClass::Interactive,
-            );
-            let active = Ok(selected.clone());
-            let shadow =
-                router.shadow_completion_plan(&proxy_router, &intent, case.provider_preference);
-            assert!(
-                matches!(
-                    compare_shadow_route(&active, &shadow),
-                    ShadowRouteComparison::Match { .. }
-                ),
-                "{}: active={active:?}, shadow={shadow:?}",
-                case.name
-            );
         }
     }
 
     #[test]
-    fn shadow_planner_matches_legacy_except_for_the_router_v2_glm_5_3_ga_fallback() {
+    fn shadow_planner_matches_healthy_router_v2_for_every_model_and_provider_configuration() {
         let router = ProviderRouter::default();
         let both = proxy_router_with_both_providers();
         let tinfoil_only = ProxyRouter::new(
@@ -1272,49 +1258,18 @@ mod tests {
         for proxy_router in [&both, &tinfoil_only] {
             for model in PROVIDER_REGISTRY.completion_models() {
                 for bucket in [0, 29, 30, 69, 70, 99] {
-                    let account_uuid = uuid_for_bucket(bucket);
-                    let intent = InferenceIntent::new(
-                        account_uuid,
-                        model.public_model_id,
-                        model.public_model_id,
-                        ModelPlan::Paid,
-                        InferenceSurface::Responses,
-                        WorkloadClass::Interactive,
+                    let mut intent = intent(model.public_model_id, model.public_model_id);
+                    intent.account_uuid = uuid_for_bucket(bucket);
+                    let active = router.select_active_completion_route(proxy_router, &intent);
+                    let shadow = router.shadow_completion_plan(proxy_router, &intent);
+                    assert!(
+                        matches!(
+                            compare_shadow_route(&active, &shadow),
+                            ShadowRouteComparison::Match { .. }
+                        ),
+                        "model={}, bucket={bucket}, active={active:?}, shadow={shadow:?}",
+                        model.public_model_id
                     );
-                    let active = router.select_completion_route_with_preference(
-                        proxy_router,
-                        account_uuid,
-                        model.public_model_id,
-                        None,
-                    );
-                    let shadow = router.shadow_completion_plan(proxy_router, &intent, None);
-                    let comparison = compare_shadow_route(&active, &shadow);
-                    let is_router_v2_only_glm_fallback = model.public_model_id == GLM_5_3_MODEL_ID
-                        && proxy_for_provider(proxy_router, ProviderId::Continuum).is_none();
-
-                    if is_router_v2_only_glm_fallback {
-                        assert!(
-                            matches!(
-                                comparison,
-                                ShadowRouteComparison::Mismatch {
-                                    active: CredentialFreeRouteOutcome::NoEligibleRoute,
-                                    shadow: CredentialFreeRouteOutcome::Selected(RouteIdentity {
-                                        provider: ProviderId::Tinfoil,
-                                        ..
-                                    }),
-                                    ..
-                                }
-                            ),
-                            "model={}, bucket={bucket}, active={active:?}, shadow={shadow:?}",
-                            model.public_model_id
-                        );
-                    } else {
-                        assert!(
-                            matches!(comparison, ShadowRouteComparison::Match { .. }),
-                            "model={}, bucket={bucket}, active={active:?}, shadow={shadow:?}",
-                            model.public_model_id
-                        );
-                    }
                 }
             }
         }
@@ -1346,7 +1301,7 @@ mod tests {
                 model,
                 None,
             );
-            let shadow = router.shadow_completion_plan(&proxy_router, &intent, None);
+            let shadow = router.shadow_completion_plan(&proxy_router, &intent);
 
             assert!(matches!(
                 compare_shadow_route(&active, &shadow),
@@ -1382,7 +1337,7 @@ mod tests {
             )
             .expect("active route before shadow health");
         let shadow_before = router
-            .shadow_completion_plan(&proxy_router, &intent, provider_preference)
+            .shadow_completion_plan(&proxy_router, &intent)
             .expect("shadow route before shadow health");
 
         let mut failure = AttemptFailure::new(
@@ -1413,53 +1368,65 @@ mod tests {
             )
             .expect("active route after shadow health");
         let shadow_after = router
-            .shadow_completion_plan(&proxy_router, &intent, provider_preference)
+            .shadow_completion_plan(&proxy_router, &intent)
             .expect("shadow route after shadow health");
 
         assert_eq!(active_after.identity(), active_before.identity());
         assert_eq!(shadow_after, shadow_before);
-        assert!(matches!(
-            compare_shadow_route(&Ok(active_after), &Ok(shadow_after)),
-            ShadowRouteComparison::Match { .. }
-        ));
+        assert_eq!(
+            active_after.public_model_id,
+            shadow_after.selected.public_model_id
+        );
+        assert_eq!(active_after.provider, shadow_after.selected.provider);
     }
 
     #[test]
-    fn active_glm_canary_preserves_healthy_preferences_and_canonical_identity() {
-        let router = ProviderRouter::default();
+    fn active_glm_health_fallback_is_symmetric_across_weighted_providers() {
         let proxy_router = proxy_router_with_both_providers();
-        let intent = intent(GLM_5_3_MODEL_ID, GLM_5_3_MODEL_ID);
-
-        let cases = [
+        for (bucket, open_provider, open_model, alternate, alternate_model) in [
             (
-                None,
+                0,
                 ProviderId::Continuum,
                 "glm-5.3",
-                RouteSelectionSource::DefaultProvider,
-            ),
-            (
-                Some(ProviderPreference::feature_flag(ProviderId::Tinfoil)),
                 ProviderId::Tinfoil,
                 GLM_5_3_MODEL_ID,
-                RouteSelectionSource::FeatureFlag,
             ),
             (
-                Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
+                73,
+                ProviderId::Tinfoil,
+                GLM_5_3_MODEL_ID,
                 ProviderId::Continuum,
                 "glm-5.3",
-                RouteSelectionSource::FeatureFlag,
             ),
-        ];
-
-        for (preference, provider, provider_model, source) in cases {
+        ] {
+            let router = ProviderRouter::default();
+            let mut intent = intent(GLM_5_3_MODEL_ID, GLM_5_3_MODEL_ID);
+            intent.account_uuid = uuid_for_bucket(bucket);
+            assert_eq!(
+                router
+                    .select_active_completion_route(&proxy_router, &intent)
+                    .expect("healthy route")
+                    .provider,
+                open_provider
+            );
+            router.observe_attempt_terminal(
+                &capacity_terminal(
+                    open_provider,
+                    GLM_5_3_MODEL_ID,
+                    open_model,
+                    429,
+                    Duration::from_secs(60),
+                ),
+                ShadowObservationMode::Update,
+            );
             let selected = router
-                .select_active_completion_route(&proxy_router, &intent, preference)
-                .expect("healthy GLM route");
-            assert_eq!(selected.provider, provider);
-            assert_eq!(selected.provider_model_id, provider_model);
+                .select_active_completion_route(&proxy_router, &intent)
+                .expect("same-model alternate");
+            assert_eq!(selected.provider, alternate);
+            assert_eq!(selected.provider_model_id, alternate_model);
             assert_eq!(selected.public_model_id, GLM_5_3_MODEL_ID);
             assert_eq!(selected.response_model_id, GLM_5_3_MODEL_ID);
-            assert_eq!(selected.selection_source, source);
+            assert_eq!(selected.selection_source, RouteSelectionSource::Fallback);
         }
     }
 
@@ -1470,7 +1437,7 @@ mod tests {
         let intent = intent(GLM_5_3_MODEL_ID, GLM_5_3_MODEL_ID);
 
         let pinned_before_failure = router
-            .select_active_completion_route(&proxy_router, &intent, None)
+            .select_active_completion_route(&proxy_router, &intent)
             .expect("initial Continuum route");
         assert_eq!(pinned_before_failure.provider, ProviderId::Continuum);
 
@@ -1491,7 +1458,7 @@ mod tests {
         assert_eq!(pinned_before_failure.provider_model_id, "glm-5.3");
 
         let selected_after_failure = router
-            .select_active_completion_route(&proxy_router, &intent, None)
+            .select_active_completion_route(&proxy_router, &intent)
             .expect("Tinfoil GLM fallback");
         assert_eq!(selected_after_failure.provider, ProviderId::Tinfoil);
         assert_eq!(selected_after_failure.provider_model_id, GLM_5_3_MODEL_ID);
@@ -1503,7 +1470,7 @@ mod tests {
     }
 
     #[test]
-    fn active_glm_canary_bypasses_an_open_feature_flag_preference() {
+    fn active_glm_canary_bypasses_an_open_provider() {
         let router = ProviderRouter::default();
         let proxy_router = proxy_router_with_both_providers();
         let intent = intent(GLM_5_3_MODEL_ID, GLM_5_3_MODEL_ID);
@@ -1520,11 +1487,7 @@ mod tests {
         );
 
         let selected = router
-            .select_active_completion_route(
-                &proxy_router,
-                &intent,
-                Some(ProviderPreference::feature_flag(ProviderId::Tinfoil)),
-            )
+            .select_active_completion_route(&proxy_router, &intent)
             .expect("Continuum GLM fallback");
         assert_eq!(selected.provider, ProviderId::Continuum);
         assert_eq!(selected.provider_model_id, "glm-5.3");
@@ -1557,7 +1520,7 @@ mod tests {
         }
 
         let error = router
-            .select_active_completion_route(&proxy_router, &intent, None)
+            .select_active_completion_route(&proxy_router, &intent)
             .expect_err("both GLM routes are open");
         match error {
             ProviderRoutingError::CapacityUnavailable { model, retry_after } => {
@@ -1578,7 +1541,7 @@ mod tests {
         for observed_failures in 1..=3 {
             router.observe_attempt_terminal(&failure(), ShadowObservationMode::Update);
             let selected = router
-                .select_active_completion_route(&proxy_router, &intent, None)
+                .select_active_completion_route(&proxy_router, &intent)
                 .expect("GLM route");
             let expected = if observed_failures < 3 {
                 ProviderId::Continuum
@@ -1608,7 +1571,6 @@ mod tests {
             .select_active_completion_route(
                 &proxy_router,
                 &intent(GLM_5_3_MODEL_ID, GLM_5_3_MODEL_ID),
-                Some(ProviderPreference::feature_flag(ProviderId::Continuum)),
             )
             .expect("Tinfoil GLM after Continuum account limit");
         assert_eq!(glm.provider, ProviderId::Tinfoil);
@@ -1617,7 +1579,6 @@ mod tests {
             .select_active_completion_route(
                 &proxy_router,
                 &intent(KIMI_K2_6_MODEL_ID, KIMI_K2_6_MODEL_ID),
-                None,
             )
             .expect_err("Kimi shares the open Continuum account scope");
         assert!(matches!(
@@ -1644,7 +1605,7 @@ mod tests {
 
         let synthetic_auto_glm = intent(AUTO_POWERFUL_MODEL_ID, GLM_5_3_MODEL_ID);
         let auto_route = router
-            .select_active_completion_route(&proxy_router, &synthetic_auto_glm, None)
+            .select_active_completion_route(&proxy_router, &synthetic_auto_glm)
             .expect("Auto Powerful uses the healthy GLM provider");
         assert_eq!(auto_route.provider, ProviderId::Tinfoil);
         assert_eq!(auto_route.public_model_id, GLM_5_3_MODEL_ID);
@@ -1681,11 +1642,7 @@ mod tests {
             );
 
             let error = router
-                .select_active_completion_route(
-                    &proxy_router,
-                    &intent(public_model, public_model),
-                    None,
-                )
+                .select_active_completion_route(&proxy_router, &intent(public_model, public_model))
                 .expect_err("an explicit model cannot fall through to another public model");
             assert!(matches!(
                 error,

--- a/src/provider_routing.rs
+++ b/src/provider_routing.rs
@@ -1,6 +1,6 @@
 use crate::inference::health::{
-    ShadowDisposition, ShadowHealthState, ShadowObservationMode, ShadowObservationReport,
-    ShadowRouteSnapshot, MIN_CAPACITY_COOLDOWN,
+    ProbeClaimResult, ProbeLease, ShadowDisposition, ShadowHealthState, ShadowObservationMode,
+    ShadowObservationReport, ShadowRouteSnapshot, MIN_CAPACITY_COOLDOWN,
 };
 use crate::inference::{AttemptTerminal, InferenceIntent, RouteIdentity, RouteKey};
 use crate::inference_planning::{
@@ -15,6 +15,7 @@ use crate::provider_registry::{
     ProviderId, ProviderRegistry, RouteSelectionSource, PROVIDER_REGISTRY,
 };
 use crate::proxy_config::{canonicalize_tinfoil_model, ProxyConfig, ProxyRouter};
+use std::collections::HashSet;
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -257,6 +258,29 @@ impl ProviderRouter {
         self.shadow_health.observe_terminal(terminal, mode)
     }
 
+    pub(crate) fn observe_attempt_terminal_with_probe(
+        &self,
+        terminal: &AttemptTerminal,
+        mode: ShadowObservationMode,
+        probe: Option<ProbeLease>,
+    ) -> ShadowObservationReport {
+        self.shadow_health
+            .observe_terminal_with_probe(terminal, mode, probe)
+    }
+
+    pub(crate) fn try_claim_probe(&self, route: &RouteKey) -> ProbeClaimResult {
+        self.shadow_health.try_claim_probe(route)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn try_claim_probe_at(
+        &self,
+        route: &RouteKey,
+        now: std::time::Instant,
+    ) -> ProbeClaimResult {
+        self.shadow_health.try_claim_probe_at(route, now)
+    }
+
     pub(crate) fn shadow_health_snapshot(&self, route: &RouteKey) -> Option<ShadowRouteSnapshot> {
         self.shadow_health.snapshot(route)
     }
@@ -336,7 +360,20 @@ impl ProviderRouter {
         intent: &InferenceIntent,
         provider_preference: Option<ProviderPreference>,
     ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
-        self.select_health_aware_route(proxy_router, intent, provider_preference)
+        self.select_health_aware_route(proxy_router, intent, provider_preference, &HashSet::new())
+    }
+
+    /// Replans a not-yet-sent logical request while excluding route resources
+    /// that lost eligibility or half-open ownership races. This never retries an
+    /// upstream attempt; callers may use it only before the first send.
+    pub(crate) fn select_active_completion_route_excluding(
+        &self,
+        proxy_router: &ProxyRouter,
+        intent: &InferenceIntent,
+        provider_preference: Option<ProviderPreference>,
+        excluded_routes: &HashSet<RouteKey>,
+    ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
+        self.select_health_aware_route(proxy_router, intent, provider_preference, excluded_routes)
     }
 
     pub(crate) fn shadow_completion_plan(
@@ -371,6 +408,7 @@ impl ProviderRouter {
         proxy_router: &ProxyRouter,
         intent: &InferenceIntent,
         provider_preference: Option<ProviderPreference>,
+        excluded_routes: &HashSet<RouteKey>,
     ) -> Result<SelectedProviderRoute, ProviderRoutingError> {
         let model = self
             .registry
@@ -392,14 +430,14 @@ impl ProviderRouter {
                 {
                     return None;
                 }
-
-                Some((
-                    route.provider,
-                    RouteKey {
-                        provider: route.provider,
-                        provider_model_id: route.provider_model_id.to_string(),
-                    },
-                ))
+                let route_key = RouteKey {
+                    provider: route.provider,
+                    provider_model_id: route.provider_model_id.to_string(),
+                };
+                if excluded_routes.contains(&route_key) {
+                    return None;
+                }
+                Some((route.provider, route_key))
             })
             .collect::<Vec<_>>();
 
@@ -430,6 +468,13 @@ impl ProviderRouter {
                     earliest_recovery = Some(
                         earliest_recovery
                             .map_or(remaining, |current: Duration| current.min(remaining)),
+                    );
+                }
+                ShadowDisposition::ProbeInFlight { retry_after } => {
+                    let retry_after = ceil_retry_after(retry_after);
+                    earliest_recovery = Some(
+                        earliest_recovery
+                            .map_or(retry_after, |current: Duration| current.min(retry_after)),
                     );
                 }
                 disposition if route_is_available_for_new_request(disposition) => {
@@ -739,7 +784,10 @@ fn ceil_retry_after(duration: Duration) -> Duration {
 }
 
 fn route_is_available_for_new_request(disposition: ShadowDisposition) -> bool {
-    !matches!(disposition, ShadowDisposition::WouldOpen { .. })
+    !matches!(
+        disposition,
+        ShadowDisposition::WouldOpen { .. } | ShadowDisposition::ProbeInFlight { .. }
+    )
 }
 
 fn proxy_for_provider(proxy_router: &ProxyRouter, provider: ProviderId) -> Option<ProxyConfig> {
@@ -1648,7 +1696,7 @@ mod tests {
     }
 
     #[test]
-    fn only_would_open_blocks_a_new_request() {
+    fn open_or_probe_in_flight_blocks_a_new_request() {
         assert!(route_is_available_for_new_request(
             ShadowDisposition::Healthy
         ));
@@ -1663,6 +1711,11 @@ mod tests {
         assert!(!route_is_available_for_new_request(
             ShadowDisposition::WouldOpen {
                 remaining: Duration::from_secs(1)
+            }
+        ));
+        assert!(!route_is_available_for_new_request(
+            ShadowDisposition::ProbeInFlight {
+                retry_after: Duration::from_secs(1)
             }
         ));
     }

--- a/src/transport_v2/gateway.rs
+++ b/src/transport_v2/gateway.rs
@@ -1194,6 +1194,8 @@ mod tests {
                 ))
                 .await
                 .unwrap();
+            assert!(!response.headers().contains_key(crate::CLIENT_REPLAY_HEADER));
+            assert!(!response.headers().contains_key(header::RETRY_AFTER));
             assert_outer_rejection(response, rejection_status, None);
             assert_eq!(dispatches.load(Ordering::SeqCst), 1);
         }
@@ -1266,6 +1268,175 @@ mod tests {
             .unwrap();
         assert_outer_rejection(response, StatusCode::BAD_REQUEST, None);
         assert_eq!(dispatches.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn responses_sse_body_failure_is_an_authenticated_transport_error() {
+        let test = test_session(15);
+        let sessions = Arc::new(SessionStore::new(NonZeroUsize::new(2).unwrap()));
+        sessions.insert(Arc::clone(&test.server)).unwrap();
+        let application = Router::new().route(
+            "/v1/responses",
+            any(|| async {
+                crate::web::responses::handlers::responses_sse_body_failure_for_test()
+            }),
+        );
+        let router = request_router(application, sessions);
+        let request_id = RequestId::from_bytes([0xa3; 16]);
+        let response = router
+            .oneshot(outer_request(
+                test.server.id(),
+                &test.routing_key,
+                seal_request(&test.client, request_id, "/v1/responses", None),
+            ))
+            .await
+            .unwrap();
+        let records = decrypt_records(&test.client, request_id, response).await;
+        assert!(matches!(&records[0], ResponseRecord::Start(start)
+            if start.status() == 200
+                && start.headers().iter().any(|header|
+                    header.name() == "content-type" && header.value() == "text/event-stream")));
+
+        let mut body = Vec::new();
+        for record in &records {
+            if let ResponseRecord::Chunk(bytes) = record {
+                body.extend_from_slice(bytes);
+            }
+        }
+        let logical_sse = std::str::from_utf8(&body).unwrap();
+        assert!(logical_sse.contains(r#"{"type":"response.created"}"#));
+        // A carrier failure must not invent a storage-authoritative terminal.
+        assert!(!logical_sse.contains("response.failed"));
+        assert!(!logical_sse.contains("response.completed"));
+        assert!(
+            matches!(records.last(), Some(ResponseRecord::Error { code })
+            if code == "application_body_failed")
+        );
+        assert_eq!(
+            records
+                .iter()
+                .filter(|record| matches!(record, ResponseRecord::Error { .. }))
+                .count(),
+            1,
+        );
+        assert!(!records
+            .iter()
+            .any(|record| matches!(record, ResponseRecord::End)));
+    }
+
+    #[tokio::test]
+    async fn inference_capacity_metadata_is_authenticated_and_does_not_allow_record_replay() {
+        for status in [
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::SERVICE_UNAVAILABLE,
+        ] {
+            for client_replay_safe in [false, true] {
+                let test = test_session(14);
+                let sessions = Arc::new(SessionStore::new(NonZeroUsize::new(2).unwrap()));
+                sessions.insert(Arc::clone(&test.server)).unwrap();
+                let dispatches = Arc::new(AtomicUsize::new(0));
+                let application = Router::new().route(
+                    "/capacity",
+                    any({
+                        let dispatches = Arc::clone(&dispatches);
+                        move || {
+                            let dispatches = Arc::clone(&dispatches);
+                            async move {
+                                dispatches.fetch_add(1, Ordering::SeqCst);
+                                ApiError::InferenceCapacity {
+                                    status,
+                                    retry_after: Some(Duration::from_secs(7)),
+                                    client_replay_safe,
+                                }
+                                .into_response()
+                            }
+                        }
+                    }),
+                );
+                let router = request_router(application, sessions);
+                let request_id = RequestId::from_bytes([0xa1; 16]);
+                let record = seal_request(&test.client, request_id, "/capacity", None);
+                let response = router
+                    .clone()
+                    .oneshot(outer_request(
+                        test.server.id(),
+                        &test.routing_key,
+                        record.clone(),
+                    ))
+                    .await
+                    .unwrap();
+
+                // Application retry instructions are authenticated inner metadata.
+                assert!(!response.headers().contains_key(crate::CLIENT_REPLAY_HEADER));
+                assert!(!response.headers().contains_key(header::RETRY_AFTER));
+                let records = decrypt_records(&test.client, request_id, response).await;
+                let ResponseRecord::Start(start) = &records[0] else {
+                    panic!("capacity response must begin with an authenticated response start");
+                };
+                assert_eq!(start.status(), status.as_u16());
+                let logical_header = |name: &str| {
+                    start
+                        .headers()
+                        .iter()
+                        .find(|header| header.name() == name)
+                        .map(|header| header.value())
+                };
+                assert_eq!(logical_header(crate::ERROR_CONTRACT_HEADER), Some("1"));
+                assert_eq!(
+                    logical_header(crate::ERROR_CODE_HEADER),
+                    Some("inference_capacity")
+                );
+                assert_eq!(logical_header("retry-after"), Some("7"));
+                assert_eq!(
+                    logical_header(crate::CLIENT_REPLAY_HEADER),
+                    client_replay_safe.then_some("safe"),
+                );
+                let mut body = Vec::new();
+                for record in &records {
+                    if let ResponseRecord::Chunk(bytes) = record {
+                        body.extend_from_slice(bytes);
+                    }
+                }
+                assert_eq!(
+                    serde_json::from_slice::<serde_json::Value>(&body).unwrap(),
+                    serde_json::json!({
+                        "status": status.as_u16(),
+                        "message": "Inference capacity is temporarily unavailable",
+                    }),
+                );
+                assert!(matches!(records.last(), Some(ResponseRecord::End)));
+                assert_eq!(dispatches.load(Ordering::SeqCst), 1);
+
+                // Even an authenticated safe marker never permits ciphertext replay.
+                let response = router
+                    .clone()
+                    .oneshot(outer_request(test.server.id(), &test.routing_key, record))
+                    .await
+                    .unwrap();
+                assert!(!response.headers().contains_key(crate::CLIENT_REPLAY_HEADER));
+                assert!(!response.headers().contains_key(header::RETRY_AFTER));
+                assert_outer_rejection(response, StatusCode::BAD_REQUEST, None);
+                assert_eq!(dispatches.load(Ordering::SeqCst), 1);
+
+                if client_replay_safe {
+                    // A permitted logical retry must use a fresh transport request ID.
+                    let retry_id = RequestId::from_bytes([0xa2; 16]);
+                    let response = router
+                        .oneshot(outer_request(
+                            test.server.id(),
+                            &test.routing_key,
+                            seal_request(&test.client, retry_id, "/capacity", None),
+                        ))
+                        .await
+                        .unwrap();
+                    let records = decrypt_records(&test.client, retry_id, response).await;
+                    assert!(matches!(&records[0], ResponseRecord::Start(start)
+                        if start.status() == status.as_u16()));
+                    assert!(matches!(records.last(), Some(ResponseRecord::End)));
+                    assert_eq!(dispatches.load(Ordering::SeqCst), 2);
+                }
+            }
+        }
     }
 
     #[tokio::test]

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -1,10 +1,10 @@
-use crate::inference::health::ShadowObservationMode;
+use crate::inference::health::{ProbeClaimResult, ProbeLease, ShadowObservationMode};
 use crate::inference::{
     AttemptFailure, AttemptFailureKind, AttemptOutcome, AttemptStage, AttemptTerminal,
     CompletionEvidence, InferenceAttempt, InferenceExecution, InferenceIntent, InferenceSurface,
     ReplaySafety, WorkloadClass,
 };
-use crate::inference_planning::{RoutePlan, RoutePlanningError};
+use crate::inference_planning::{ProviderPreference, RoutePlan, RoutePlanningError};
 use crate::model_config::{
     model_alias_requires_flag_lookup, model_catalog_response, openai_models_response,
     ModelAliasTargets, ModelPlan,
@@ -50,7 +50,7 @@ use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::{sleep, timeout};
@@ -818,11 +818,30 @@ pub struct CompletionStream {
 #[derive(Debug, Clone)]
 pub(crate) struct PinnedCompletionRequest {
     intent: InferenceIntent,
+    /// The route selected during request preparation. It remains provisional
+    /// until the first provider turn atomically claims any half-open gates.
     route: SelectedProviderRoute,
     routing_mode: InferenceRoutingMode,
+    provider_preference: Option<ProviderPreference>,
+    finalized_route: Arc<OnceLock<SelectedProviderRoute>>,
 }
 
 impl PinnedCompletionRequest {
+    fn new(
+        intent: InferenceIntent,
+        route: SelectedProviderRoute,
+        provider_preference: Option<ProviderPreference>,
+        routing_mode: InferenceRoutingMode,
+    ) -> Self {
+        Self {
+            intent,
+            route,
+            routing_mode,
+            provider_preference,
+            finalized_route: Arc::new(OnceLock::new()),
+        }
+    }
+
     pub(crate) fn intent(&self) -> &InferenceIntent {
         &self.intent
     }
@@ -831,8 +850,20 @@ impl PinnedCompletionRequest {
         self.routing_mode
     }
 
+    pub(crate) fn public_model_id(&self) -> &str {
+        &self.selected_route().public_model_id
+    }
+
     fn begin_execution(&self) -> InferenceExecution {
         self.intent.begin_execution()
+    }
+
+    fn selected_route(&self) -> &SelectedProviderRoute {
+        self.finalized_route.get().unwrap_or(&self.route)
+    }
+
+    fn finalize_route(&self, route: SelectedProviderRoute) -> bool {
+        self.finalized_route.set(route).is_ok()
     }
 }
 
@@ -891,6 +922,7 @@ impl From<ApiError> for CompletionExecutionError {
     }
 }
 
+#[cfg(test)]
 fn failed_completion_execution(
     provider_router: &ProviderRouter,
     attempt: InferenceAttempt,
@@ -1038,51 +1070,69 @@ fn record_attempt_outcome(
             );
         }
         AttemptOutcome::Terminal(terminal) => {
-            let attempt = terminal.attempt();
             let shadow_report = provider_router.observe_attempt_terminal(terminal, shadow_mode);
-            debug!(
-                "Inference shadow health observation: request_id={}, execution_id={}, attempt_id={}, policy_version={}, mode={:?}, route_provider={}, route_model={}, signal={:?}, capacity_pool={:?}, snapshot={:?}, mutated={}",
-                attempt.request_id,
-                attempt.execution_id,
-                attempt.attempt_id,
-                shadow_report.policy_version,
-                shadow_report.mode,
-                shadow_report.route.provider.as_str(),
-                shadow_report.route.provider_model_id,
-                shadow_report.signal,
-                shadow_report.capacity_pool,
-                shadow_report.snapshot,
-                shadow_report.mutated
-            );
-            match terminal {
-                AttemptTerminal::Completed { evidence, .. } => debug!(
-                    "Inference attempt completed: request_id={}, execution_id={}, attempt_id={}, provider={}, public_model={}, provider_model={}, evidence={:?}",
-                    attempt.request_id,
-                    attempt.execution_id,
-                    attempt.attempt_id,
-                    attempt.route.provider.as_str(),
-                    attempt.route.public_model_id,
-                    attempt.route.provider_model_id,
-                    evidence
-                ),
-                AttemptTerminal::Failed { failure, .. } => warn!(
-                    "Inference attempt failed: request_id={}, execution_id={}, attempt_id={}, provider={}, public_model={}, provider_model={}, kind={:?}, stage={:?}, replay_safety={:?}, status={:?}, retry_after_ms={:?}, upstream_request_id={:?}, upstream_code={:?}",
-                    attempt.request_id,
-                    attempt.execution_id,
-                    attempt.attempt_id,
-                    attempt.route.provider.as_str(),
-                    attempt.route.public_model_id,
-                    attempt.route.provider_model_id,
-                    failure.kind,
-                    failure.stage,
-                    failure.replay_safety,
-                    failure.status,
-                    failure.retry_after.map(|duration| duration.as_millis()),
-                    failure.upstream_request_id,
-                    failure.upstream_code
-                ),
-            }
+            log_attempt_terminal(terminal, &shadow_report);
         }
+    }
+}
+
+fn record_attempt_terminal_with_probe(
+    provider_router: &ProviderRouter,
+    terminal: &AttemptTerminal,
+    shadow_mode: ShadowObservationMode,
+    probe: Option<ProbeLease>,
+) {
+    let shadow_report =
+        provider_router.observe_attempt_terminal_with_probe(terminal, shadow_mode, probe);
+    log_attempt_terminal(terminal, &shadow_report);
+}
+
+fn log_attempt_terminal(
+    terminal: &AttemptTerminal,
+    shadow_report: &crate::inference::health::ShadowObservationReport,
+) {
+    let attempt = terminal.attempt();
+    debug!(
+        "Inference shadow health observation: request_id={}, execution_id={}, attempt_id={}, policy_version={}, mode={:?}, route_provider={}, route_model={}, signal={:?}, capacity_pool={:?}, snapshot={:?}, mutated={}",
+        attempt.request_id,
+        attempt.execution_id,
+        attempt.attempt_id,
+        shadow_report.policy_version,
+        shadow_report.mode,
+        shadow_report.route.provider.as_str(),
+        shadow_report.route.provider_model_id,
+        shadow_report.signal,
+        shadow_report.capacity_pool,
+        shadow_report.snapshot,
+        shadow_report.mutated
+    );
+    match terminal {
+        AttemptTerminal::Completed { evidence, .. } => debug!(
+            "Inference attempt completed: request_id={}, execution_id={}, attempt_id={}, provider={}, public_model={}, provider_model={}, evidence={:?}",
+            attempt.request_id,
+            attempt.execution_id,
+            attempt.attempt_id,
+            attempt.route.provider.as_str(),
+            attempt.route.public_model_id,
+            attempt.route.provider_model_id,
+            evidence
+        ),
+        AttemptTerminal::Failed { failure, .. } => warn!(
+            "Inference attempt failed: request_id={}, execution_id={}, attempt_id={}, provider={}, public_model={}, provider_model={}, kind={:?}, stage={:?}, replay_safety={:?}, status={:?}, retry_after_ms={:?}, upstream_request_id={:?}, upstream_code={:?}",
+            attempt.request_id,
+            attempt.execution_id,
+            attempt.attempt_id,
+            attempt.route.provider.as_str(),
+            attempt.route.public_model_id,
+            attempt.route.provider_model_id,
+            failure.kind,
+            failure.stage,
+            failure.replay_safety,
+            failure.status,
+            failure.retry_after.map(|duration| duration.as_millis()),
+            failure.upstream_request_id,
+            failure.upstream_code
+        ),
     }
 }
 
@@ -1888,11 +1938,153 @@ pub(crate) async fn prepare_completion_request(
         route.selection_source
     );
 
-    Ok(PinnedCompletionRequest {
+    Ok(PinnedCompletionRequest::new(
         intent,
         route,
-        routing_mode: routing.mode(),
-    })
+        provider_preference,
+        routing.mode(),
+    ))
+}
+
+fn probe_api_error(retry_after: Duration) -> ApiError {
+    ApiError::InferenceCapacity {
+        status: StatusCode::SERVICE_UNAVAILABLE,
+        retry_after: Some(retry_after),
+        // The owning API surface promotes this only when its complete logical
+        // request is still known to be replay-safe.
+        client_replay_safe: false,
+    }
+}
+
+fn replan_completion_route_excluding(
+    provider_router: &ProviderRouter,
+    proxy_router: &ProxyRouter,
+    pinned: &PinnedCompletionRequest,
+    excluded_routes: &mut HashSet<crate::inference::RouteKey>,
+) -> Result<SelectedProviderRoute, ApiError> {
+    loop {
+        let route = provider_router
+            .select_active_completion_route_excluding(
+                proxy_router,
+                &pinned.intent,
+                pinned.provider_preference,
+                excluded_routes,
+            )
+            .map_err(provider_routing_api_error)?;
+
+        // Auto model selection is finalized during request preparation, before
+        // Responses builds model-specific context. A lost probe claim may move
+        // the first turn to another provider, but never to another public model.
+        if route.public_model_id == pinned.route.public_model_id {
+            return Ok(route);
+        }
+        excluded_routes.insert(route.identity().route_key());
+    }
+}
+
+#[derive(Debug)]
+struct ClaimedProviderTurn {
+    route: SelectedProviderRoute,
+    probe: Option<ProbeLease>,
+}
+
+fn claim_finalized_completion_turn(
+    provider_router: &ProviderRouter,
+    pinned: &PinnedCompletionRequest,
+    route: &SelectedProviderRoute,
+) -> Result<ClaimedProviderTurn, ApiError> {
+    let route_key = route.identity().route_key();
+    match provider_router.try_claim_probe(&route_key) {
+        ProbeClaimResult::Ready(probe) => Ok(ClaimedProviderTurn {
+            route: route.clone(),
+            probe,
+        }),
+        ProbeClaimResult::Rejected {
+            reason,
+            retry_after,
+        } => {
+            debug!(
+                "Pinned inference route unavailable before send: request_id={}, provider={}, provider_model={}, reason={:?}",
+                pinned.intent.request_id,
+                route.provider.as_str(),
+                route.provider_model_id,
+                reason
+            );
+            Err(probe_api_error(retry_after))
+        }
+    }
+}
+
+/// Atomically claims any expired health gates immediately before every provider
+/// send. Losing a first-turn claim may replan only to another provider for the
+/// already-prepared public model. Later Responses tool turns stay pinned to
+/// the finalized route and fail locally instead of switching providers.
+fn claim_completion_turn(
+    provider_router: &ProviderRouter,
+    proxy_router: &ProxyRouter,
+    pinned: &PinnedCompletionRequest,
+    allow_replan: bool,
+) -> Result<ClaimedProviderTurn, ApiError> {
+    if pinned.routing_mode() == InferenceRoutingMode::Legacy {
+        return Ok(ClaimedProviderTurn {
+            route: pinned.route.clone(),
+            probe: None,
+        });
+    }
+
+    if let Some(route) = pinned.finalized_route.get() {
+        return claim_finalized_completion_turn(provider_router, pinned, route);
+    }
+
+    let mut excluded_routes = HashSet::new();
+    let mut route = pinned.route.clone();
+    loop {
+        let route_key = route.identity().route_key();
+        let probe = match provider_router.try_claim_probe(&route_key) {
+            ProbeClaimResult::Ready(probe) => probe,
+            ProbeClaimResult::Rejected {
+                reason,
+                retry_after,
+            } => {
+                debug!(
+                    "Inference route lost half-open claim before send: request_id={}, provider={}, provider_model={}, reason={:?}",
+                    pinned.intent.request_id,
+                    route.provider.as_str(),
+                    route.provider_model_id,
+                    reason
+                );
+                let local_error = probe_api_error(retry_after);
+                if !allow_replan {
+                    return Err(local_error);
+                }
+                excluded_routes.insert(route_key);
+                route = match replan_completion_route_excluding(
+                    provider_router,
+                    proxy_router,
+                    pinned,
+                    &mut excluded_routes,
+                ) {
+                    Ok(replanned) => replanned,
+                    Err(_) => return Err(local_error),
+                };
+                continue;
+            }
+        };
+
+        if pinned.finalize_route(route.clone()) {
+            return Ok(ClaimedProviderTurn { route, probe });
+        }
+
+        // Pinned turns are serialized today. If that invariant changes, release
+        // this speculative claim and use the route already finalized by the
+        // concurrent first turn without sending a second half-open probe.
+        drop(probe);
+        let route = pinned
+            .finalized_route
+            .get()
+            .expect("failed OnceLock set means another route was finalized");
+        return claim_finalized_completion_turn(provider_router, pinned, route);
+    }
 }
 
 /// Ensures cancellation or panic cannot make an in-flight attempt disappear
@@ -1902,19 +2094,31 @@ struct AttemptObservationGuard {
     attempt: InferenceAttempt,
     provider_router: Arc<ProviderRouter>,
     stage: AttemptStage,
+    probe: Option<ProbeLease>,
     armed: bool,
 }
 
 impl AttemptObservationGuard {
+    #[cfg(test)]
     fn new(
         attempt: InferenceAttempt,
         provider_router: Arc<ProviderRouter>,
         stage: AttemptStage,
     ) -> Self {
+        Self::new_with_probe(attempt, provider_router, stage, None)
+    }
+
+    fn new_with_probe(
+        attempt: InferenceAttempt,
+        provider_router: Arc<ProviderRouter>,
+        stage: AttemptStage,
+        probe: Option<ProbeLease>,
+    ) -> Self {
         Self {
             attempt,
             provider_router,
             stage,
+            probe,
             armed: true,
         }
     }
@@ -1933,10 +2137,11 @@ impl AttemptObservationGuard {
 
     fn record_terminal(&mut self, terminal: &AttemptTerminal) {
         debug_assert_eq!(terminal.attempt(), &self.attempt);
-        record_attempt_outcome(
+        record_attempt_terminal_with_probe(
             &self.provider_router,
-            &AttemptOutcome::Terminal(terminal.clone()),
+            terminal,
             ShadowObservationMode::Update,
+            self.probe.take(),
         );
         self.disarm();
     }
@@ -1960,10 +2165,11 @@ impl Drop for AttemptObservationGuard {
         }
 
         let terminal = self.cancellation_terminal();
-        record_attempt_outcome(
+        record_attempt_terminal_with_probe(
             &self.provider_router,
-            &AttemptOutcome::Terminal(terminal),
+            &terminal,
             ShadowObservationMode::Update,
+            self.probe.take(),
         );
         warn!(
             "Inference attempt abandoned before terminal processing: request_id={}, execution_id={}, attempt_id={}, stage={:?}",
@@ -2183,20 +2389,64 @@ async fn get_chat_completion_response_with_options(
         })?
         .to_string();
 
-    if body_model_name != pinned.intent.public_model_id {
+    if body_model_name != pinned.public_model_id() {
         error!(
-            "Prepared inference model did not match execution body: request_id={}, prepared_model={}, body_model={}",
-            pinned.intent.request_id, pinned.intent.public_model_id, body_model_name
+            "Prepared inference model did not match execution body: request_id={}, preferred_model={}, prepared_model={}, body_model={}",
+            pinned.intent.request_id,
+            pinned.intent.public_model_id,
+            pinned.public_model_id(),
+            body_model_name
         );
         return Err(ApiError::InternalServerError.into());
     }
 
-    ensure_completion_model_access(&pinned.intent.public_model_id, pinned.intent.model_plan)?;
-    let selected_route = pinned.route.clone();
+    ensure_completion_model_access(pinned.public_model_id(), pinned.intent.model_plan)?;
+    if let Some(expected_route) = &options.exact_route {
+        let prepared_route = pinned.selected_route();
+        if !completion_route_matches_exact_constraint(prepared_route, expected_route) {
+            error!(
+                "Completion route did not match the server-selected constraint: request_id={}, public_model={}, expected_provider={}, expected_provider_model={}, selected_provider={}, selected_proxy_provider={}, selected_provider_model={}",
+                pinned.intent.request_id,
+                prepared_route.public_model_id,
+                expected_route.provider_name,
+                expected_route.provider_model_id,
+                prepared_route.provider.as_str(),
+                prepared_route.proxy.provider_name,
+                prepared_route.provider_model_id
+            );
+            return Err(CompletionExecutionError::Request(
+                ApiError::ServiceUnavailable,
+            ));
+        }
+    }
+
+    let ClaimedProviderTurn {
+        route: selected_route,
+        probe,
+    } = claim_completion_turn(
+        &state.provider_router,
+        &state.proxy_router,
+        pinned,
+        options.exact_route.is_none(),
+    )
+    .map_err(CompletionExecutionError::from)?;
+    if selected_route.public_model_id != body_model_name {
+        error!(
+            "Probe recovery changed the prepared public model: request_id={}, prepared_model={}, selected_model={}",
+            pinned.intent.request_id,
+            body_model_name,
+            selected_route.public_model_id
+        );
+        drop(probe);
+        return Err(CompletionExecutionError::Request(
+            ApiError::InternalServerError,
+        ));
+    }
+    ensure_completion_model_access(&selected_route.public_model_id, pinned.intent.model_plan)?;
     if let Some(expected_route) = &options.exact_route {
         if !completion_route_matches_exact_constraint(&selected_route, expected_route) {
             error!(
-                "Completion route did not match the server-selected constraint: request_id={}, public_model={}, expected_provider={}, expected_provider_model={}, selected_provider={}, selected_proxy_provider={}, selected_provider_model={}",
+                "Claimed completion route did not match the server-selected constraint: request_id={}, public_model={}, expected_provider={}, expected_provider_model={}, selected_provider={}, selected_proxy_provider={}, selected_provider_model={}",
                 pinned.intent.request_id,
                 selected_route.public_model_id,
                 expected_route.provider_name,
@@ -2205,6 +2455,7 @@ async fn get_chat_completion_response_with_options(
                 selected_route.proxy.provider_name,
                 selected_route.provider_model_id
             );
+            drop(probe);
             return Err(CompletionExecutionError::Request(
                 ApiError::ServiceUnavailable,
             ));
@@ -2252,10 +2503,16 @@ async fn get_chat_completion_response_with_options(
         ensure_stream_usage(&mut request_body);
 
         let request_body_value = Value::Object(request_body);
+        let attempt = execution.begin_attempt(route_identity.clone());
+        let mut terminal_guard = AttemptObservationGuard::new_with_probe(
+            attempt.clone(),
+            Arc::clone(&state.provider_router),
+            AttemptStage::BeforeSend,
+            probe,
+        );
         let request_body_json = match serde_json::to_string(&request_body_value) {
             Ok(json) => json,
             Err(error) => {
-                let attempt = execution.begin_attempt(route_identity.clone());
                 let failure = AttemptFailure::new(
                     AttemptFailureKind::RequestBuild,
                     AttemptStage::BeforeSend,
@@ -2265,12 +2522,12 @@ async fn get_chat_completion_response_with_options(
                     "Failed to serialize inference request: request_id={}, execution_id={}, attempt_id={}, error={:?}",
                     attempt.request_id, attempt.execution_id, attempt.attempt_id, error
                 );
-                return Err(failed_completion_execution(
-                    &state.provider_router,
-                    attempt,
-                    failure,
-                    ApiError::InternalServerError,
-                ));
+                let terminal = AttemptTerminal::Failed { attempt, failure };
+                terminal_guard.record_terminal(&terminal);
+                return Err(CompletionExecutionError::Attempt {
+                    terminal,
+                    public_error: ApiError::InternalServerError,
+                });
             }
         };
         let request_log_metadata =
@@ -2285,11 +2542,7 @@ async fn get_chat_completion_response_with_options(
             request_log_metadata
         );
 
-        let terminal_guard = AttemptObservationGuard::new(
-            execution.begin_attempt(route_identity.clone()),
-            Arc::clone(&state.provider_router),
-            AttemptStage::AwaitingResponse,
-        );
+        terminal_guard.set_stage(AttemptStage::AwaitingResponse);
         let (
             ProviderSendTrace {
                 prior_failures,
@@ -2348,14 +2601,13 @@ async fn get_chat_completion_response_with_options(
                     failure.stage,
                     request_log_metadata
                 );
-                let execution_error = failed_completion_execution(
-                    &state.provider_router,
-                    attempt,
-                    failure.clone(),
-                    public_completion_error(&err, &failure),
-                );
-                terminal_guard.disarm();
-                return Err(execution_error);
+                let public_error = public_completion_error(&err, &failure);
+                let terminal = AttemptTerminal::Failed { attempt, failure };
+                terminal_guard.record_terminal(&terminal);
+                return Err(CompletionExecutionError::Attempt {
+                    terminal,
+                    public_error,
+                });
             }
         }
     };
@@ -2421,14 +2673,15 @@ pub(crate) async fn finish_started_completion(
         {
             Ok(response_json) => response_json,
             Err(failure) => {
-                let execution_error = failed_completion_execution(
-                    &state.provider_router,
-                    attempt.clone(),
+                let terminal = AttemptTerminal::Failed {
+                    attempt: attempt.clone(),
                     failure,
-                    ApiError::InternalServerError,
-                );
-                terminal_guard.disarm();
-                return Err(execution_error);
+                };
+                terminal_guard.record_terminal(&terminal);
+                return Err(CompletionExecutionError::Attempt {
+                    terminal,
+                    public_error: ApiError::InternalServerError,
+                });
             }
         };
 
@@ -3948,8 +4201,8 @@ mod tests {
     }
 
     fn pinned_test_completion() -> PinnedCompletionRequest {
-        PinnedCompletionRequest {
-            intent: InferenceIntent::new(
+        PinnedCompletionRequest::new(
+            InferenceIntent::new(
                 Uuid::nil(),
                 crate::model_config::AUTO_POWERFUL_MODEL_ID,
                 "glm-5-2",
@@ -3957,7 +4210,7 @@ mod tests {
                 InferenceSurface::Responses,
                 WorkloadClass::Interactive,
             ),
-            route: SelectedProviderRoute {
+            SelectedProviderRoute {
                 provider: ProviderId::Tinfoil,
                 proxy: ProxyConfig {
                     base_url: "http://tinfoil.example.com".to_string(),
@@ -3970,8 +4223,9 @@ mod tests {
                 bucket: None,
                 selection_source: crate::provider_registry::RouteSelectionSource::DefaultProvider,
             },
-            routing_mode: InferenceRoutingMode::V2,
-        }
+            None,
+            InferenceRoutingMode::V2,
+        )
     }
 
     #[test]
@@ -4003,6 +4257,246 @@ mod tests {
             &pinned.route,
             &wrong_model
         ));
+    }
+
+    fn probe_test_proxy_router() -> ProxyRouter {
+        ProxyRouter::new(
+            "http://continuum.example.com".to_string(),
+            None,
+            "http://tinfoil.example.com".to_string(),
+        )
+    }
+
+    fn pinned_glm_5_3_completion(
+        provider_router: &ProviderRouter,
+        proxy_router: &ProxyRouter,
+    ) -> PinnedCompletionRequest {
+        let intent = InferenceIntent::new(
+            Uuid::nil(),
+            crate::model_config::GLM_5_3_MODEL_ID,
+            crate::model_config::GLM_5_3_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+        let route = provider_router
+            .select_active_completion_route(proxy_router, &intent, None)
+            .expect("initial GLM 5.3 route");
+        assert_eq!(route.provider, ProviderId::Continuum);
+        PinnedCompletionRequest::new(intent, route, None, InferenceRoutingMode::V2)
+    }
+
+    fn open_and_claim_probe_at_boundary(
+        provider_router: &ProviderRouter,
+        intent: &InferenceIntent,
+        route: &SelectedProviderRoute,
+    ) -> ProbeLease {
+        let terminal = AttemptTerminal::Failed {
+            attempt: intent.begin_execution().begin_attempt(route.identity()),
+            failure: AttemptFailure::new(
+                AttemptFailureKind::CapacityRejected,
+                AttemptStage::AwaitingResponse,
+                ReplaySafety::ProvenPreAcceptance,
+            )
+            .with_upstream_response(429, Some(Duration::from_secs(30)), None),
+        };
+        provider_router.observe_attempt_terminal(&terminal, ShadowObservationMode::Update);
+
+        match provider_router.try_claim_probe_at(
+            &route.identity().route_key(),
+            std::time::Instant::now() + Duration::from_secs(31),
+        ) {
+            ProbeClaimResult::Ready(Some(probe)) => probe,
+            other => panic!("expected a half-open probe lease, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn legacy_router_bypasses_probe_claims_and_replanning() {
+        let provider_router = ProviderRouter::default();
+        let proxy_router = probe_test_proxy_router();
+        let intent = InferenceIntent::new(
+            Uuid::nil(),
+            crate::model_config::KIMI_K3_MODEL_ID,
+            crate::model_config::KIMI_K3_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::ChatCompletions,
+            WorkloadClass::Interactive,
+        );
+        let route = provider_router
+            .select_completion_route_with_preference(
+                &proxy_router,
+                intent.account_uuid,
+                &intent.public_model_id,
+                None,
+            )
+            .expect("legacy K3 route");
+        let pinned = PinnedCompletionRequest::new(
+            intent.clone(),
+            route.clone(),
+            None,
+            InferenceRoutingMode::Legacy,
+        );
+        let winning_probe = open_and_claim_probe_at_boundary(&provider_router, &intent, &route);
+
+        let claimed = claim_completion_turn(&provider_router, &proxy_router, &pinned, true)
+            .expect("legacy routing ignores Router v2 recovery state");
+
+        assert_eq!(claimed.route.identity(), route.identity());
+        assert!(claimed.probe.is_none());
+        assert!(pinned.finalized_route.get().is_none());
+        drop(winning_probe);
+    }
+
+    #[test]
+    fn lost_auto_powerful_probe_claim_replans_within_glm_before_send() {
+        let provider_router = ProviderRouter::default();
+        let proxy_router = probe_test_proxy_router();
+        let intent = InferenceIntent::new(
+            Uuid::nil(),
+            crate::model_config::AUTO_POWERFUL_MODEL_ID,
+            crate::model_config::GLM_5_3_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::ChatCompletions,
+            WorkloadClass::Interactive,
+        );
+        let route = provider_router
+            .select_active_completion_route(&proxy_router, &intent, None)
+            .expect("initial GLM route");
+        assert_eq!(route.provider, ProviderId::Continuum);
+        let pinned = PinnedCompletionRequest::new(
+            intent.clone(),
+            route.clone(),
+            None,
+            InferenceRoutingMode::V2,
+        );
+        let winning_probe = open_and_claim_probe_at_boundary(&provider_router, &intent, &route);
+
+        let claimed = claim_completion_turn(&provider_router, &proxy_router, &pinned, true)
+            .expect("loser should replan before sending");
+
+        assert_eq!(
+            claimed.route.public_model_id,
+            crate::model_config::GLM_5_3_MODEL_ID
+        );
+        assert_eq!(claimed.route.provider, ProviderId::Tinfoil);
+        assert_eq!(claimed.route.provider_model_id, "glm-5-3");
+        assert!(claimed.probe.is_none());
+        assert_eq!(pinned.selected_route().provider, ProviderId::Tinfoil);
+        drop(winning_probe);
+    }
+
+    #[test]
+    fn singleton_probe_loser_fails_before_send_without_finalizing_a_route() {
+        let provider_router = ProviderRouter::default();
+        let proxy_router = probe_test_proxy_router();
+        let intent = InferenceIntent::new(
+            Uuid::nil(),
+            crate::model_config::KIMI_K3_MODEL_ID,
+            crate::model_config::KIMI_K3_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::ChatCompletions,
+            WorkloadClass::Interactive,
+        );
+        let route = provider_router
+            .select_active_completion_route(&proxy_router, &intent, None)
+            .expect("initial K3 route");
+        let pinned = PinnedCompletionRequest::new(
+            intent.clone(),
+            route.clone(),
+            None,
+            InferenceRoutingMode::V2,
+        );
+        let winning_probe = open_and_claim_probe_at_boundary(&provider_router, &intent, &route);
+
+        let error = claim_completion_turn(&provider_router, &proxy_router, &pinned, true)
+            .expect_err("a singleton route has no same-model fallback");
+
+        assert!(matches!(error, ApiError::InferenceCapacity { .. }));
+        assert!(pinned.finalized_route.get().is_none());
+        drop(winning_probe);
+    }
+
+    #[test]
+    fn exact_route_probe_loser_does_not_replan() {
+        let provider_router = ProviderRouter::default();
+        let proxy_router = probe_test_proxy_router();
+        let pinned = pinned_glm_5_3_completion(&provider_router, &proxy_router);
+        let route = pinned.route.clone();
+        let winning_probe =
+            open_and_claim_probe_at_boundary(&provider_router, pinned.intent(), &route);
+        let alternate = provider_router
+            .select_active_completion_route(&proxy_router, pinned.intent(), None)
+            .expect("same-model alternate remains eligible");
+        assert_eq!(alternate.provider, ProviderId::Tinfoil);
+
+        let error = claim_completion_turn(&provider_router, &proxy_router, &pinned, false)
+            .expect_err("an exact route must not move to another provider");
+
+        assert!(matches!(error, ApiError::InferenceCapacity { .. }));
+        assert!(pinned.finalized_route.get().is_none());
+        drop(winning_probe);
+    }
+
+    #[test]
+    fn cancelled_probe_guard_releases_ownership_without_healing() {
+        let provider_router = Arc::new(ProviderRouter::default());
+        let proxy_router = probe_test_proxy_router();
+        let intent = InferenceIntent::new(
+            Uuid::nil(),
+            crate::model_config::KIMI_K3_MODEL_ID,
+            crate::model_config::KIMI_K3_MODEL_ID,
+            ModelPlan::Paid,
+            InferenceSurface::Responses,
+            WorkloadClass::Interactive,
+        );
+        let route = provider_router
+            .select_active_completion_route(&proxy_router, &intent, None)
+            .expect("initial K3 route");
+        let probe = open_and_claim_probe_at_boundary(&provider_router, &intent, &route);
+        let attempt = intent.begin_execution().begin_attempt(route.identity());
+
+        drop(AttemptObservationGuard::new_with_probe(
+            attempt,
+            Arc::clone(&provider_router),
+            AttemptStage::AwaitingResponse,
+            Some(probe),
+        ));
+
+        let next = provider_router.try_claim_probe_at(
+            &route.identity().route_key(),
+            std::time::Instant::now() + Duration::from_secs(31),
+        );
+        assert!(matches!(next, ProbeClaimResult::Ready(Some(_))));
+    }
+
+    #[test]
+    fn later_tool_turn_stays_pinned_and_fails_while_recovery_probe_is_owned() {
+        let provider_router = ProviderRouter::default();
+        let proxy_router = probe_test_proxy_router();
+        let pinned = pinned_glm_5_3_completion(&provider_router, &proxy_router);
+        let route = pinned.route.clone();
+
+        let first = claim_completion_turn(&provider_router, &proxy_router, &pinned, true)
+            .expect("first turn finalizes the route");
+        assert_eq!(first.route.provider, ProviderId::Continuum);
+        assert!(first.probe.is_none());
+
+        let healthy_later = claim_completion_turn(&provider_router, &proxy_router, &pinned, true)
+            .expect("healthy later turn remains pinned");
+        assert_eq!(healthy_later.route.identity(), route.identity());
+        assert!(healthy_later.probe.is_none());
+
+        let _external_probe =
+            open_and_claim_probe_at_boundary(&provider_router, pinned.intent(), &route);
+        let alternate = provider_router
+            .select_active_completion_route(&proxy_router, pinned.intent(), None)
+            .expect("same-model alternate remains eligible");
+        assert_eq!(alternate.provider, ProviderId::Tinfoil);
+        let error = claim_completion_turn(&provider_router, &proxy_router, &pinned, true)
+            .expect_err("later turn must not bypass another recovery probe");
+        assert!(matches!(error, ApiError::InferenceCapacity { .. }));
+        assert_eq!(pinned.selected_route().identity(), route.identity());
     }
 
     async fn record_terminal_once(
@@ -4453,7 +4947,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn glm_tool_turns_keep_the_original_mock_provider_after_health_opens() {
+    async fn glm_tool_turns_stay_pinned_and_block_when_health_opens() {
         let tinfoil_count = Arc::new(AtomicUsize::new(0));
         let tinfoil_app = {
             let count = Arc::clone(&tinfoil_count);
@@ -4511,21 +5005,23 @@ mod tests {
             baseline,
         )
         .expect("initial GLM route");
-        let pinned = PinnedCompletionRequest {
-            intent,
-            route,
-            routing_mode: InferenceRoutingMode::V2,
-        };
+        let pinned = PinnedCompletionRequest::new(intent, route, None, InferenceRoutingMode::V2);
+        let provider_router_ref = &provider_router;
+        let proxy_router_ref = &proxy_router;
 
         let send_pinned_turn = |content: &'static str| {
             let provider_client = &provider_client;
             let pinned = &pinned;
             async move {
+                let claimed =
+                    claim_completion_turn(provider_router_ref, proxy_router_ref, pinned, true)
+                        .expect("healthy pinned turn is admitted");
+                assert!(claimed.probe.is_none());
                 let trace = try_provider(
                     provider_client,
-                    &pinned.route.proxy,
+                    &claimed.route.proxy,
                     json!({
-                        "model": pinned.route.provider_model_id,
+                        "model": claimed.route.provider_model_id,
                         "messages": [{"role": "user", "content": content}]
                     })
                     .to_string(),
@@ -4536,10 +5032,10 @@ mod tests {
                 let response = trace.result.expect("pinned mock turn succeeds");
                 let attempt = pinned
                     .begin_execution()
-                    .begin_attempt(pinned.route.identity());
+                    .begin_attempt(claimed.route.identity());
                 let response = read_non_streaming_completion_response(
                     response,
-                    &pinned.route.response_model_id,
+                    &claimed.route.response_model_id,
                     &attempt,
                     None,
                 )
@@ -4574,11 +5070,12 @@ mod tests {
             public_completion_error(&external_error, &external_failure),
         );
 
-        let second_attempt = send_pinned_turn("second tool turn").await;
-        assert_eq!(first_attempt.request_id, second_attempt.request_id);
-        assert_ne!(first_attempt.execution_id, second_attempt.execution_id);
-        assert_eq!(first_attempt.route, second_attempt.route);
-        assert_eq!(continuum_count.load(Ordering::SeqCst), 2);
+        let error = claim_completion_turn(&provider_router, &proxy_router, &pinned, true)
+            .expect_err("later tool turn must not bypass an open pinned route");
+        assert!(matches!(error, ApiError::InferenceCapacity { .. }));
+        assert_eq!(pinned.selected_route().provider, ProviderId::Continuum);
+        assert_eq!(first_attempt.route.provider, ProviderId::Continuum);
+        assert_eq!(continuum_count.load(Ordering::SeqCst), 1);
         assert_eq!(tinfoil_count.load(Ordering::SeqCst), 0);
 
         let next_intent = InferenceIntent::new(

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -4,7 +4,7 @@ use crate::inference::{
     CompletionEvidence, InferenceAttempt, InferenceExecution, InferenceIntent, InferenceSurface,
     ReplaySafety, WorkloadClass,
 };
-use crate::inference_planning::{ProviderPreference, RoutePlan, RoutePlanningError};
+use crate::inference_planning::{RoutePlan, RoutePlanningError};
 use crate::model_config::{
     model_alias_requires_flag_lookup, model_catalog_response, openai_models_response,
     ModelAliasTargets, ModelPlan,
@@ -822,7 +822,6 @@ pub(crate) struct PinnedCompletionRequest {
     /// until the first provider turn atomically claims any half-open gates.
     route: SelectedProviderRoute,
     routing_mode: InferenceRoutingMode,
-    provider_preference: Option<ProviderPreference>,
     finalized_route: Arc<OnceLock<SelectedProviderRoute>>,
 }
 
@@ -830,14 +829,12 @@ impl PinnedCompletionRequest {
     fn new(
         intent: InferenceIntent,
         route: SelectedProviderRoute,
-        provider_preference: Option<ProviderPreference>,
         routing_mode: InferenceRoutingMode,
     ) -> Self {
         Self {
             intent,
             route,
             routing_mode,
-            provider_preference,
             finalized_route: Arc::new(OnceLock::new()),
         }
     }
@@ -1605,8 +1602,12 @@ async fn proxy_openai(
         })?
         .to_string();
 
+    let routing =
+        InferenceRoutingContext::new(model_plan, state.inference_routing_mode(user.uuid).await);
     let alias_targets = if model_alias_requires_flag_lookup(&requested_model_name) {
-        state.model_alias_targets(user.uuid, model_plan).await
+        state
+            .model_alias_targets(user.uuid, model_plan, routing.mode())
+            .await
     } else {
         ModelAliasTargets::for_plan(model_plan)
     };
@@ -1619,8 +1620,6 @@ async fn proxy_openai(
         InferenceSurface::ChatCompletions,
         WorkloadClass::Interactive,
     );
-    let routing =
-        InferenceRoutingContext::new(model_plan, state.inference_routing_mode(user.uuid).await);
     let pinned_completion = prepare_completion_request(&state, &user, intent, routing).await?;
     if requested_model_name != model_name {
         debug!(
@@ -1844,11 +1843,9 @@ fn select_prepared_completion_route(
     provider_router: &ProviderRouter,
     proxy_router: &ProxyRouter,
     intent: &InferenceIntent,
-    provider_preference: Option<crate::inference_planning::ProviderPreference>,
     baseline_plan: Result<RoutePlan, RoutePlanningError>,
 ) -> Result<SelectedProviderRoute, ApiError> {
-    let active =
-        provider_router.select_active_completion_route(proxy_router, intent, provider_preference);
+    let active = provider_router.select_active_completion_route(proxy_router, intent);
     retain_active_route_after_shadow_observation(intent, active, baseline_plan)
         .map_err(provider_routing_api_error)
 }
@@ -1869,25 +1866,25 @@ pub(crate) async fn prepare_completion_request(
     }
 
     ensure_completion_model_access(&intent.public_model_id, intent.model_plan)?;
-    let provider_preference = state
-        .provider_routing_preference(user.uuid, &intent.public_model_id)
-        .await;
     let route = match routing.mode() {
-        InferenceRoutingMode::Legacy => state
-            .provider_router
-            .select_completion_route_for_mode(
-                &state.proxy_router,
-                &intent,
-                provider_preference,
-                InferenceRoutingMode::Legacy,
-            )
-            .map_err(provider_routing_api_error)?,
+        InferenceRoutingMode::Legacy => {
+            let provider_preference = state
+                .provider_routing_preference(user.uuid, &intent.public_model_id)
+                .await;
+            state
+                .provider_router
+                .select_completion_route_for_mode(
+                    &state.proxy_router,
+                    &intent,
+                    provider_preference,
+                    InferenceRoutingMode::Legacy,
+                )
+                .map_err(provider_routing_api_error)?
+        }
         InferenceRoutingMode::V2 => {
-            let shadow = state.provider_router.shadow_completion_plan(
-                &state.proxy_router,
-                &intent,
-                provider_preference,
-            );
+            let shadow = state
+                .provider_router
+                .shadow_completion_plan(&state.proxy_router, &intent);
             if let Ok(plan) = &shadow {
                 let candidate_health = plan
                     .eligible_routes
@@ -1916,7 +1913,6 @@ pub(crate) async fn prepare_completion_request(
                 &state.provider_router,
                 &state.proxy_router,
                 &intent,
-                provider_preference,
                 shadow,
             )?
         }
@@ -1938,12 +1934,7 @@ pub(crate) async fn prepare_completion_request(
         route.selection_source
     );
 
-    Ok(PinnedCompletionRequest::new(
-        intent,
-        route,
-        provider_preference,
-        routing.mode(),
-    ))
+    Ok(PinnedCompletionRequest::new(intent, route, routing.mode()))
 }
 
 fn probe_api_error(retry_after: Duration) -> ApiError {
@@ -1964,12 +1955,7 @@ fn replan_completion_route_excluding(
 ) -> Result<SelectedProviderRoute, ApiError> {
     loop {
         let route = provider_router
-            .select_active_completion_route_excluding(
-                proxy_router,
-                &pinned.intent,
-                pinned.provider_preference,
-                excluded_routes,
-            )
+            .select_active_completion_route_excluding(proxy_router, &pinned.intent, excluded_routes)
             .map_err(provider_routing_api_error)?;
 
         // Auto model selection is finalized during request preparation, before
@@ -3222,7 +3208,10 @@ async fn proxy_model_catalog(
     let model_plan = ModelPlan::from_is_paid(
         billing_access.is_some_and(crate::billing::ChatBillingAccess::is_paid),
     );
-    let alias_targets = state.model_alias_targets(user.uuid, model_plan).await;
+    let routing_mode = state.inference_routing_mode(user.uuid).await;
+    let alias_targets = state
+        .model_alias_targets(user.uuid, model_plan, routing_mode)
+        .await;
     let catalog_response = model_catalog_response(alias_targets);
     encrypt_response(&state, &session_id, &catalog_response).await
 }
@@ -4223,7 +4212,6 @@ mod tests {
                 bucket: None,
                 selection_source: crate::provider_registry::RouteSelectionSource::DefaultProvider,
             },
-            None,
             InferenceRoutingMode::V2,
         )
     }
@@ -4280,10 +4268,10 @@ mod tests {
             WorkloadClass::Interactive,
         );
         let route = provider_router
-            .select_active_completion_route(proxy_router, &intent, None)
+            .select_active_completion_route(proxy_router, &intent)
             .expect("initial GLM 5.3 route");
         assert_eq!(route.provider, ProviderId::Continuum);
-        PinnedCompletionRequest::new(intent, route, None, InferenceRoutingMode::V2)
+        PinnedCompletionRequest::new(intent, route, InferenceRoutingMode::V2)
     }
 
     fn open_and_claim_probe_at_boundary(
@@ -4334,7 +4322,6 @@ mod tests {
         let pinned = PinnedCompletionRequest::new(
             intent.clone(),
             route.clone(),
-            None,
             InferenceRoutingMode::Legacy,
         );
         let winning_probe = open_and_claim_probe_at_boundary(&provider_router, &intent, &route);
@@ -4361,15 +4348,11 @@ mod tests {
             WorkloadClass::Interactive,
         );
         let route = provider_router
-            .select_active_completion_route(&proxy_router, &intent, None)
+            .select_active_completion_route(&proxy_router, &intent)
             .expect("initial GLM route");
         assert_eq!(route.provider, ProviderId::Continuum);
-        let pinned = PinnedCompletionRequest::new(
-            intent.clone(),
-            route.clone(),
-            None,
-            InferenceRoutingMode::V2,
-        );
+        let pinned =
+            PinnedCompletionRequest::new(intent.clone(), route.clone(), InferenceRoutingMode::V2);
         let winning_probe = open_and_claim_probe_at_boundary(&provider_router, &intent, &route);
 
         let claimed = claim_completion_turn(&provider_router, &proxy_router, &pinned, true)
@@ -4399,14 +4382,10 @@ mod tests {
             WorkloadClass::Interactive,
         );
         let route = provider_router
-            .select_active_completion_route(&proxy_router, &intent, None)
+            .select_active_completion_route(&proxy_router, &intent)
             .expect("initial K3 route");
-        let pinned = PinnedCompletionRequest::new(
-            intent.clone(),
-            route.clone(),
-            None,
-            InferenceRoutingMode::V2,
-        );
+        let pinned =
+            PinnedCompletionRequest::new(intent.clone(), route.clone(), InferenceRoutingMode::V2);
         let winning_probe = open_and_claim_probe_at_boundary(&provider_router, &intent, &route);
 
         let error = claim_completion_turn(&provider_router, &proxy_router, &pinned, true)
@@ -4426,7 +4405,7 @@ mod tests {
         let winning_probe =
             open_and_claim_probe_at_boundary(&provider_router, pinned.intent(), &route);
         let alternate = provider_router
-            .select_active_completion_route(&proxy_router, pinned.intent(), None)
+            .select_active_completion_route(&proxy_router, pinned.intent())
             .expect("same-model alternate remains eligible");
         assert_eq!(alternate.provider, ProviderId::Tinfoil);
 
@@ -4451,7 +4430,7 @@ mod tests {
             WorkloadClass::Interactive,
         );
         let route = provider_router
-            .select_active_completion_route(&proxy_router, &intent, None)
+            .select_active_completion_route(&proxy_router, &intent)
             .expect("initial K3 route");
         let probe = open_and_claim_probe_at_boundary(&provider_router, &intent, &route);
         let attempt = intent.begin_execution().begin_attempt(route.identity());
@@ -4490,7 +4469,7 @@ mod tests {
         let _external_probe =
             open_and_claim_probe_at_boundary(&provider_router, pinned.intent(), &route);
         let alternate = provider_router
-            .select_active_completion_route(&proxy_router, pinned.intent(), None)
+            .select_active_completion_route(&proxy_router, pinned.intent())
             .expect("same-model alternate remains eligible");
         assert_eq!(alternate.provider, ProviderId::Tinfoil);
         let error = claim_completion_turn(&provider_router, &proxy_router, &pinned, true)
@@ -4833,12 +4812,11 @@ mod tests {
             WorkloadClass::Interactive,
         );
 
-        let first_baseline = provider_router.shadow_completion_plan(&proxy_router, &intent, None);
+        let first_baseline = provider_router.shadow_completion_plan(&proxy_router, &intent);
         let first_route = select_prepared_completion_route(
             &provider_router,
             &proxy_router,
             &intent,
-            None,
             first_baseline,
         )
         .expect("initial GLM route");
@@ -4881,13 +4859,11 @@ mod tests {
             WorkloadClass::Interactive,
         );
         assert_ne!(second_intent.request_id, intent.request_id);
-        let second_baseline =
-            provider_router.shadow_completion_plan(&proxy_router, &second_intent, None);
+        let second_baseline = provider_router.shadow_completion_plan(&proxy_router, &second_intent);
         let second_route = select_prepared_completion_route(
             &provider_router,
             &proxy_router,
             &second_intent,
-            None,
             second_baseline,
         )
         .expect("next request uses Tinfoil GLM");
@@ -4996,16 +4972,11 @@ mod tests {
             InferenceSurface::Responses,
             WorkloadClass::Interactive,
         );
-        let baseline = provider_router.shadow_completion_plan(&proxy_router, &intent, None);
-        let route = select_prepared_completion_route(
-            &provider_router,
-            &proxy_router,
-            &intent,
-            None,
-            baseline,
-        )
-        .expect("initial GLM route");
-        let pinned = PinnedCompletionRequest::new(intent, route, None, InferenceRoutingMode::V2);
+        let baseline = provider_router.shadow_completion_plan(&proxy_router, &intent);
+        let route =
+            select_prepared_completion_route(&provider_router, &proxy_router, &intent, baseline)
+                .expect("initial GLM route");
+        let pinned = PinnedCompletionRequest::new(intent, route, InferenceRoutingMode::V2);
         let provider_router_ref = &provider_router;
         let proxy_router_ref = &proxy_router;
 
@@ -5086,13 +5057,11 @@ mod tests {
             InferenceSurface::Responses,
             WorkloadClass::Interactive,
         );
-        let next_baseline =
-            provider_router.shadow_completion_plan(&proxy_router, &next_intent, None);
+        let next_baseline = provider_router.shadow_completion_plan(&proxy_router, &next_intent);
         let next_route = select_prepared_completion_route(
             &provider_router,
             &proxy_router,
             &next_intent,
-            None,
             next_baseline,
         )
         .expect("next logical request switches providers");
@@ -5286,13 +5255,11 @@ mod tests {
             )
         };
         let first_intent = new_intent();
-        let first_baseline =
-            provider_router.shadow_completion_plan(&proxy_router, &first_intent, None);
+        let first_baseline = provider_router.shadow_completion_plan(&proxy_router, &first_intent);
         let first_route = select_prepared_completion_route(
             &provider_router,
             &proxy_router,
             &first_intent,
-            None,
             first_baseline,
         )
         .expect("initial Continuum GLM route");
@@ -5313,13 +5280,11 @@ mod tests {
         );
 
         let second_intent = new_intent();
-        let second_baseline =
-            provider_router.shadow_completion_plan(&proxy_router, &second_intent, None);
+        let second_baseline = provider_router.shadow_completion_plan(&proxy_router, &second_intent);
         let second_route = select_prepared_completion_route(
             &provider_router,
             &proxy_router,
             &second_intent,
-            None,
             second_baseline,
         )
         .expect("Tinfoil GLM route while Continuum is open");
@@ -5340,13 +5305,11 @@ mod tests {
         );
 
         let third_intent = new_intent();
-        let third_baseline =
-            provider_router.shadow_completion_plan(&proxy_router, &third_intent, None);
+        let third_baseline = provider_router.shadow_completion_plan(&proxy_router, &third_intent);
         let error = select_prepared_completion_route(
             &provider_router,
             &proxy_router,
             &third_intent,
-            None,
             third_baseline,
         )
         .expect_err("both GLM routes are open");
@@ -5829,7 +5792,7 @@ mod tests {
                 Some(73),
             ),
             eligible_routes: Vec::new(),
-            decision: PlanDecision::PreferredProviderUnavailable,
+            decision: PlanDecision::FixedRoute,
             candidate_scope: CandidateScope::SamePublicModelOnly,
             policy_version: SHADOW_ROUTING_POLICY_VERSION,
         };

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -5176,14 +5176,16 @@ async fn create_response_stream(
         );
         return Err(ApiError::Unauthorized);
     }
+    let routing =
+        InferenceRoutingContext::new(model_plan, state.inference_routing_mode(user.uuid).await);
     let alias_targets = if model_alias_requires_flag_lookup(&requested_model) {
-        state.model_alias_targets(user.uuid, model_plan).await
+        state
+            .model_alias_targets(user.uuid, model_plan, routing.mode())
+            .await
     } else {
         ModelAliasTargets::for_plan(model_plan)
     };
     let selected_model = alias_targets.resolve(&requested_model).to_string();
-    let routing =
-        InferenceRoutingContext::new(model_plan, state.inference_routing_mode(user.uuid).await);
     let completion_provider = state.proxy_router.get_completion_proxy();
     let resolved_model = resolve_responses_model(
         &selected_model,

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -304,10 +304,18 @@ pub enum PublicResponseFailure {
 
 impl PublicResponseFailure {
     fn from_completion_error(error: &CompletionExecutionError) -> Self {
-        match error.terminal() {
-            Some(AttemptTerminal::Failed { failure, .. })
-                if failure.kind == crate::inference::AttemptFailureKind::CapacityRejected =>
-            {
+        match error {
+            CompletionExecutionError::Request(ApiError::InferenceCapacity { status, .. }) => {
+                if *status == axum::http::StatusCode::TOO_MANY_REQUESTS {
+                    Self::CapacityRateLimited
+                } else {
+                    Self::CapacityOverloaded
+                }
+            }
+            CompletionExecutionError::Attempt {
+                terminal: AttemptTerminal::Failed { failure, .. },
+                ..
+            } if failure.kind == crate::inference::AttemptFailureKind::CapacityRejected => {
                 if failure.status == Some(429) {
                     Self::CapacityRateLimited
                 } else {
@@ -969,6 +977,15 @@ mod tests {
         }
         assert_eq!(
             image_description_api_error(ApiError::ServiceUnavailable).class,
+            ImageDescriptionFailureClass::PreAcceptance
+        );
+        assert_eq!(
+            image_description_api_error(ApiError::InferenceCapacity {
+                status: axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                retry_after: Some(Duration::from_secs(1)),
+                client_replay_safe: false,
+            })
+            .class,
             ImageDescriptionFailureClass::PreAcceptance
         );
         assert_eq!(
@@ -1697,6 +1714,40 @@ mod tests {
         assert!(PublicResponseFailure::DeadlineExceeded
             .contract_metadata()
             .is_none());
+    }
+
+    #[test]
+    fn local_capacity_request_errors_remain_typed_after_persistence() {
+        for (status, expected) in [
+            (
+                axum::http::StatusCode::TOO_MANY_REQUESTS,
+                PublicResponseFailure::CapacityRateLimited,
+            ),
+            (
+                axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                PublicResponseFailure::CapacityOverloaded,
+            ),
+        ] {
+            let error = CompletionExecutionError::from(ApiError::InferenceCapacity {
+                status,
+                retry_after: Some(Duration::from_secs(30)),
+                client_replay_safe: false,
+            });
+
+            let actual = PublicResponseFailure::from_completion_error(&error);
+            assert_eq!(actual, expected);
+            assert_eq!(
+                actual.contract_metadata().unwrap().error_code,
+                crate::INFERENCE_CAPACITY_ERROR_CODE
+            );
+        }
+
+        assert_eq!(
+            PublicResponseFailure::from_completion_error(&CompletionExecutionError::from(
+                ApiError::InternalServerError
+            )),
+            PublicResponseFailure::Internal
+        );
     }
 
     #[test]
@@ -3385,7 +3436,9 @@ fn image_description_api_error(error: ApiError) -> ImageDescriptionAttemptError 
         ApiError::BadRequest | ApiError::Unauthorized | ApiError::ModelNotAvailableOnPlan => {
             ImageDescriptionFailureClass::Terminal
         }
-        ApiError::ServiceUnavailable => ImageDescriptionFailureClass::PreAcceptance,
+        ApiError::ServiceUnavailable | ApiError::InferenceCapacity { .. } => {
+            ImageDescriptionFailureClass::PreAcceptance
+        }
         ApiError::TooManyRequests => ImageDescriptionFailureClass::RetryableResponse,
         _ => ImageDescriptionFailureClass::AmbiguousAfterSend,
     };

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -5908,6 +5908,18 @@ where
         .into_response()
 }
 
+// Test-only seam for checking that the real Responses SSE carrier preserves
+// an application-body failure for the Transport V2 gateway to authenticate.
+#[cfg(test)]
+pub(crate) fn responses_sse_body_failure_for_test() -> Response {
+    responses_sse_response(futures::stream::iter([
+        Ok(Event::default()
+            .event("response.created")
+            .data(r#"{"type":"response.created"}"#)),
+        Err(ApiError::InternalServerError),
+    ]))
+}
+
 /// Helper to create encrypted SSE event
 pub async fn encrypt_event(
     state: &AppState,


### PR DESCRIPTION
When a Router-v2 circuit becomes eligible for recovery, only one request per affected gate can probe it in an enclave process. Ownership lasts through the provider terminal, and stale attempts cannot heal a newer circuit state.

- Claim route, deployment, and registry-declared rate-scope gates atomically. A move-only RAII lease releases ownership on completion, cancellation, drop, or unwind; generation fencing rejects stale, duplicate, unrelated, and unleased settlement.
- Replan a provisional route only before its first provider send and only within the already-resolved public model. Exact-route work stays fixed; later Responses turns remain pinned to the finalized provider and fail locally if its gates cannot be claimed.
- Preserve distinct GLM 5.2, standard GLM 5.3, and GLM 5.3 Flash provider/model recovery state. No started inference is replayed or failed over.
- Retain typed capacity failure after persistence without granting whole-request replay safety. Proven local pre-send descriptor rejection can continue the existing image-description candidate sequence.

Router v1 exits the pre-send seam before probe claims, health rejection, exclusions, or replanning. Router v2 remains default off. Health/probe state is enclave-local and in memory; a process restart resets it. Existing flag cache semantics still apply to cohort changes. This is circuit recovery infrastructure, with no customer admission policy or distributed coordination.

The complete stack retains [#300's client-disconnect durability, storage-authoritative terminals, absence of imposed generation limits, and literal context-window catalog](https://github.com/OpenSecretCloud/opensecret/pull/300), integrated with [#343's ownership and cancellation/deletion quiescence](https://github.com/OpenSecretCloud/opensecret/pull/343). Successful probe recovery at production traffic rates and cross-enclave behavior are operational evidence still distinct from deterministic tests.

Local validation at `fc0e798a6f3dda83bc6894b79156bd92d6e45f6f`: the pinned Rust all-feature suite passed 572 tests, with 0 failed and 23 ignored. Direct pinned format and warning-denied all-target/all-feature Clippy passed; independent exact-head review found no P0/P1 blockers. Focused coverage includes concurrent claims, generation fencing, stale settlement, lease cleanup, exact routes, pinned turns, model isolation, and persisted capacity failures.

GitHub checks and ancestry snapshot, 2026-09-04 23:32:16 UTC: OPEN, non-draft, mergeable/CLEAN, and 0 commits behind. The exact head matches the local validation above; base `codex-routing-v2-auto-substitution` at `d3a918307f8a8b9fda12a59f6c35a1976eaffbf7` is also the merge base. RustSec is SUCCESS, with no pending or failed checks. It is the only attached check because full workflows target master; this is the existing stacked-PR coverage limitation.

Cumulative integration at backend `fc0e798a` / Maple `9cfcbc0e` passed all five encrypted Kimi mock scenarios with Router v2 off and on: Chat, Responses, disconnect/reload, explicit cancellation, and tool continuation. Disconnect at 24 characters produced all 7,917 characters through fresh encrypted retrieval; HTTP-200 cancellation preserved 24 durable characters and aborted the upstream stream. Advertised `web_search` persisted the local empty-query error and continued on a second provider turn without external Kagi access. Mock requests contained no numeric generation-limit fields; the final mock instance recorded 9 requests, 7 completed, 2 aborted, and 0 failed.

Live standard GLM 5.3 Chat and Responses passed in both modes with one client inference send each. Chat verified usage and one finish/`[DONE]`; Responses verified one terminal event and fresh encrypted retrieval of durable completion. Routing evidence confirmed Continuum inference and Tinfoil Llama titles. A separate legacy Chat check passed for the distinct Tinfoil GLM 5.3 Flash model. These results exercise the cumulative stack with Maple.

DB qualification: exact final #300 (`91ed2e57`) passed 20 AEAD/database tests, with 0 failed, 0 ignored, and process exit 0. The separate whole disposable-DB helper remains failed because of the inherited OAuth exit SIGSEGV also reproduced on unchanged master.

Stack **8/8**, based on [#303](https://github.com/OpenSecretCloud/opensecret/pull/303). Final base: **d3a918307f8a8b9fda12a59f6c35a1976eaffbf7**. Client integration: [Maple #865](https://github.com/OpenSecretCloud/Maple/pull/865), pinned to the exact final #300 contract. This PR does not merge, deploy, or enable Router v2.

[Routing walkthrough: fenced recovery](https://maple-routing-review.anthony599874.chatgpt.site/#stack-8) · [Recovery state](https://github.com/OpenSecretCloud/opensecret/blob/fc0e798a6f3dda83bc6894b79156bd92d6e45f6f/src/inference/health.rs) · [Pre-send claim seam](https://github.com/OpenSecretCloud/opensecret/blob/fc0e798a6f3dda83bc6894b79156bd92d6e45f6f/src/web/openai.rs).
