### PR TITLE
feat(models): add staged GLM 5.3 routing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use crate::encrypt::{
 };
 use crate::jwt::validate_platform_jwt;
 use crate::login_routes::RegisterCredentials;
+use crate::model_config::{ModelAliasTargets, ModelPlan, PaidModelAliasOverrides};
 use crate::models::account_deletion::{AccountDeletionError, NewAccountDeletionRequest};
 use crate::models::email_verification::{EmailVerificationError, NewEmailVerification};
 use crate::models::oauth::{NewUserOAuthConnection, OAuthError};
@@ -129,7 +130,7 @@ mod aead_db_tamper_tests;
 use apple_signin::AppleJwtVerifier;
 use oauth::{AppleProvider, GithubProvider, GoogleProvider, OAuthManager};
 use provider_client::{ProviderClient, ProviderRequestError};
-use provider_routing::{ProviderName, ProviderPreference, ProviderRouter};
+use provider_routing::{ProviderPreference, ProviderRouter};
 use proxy_config::ProxyRouter;
 
 const ENCLAVE_KEY_NAME: &str = "enclave_key";
@@ -148,6 +149,7 @@ const BILLING_SERVER_URL_NAME: &str = "billing_server_url";
 const KAGI_API_KEY_NAME: &str = "kagi_api_key";
 const OS_FLAGS_API_KEY_NAME: &str = "os_flags_api_key";
 const OS_FLAGS_BASE_URL_NAME: &str = "os_flags_base_url";
+const MODEL_ALIAS_FLAGS_TIMEOUT_SECS: u64 = 5;
 const PROVIDER_ROUTING_FLAGS_TIMEOUT_SECS: u64 = 5;
 const BILLING_ACCESS_TIMEOUT_SECS: u64 = 5;
 const MAX_ATTESTATION_NONCE_BYTES: usize = 512;
@@ -1158,6 +1160,52 @@ impl AppState {
         }
     }
 
+    /// Resolve automatic model aliases for this user's plan. Paid overrides
+    /// default off on missing configuration, a missing flag, service failure,
+    /// or timeout. Free plans never apply paid alias overrides.
+    pub(crate) async fn model_alias_targets(
+        &self,
+        user_uuid: Uuid,
+        model_plan: ModelPlan,
+    ) -> ModelAliasTargets {
+        if !model_plan.is_paid() {
+            return ModelAliasTargets::for_plan(model_plan);
+        }
+
+        let Some(client) = &self.os_flags_client else {
+            trace!(
+                "os-flags client not configured; using default paid model aliases (user_uuid={})",
+                user_uuid
+            );
+            return ModelAliasTargets::for_plan(model_plan);
+        };
+
+        let overrides = match tokio::time::timeout(
+            Duration::from_secs(MODEL_ALIAS_FLAGS_TIMEOUT_SECS),
+            client.get_user_flags(user_uuid, Some(os_flags::PAID_MODEL_ALIAS_FLAG_KEYS)),
+        )
+        .await
+        {
+            Ok(Ok(response)) => PaidModelAliasOverrides::from_flag_values(&response.flags),
+            Ok(Err(e)) => {
+                warn!(
+                    "os-flags paid model alias check failed (user_uuid={}): {}; using default aliases",
+                    user_uuid, e
+                );
+                PaidModelAliasOverrides::default()
+            }
+            Err(_) => {
+                warn!(
+                    "os-flags paid model alias check timed out after {}s (user_uuid={}); using default aliases",
+                    MODEL_ALIAS_FLAGS_TIMEOUT_SECS, user_uuid
+                );
+                PaidModelAliasOverrides::default()
+            }
+        };
+
+        ModelAliasTargets::for_plan_with_overrides(model_plan, overrides)
+    }
+
     /// Resolve an explicit provider preference only for models configured for
     /// flag-controlled routing. Missing configuration, flags, failures, and
     /// timeouts retain the model's default provider.
