### PR TITLE
Send in-stream errors as OpenAI-shaped JSON frames

### DIFF
--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -845,7 +845,11 @@ async fn proxy_openai(
                         Ok(event) => yield Ok::<Event, std::convert::Infallible>(event),
                         Err(e) => {
                             error!("Failed to encrypt event data: {:?}", e);
-                            yield Ok(Event::default().data("Error: Encryption failed"));
+                            // Encryption is down, so this frame cannot be
+                            // encrypted either; plaintext JSON at least
+                            // parses if the client tries.
+                            yield Ok(Event::default()
+                                .data(stream_error_payload("Encryption failed").to_string()));
                             break;
                         }
                     }
@@ -860,19 +864,48 @@ async fn proxy_openai(
                 }
                 CompletionChunk::Error(error_msg) => {
                     error!("Stream error from completion API: {}", error_msg);
-                    yield Ok(Event::default().data(format!("Error: {}", error_msg)));
+                    match encrypt_sse_event(&state, &session_id, &stream_error_payload(&error_msg)).await {
+                        Ok(event) => yield Ok(event),
+                        Err(e) => {
+                            error!("Failed to encrypt error event: {:?}", e);
+                            yield Ok(Event::default()
+                                .data(stream_error_payload(&error_msg).to_string()));
+                        }
+                    }
                     break;
                 }
                 CompletionChunk::FullResponse(_) => {
                     // Shouldn't happen in streaming mode
                     error!("Received FullResponse in streaming mode");
-                    yield Ok(Event::default().data("Error: Invalid event format"));
+                    match encrypt_sse_event(&state, &session_id, &stream_error_payload("Invalid event format")).await {
+                        Ok(event) => yield Ok(event),
+                        Err(e) => {
+                            error!("Failed to encrypt error event: {:?}", e);
+                            yield Ok(Event::default()
+                                .data(stream_error_payload("Invalid event format").to_string()));
+                        }
+                    }
                     break;
                 }
             }
         }
     };
     Ok(Sse::new(stream).into_response())
+}
+
+/// OpenAI-style error payload for in-stream failures. Streaming
+/// clients decrypt and JSON-parse every `data:` frame, so a prose
+/// frame ("Error: ...") is indistinguishable from a corrupted
+/// stream; this shape lets them surface the actual cause.
+fn stream_error_payload(message: &str) -> Value {
+    json!({
+        "error": {
+            "message": message,
+            "type": "server_error",
+            "param": null,
+            "code": null,
+        }
+    })
 }
 
 /// Internal function to get chat completion response with automatic billing
@@ -2593,6 +2626,21 @@ async fn try_provider(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn stream_error_payload_is_openai_shaped_json() {
+        let payload = stream_error_payload("Stream timeout");
+
+        assert_eq!(payload["error"]["message"], "Stream timeout");
+        assert_eq!(payload["error"]["type"], "server_error");
+        assert!(payload["error"]["param"].is_null());
+        assert!(payload["error"]["code"].is_null());
+        // The rendered frame must parse back as JSON; prose frames
+        // ("Error: ...") read as a corrupted stream to clients.
+        let rendered = payload.to_string();
+        assert!(serde_json::from_str::<Value>(&rendered).is_ok());
+        assert!(!rendered.starts_with("Error:"));
+    }
 
     #[tokio::test]
     async fn bounded_provider_response_body_accepts_exact_limit_across_chunks() {


### PR DESCRIPTION
## Problem

When a completion stream fails mid-flight (provider transport error, the 120s per-chunk idle timeout, or an unexpected `FullResponse`), the SSE consumer emits a plaintext prose frame:

```
data: Error: Stream timeout
```

Every other data frame on this stream is a session-encrypted JSON payload, so clients decrypt and JSON-parse each frame — a prose frame is indistinguishable from a corrupted stream. Observed in the wild: maple-proxy surfaces every upstream stream break as

```
Stream error: API error: 0: SSE error: Transport error: error decoding response body
```

and the actual cause (`Stream timeout`, the provider's transport error, ...) is lost. The server knows exactly what went wrong but the client can never see it.

## Fix

Emit an OpenAI-style error payload instead, encrypted through the same `encrypt_sse_event` path as normal chunks:

```json
{"error": {"message": "Stream timeout", "type": "server_error", "param": null, "code": null}}
```

When encryption itself is the failure, fall back to the same payload in plaintext — it cannot be decrypted, but it at least parses if the client tries.

Unit test pins the frame shape. `cargo check`, `cargo test`, `cargo clippy`, `cargo fmt` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)