@@ -1166,9 +1214,10 @@ impl AppState {
         user_uuid: Uuid,
         requested_model: &str,
     ) -> Option<ProviderPreference> {
-        let flag_key = self
+        let provider_flag = self
             .provider_router
-            .continuum_flag_key_for_completion_model(requested_model)?;
+            .provider_routing_flag_for_completion_model(requested_model)?;
+        let flag_key = provider_flag.key();
 
         let Some(client) = &self.os_flags_client else {
             trace!(
@@ -1184,8 +1233,7 @@ impl AppState {
         )
         .await
         {
-            Ok(Ok(Some(true))) => Some(ProviderPreference::feature_flag(ProviderName::Continuum)),
-            Ok(Ok(Some(false))) => Some(ProviderPreference::feature_flag(ProviderName::Tinfoil)),
+            Ok(Ok(Some(enabled))) => Some(provider_flag.preference_for(enabled)),
             Ok(Ok(None)) => {
                 debug!(
                     "os-flags provider routing flag missing (user_uuid={}, requested_model={}, flag_key={}); using default provider routing",

--- a/src/model_config.rs
+++ b/src/model_config.rs
@@ -1,6 +1,8 @@
 //! Central model-specific configuration and public model catalog.
 
+use crate::os_flags::PAID_POWERFUL_GLM_5_3_ALIAS_FLAG_KEY;
 use serde_json::{json, Value};
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ModelConfig {
@@ -101,6 +103,11 @@ pub(crate) struct ModelAliasTargets {
     powerful: &'static str,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct PaidModelAliasOverrides {
+    powerful_glm_5_3: bool,
+}
+
 pub const DEFAULT_CONTEXT_WINDOW: usize = 64_000;
 pub const DEFAULT_TEMPERATURE: f32 = 0.7;
 pub const DEFAULT_TOP_P: f32 = 1.0;
@@ -108,6 +115,7 @@ pub const AUTO_QUICK_MODEL_ID: &str = "auto:quick";
 pub const AUTO_POWERFUL_MODEL_ID: &str = "auto:powerful";
 pub const QUICK_MODEL_ID: &str = "gpt-oss-120b";
 pub const GLM_5_2_MODEL_ID: &str = "glm-5-2";
+pub const GLM_5_3_MODEL_ID: &str = "glm-5-3";
 pub const POWERFUL_MODEL_ID: &str = GLM_5_2_MODEL_ID;
 pub const KIMI_K3_MODEL_ID: &str = "kimi-k3";
 pub const DEEPSEEK_V4_FLASH_MODEL_ID: &str = "deepseek-v4-flash";
@@ -392,6 +400,23 @@ impl ModelAliasTargets {
         }
     }
 
+    pub(crate) const fn for_plan_with_overrides(
+        plan: ModelPlan,
+        overrides: PaidModelAliasOverrides,
+    ) -> Self {
+        match plan {
+            ModelPlan::Free => FREE_MODEL_ALIAS_TARGETS,
+            ModelPlan::Paid => Self {
+                quick: PAID_MODEL_ALIAS_TARGETS.quick,
+                powerful: if overrides.powerful_glm_5_3 {
+                    GLM_5_3_MODEL_ID
+                } else {
+                    PAID_MODEL_ALIAS_TARGETS.powerful
+                },
+            },
+        }
+    }
+
     pub(crate) fn resolve(self, model: &str) -> &str {
         match model {
             AUTO_QUICK_MODEL_ID => self.quick,
@@ -405,6 +430,17 @@ impl ModelAliasTargets {
             AUTO_QUICK_MODEL_ID => Some(self.quick),
             AUTO_POWERFUL_MODEL_ID => Some(self.powerful),
             _ => None,
+        }
+    }
+}
+
+impl PaidModelAliasOverrides {
+    pub(crate) fn from_flag_values(flags: &HashMap<String, bool>) -> Self {
+        Self {
+            powerful_glm_5_3: flags
+                .get(PAID_POWERFUL_GLM_5_3_ALIAS_FLAG_KEY)
+                .copied()
+                .unwrap_or(false),
         }
     }
 }
@@ -536,6 +572,22 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
     )
     .with_catalog_provider("continuum", "kimi-k2.6"),
     ModelConfigEntry::new(
+        GLM_5_3_MODEL_ID,
+        "GLM 5.3",
+        "GLM 5.3",
+        "Flagship reasoning model for complex engineering and long-horizon agent work.",
+        ModelAccessTier::Pro,
+        ModelCapabilities::chat(true, false),
+        &["New", "Reasoning"],
+        true,
+        true,
+        false,
+        50,
+        256_000,
+    )
+    .with_catalog_provider("continuum", "glm-5.3")
+    .with_catalog_metadata(ModelCatalogMetadata::new(&["text"], &["text"], None, None)),
+    ModelConfigEntry::new(
         GLM_5_2_MODEL_ID,
         "GLM 5.2",
         "GLM 5.2",
@@ -546,7 +598,7 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
         true,
         true,
         false,
-        50,
+        60,
         256_000,
     ),
     ModelConfigEntry::new(
@@ -560,7 +612,7 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
         true,
         true,
         false,
-        60,
+        70,
         800_000,
     )
     .with_catalog_metadata(ModelCatalogMetadata::new(
@@ -580,7 +632,7 @@ const MODEL_CONFIGS: &[ModelConfigEntry] = &[
         true,
         true,
         false,
-        70,
+        80,
         128_000,
     ),
     ModelConfigEntry::api_only(
@@ -615,6 +667,10 @@ const MODEL_ALIAS_ENTRIES: &[ModelAliasEntry] = &[
 
 fn alias_target(model: &str) -> Option<&'static str> {
     ModelAliasTargets::default().target_for(model)
+}
+
+pub(crate) fn model_alias_requires_flag_lookup(model: &str) -> bool {
+    model == AUTO_POWERFUL_MODEL_ID
 }
 
 fn model_entry(model: &str) -> Option<ModelConfigEntry> {
@@ -671,7 +727,9 @@ pub fn model_reasoning_history_strategy(model: &str) -> Option<ReasoningHistoryS
         "kimi-k2-6" | "kimi-k2.6" | "kimi-k3" => {
             Some(ReasoningHistoryStrategy::KimiPreserveThinking)
         }
-        "glm-5-2" | "glm-5.2" => Some(ReasoningHistoryStrategy::GlmClearThinking),
+        "glm-5-2" | "glm-5.2" | "glm-5-3" | "glm-5.3" => {
+            Some(ReasoningHistoryStrategy::GlmClearThinking)
+        }
         _ => None,
     }
 }
@@ -811,6 +869,7 @@ mod tests {
         assert_eq!(model_context_window("kimi-k2-6"), 256_000);
         assert_eq!(model_context_window("gemma4-31b"), 256_000);
         assert_eq!(model_context_window("glm-5-2"), 256_000);
+        assert_eq!(model_context_window("glm-5-3"), 256_000);
         assert_eq!(model_context_window("kimi-k3"), 256_000);
         assert_eq!(model_context_window("deepseek-v4-flash"), 800_000);
         assert_eq!(model_context_window(AUTO_QUICK_MODEL_ID), 128_000);
@@ -826,6 +885,7 @@ mod tests {
             "kimi-k2-6",
             "gemma4-31b",
             "glm-5-2",
+            "glm-5-3",
             "kimi-k3",
             "deepseek-v4-flash",
         ] {
@@ -851,6 +911,8 @@ mod tests {
         assert!(model_supports_reasoning_history("kimi-k3"));
         assert!(model_supports_reasoning_history("glm-5-2"));
         assert!(model_supports_reasoning_history("glm-5.2"));
+        assert!(model_supports_reasoning_history("glm-5-3"));
+        assert!(model_supports_reasoning_history("glm-5.3"));
         assert!(model_supports_reasoning_history(AUTO_POWERFUL_MODEL_ID));
 
         assert!(!model_supports_reasoning_history("gpt-oss-120b"));
@@ -879,6 +941,10 @@ mod tests {
         );
         assert_eq!(
             model_reasoning_history_strategy("glm-5-2"),
+            Some(ReasoningHistoryStrategy::GlmClearThinking)
+        );
+        assert_eq!(
+            model_reasoning_history_strategy("glm-5.3"),
             Some(ReasoningHistoryStrategy::GlmClearThinking)
         );
         assert_eq!(
@@ -934,6 +1000,7 @@ mod tests {
         assert_eq!(resolve_completion_model_id("quick"), None);
         assert_eq!(resolve_completion_model_id("kimi-k2-5"), None);
         assert_eq!(resolve_completion_model_id("kimi-k3"), Some("kimi-k3"));
+        assert_eq!(resolve_completion_model_id("glm-5-3"), Some("glm-5-3"));
         assert_eq!(
             resolve_completion_model_id("deepseek-v4-flash"),
             Some("deepseek-v4-flash")
@@ -957,6 +1024,7 @@ mod tests {
         );
         assert_eq!(resolve_public_model_id("kimi-k2-5"), None);
         assert_eq!(resolve_public_model_id("kimi-k3"), Some("kimi-k3"));
+        assert_eq!(resolve_public_model_id("glm-5-3"), Some("glm-5-3"));
         assert_eq!(
             resolve_public_model_id("deepseek-v4-flash"),
             Some("deepseek-v4-flash")
@@ -979,6 +1047,72 @@ mod tests {
         );
         assert_eq!(paid.resolve(AUTO_POWERFUL_MODEL_ID), GLM_5_2_MODEL_ID);
         assert_eq!(paid.resolve(KIMI_K3_MODEL_ID), KIMI_K3_MODEL_ID);
+    }
+
+    #[test]
+    fn test_paid_powerful_glm_5_3_alias_override_is_plan_gated_and_default_off() {
+        for powerful_enabled in [false, true] {
+            let flags = HashMap::from([(
+                PAID_POWERFUL_GLM_5_3_ALIAS_FLAG_KEY.to_string(),
+                powerful_enabled,
+            )]);
+            let overrides = PaidModelAliasOverrides::from_flag_values(&flags);
+
+            let free = ModelAliasTargets::for_plan_with_overrides(ModelPlan::Free, overrides);
+            assert_eq!(free.resolve(AUTO_QUICK_MODEL_ID), QUICK_MODEL_ID);
+            assert_eq!(free.resolve(AUTO_POWERFUL_MODEL_ID), GLM_5_2_MODEL_ID);
+
+            let paid = ModelAliasTargets::for_plan_with_overrides(ModelPlan::Paid, overrides);
+            assert_eq!(
+                paid.resolve(AUTO_QUICK_MODEL_ID),
+                DEEPSEEK_V4_FLASH_MODEL_ID
+            );
+            assert_eq!(
+                paid.resolve(AUTO_POWERFUL_MODEL_ID),
+                if powerful_enabled {
+                    GLM_5_3_MODEL_ID
+                } else {
+                    GLM_5_2_MODEL_ID
+                }
+            );
+        }
+
+        assert_eq!(
+            PaidModelAliasOverrides::from_flag_values(&HashMap::new()),
+            PaidModelAliasOverrides::default()
+        );
+        assert_eq!(
+            PAID_POWERFUL_GLM_5_3_ALIAS_FLAG_KEY,
+            "model-alias.paid.powerful.glm-5-3"
+        );
+        assert_eq!(
+            crate::os_flags::PAID_MODEL_ALIAS_FLAG_KEYS,
+            &[PAID_POWERFUL_GLM_5_3_ALIAS_FLAG_KEY]
+        );
+        assert!(model_alias_requires_flag_lookup(AUTO_POWERFUL_MODEL_ID));
+        assert!(!model_alias_requires_flag_lookup(AUTO_QUICK_MODEL_ID));
+        assert!(!model_alias_requires_flag_lookup(GLM_5_3_MODEL_ID));
+    }
+
+    #[test]
+    fn test_catalog_alias_metadata_tracks_paid_glm_5_3_override() {
+        let flags = HashMap::from([(PAID_POWERFUL_GLM_5_3_ALIAS_FLAG_KEY.to_string(), true)]);
+        let targets = ModelAliasTargets::for_plan_with_overrides(
+            ModelPlan::Paid,
+            PaidModelAliasOverrides::from_flag_values(&flags),
+        );
+        let catalog = model_catalog_response(targets);
+        let powerful = catalog["aliases"]
+            .as_array()
+            .expect("aliases")
+            .iter()
+            .find(|alias| alias["id"] == AUTO_POWERFUL_MODEL_ID)
+            .expect("powerful alias");
+
+        assert_eq!(powerful["target_model"], GLM_5_3_MODEL_ID);
+        assert_eq!(powerful["access"], "pro");
+        assert_eq!(powerful["capabilities"]["reasoning"], true);
+        assert_eq!(powerful["capabilities"]["vision"], false);
     }
 
     #[test]
@@ -1021,6 +1155,7 @@ mod tests {
             "kimi-k3",
             "kimi-k2-6",
             "glm-5-2",
+            "glm-5-3",
             "deepseek-v4-flash",
             AUTO_POWERFUL_MODEL_ID,
         ] {
@@ -1105,6 +1240,34 @@ mod tests {
     }
 
     #[test]
+    fn test_catalog_adds_glm_5_3_directly_through_continuum_without_changing_aliases() {
+        let catalog = model_catalog_response(ModelAliasTargets::for_plan(ModelPlan::Paid));
+        let glm = catalog_model(&catalog, GLM_5_3_MODEL_ID);
+
+        assert_eq!(glm["provider"], "continuum");
+        assert_eq!(glm["provider_id"], "glm-5.3");
+        assert_eq!(glm["access"], "pro");
+        assert_eq!(glm["context_window"], 256_000);
+        assert_eq!(glm["input_modalities"], json!(["text"]));
+        assert_eq!(glm["output_modalities"], json!(["text"]));
+        assert_eq!(glm["capabilities"]["vision"], false);
+        assert_eq!(glm["capabilities"]["reasoning"], true);
+        assert_eq!(glm["capabilities"]["tool_use"], true);
+        assert_eq!(
+            resolve_completion_model_id(GLM_5_3_MODEL_ID),
+            Some(GLM_5_3_MODEL_ID)
+        );
+
+        let powerful = catalog["aliases"]
+            .as_array()
+            .expect("aliases")
+            .iter()
+            .find(|alias| alias["id"] == AUTO_POWERFUL_MODEL_ID)
+            .expect("powerful alias");
+        assert_eq!(powerful["target_model"], GLM_5_2_MODEL_ID);
+    }
+
+    #[test]
     fn test_kimi_k3_and_deepseek_are_generally_listed() {
         let catalog = model_catalog_response(ModelAliasTargets::default());
         let openai_models = openai_models_response();
@@ -1116,9 +1279,10 @@ mod tests {
     }
 
     #[test]
-    fn test_only_kimi_k3_and_deepseek_have_new_badges() {
+    fn test_new_badges_match_the_currently_launched_models() {
         let expected = vec![
             DEEPSEEK_V4_FLASH_MODEL_ID.to_string(),
+            GLM_5_3_MODEL_ID.to_string(),
             KIMI_K3_MODEL_ID.to_string(),
         ];
 

--- a/src/os_flags.rs
+++ b/src/os_flags.rs
@@ -15,7 +15,9 @@ const USER_FLAGS_CACHE_TTL: Duration = Duration::from_secs(10 * 60);
 // externally configured identifiers.
 #[allow(dead_code)]
 pub const AGENT_FEATURE_FLAG_KEY: &str = "agent";
-pub const GLM_5_2_CONTINUUM_FLAG_KEY: &str = "provider-routing.glm-5-2.continuum";
+pub const PAID_POWERFUL_GLM_5_3_ALIAS_FLAG_KEY: &str = "model-alias.paid.powerful.glm-5-3";
+pub const PAID_MODEL_ALIAS_FLAG_KEYS: &[&str] = &[PAID_POWERFUL_GLM_5_3_ALIAS_FLAG_KEY];
+pub const GLM_5_3_TINFOIL_FLAG_KEY: &str = "provider-routing.glm-5-3.tinfoil";
 
 #[derive(Debug, thiserror::Error)]
 pub enum OsFlagsError {

--- a/src/provider_routing.rs
+++ b/src/provider_routing.rs
@@ -1,5 +1,7 @@
-use crate::model_config::{resolve_completion_model_id, resolve_public_model_id, GLM_5_2_MODEL_ID};
-use crate::os_flags::GLM_5_2_CONTINUUM_FLAG_KEY;
+use crate::model_config::{
+    resolve_completion_model_id, resolve_public_model_id, GLM_5_2_MODEL_ID, GLM_5_3_MODEL_ID,
+};
+use crate::os_flags::GLM_5_3_TINFOIL_FLAG_KEY;
 use crate::proxy_config::{canonicalize_tinfoil_model, ProxyConfig, ProxyRouter};
 use uuid::Uuid;
 
@@ -61,14 +63,36 @@ struct ModelProviderRoute {
     provider_model_id: &'static str,
     weight: u16,
     enabled: bool,
+    requires_explicit_preference: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
 struct ModelRoutingConfig {
     public_model_id: &'static str,
     routes: &'static [ModelProviderRoute],
-    continuum_flag_key: Option<&'static str>,
+    provider_flag: Option<ProviderRoutingFlag>,
     default_provider: Option<ProviderName>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProviderRoutingFlag {
+    key: &'static str,
+    enabled_provider: ProviderName,
+    disabled_provider: ProviderName,
+}
+
+impl ProviderRoutingFlag {
+    pub(crate) const fn key(self) -> &'static str {
+        self.key
+    }
+
+    pub(crate) const fn preference_for(self, enabled: bool) -> ProviderPreference {
+        ProviderPreference::feature_flag(if enabled {
+            self.enabled_provider
+        } else {
+            self.disabled_provider
+        })
+    }
 }
 
 #[derive(Debug)]
@@ -124,20 +148,34 @@ const KIMI_K2_6_ROUTES: &[ModelProviderRoute] = &[ModelProviderRoute {
     provider_model_id: "kimi-k2.6",
     weight: 100,
     enabled: true,
+    requires_explicit_preference: false,
 }];
 
-const GLM_5_2_ROUTES: &[ModelProviderRoute] = &[
-    ModelProviderRoute {
-        provider: ProviderName::Tinfoil,
-        provider_model_id: GLM_5_2_MODEL_ID,
-        weight: 100,
-        enabled: true,
-    },
+const GLM_5_2_ROUTES: &[ModelProviderRoute] = &[ModelProviderRoute {
+    provider: ProviderName::Tinfoil,
+    provider_model_id: GLM_5_2_MODEL_ID,
+    weight: 100,
+    enabled: true,
+    requires_explicit_preference: false,
+}];
+
+const GLM_5_3_ROUTES: &[ModelProviderRoute] = &[
     ModelProviderRoute {
         provider: ProviderName::Continuum,
-        provider_model_id: "glm-5.2",
+        provider_model_id: "glm-5.3",
         weight: 100,
         enabled: true,
+        requires_explicit_preference: false,
+    },
+    ModelProviderRoute {
+        // Staged for Tinfoil's in-progress launch. Keep this route out of
+        // automatic fallback until the live catalog publishes the model and
+        // billing rates have been added.
+        provider: ProviderName::Tinfoil,
+        provider_model_id: GLM_5_3_MODEL_ID,
+        weight: 100,
+        enabled: true,
+        requires_explicit_preference: true,
     },
 ];
 
@@ -145,14 +183,24 @@ const MODEL_ROUTES: &[ModelRoutingConfig] = &[
     ModelRoutingConfig {
         public_model_id: "kimi-k2-6",
         routes: KIMI_K2_6_ROUTES,
-        continuum_flag_key: None,
+        provider_flag: None,
         default_provider: Some(ProviderName::Continuum),
     },
     ModelRoutingConfig {
         public_model_id: GLM_5_2_MODEL_ID,
         routes: GLM_5_2_ROUTES,
-        continuum_flag_key: Some(GLM_5_2_CONTINUUM_FLAG_KEY),
+        provider_flag: None,
         default_provider: Some(ProviderName::Tinfoil),
+    },
+    ModelRoutingConfig {
+        public_model_id: GLM_5_3_MODEL_ID,
+        routes: GLM_5_3_ROUTES,
+        provider_flag: Some(ProviderRoutingFlag {
+            key: GLM_5_3_TINFOIL_FLAG_KEY,
+            enabled_provider: ProviderName::Tinfoil,
+            disabled_provider: ProviderName::Continuum,
+        }),
+        default_provider: Some(ProviderName::Continuum),
     },
 ];
 
@@ -206,12 +254,12 @@ impl ProviderRouter {
         self.fallback_completion_route(proxy_router, requested_model)
     }
 
-    pub(crate) fn continuum_flag_key_for_completion_model(
+    pub(crate) fn provider_routing_flag_for_completion_model(
         &self,
         requested_model: &str,
-    ) -> Option<&'static str> {
+    ) -> Option<ProviderRoutingFlag> {
         let public_model_id = resolve_public_model_id(requested_model)?;
-        self.model_config(public_model_id)?.continuum_flag_key
+        self.model_config(public_model_id)?.provider_flag
     }
 
     fn select_configured_route(
@@ -225,6 +273,12 @@ impl ProviderRouter {
 
         for route in model_config.routes {
             if !route.enabled || route.weight == 0 {
+                continue;
+            }
+            if route.requires_explicit_preference
+                && provider_preference
+                    .is_none_or(|preference| preference.provider != route.provider)
+            {
                 continue;
             }
 
@@ -416,6 +470,9 @@ fn proxy_for_provider(proxy_router: &ProxyRouter, provider: ProviderName) -> Opt
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model_config::{ModelAliasTargets, ModelPlan, PaidModelAliasOverrides};
+    use crate::os_flags::PAID_POWERFUL_GLM_5_3_ALIAS_FLAG_KEY;
+    use std::collections::HashMap;
 
     fn proxy_router_with_both_providers() -> ProxyRouter {
         ProxyRouter::new(
@@ -438,7 +495,7 @@ mod tests {
     }
 
     #[test]
-    fn test_glm_defaults_to_tinfoil_without_feature_flag_preference() {
+    fn test_glm_5_2_always_uses_tinfoil() {
         let router = ProviderRouter::default();
         let proxy_router = proxy_router_with_both_providers();
 
@@ -460,31 +517,47 @@ mod tests {
     }
 
     #[test]
-    fn test_glm_routing_flag_key_does_not_apply_to_kimi_or_other_models() {
+    fn test_glm_5_2_and_alias_have_no_provider_routing_flag() {
         let router = ProviderRouter::default();
 
         assert_eq!(
-            router.continuum_flag_key_for_completion_model(GLM_5_2_MODEL_ID),
-            Some(GLM_5_2_CONTINUUM_FLAG_KEY)
-        );
-        assert_eq!(
-            router.continuum_flag_key_for_completion_model(
-                crate::model_config::AUTO_POWERFUL_MODEL_ID
-            ),
-            Some(GLM_5_2_CONTINUUM_FLAG_KEY)
-        );
-        assert_eq!(
-            router.continuum_flag_key_for_completion_model("kimi-k2-6"),
+            router.provider_routing_flag_for_completion_model(GLM_5_2_MODEL_ID),
             None
         );
         assert_eq!(
-            router.continuum_flag_key_for_completion_model("gpt-oss-120b"),
+            router.provider_routing_flag_for_completion_model(
+                crate::model_config::AUTO_POWERFUL_MODEL_ID
+            ),
+            None
+        );
+        assert_eq!(
+            router.provider_routing_flag_for_completion_model("kimi-k2-6"),
+            None
+        );
+        assert_eq!(
+            router.provider_routing_flag_for_completion_model("gpt-oss-120b"),
             None
         );
     }
 
     #[test]
-    fn test_glm_true_feature_flag_selects_continuum_model_id() {
+    fn test_glm_5_3_tinfoil_flag_maps_true_and_false_to_separate_providers() {
+        let router = ProviderRouter::default();
+        let flag = router
+            .provider_routing_flag_for_completion_model(GLM_5_3_MODEL_ID)
+            .expect("GLM 5.3 provider flag");
+
+        assert_eq!(flag.key(), GLM_5_3_TINFOIL_FLAG_KEY);
+        assert_eq!(flag.preference_for(true).provider, ProviderName::Tinfoil);
+        assert_eq!(flag.preference_for(false).provider, ProviderName::Continuum);
+        assert_eq!(
+            flag.preference_for(true).source,
+            ProviderSelectionSource::FeatureFlag
+        );
+    }
+
+    #[test]
+    fn test_glm_5_2_rejects_continuum_preference_and_stays_on_tinfoil() {
         let router = ProviderRouter::default();
         let proxy_router = proxy_router_with_both_providers();
 
@@ -497,19 +570,16 @@ mod tests {
             )
             .expect("route");
 
-        assert_eq!(selected.proxy.provider_name, "continuum");
+        assert_eq!(selected.proxy.provider_name, "tinfoil");
         assert_eq!(selected.public_model_id, GLM_5_2_MODEL_ID);
-        assert_eq!(selected.provider_model_id, "glm-5.2");
+        assert_eq!(selected.provider_model_id, GLM_5_2_MODEL_ID);
         assert_eq!(selected.response_model_id, GLM_5_2_MODEL_ID);
         assert_eq!(selected.bucket, None);
-        assert_eq!(
-            selected.selection_source,
-            ProviderSelectionSource::FeatureFlag
-        );
+        assert_eq!(selected.selection_source, ProviderSelectionSource::Fallback);
     }
 
     #[test]
-    fn test_glm_false_feature_flag_selects_tinfoil_model_id() {
+    fn test_generic_tinfoil_preference_selects_glm_5_2_route() {
         let router = ProviderRouter::default();
         let proxy_router = proxy_router_with_both_providers();
 
@@ -578,6 +648,70 @@ mod tests {
     }
 
     #[test]
+    fn test_glm_5_3_always_uses_continuum_and_canonicalizes_the_response() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+
+        let selected = router
+            .select_completion_route(&proxy_router, uuid_for_bucket(50), GLM_5_3_MODEL_ID)
+            .expect("route");
+
+        assert_eq!(selected.proxy.provider_name, "continuum");
+        assert_eq!(selected.public_model_id, GLM_5_3_MODEL_ID);
+        assert_eq!(selected.provider_model_id, "glm-5.3");
+        assert_eq!(selected.response_model_id, GLM_5_3_MODEL_ID);
+        assert_eq!(selected.bucket, None);
+        assert_eq!(
+            selected.selection_source,
+            ProviderSelectionSource::DefaultProvider
+        );
+    }
+
+    #[test]
+    fn test_glm_5_3_tinfoil_route_requires_explicit_enabled_preference() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        let flag = router
+            .provider_routing_flag_for_completion_model(GLM_5_3_MODEL_ID)
+            .expect("GLM 5.3 provider flag");
+
+        let selected = router
+            .select_completion_route_with_preference(
+                &proxy_router,
+                uuid_for_bucket(50),
+                GLM_5_3_MODEL_ID,
+                Some(flag.preference_for(true)),
+            )
+            .expect("Tinfoil route");
+
+        assert_eq!(selected.proxy.provider_name, "tinfoil");
+        assert_eq!(selected.public_model_id, GLM_5_3_MODEL_ID);
+        assert_eq!(selected.provider_model_id, GLM_5_3_MODEL_ID);
+        assert_eq!(selected.response_model_id, GLM_5_3_MODEL_ID);
+        assert_eq!(selected.bucket, None);
+        assert_eq!(
+            selected.selection_source,
+            ProviderSelectionSource::FeatureFlag
+        );
+
+        let selected = router
+            .select_completion_route_with_preference(
+                &proxy_router,
+                uuid_for_bucket(50),
+                GLM_5_3_MODEL_ID,
+                Some(flag.preference_for(false)),
+            )
+            .expect("PrivateMode route");
+
+        assert_eq!(selected.proxy.provider_name, "continuum");
+        assert_eq!(selected.provider_model_id, "glm-5.3");
+        assert_eq!(
+            selected.selection_source,
+            ProviderSelectionSource::FeatureFlag
+        );
+    }
+
+    #[test]
     fn test_auto_powerful_uses_glm_route_table() {
         let router = ProviderRouter::default();
         let proxy_router = proxy_router_with_both_providers();
@@ -594,6 +728,35 @@ mod tests {
         assert_eq!(selected.public_model_id, GLM_5_2_MODEL_ID);
         assert_eq!(selected.provider_model_id, GLM_5_2_MODEL_ID);
         assert_eq!(selected.response_model_id, GLM_5_2_MODEL_ID);
+        assert_eq!(selected.bucket, None);
+        assert_eq!(
+            selected.selection_source,
+            ProviderSelectionSource::DefaultProvider
+        );
+    }
+
+    #[test]
+    fn test_paid_powerful_glm_5_3_override_uses_continuum_route() {
+        let router = ProviderRouter::default();
+        let proxy_router = proxy_router_with_both_providers();
+        let flags = HashMap::from([(PAID_POWERFUL_GLM_5_3_ALIAS_FLAG_KEY.to_string(), true)]);
+        let targets = ModelAliasTargets::for_plan_with_overrides(
+            ModelPlan::Paid,
+            PaidModelAliasOverrides::from_flag_values(&flags),
+        );
+
+        let selected = router
+            .select_completion_route(
+                &proxy_router,
+                uuid_for_bucket(70),
+                targets.resolve(crate::model_config::AUTO_POWERFUL_MODEL_ID),
+            )
+            .expect("route");
+
+        assert_eq!(selected.proxy.provider_name, "continuum");
+        assert_eq!(selected.public_model_id, GLM_5_3_MODEL_ID);
+        assert_eq!(selected.provider_model_id, "glm-5.3");
+        assert_eq!(selected.response_model_id, GLM_5_3_MODEL_ID);
         assert_eq!(selected.bucket, None);
         assert_eq!(
             selected.selection_source,
@@ -759,6 +922,15 @@ mod tests {
         assert_eq!(
             error,
             ProviderRoutingError::NoEligibleRoute("kimi-k2-6".to_string())
+        );
+
+        let error = router
+            .select_completion_route(&proxy_router, uuid_for_bucket(50), GLM_5_3_MODEL_ID)
+            .expect_err("no eligible GLM 5.3 route");
+
+        assert_eq!(
+            error,
+            ProviderRoutingError::NoEligibleRoute(GLM_5_3_MODEL_ID.to_string())
         );
     }
 }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -52,6 +52,7 @@ mod tests {
         assert_eq!(model_max_ctx("kimi-k2-6"), 256_000);
         assert_eq!(model_max_ctx("gemma4-31b"), 256_000);
         assert_eq!(model_max_ctx("glm-5-2"), 256_000);
+        assert_eq!(model_max_ctx("glm-5-3"), 256_000);
         assert_eq!(model_max_ctx("kimi-k3"), 256_000);
         assert_eq!(model_max_ctx("deepseek-v4-flash"), 800_000);
         assert_eq!(model_max_ctx("auto:quick"), 128_000);

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -1,5 +1,6 @@
 use crate::model_config::{
-    model_catalog_response, openai_models_response, ModelAliasTargets, ModelPlan,
+    model_alias_requires_flag_lookup, model_catalog_response, openai_models_response,
+    ModelAliasTargets, ModelPlan,
 };
 use crate::models::token_usage::NewTokenUsage;
 use crate::models::users::User;
@@ -789,7 +790,11 @@ async fn proxy_openai(
         })?
         .to_string();
 
-    let alias_targets = ModelAliasTargets::for_plan(model_plan);
+    let alias_targets = if model_alias_requires_flag_lookup(&requested_model_name) {
+        state.model_alias_targets(user.uuid, model_plan).await
+    } else {
+        ModelAliasTargets::for_plan(model_plan)
+    };
     let model_name = alias_targets.resolve(&requested_model_name).to_string();
     if requested_model_name != model_name {
         debug!(
@@ -1777,7 +1782,7 @@ async fn proxy_model_catalog(
     let model_plan = ModelPlan::from_is_paid(
         billing_access.is_some_and(crate::billing::ChatBillingAccess::is_paid),
     );
-    let alias_targets = ModelAliasTargets::for_plan(model_plan);
+    let alias_targets = state.model_alias_targets(user.uuid, model_plan).await;
     let catalog_response = model_catalog_response(alias_targets);
     encrypt_response(&state, &session_id, &catalog_response).await
 }
@@ -2651,6 +2656,11 @@ mod tests {
             Err(ApiError::ModelNotAvailableOnPlan)
         ));
         assert!(ensure_completion_model_access("glm-5-2", ModelPlan::Paid).is_ok());
+        assert!(matches!(
+            ensure_completion_model_access("glm-5-3", ModelPlan::Free),
+            Err(ApiError::ModelNotAvailableOnPlan)
+        ));
+        assert!(ensure_completion_model_access("glm-5-3", ModelPlan::Paid).is_ok());
         assert!(matches!(
             ensure_completion_model_access(
                 crate::model_config::AUTO_POWERFUL_MODEL_ID,

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -7,8 +7,9 @@ use crate::{
     encrypt::{decrypt_content, decrypt_string, encrypt_with_key},
     jwt::AuthContext,
     model_config::{
-        model_config, model_reasoning_history_strategy, resolve_public_model_id, ModelAliasTargets,
-        ModelPlan, ReasoningHistoryStrategy, ResponsesModelConfig, SamplingConfig,
+        model_alias_requires_flag_lookup, model_config, model_reasoning_history_strategy,
+        resolve_public_model_id, ModelAliasTargets, ModelPlan, ReasoningHistoryStrategy,
+        ResponsesModelConfig, SamplingConfig,
     },
     models::responses::{
         NewToolCall, NewToolOutput, NewUserMessage, ResponseStatus, ResponsesError,
@@ -890,6 +891,14 @@ mod tests {
             "glm-5-2"
         );
         assert!(matches!(
+            resolve_responses_model("glm-5-3", "continuum", ModelPlan::Free),
+            Err(ApiError::ModelNotAvailableOnPlan)
+        ));
+        assert_eq!(
+            resolve_responses_model("glm-5-3", "continuum", ModelPlan::Paid).unwrap(),
+            "glm-5-3"
+        );
+        assert!(matches!(
             resolve_responses_model("deepseek-v4-flash", "tinfoil", ModelPlan::Free),
             Err(ApiError::ModelNotAvailableOnPlan)
         ));
@@ -946,6 +955,18 @@ mod tests {
             build_model_turn_request(&glm, &[json!({"role": "user", "content": "hello"})], false);
         assert_eq!(glm_request["chat_template_kwargs"]["clear_thinking"], false);
 
+        let glm_5_3 = responses_request_for_model("glm-5-3");
+        let glm_5_3_request = build_model_turn_request(
+            &glm_5_3,
+            &[json!({"role": "user", "content": "hello"})],
+            false,
+        );
+        assert_eq!(glm_5_3_request["model"], "glm-5-3");
+        assert_eq!(
+            glm_5_3_request["chat_template_kwargs"]["clear_thinking"],
+            false
+        );
+
         let targets = ModelAliasTargets::for_plan(ModelPlan::Paid);
         let auto_powerful = responses_request_for_model(
             targets.resolve(crate::model_config::AUTO_POWERFUL_MODEL_ID),
@@ -963,6 +984,31 @@ mod tests {
         assert!(auto_request["chat_template_kwargs"]
             .get("preserve_thinking")
             .is_none());
+
+        let flags = std::collections::HashMap::from([(
+            crate::os_flags::PAID_POWERFUL_GLM_5_3_ALIAS_FLAG_KEY.to_string(),
+            true,
+        )]);
+        let flagged_targets = ModelAliasTargets::for_plan_with_overrides(
+            ModelPlan::Paid,
+            crate::model_config::PaidModelAliasOverrides::from_flag_values(&flags),
+        );
+        let flagged_powerful = responses_request_for_model(
+            flagged_targets.resolve(crate::model_config::AUTO_POWERFUL_MODEL_ID),
+        );
+        let flagged_request = build_model_turn_request(
+            &flagged_powerful,
+            &[json!({"role": "user", "content": "hello"})],
+            false,
+        );
+        assert_eq!(
+            flagged_request["model"],
+            crate::model_config::GLM_5_3_MODEL_ID
+        );
+        assert_eq!(
+            flagged_request["chat_template_kwargs"]["clear_thinking"],
+            false
+        );
 
         let paid_quick =
             responses_request_for_model(targets.resolve(crate::model_config::AUTO_QUICK_MODEL_ID));
@@ -3776,7 +3822,11 @@ async fn create_response_stream(
         );
         return Err(ApiError::Unauthorized);
     }
-    let alias_targets = ModelAliasTargets::for_plan(model_plan);
+    let alias_targets = if model_alias_requires_flag_lookup(&requested_model) {
+        state.model_alias_targets(user.uuid, model_plan).await
+    } else {
+        ModelAliasTargets::for_plan(model_plan)
+    };
     let selected_model = alias_targets.resolve(&requested_model).to_string();
     let completion_provider = state.proxy_router.get_completion_proxy();
     let resolved_model = resolve_responses_model(


### PR DESCRIPTION
## Summary

- add `glm-5-3` as a directly selectable Pro model through PrivateMode, using the lowest shared provider context limit of 256,000 tokens
- remove PrivateMode/Continuum from all GLM 5.2 replica-provider routing so `glm-5-2` remains Tinfoil-only
- restore the paid-only, default-off `model-alias.paid.powerful.glm-5-3` override without changing Free access
- add the independent, default-off `provider-routing.glm-5-3.tinfoil` route flag
- keep the staged Tinfoil GLM 5.3 route out of automatic fallback; it requires an explicit true flag

## Rollout notes

The two decisions stay independent:

1. `model-alias.paid.powerful.glm-5-3` selects GLM 5.3 for paid `auto:powerful` users.
2. `provider-routing.glm-5-3.tinfoil` selects Tinfoil for canonical GLM 5.3 traffic; missing, false, failed, or timed-out lookups retain PrivateMode.

Tinfoil does not yet advertise GLM 5.3 or its rates in the live model catalog. Do not create or enable the Tinfoil provider flag until the model is live, billing contains its published rates, and an attested provider smoke passes.

## Coordination

- billing: https://github.com/OpenSecretCloud/maple-billing-server/pull/89
- marketing: https://github.com/OpenSecretCloud/maple-marketing/pull/25

## Validation

**Static/unit**

- `cargo fmt --all -- --check` through the pinned, state-disabled Nix shell
- warning-denied `cargo clippy --locked --all-targets --all-features -- -D warnings`
- warning-denied `cargo test --locked --all-features`: 438 passed, 0 failed, 20 ignored
- focused alias, Free/paid admission, Chat, Responses, provider-routing, canonicalization, and context-limit regressions

**Local encrypted full stack**

- built the Maple web client and signed in with an isolated local Pro user
- selected GLM 5.3 in real Google Chrome
- received the exact smoke response `MAPLE_GLM53_WEB_SMOKE_20260901_OK`
- the PrivateMode completion returned HTTP 200

**Not claimed**

- no live Tinfoil GLM 5.3 probe because the model is absent from the live catalog
- no deployment, EIF/PCR comparison, or remote feature-flag mutation
