### PR TITLE
fix(responses): make cancellation a quiescence barrier

### DIFF
--- a/src/aead_db_tamper_tests.rs
+++ b/src/aead_db_tamper_tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     db::{setup_db, DBError},
-    encrypt::encrypt_with_key,
+    encrypt::{decrypt_with_key, encrypt_with_key},
     generate_reset_hash,
     login_routes::RegisterCredentials,
     models::{
@@ -24,6 +24,7 @@ use crate::{
     },
     private_key::generate_twelve_word_seed,
     seed_wrapping::{password_reset_code_mac, CredentialKind},
+    web::responses::{handlers::StorageMessage, storage_task, StorageTaskOutcome},
     AppMode, AppState, AppStateBuilder, Error,
 };
 use chrono::Utc;
@@ -31,7 +32,7 @@ use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
 use password_auth::generate_hash;
 use secp256k1::SecretKey;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{mpsc, RwLock};
 use uuid::Uuid;
 
 fn test_credential(label: &str) -> &'static str {
@@ -1395,6 +1396,257 @@ async fn db_atomic_response_tool_items_roll_back_on_mid_batch_constraint_failure
     );
 
     let _ = app_state.db.delete_user(&owner);
+}
+
+#[tokio::test]
+#[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+async fn db_response_storage_completion_acknowledges_durable_assistant() {
+    let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+        eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+        return;
+    };
+
+    let app_state = build_local_test_app_state(database_url).await;
+    let project = first_active_project(&app_state);
+    let marker = Uuid::new_v4();
+    let user =
+        create_response_transaction_test_user(&app_state, project.id, marker, "storage-completion");
+    let conversation_id = insert_response_transaction_test_conversation(&app_state, user.uuid);
+    let response_uuid = Uuid::new_v4();
+    let response = app_state
+        .db
+        .create_response(response_transaction_test_response(
+            response_uuid,
+            user.uuid,
+            conversation_id,
+        ))
+        .expect("response should insert");
+    let assistant_item_id = Uuid::new_v4();
+    let assistant_text = "durable assistant before completion";
+    let user_key = SecretKey::from_slice(&[7u8; 32]).expect("test key should be valid");
+    let decryption_key = user_key;
+    let (storage_tx, storage_rx) = mpsc::channel(8);
+    let storage_handle = tokio::spawn(storage_task(
+        storage_rx,
+        None,
+        app_state.db.clone(),
+        response.id,
+        response_uuid,
+        Utc::now(),
+        conversation_id,
+        user.uuid,
+        user_key,
+    ));
+
+    storage_tx
+        .send(StorageMessage::MessageStarted {
+            item_id: assistant_item_id,
+        })
+        .await
+        .expect("queue assistant start");
+    storage_tx
+        .send(StorageMessage::ContentDelta {
+            item_id: assistant_item_id,
+            delta: assistant_text.to_string(),
+        })
+        .await
+        .expect("queue assistant content");
+    storage_tx
+        .send(StorageMessage::MessageDone {
+            item_id: assistant_item_id,
+            finish_reason: "stop".to_string(),
+        })
+        .await
+        .expect("queue assistant completion");
+    storage_tx
+        .send(StorageMessage::ResponseDone {
+            finish_reason: "stop".to_string(),
+        })
+        .await
+        .expect("queue response completion");
+
+    assert_eq!(
+        storage_handle.await.expect("join storage task"),
+        StorageTaskOutcome::Completed
+    );
+    let persisted_response = app_state
+        .db
+        .get_response_by_uuid_and_user(response_uuid, user.uuid)
+        .expect("completed response should be readable");
+    assert_eq!(persisted_response.status, ResponseStatus::Completed);
+    let assistant = app_state
+        .db
+        .get_assistant_message_by_uuid(assistant_item_id)
+        .expect("assistant lookup should succeed")
+        .expect("assistant should exist before completion acknowledgement");
+    assert_eq!(assistant.response_id, Some(response.id));
+    assert_eq!(assistant.status, "completed");
+    assert_eq!(assistant.finish_reason.as_deref(), Some("stop"));
+    let plaintext = decrypt_with_key(
+        &decryption_key,
+        assistant
+            .content_enc
+            .as_deref()
+            .expect("completed assistant should have ciphertext"),
+    )
+    .expect("assistant ciphertext should decrypt");
+    assert_eq!(plaintext, assistant_text.as_bytes());
+
+    let _ = app_state.db.delete_user(&user);
+}
+
+#[tokio::test]
+#[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+async fn db_response_storage_completion_yields_to_committed_cancellation() {
+    let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+        eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+        return;
+    };
+
+    let app_state = build_local_test_app_state(database_url).await;
+    let project = first_active_project(&app_state);
+    let marker = Uuid::new_v4();
+    let user = create_response_transaction_test_user(
+        &app_state,
+        project.id,
+        marker,
+        "storage-cancellation-race",
+    );
+    let conversation_id = insert_response_transaction_test_conversation(&app_state, user.uuid);
+    let response_uuid = Uuid::new_v4();
+    let response = app_state
+        .db
+        .create_response(response_transaction_test_response(
+            response_uuid,
+            user.uuid,
+            conversation_id,
+        ))
+        .expect("response should insert");
+    app_state
+        .db
+        .cancel_response(response_uuid, user.uuid)
+        .expect("cancellation should commit before its broadcast");
+    let user_key = SecretKey::from_slice(&[8u8; 32]).expect("test key should be valid");
+    let (storage_tx, storage_rx) = mpsc::channel(2);
+    let storage_handle = tokio::spawn(storage_task(
+        storage_rx,
+        None,
+        app_state.db.clone(),
+        response.id,
+        response_uuid,
+        Utc::now(),
+        conversation_id,
+        user.uuid,
+        user_key,
+    ));
+    storage_tx
+        .send(StorageMessage::ResponseDone {
+            finish_reason: "stop".to_string(),
+        })
+        .await
+        .expect("queue racing response completion");
+
+    assert_eq!(
+        storage_handle.await.expect("join storage task"),
+        StorageTaskOutcome::Cancelled
+    );
+    let persisted_response = app_state
+        .db
+        .get_response_by_uuid_and_user(response_uuid, user.uuid)
+        .expect("cancelled response should be readable");
+    assert_eq!(persisted_response.status, ResponseStatus::Cancelled);
+
+    let _ = app_state.db.delete_user(&user);
+}
+
+#[tokio::test]
+#[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]
+async fn db_response_storage_write_failure_never_acknowledges_completion() {
+    let Some(database_url) = std::env::var("AEAD_TAMPER_TEST_DATABASE_URL").ok() else {
+        eprintln!("skipping: AEAD_TAMPER_TEST_DATABASE_URL is not set");
+        return;
+    };
+
+    let app_state = build_local_test_app_state(database_url).await;
+    let project = first_active_project(&app_state);
+    let marker = Uuid::new_v4();
+    let user = create_response_transaction_test_user(
+        &app_state,
+        project.id,
+        marker,
+        "storage-write-failure",
+    );
+    let conversation_id = insert_response_transaction_test_conversation(&app_state, user.uuid);
+    let response_uuid = Uuid::new_v4();
+    let response = app_state
+        .db
+        .create_response(response_transaction_test_response(
+            response_uuid,
+            user.uuid,
+            conversation_id,
+        ))
+        .expect("response should insert");
+    let missing_conversation_id = i64::MAX;
+    let assistant_item_id = Uuid::new_v4();
+    let user_key = SecretKey::from_slice(&[9u8; 32]).expect("test key should be valid");
+    let (storage_tx, storage_rx) = mpsc::channel(8);
+    let storage_handle = tokio::spawn(storage_task(
+        storage_rx,
+        None,
+        app_state.db.clone(),
+        response.id,
+        response_uuid,
+        Utc::now(),
+        missing_conversation_id,
+        user.uuid,
+        user_key,
+    ));
+    storage_tx
+        .send(StorageMessage::MessageStarted {
+            item_id: assistant_item_id,
+        })
+        .await
+        .expect("queue assistant start");
+    storage_tx
+        .send(StorageMessage::ContentDelta {
+            item_id: assistant_item_id,
+            delta: "must not be acknowledged".to_string(),
+        })
+        .await
+        .expect("queue assistant content");
+    storage_tx
+        .send(StorageMessage::MessageDone {
+            item_id: assistant_item_id,
+            finish_reason: "stop".to_string(),
+        })
+        .await
+        .expect("queue assistant completion");
+    storage_tx
+        .send(StorageMessage::ResponseDone {
+            finish_reason: "stop".to_string(),
+        })
+        .await
+        .expect("queue response completion");
+
+    assert_eq!(
+        storage_handle.await.expect("join storage task"),
+        StorageTaskOutcome::Failed
+    );
+    let persisted_response = app_state
+        .db
+        .get_response_by_uuid_and_user(response_uuid, user.uuid)
+        .expect("failed response should be readable");
+    assert_eq!(persisted_response.status, ResponseStatus::Failed);
+    assert!(
+        app_state
+            .db
+            .get_assistant_message_by_uuid(assistant_item_id)
+            .expect("assistant lookup should succeed")
+            .is_none(),
+        "failed assistant write must not produce a false durable item"
+    );
+
+    let _ = app_state.db.delete_user(&user);
 }
 
 fn create_response_transaction_test_user(

--- a/src/main.rs
+++ b/src/main.rs
@@ -789,7 +789,7 @@ pub struct AppState {
     billing_client: Option<BillingClient>,
     os_flags_client: Option<os_flags::OsFlagsClient>,
     apple_jwt_verifier: Arc<AppleJwtVerifier>,
-    cancellation_broadcast: tokio::sync::broadcast::Sender<Uuid>,
+    response_executions: web::responses::ResponseExecutionRegistry,
     kagi_client: Option<Arc<crate::kagi::KagiClient>>,
 }
 
@@ -1085,8 +1085,6 @@ impl AppStateBuilder {
         ));
         let provider_router = Arc::new(ProviderRouter::default());
 
-        let (cancellation_tx, _) = tokio::sync::broadcast::channel(1024);
-
         let kagi_client = if let Some(ref api_key) = self.kagi_api_key {
             tracing::info!("Initializing Kagi client");
             match crate::kagi::KagiClient::new(api_key.clone()) {
@@ -1132,7 +1130,7 @@ impl AppStateBuilder {
             billing_client,
             os_flags_client,
             apple_jwt_verifier,
-            cancellation_broadcast: cancellation_tx,
+            response_executions: web::responses::ResponseExecutionRegistry::default(),
             kagi_client,
         })
     }

--- a/src/models/responses.rs
+++ b/src/models/responses.rs
@@ -1225,6 +1225,8 @@ pub struct RawThreadMessage {
     pub id: i64,
     #[diesel(sql_type = diesel::sql_types::Uuid)]
     pub uuid: Uuid,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Uuid>)]
+    pub response_uuid: Option<Uuid>,
     #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Bytea>)]
     pub content_enc: Option<Vec<u8>>,
     #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
@@ -1268,6 +1270,7 @@ impl RawThreadMessage {
                         'user' as message_type,
                         um.id,
                         um.uuid,
+                        r.uuid as response_uuid,
                         um.content_enc,
                         'completed'::text as status,
                         um.created_at,
@@ -1287,6 +1290,7 @@ impl RawThreadMessage {
                         'assistant' as message_type,
                         am.id,
                         am.uuid,
+                        r.uuid as response_uuid,
                         am.content_enc,
                         am.status,
                         am.created_at,
@@ -1306,6 +1310,7 @@ impl RawThreadMessage {
                         'tool_call' as message_type,
                         tc.id,
                         tc.uuid,
+                        r.uuid as response_uuid,
                         tc.arguments_enc as content_enc,
                         'completed'::text as status,
                         tc.created_at,
@@ -1315,6 +1320,7 @@ impl RawThreadMessage {
                         NULL::text as finish_reason,
                         tc.name as tool_name
                     FROM tool_calls tc
+                    LEFT JOIN responses r ON tc.response_id = r.id
                     WHERE tc.conversation_id = $1
 
                     UNION ALL
@@ -1324,6 +1330,7 @@ impl RawThreadMessage {
                         'tool_output' as message_type,
                         tto.id,
                         tto.uuid,
+                        r.uuid as response_uuid,
                         tto.output_enc as content_enc,
                         'completed'::text as status,
                         tto.created_at,
@@ -1334,6 +1341,7 @@ impl RawThreadMessage {
                         tc.name as tool_name
                     FROM tool_outputs tto
                     JOIN tool_calls tc ON tto.tool_call_fk = tc.id
+                    LEFT JOIN responses r ON tto.response_id = r.id
                     WHERE tto.conversation_id = $1
 
                     UNION ALL
@@ -1343,6 +1351,7 @@ impl RawThreadMessage {
                         'reasoning' as message_type,
                         ri.id,
                         ri.uuid,
+                        r.uuid as response_uuid,
                         ri.content_enc,
                         ri.status,
                         ri.created_at,
@@ -1352,6 +1361,7 @@ impl RawThreadMessage {
                         NULL::text as finish_reason,
                         NULL::text as tool_name
                     FROM reasoning_items ri
+                    LEFT JOIN responses r ON ri.response_id = r.id
                     WHERE ri.conversation_id = $1
                 ),
                 cursor_message AS (
@@ -1381,6 +1391,7 @@ impl RawThreadMessage {
                         'user' as message_type,
                         um.id,
                         um.uuid,
+                        r.uuid as response_uuid,
                         um.content_enc,
                         'completed'::text as status,
                         um.created_at,
@@ -1400,6 +1411,7 @@ impl RawThreadMessage {
                         'assistant' as message_type,
                         am.id,
                         am.uuid,
+                        r.uuid as response_uuid,
                         am.content_enc,
                         am.status,
                         am.created_at,
@@ -1419,6 +1431,7 @@ impl RawThreadMessage {
                         'tool_call' as message_type,
                         tc.id,
                         tc.uuid,
+                        r.uuid as response_uuid,
                         tc.arguments_enc as content_enc,
                         'completed'::text as status,
                         tc.created_at,
@@ -1428,6 +1441,7 @@ impl RawThreadMessage {
                         NULL::text as finish_reason,
                         tc.name as tool_name
                     FROM tool_calls tc
+                    LEFT JOIN responses r ON tc.response_id = r.id
                     WHERE tc.conversation_id = $1
 
                     UNION ALL
@@ -1437,6 +1451,7 @@ impl RawThreadMessage {
                         'tool_output' as message_type,
                         tto.id,
                         tto.uuid,
+                        r.uuid as response_uuid,
                         tto.output_enc as content_enc,
                         'completed'::text as status,
                         tto.created_at,
@@ -1447,6 +1462,7 @@ impl RawThreadMessage {
                         tc.name as tool_name
                     FROM tool_outputs tto
                     JOIN tool_calls tc ON tto.tool_call_fk = tc.id
+                    LEFT JOIN responses r ON tto.response_id = r.id
                     WHERE tto.conversation_id = $1
 
                     UNION ALL
@@ -1456,6 +1472,7 @@ impl RawThreadMessage {
                         'reasoning' as message_type,
                         ri.id,
                         ri.uuid,
+                        r.uuid as response_uuid,
                         ri.content_enc,
                         ri.status,
                         ri.created_at,
@@ -1465,6 +1482,7 @@ impl RawThreadMessage {
                         NULL::text as finish_reason,
                         NULL::text as tool_name
                     FROM reasoning_items ri
+                    LEFT JOIN responses r ON ri.response_id = r.id
                     WHERE ri.conversation_id = $1
                 )
                 SELECT *
@@ -1503,6 +1521,7 @@ impl RawThreadMessage {
                     'user' as message_type,
                     um.id,
                     um.uuid,
+                    r.uuid as response_uuid,
                     um.content_enc,
                     'completed'::text as status,
                     um.created_at,
@@ -1522,6 +1541,7 @@ impl RawThreadMessage {
                     'assistant' as message_type,
                     am.id,
                     am.uuid,
+                    r.uuid as response_uuid,
                     am.content_enc,
                     am.status,
                     am.created_at,
@@ -1541,6 +1561,7 @@ impl RawThreadMessage {
                     'tool_call' as message_type,
                     tc.id,
                     tc.uuid,
+                    r.uuid as response_uuid,
                     tc.arguments_enc as content_enc,
                     'completed'::text as status,
                     tc.created_at,
@@ -1550,6 +1571,7 @@ impl RawThreadMessage {
                     NULL::text as finish_reason,
                     tc.name as tool_name
                 FROM tool_calls tc
+                LEFT JOIN responses r ON tc.response_id = r.id
                 WHERE tc.response_id = $1
 
                 UNION ALL
@@ -1559,6 +1581,7 @@ impl RawThreadMessage {
                     'tool_output' as message_type,
                     tto.id,
                     tto.uuid,
+                    r.uuid as response_uuid,
                     tto.output_enc as content_enc,
                     'completed'::text as status,
                     tto.created_at,
@@ -1569,6 +1592,7 @@ impl RawThreadMessage {
                     tc.name as tool_name
                 FROM tool_outputs tto
                 JOIN tool_calls tc ON tto.tool_call_fk = tc.id
+                LEFT JOIN responses r ON tto.response_id = r.id
                 WHERE tto.response_id = $1
 
                 UNION ALL
@@ -1578,6 +1602,7 @@ impl RawThreadMessage {
                     'reasoning' as message_type,
                     ri.id,
                     ri.uuid,
+                    r.uuid as response_uuid,
                     ri.content_enc,
                     ri.status,
                     ri.created_at,
@@ -1587,6 +1612,7 @@ impl RawThreadMessage {
                     NULL::text as finish_reason,
                     NULL::text as tool_name
                 FROM reasoning_items ri
+                LEFT JOIN responses r ON ri.response_id = r.id
                 WHERE ri.response_id = $1
             )
             SELECT * FROM response_messages
@@ -1645,6 +1671,7 @@ impl RawThreadMessage {
                     'user' as message_type,
                     um.id,
                     um.uuid,
+                    r.uuid as response_uuid,
                     um.content_enc,
                     'completed'::text as status,
                     um.created_at,
@@ -1664,6 +1691,7 @@ impl RawThreadMessage {
                     'assistant' as message_type,
                     am.id,
                     am.uuid,
+                    r.uuid as response_uuid,
                     am.content_enc,
                     am.status,
                     am.created_at,
@@ -1683,6 +1711,7 @@ impl RawThreadMessage {
                     'tool_call' as message_type,
                     tc.id,
                     tc.uuid,
+                    r.uuid as response_uuid,
                     tc.arguments_enc as content_enc,
                     'completed'::text as status,
                     tc.created_at,
@@ -1692,6 +1721,7 @@ impl RawThreadMessage {
                     NULL::text as finish_reason,
                     tc.name as tool_name
                 FROM tool_calls tc
+                LEFT JOIN responses r ON tc.response_id = r.id
                 WHERE tc.conversation_id = $1
 
                 UNION ALL
@@ -1701,6 +1731,7 @@ impl RawThreadMessage {
                     'tool_output' as message_type,
                     tto.id,
                     tto.uuid,
+                    r.uuid as response_uuid,
                     tto.output_enc as content_enc,
                     'completed'::text as status,
                     tto.created_at,
@@ -1711,6 +1742,7 @@ impl RawThreadMessage {
                     tc.name as tool_name
                 FROM tool_outputs tto
                 JOIN tool_calls tc ON tto.tool_call_fk = tc.id
+                LEFT JOIN responses r ON tto.response_id = r.id
                 WHERE tto.conversation_id = $1
 
                 UNION ALL
@@ -1720,6 +1752,7 @@ impl RawThreadMessage {
                     'reasoning' as message_type,
                     ri.id,
                     ri.uuid,
+                    r.uuid as response_uuid,
                     ri.content_enc,
                     ri.status,
                     ri.created_at,
@@ -1729,6 +1762,7 @@ impl RawThreadMessage {
                     NULL::text as finish_reason,
                     NULL::text as tool_name
                 FROM reasoning_items ri
+                LEFT JOIN responses r ON ri.response_id = r.id
                 WHERE ri.conversation_id = $1
             )
             SELECT * FROM conversation_messages

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -13,6 +13,7 @@ use crate::sqs::UsageEvent;
 use crate::web::audio_utils::{merge_transcriptions, AudioSplitter, TINFOIL_MAX_SIZE};
 use crate::web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse};
 use crate::web::openai_auth::AuthMethod;
+use crate::web::responses::{ResponseExecution, ResponseExecutionTaskGuard};
 use crate::{ApiError, AppState};
 use axum::http::HeaderMap;
 use axum::{
@@ -933,6 +934,37 @@ pub async fn get_chat_completion_response(
         billing_context,
         model_plan,
         None,
+        None,
+        None,
+    )
+    .await
+}
+
+/// Responses-only completion entry point with process-local task ownership.
+/// Ordinary Chat Completions retain their existing independent lifecycle.
+pub(crate) async fn get_chat_completion_response_for_execution(
+    state: &Arc<AppState>,
+    user: &User,
+    body: Value,
+    headers: &HeaderMap,
+    billing_context: BillingContext,
+    model_plan: ModelPlan,
+    response_execution: ResponseExecution,
+) -> Result<CompletionStream, ApiError> {
+    let response_execution_guard = response_execution.begin_task().map_err(|_| {
+        debug!("Response execution was cancelled before a provider turn could start");
+        ApiError::ServiceUnavailable
+    })?;
+    get_chat_completion_response_with_expected_route(
+        state,
+        user,
+        body,
+        headers,
+        billing_context,
+        model_plan,
+        None,
+        Some(response_execution),
+        Some(response_execution_guard),
     )
     .await
 }
@@ -964,6 +996,8 @@ pub(crate) async fn get_chat_completion_response_for_expected_route(
             provider_model_id: route.provider_model_id,
             continuum_cache_salt,
         }),
+        None,
+        None,
     )
     .await
 }
@@ -989,6 +1023,8 @@ async fn get_chat_completion_response_with_expected_route(
     mut billing_context: BillingContext,
     model_plan: ModelPlan,
     expected_route: Option<ExpectedCompletionRoute<'_>>,
+    response_execution: Option<ResponseExecution>,
+    response_execution_guard: Option<ResponseExecutionTaskGuard>,
 ) -> Result<CompletionStream, ApiError> {
     if body.is_null() || body.as_object().is_none_or(|obj| obj.is_empty()) {
         error!("Request body is empty or invalid");
@@ -1248,17 +1284,40 @@ async fn get_chat_completion_response_with_expected_route(
     let response_model_id = selected_route.response_model_id.clone();
 
     tokio::spawn(async move {
+        let _response_execution_guard = response_execution_guard;
         let mut body_stream = res.bytes_stream();
         let mut buffer = Vec::new();
         let mut usage_accumulator = StreamUsageAccumulator::default();
 
         loop {
-            match timeout(
+            let next_chunk = timeout(
                 Duration::from_secs(STREAM_CHUNK_TIMEOUT_SECS),
                 body_stream.next(),
-            )
-            .await
-            {
+            );
+            tokio::pin!(next_chunk);
+            let next_chunk = if let Some(execution) = response_execution.as_ref() {
+                tokio::select! {
+                    biased;
+                    _ = execution.cancelled() => {
+                        finalize_stream_usage(
+                            &mut usage_accumulator,
+                            StreamUsageFinalization::ConsumerDropped,
+                            &state_clone,
+                            &user_clone,
+                            &billing_ctx,
+                            &provider,
+                            &tx_consumer,
+                        )
+                        .await;
+                        return;
+                    }
+                    result = &mut next_chunk => result,
+                }
+            } else {
+                next_chunk.await
+            };
+
+            match next_chunk {
                 Ok(Some(chunk_result)) => {
                     match chunk_result {
                         Ok(bytes) => {

--- a/src/web/responses/context_builder.rs
+++ b/src/web/responses/context_builder.rs
@@ -1911,6 +1911,7 @@ mod tests {
             message_type: message_type.to_string(),
             id,
             uuid: uuid::Uuid::new_v4(),
+            response_uuid: None,
             content_enc: None,
             status: Some("completed".to_string()),
             created_at: chrono::Utc::now(),

--- a/src/web/responses/conversions.rs
+++ b/src/web/responses/conversions.rs
@@ -303,6 +303,9 @@ pub enum ConversationItem {
     #[serde(rename = "message")]
     Message {
         id: Uuid,
+        /// Response that created this item, if it was created through the Responses API.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        response_id: Option<Uuid>,
         #[serde(skip_serializing_if = "Option::is_none")]
         status: Option<String>,
         role: String,
@@ -313,6 +316,9 @@ pub enum ConversationItem {
     #[serde(rename = "function_call")]
     FunctionToolCall {
         id: Uuid,
+        /// Response that created this item, if it was created through the Responses API.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        response_id: Option<Uuid>,
         call_id: Uuid,
         name: String,
         arguments: String,
@@ -324,6 +330,9 @@ pub enum ConversationItem {
     #[serde(rename = "function_call_output")]
     FunctionToolCallOutput {
         id: Uuid,
+        /// Response that created this item, if it was created through the Responses API.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        response_id: Option<Uuid>,
         call_id: Uuid,
         output: String,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -335,6 +344,9 @@ pub enum ConversationItem {
     #[serde(rename = "reasoning")]
     Reasoning {
         id: Uuid,
+        /// Response that created this item, if it was created through the Responses API.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        response_id: Option<Uuid>,
         /// Reasoning text content
         content: Vec<ReasoningContentItem>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -407,6 +419,7 @@ impl ConversationItemConverter {
 
         Ok(ConversationItem::Message {
             id: msg.uuid,
+            response_id: msg.response_uuid,
             status: msg.status.clone(),
             role: ROLE_USER.to_string(),
             content: Vec::<ConversationContent>::from(message_content),
@@ -429,6 +442,7 @@ impl ConversationItemConverter {
 
         Ok(ConversationItem::Message {
             id: msg.uuid,
+            response_id: msg.response_uuid,
             status: msg.status.clone(),
             role: ROLE_ASSISTANT.to_string(),
             content: content_parts,
@@ -443,6 +457,7 @@ impl ConversationItemConverter {
     ) -> Result<ConversationItem, ApiError> {
         Ok(ConversationItem::FunctionToolCall {
             id: msg.uuid,
+            response_id: msg.response_uuid,
             call_id: msg.tool_call_id.ok_or_else(|| {
                 error!("tool_call_id missing for tool call");
                 ApiError::InternalServerError
@@ -464,6 +479,7 @@ impl ConversationItemConverter {
     ) -> Result<ConversationItem, ApiError> {
         Ok(ConversationItem::FunctionToolCallOutput {
             id: msg.uuid,
+            response_id: msg.response_uuid,
             call_id: msg.tool_call_id.ok_or_else(|| {
                 error!("tool_call_id missing for tool output");
                 ApiError::InternalServerError
@@ -488,6 +504,7 @@ impl ConversationItemConverter {
 
         Ok(ConversationItem::Reasoning {
             id: msg.uuid,
+            response_id: msg.response_uuid,
             content: content_items,
             status: msg.status.clone(),
             created_at: Some(msg.created_at.timestamp()),
@@ -528,12 +545,83 @@ impl ConversationItemConverter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::encrypt::encrypt_with_key;
+
+    async fn serialized_conversation_items(response_uuid: Option<Uuid>) -> Vec<Value> {
+        let user_key = SecretKey::from_slice(&[0x42; 32]).expect("valid test key");
+        let tool_call_id = Uuid::new_v4();
+        let cases = [
+            (
+                "user",
+                serde_json::to_string(&MessageContent::Text("hello".to_string()))
+                    .expect("serialize user content"),
+                None,
+                None,
+            ),
+            ("assistant", "hello back".to_string(), None, None),
+            (
+                "tool_call",
+                r#"{"query":"hello"}"#.to_string(),
+                Some(tool_call_id),
+                Some("search".to_string()),
+            ),
+            (
+                "tool_output",
+                "result".to_string(),
+                Some(tool_call_id),
+                Some("search".to_string()),
+            ),
+            ("reasoning", "thinking".to_string(), None, None),
+        ];
+
+        let mut values = Vec::with_capacity(cases.len());
+        for (message_type, content, item_tool_call_id, tool_name) in cases {
+            let raw_message = RawThreadMessage {
+                message_type: message_type.to_string(),
+                id: 1,
+                uuid: Uuid::new_v4(),
+                response_uuid,
+                content_enc: Some(encrypt_with_key(&user_key, content.as_bytes()).await),
+                status: Some("completed".to_string()),
+                created_at: chrono::Utc::now(),
+                model: None,
+                token_count: Some(1),
+                tool_call_id: item_tool_call_id,
+                finish_reason: None,
+                tool_name,
+            };
+            let item = ConversationItemConverter::message_to_item(&raw_message, &user_key)
+                .expect("convert conversation item");
+            values.push(serde_json::to_value(item).expect("serialize conversation item"));
+        }
+
+        values
+    }
 
     fn input_image(image_url: Option<&str>) -> MessageContentPart {
         MessageContentPart::InputImage {
             image_url: image_url.map(str::to_string),
             file_id: None,
             detail: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn response_id_is_serialized_for_every_response_backed_conversation_item() {
+        let response_uuid = Uuid::new_v4();
+
+        for item in serialized_conversation_items(Some(response_uuid)).await {
+            assert_eq!(item.get("response_id"), Some(&json!(response_uuid)));
+        }
+    }
+
+    #[tokio::test]
+    async fn response_id_is_omitted_for_standalone_conversation_items() {
+        for item in serialized_conversation_items(None).await {
+            assert!(!item
+                .as_object()
+                .expect("conversation item object")
+                .contains_key("response_id"));
         }
     }
 

--- a/src/web/responses/execution.rs
+++ b/src/web/responses/execution.rs
@@ -1,0 +1,399 @@
+//! In-memory ownership for one live Responses execution.
+//!
+//! The database response status describes durable transcript state. It cannot
+//! by itself prove that the main provider work has stopped. This registry
+//! provides that process-local execution barrier. Usage publication,
+//! conversation-title, and pre-persistence image-description work deliberately
+//! retain their independent lifecycles.
+
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex, Weak,
+    },
+};
+use tokio::sync::{watch, Notify};
+use uuid::Uuid;
+
+#[derive(Clone, Default)]
+pub(crate) struct ResponseExecutionRegistry {
+    inner: Arc<RegistryInner>,
+}
+
+#[derive(Default)]
+struct RegistryInner {
+    entries: Mutex<HashMap<Uuid, Arc<ResponseExecutionInner>>>,
+}
+
+struct ResponseExecutionInner {
+    response_id: Uuid,
+    user_id: Uuid,
+    cancellation: watch::Sender<bool>,
+    task_state: Mutex<ResponseExecutionTaskState>,
+    task_finished: Notify,
+    owner_finished: AtomicBool,
+    registry: Weak<RegistryInner>,
+}
+
+struct ResponseExecutionTaskState {
+    accepting_tasks: bool,
+    active_tasks: usize,
+}
+
+#[derive(Clone)]
+pub(crate) struct ResponseExecution {
+    inner: Arc<ResponseExecutionInner>,
+}
+
+pub(crate) struct ResponseExecutionRegistration {
+    execution: ResponseExecution,
+}
+
+pub(crate) struct ResponseExecutionTaskGuard {
+    inner: Arc<ResponseExecutionInner>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DuplicateResponseExecution;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ClosedResponseExecution;
+
+impl ResponseExecutionRegistry {
+    pub(crate) fn register(
+        &self,
+        response_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<ResponseExecutionRegistration, DuplicateResponseExecution> {
+        let (cancellation, _) = watch::channel(false);
+        let execution = Arc::new(ResponseExecutionInner {
+            response_id,
+            user_id,
+            cancellation,
+            task_state: Mutex::new(ResponseExecutionTaskState {
+                accepting_tasks: true,
+                active_tasks: 0,
+            }),
+            task_finished: Notify::new(),
+            owner_finished: AtomicBool::new(false),
+            registry: Arc::downgrade(&self.inner),
+        });
+
+        let mut entries = self
+            .inner
+            .entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if entries.contains_key(&response_id) {
+            return Err(DuplicateResponseExecution);
+        }
+        entries.insert(response_id, execution.clone());
+
+        Ok(ResponseExecutionRegistration {
+            execution: ResponseExecution { inner: execution },
+        })
+    }
+
+    pub(crate) fn execution_for_user(
+        &self,
+        response_id: Uuid,
+        user_id: Uuid,
+    ) -> Option<ResponseExecution> {
+        let entries = self
+            .inner
+            .entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        entries
+            .get(&response_id)
+            .filter(|execution| execution.user_id == user_id)
+            .cloned()
+            .map(|inner| ResponseExecution { inner })
+    }
+
+    #[cfg(test)]
+    fn contains(&self, response_id: Uuid) -> bool {
+        self.inner
+            .entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .contains_key(&response_id)
+    }
+}
+
+impl ResponseExecutionRegistration {
+    pub(crate) fn execution(&self) -> ResponseExecution {
+        self.execution.clone()
+    }
+}
+
+impl Drop for ResponseExecutionRegistration {
+    fn drop(&mut self) {
+        let mut state = self
+            .execution
+            .inner
+            .task_state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        self.execution
+            .inner
+            .owner_finished
+            .store(true, Ordering::Release);
+        if state.active_tasks == 0 {
+            // Seal the zero-child transition under the same lock used by
+            // begin_task. A retained execution handle cannot race owner
+            // completion and register work after observers saw quiescence.
+            state.accepting_tasks = false;
+        }
+        drop(state);
+        self.execution.inner.task_finished.notify_waiters();
+        remove_if_finished(&self.execution.inner);
+    }
+}
+
+impl ResponseExecution {
+    /// Acquire task ownership synchronously before spawning the child.
+    pub(crate) fn begin_task(&self) -> Result<ResponseExecutionTaskGuard, ClosedResponseExecution> {
+        let mut state = self
+            .inner
+            .task_state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !state.accepting_tasks {
+            return Err(ClosedResponseExecution);
+        }
+        state.active_tasks += 1;
+        Ok(ResponseExecutionTaskGuard {
+            inner: self.inner.clone(),
+        })
+    }
+
+    /// Cancellation is sticky so children registered after the request raced
+    /// with setup still observe it before doing provider or persistence work.
+    pub(crate) fn cancel(&self) {
+        self.inner
+            .task_state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .accepting_tasks = false;
+        self.inner.cancellation.send_replace(true);
+    }
+
+    pub(crate) async fn cancelled(&self) {
+        let mut cancellation = self.inner.cancellation.subscribe();
+        if *cancellation.borrow() {
+            return;
+        }
+
+        while cancellation.changed().await.is_ok() {
+            if *cancellation.borrow() {
+                return;
+            }
+        }
+
+        // The sender lives as long as this execution, so channel closure is
+        // equivalent to the execution owner going away.
+    }
+
+    pub(crate) async fn wait_for_quiescence(&self) {
+        loop {
+            let finished = self.inner.task_finished.notified();
+            tokio::pin!(finished);
+            // Register this waiter before reading the counter so a child cannot
+            // drop between the read and await and lose the wakeup.
+            finished.as_mut().enable();
+            let active_tasks = self
+                .inner
+                .task_state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .active_tasks;
+            if active_tasks == 0 && self.inner.owner_finished.load(Ordering::Acquire) {
+                return;
+            }
+            finished.await;
+        }
+    }
+}
+
+impl Drop for ResponseExecutionTaskGuard {
+    fn drop(&mut self) {
+        let mut state = self
+            .inner
+            .task_state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        debug_assert!(
+            state.active_tasks > 0,
+            "response execution task count underflow"
+        );
+        state.active_tasks = state.active_tasks.saturating_sub(1);
+        if state.active_tasks == 0 && self.inner.owner_finished.load(Ordering::Acquire) {
+            state.accepting_tasks = false;
+        }
+        drop(state);
+        self.inner.task_finished.notify_waiters();
+        remove_if_finished(&self.inner);
+    }
+}
+
+fn remove_if_finished(execution: &Arc<ResponseExecutionInner>) {
+    if !execution.owner_finished.load(Ordering::Acquire) {
+        return;
+    }
+
+    let mut task_state = execution
+        .task_state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if task_state.active_tasks != 0 {
+        return;
+    }
+    // Seal natural completion before removing the map entry. A retained Arc
+    // can no longer create work after observers saw a stable zero count.
+    task_state.accepting_tasks = false;
+    drop(task_state);
+
+    let Some(registry) = execution.registry.upgrade() else {
+        return;
+    };
+    let mut entries = registry
+        .entries
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if entries
+        .get(&execution.response_id)
+        .is_some_and(|current| Arc::ptr_eq(current, execution))
+    {
+        entries.remove(&execution.response_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::time::{timeout, Duration};
+
+    #[tokio::test]
+    async fn cancellation_is_sticky_for_late_children() {
+        let registry = ResponseExecutionRegistry::default();
+        let response_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let registration = registry.register(response_id, user_id).unwrap();
+        let execution = registration.execution();
+
+        execution.cancel();
+
+        timeout(Duration::from_millis(50), execution.cancelled())
+            .await
+            .expect("late child must observe prior cancellation");
+    }
+
+    #[tokio::test]
+    async fn quiescence_waits_for_every_synchronously_registered_child() {
+        let registry = ResponseExecutionRegistry::default();
+        let registration = registry.register(Uuid::new_v4(), Uuid::new_v4()).unwrap();
+        let execution = registration.execution();
+        let first = execution.begin_task().unwrap();
+        let second = execution.begin_task().unwrap();
+
+        let waiter = tokio::spawn({
+            let execution = execution.clone();
+            async move { execution.wait_for_quiescence().await }
+        });
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished());
+
+        drop(first);
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished());
+
+        drop(second);
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished());
+
+        drop(registration);
+        timeout(Duration::from_millis(50), waiter)
+            .await
+            .expect("all child guards released")
+            .expect("join quiescence waiter");
+    }
+
+    #[tokio::test]
+    async fn zero_child_execution_does_not_quiesce_before_registration_finishes() {
+        let registry = ResponseExecutionRegistry::default();
+        let registration = registry.register(Uuid::new_v4(), Uuid::new_v4()).unwrap();
+        let execution = registration.execution();
+
+        let waiter = tokio::spawn({
+            let execution = execution.clone();
+            async move { execution.wait_for_quiescence().await }
+        });
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished());
+
+        drop(registration);
+        timeout(Duration::from_millis(50), waiter)
+            .await
+            .expect("owner completion releases quiescence waiter")
+            .expect("join quiescence waiter");
+        assert!(execution.begin_task().is_err());
+    }
+
+    #[test]
+    fn lookup_is_user_scoped_and_duplicate_registration_is_rejected() {
+        let registry = ResponseExecutionRegistry::default();
+        let response_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let _registration = registry.register(response_id, user_id).unwrap();
+
+        assert!(registry.execution_for_user(response_id, user_id).is_some());
+        assert!(registry
+            .execution_for_user(response_id, Uuid::new_v4())
+            .is_none());
+        assert!(registry.register(response_id, user_id).is_err());
+    }
+
+    #[test]
+    fn registration_is_removed_only_after_owner_and_children_finish() {
+        let registry = ResponseExecutionRegistry::default();
+        let response_id = Uuid::new_v4();
+        let registration = registry.register(response_id, Uuid::new_v4()).unwrap();
+        let execution = registration.execution();
+        let child = execution.begin_task().unwrap();
+
+        drop(registration);
+        assert!(registry.contains(response_id));
+
+        drop(child);
+        assert!(!registry.contains(response_id));
+        assert!(execution.begin_task().is_err());
+    }
+
+    #[tokio::test]
+    async fn cancellation_atomically_seals_late_task_admission() {
+        let registry = ResponseExecutionRegistry::default();
+        let registration = registry.register(Uuid::new_v4(), Uuid::new_v4()).unwrap();
+        let execution = registration.execution();
+        let existing_child = execution.begin_task().unwrap();
+
+        execution.cancel();
+        assert!(execution.begin_task().is_err());
+        drop(registration);
+
+        let waiter = tokio::spawn({
+            let execution = execution.clone();
+            async move { execution.wait_for_quiescence().await }
+        });
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished());
+
+        drop(existing_child);
+        timeout(Duration::from_millis(50), waiter)
+            .await
+            .expect("sealed execution reaches stable quiescence")
+            .expect("join quiescence waiter");
+        assert!(execution.begin_task().is_err());
+    }
+}

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -38,7 +38,8 @@ use crate::{
             },
             prompt_token_budget, storage_task, tools, ContentPartBuilder, DeletedObjectResponse,
             MessageContent, MessageContentConverter, MessageContentPart, OutputItemBuilder,
-            ResponseBuilder, ResponseEvent, ResponseExecution, SseEventEmitter, StorageTaskOutcome,
+            ResponseBuilder, ResponseEvent, ResponseExecution, ResponseExecutionRegistry,
+            SseEventEmitter, StorageTaskOutcome,
         },
     },
     ApiError, AppState,
@@ -108,6 +109,29 @@ async fn wait_for_local_response_execution_quiescence(
     tokio::time::timeout(wait_timeout, execution.wait_for_quiescence())
         .await
         .is_ok()
+}
+
+/// Resolve the process-local execution barrier without guessing what a missing
+/// entry means. For an active persisted response, absence is ambiguous: the
+/// worker may belong to another replica or to a prior server lifetime. Until a
+/// durable cross-process ownership protocol exists, cancel/delete must fail
+/// closed rather than acknowledge quiescence that this process cannot prove.
+fn response_execution_for_status(
+    registry: &ResponseExecutionRegistry,
+    response_id: Uuid,
+    user_id: Uuid,
+    status: ResponseStatus,
+) -> Result<Option<ResponseExecution>, ApiError> {
+    let execution = registry.execution_for_user(response_id, user_id);
+    if execution.is_none() && matches!(status, ResponseStatus::Queued | ResponseStatus::InProgress)
+    {
+        warn!(
+            "No process-local execution owner can prove quiescence for active response {}",
+            response_id
+        );
+        return Err(ApiError::ServiceUnavailable);
+    }
+    Ok(execution)
 }
 
 // Default functions for serde
@@ -438,7 +462,8 @@ mod tests {
         finalize_first_model_tool_call, has_streamed_tool_call_entries, image_attachments,
         image_description_access, image_description_api_error, maple_kagi_web_search_prompt,
         model_turn_request_without_user_payload, resolve_responses_model,
-        resolve_responses_sampling, response_cancellation_ack_decision, send_storage_message,
+        resolve_responses_sampling, response_cancellation_ack_decision,
+        response_execution_for_status, send_storage_message,
         wait_for_local_response_execution_quiescence, web_search_is_selected,
         web_search_tool_turn_limit, web_search_tool_turn_limit_error,
         web_search_tool_turn_limit_reached, ClientResponseState, ConversationParam,
@@ -876,6 +901,38 @@ mod tests {
                 ResponseCancellationAckDecision::LostTerminalRace
             );
         }
+    }
+
+    #[test]
+    fn active_response_from_another_process_or_prior_lifetime_fails_closed() {
+        let prior_lifetime_registry = crate::web::responses::ResponseExecutionRegistry::default();
+        let current_registry = crate::web::responses::ResponseExecutionRegistry::default();
+        let response_id = Uuid::new_v4();
+        let user_id = Uuid::new_v4();
+        let foreign_registration = prior_lifetime_registry
+            .register(response_id, user_id)
+            .expect("register foreign execution");
+
+        for status in [ResponseStatus::Queued, ResponseStatus::InProgress] {
+            assert!(matches!(
+                response_execution_for_status(&current_registry, response_id, user_id, status,),
+                Err(ApiError::ServiceUnavailable)
+            ));
+        }
+
+        // Simulate that foreign process exiting. The current process still
+        // cannot distinguish this orphan from a live owner, so recovery is
+        // intentionally fail-closed until durable ownership/fencing is added.
+        drop(foreign_registration);
+        for status in [ResponseStatus::Queued, ResponseStatus::InProgress] {
+            assert!(matches!(
+                response_execution_for_status(&current_registry, response_id, user_id, status,),
+                Err(ApiError::ServiceUnavailable)
+            ));
+        }
+        assert!(current_registry
+            .execution_for_user(response_id, user_id)
+            .is_none());
     }
 
     #[tokio::test]
@@ -5181,7 +5238,8 @@ async fn cancel_response(
             }
         })?;
 
-    let local_execution = state.response_executions.execution_for_user(id, user.uuid);
+    let local_execution =
+        response_execution_for_status(&state.response_executions, id, user.uuid, response.status)?;
 
     // A terminal-status rejection is client-visible as an already-finished
     // acknowledgement. If process-local work for that response is still
@@ -5206,15 +5264,7 @@ async fn cancel_response(
         return Err(ApiError::BadRequest);
     }
 
-    let execution = local_execution.ok_or_else(|| {
-        // A process-local registry cannot safely acknowledge a stale row
-        // from another process or a prior server lifetime.
-        warn!(
-            "No live execution owner can acknowledge cancellation for response {}",
-            id
-        );
-        ApiError::ServiceUnavailable
-    })?;
+    let execution = local_execution.ok_or(ApiError::ServiceUnavailable)?;
 
     debug!("Signalling cancellation for response {}", id);
     execution.cancel();
@@ -5313,7 +5363,10 @@ async fn delete_response(
             }
         })?;
 
-    if let Some(execution) = state.response_executions.execution_for_user(id, user.uuid) {
+    let local_execution =
+        response_execution_for_status(&state.response_executions, id, user.uuid, existing.status)?;
+
+    if let Some(execution) = local_execution {
         execution.cancel();
         if tokio::time::timeout(RESPONSE_CANCEL_ACK_TIMEOUT, execution.wait_for_quiescence())
             .await
@@ -5325,15 +5378,6 @@ async fn delete_response(
             );
             return Err(ApiError::ServiceUnavailable);
         }
-    } else if matches!(
-        existing.status,
-        ResponseStatus::Queued | ResponseStatus::InProgress
-    ) {
-        warn!(
-            "Refusing to delete active response {} without a local execution owner",
-            id
-        );
-        return Err(ApiError::ServiceUnavailable);
     }
 
     // Delete the response (cascade will handle related records)

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -74,8 +74,7 @@ use uuid::Uuid;
 const RESPONSES_SSE_KEEPALIVE_INTERVAL_SECS: u64 = 1;
 const RESPONSE_CANCEL_ACK_TIMEOUT: Duration = Duration::from_secs(4);
 const RESPONSE_CANCEL_ACK_POLL_INTERVAL: Duration = Duration::from_millis(20);
-const RESPONSE_STORAGE_JOIN_TIMEOUT: Duration = Duration::from_secs(4);
-const RESPONSE_STORAGE_ABORT_JOIN_TIMEOUT: Duration = Duration::from_millis(100);
+const RESPONSE_STORAGE_JOIN_WARNING_AFTER: Duration = Duration::from_secs(4);
 const MAX_WEB_SEARCH_TOOL_TURNS_FREE: usize = 5;
 const MAX_WEB_SEARCH_TOOL_TURNS_PAID: usize = 30;
 
@@ -457,21 +456,22 @@ mod tests {
     use super::{
         append_streamed_tool_calls, apply_responses_model_defaults,
         assistant_turn_finished_with_tool_call, await_storage_completion,
-        await_storage_completion_with_timeout, build_internal_system_prompt_for_now,
-        build_model_turn_request, build_provider_tools, final_assistant_finish_reason,
-        finalize_first_model_tool_call, has_streamed_tool_call_entries, image_attachments,
-        image_description_access, image_description_api_error, maple_kagi_web_search_prompt,
-        model_turn_request_without_user_payload, resolve_responses_model,
-        resolve_responses_sampling, response_cancellation_ack_decision,
+        await_storage_completion_with_warning_after, build_internal_system_prompt_for_now,
+        build_model_turn_request, build_provider_tools, client_cancellation_terminal_decision,
+        final_assistant_finish_reason, finalize_first_model_tool_call,
+        has_streamed_tool_call_entries, image_attachments, image_description_access,
+        image_description_api_error, maple_kagi_web_search_prompt,
+        model_turn_request_without_user_payload, next_client_message_after_durable_completion,
+        resolve_responses_model, resolve_responses_sampling, response_cancellation_ack_decision,
         response_execution_for_status, send_storage_message,
         wait_for_local_response_execution_quiescence, web_search_is_selected,
         web_search_tool_turn_limit, web_search_tool_turn_limit_error,
-        web_search_tool_turn_limit_reached, ClientResponseState, ConversationParam,
-        ImageAttachment, ImageDescriptionFailureClass, ImageDescriptionInput,
-        ImageDescriptionToolPair, InputMessage, MessageContent, MessageContentPart, MessageInput,
-        ResponseCancellationAckDecision, ResponsesCreateRequest, StorageCompletionDecision,
-        StorageMessage, StreamedToolCall, MAX_WEB_SEARCH_TOOL_TURNS_FREE,
-        MAX_WEB_SEARCH_TOOL_TURNS_PAID, READ_IMAGE_TOOL_NAME,
+        web_search_tool_turn_limit_reached, ClientCancellationTerminalDecision,
+        ClientResponseState, ConversationParam, ImageAttachment, ImageDescriptionFailureClass,
+        ImageDescriptionInput, ImageDescriptionToolPair, InputMessage, MessageContent,
+        MessageContentPart, MessageInput, ResponseCancellationAckDecision, ResponsesCreateRequest,
+        StorageCompletionDecision, StorageMessage, StreamedToolCall,
+        MAX_WEB_SEARCH_TOOL_TURNS_FREE, MAX_WEB_SEARCH_TOOL_TURNS_PAID, READ_IMAGE_TOOL_NAME,
     };
     use crate::web::responses::{tools, StorageTaskOutcome};
     use crate::{
@@ -1036,6 +1036,123 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn durable_completion_replays_buffered_output_when_client_terminal_send_is_interrupted() {
+        let (storage_tx, mut storage_rx) = mpsc::channel(1);
+        let (client_tx, mut client_rx) = mpsc::channel(3);
+        let item_id = Uuid::new_v4();
+        client_tx
+            .send(StorageMessage::MessageStarted { item_id })
+            .await
+            .expect("queue message start");
+        client_tx
+            .send(StorageMessage::ContentDelta {
+                item_id,
+                delta: "buffered output".to_string(),
+            })
+            .await
+            .expect("queue message content");
+        client_tx
+            .send(StorageMessage::MessageDone {
+                item_id,
+                finish_reason: "stop".to_string(),
+            })
+            .await
+            .expect("fill client channel");
+
+        let terminal_sender = tokio::spawn(async move {
+            send_storage_message(
+                &storage_tx,
+                &client_tx,
+                StorageMessage::ResponseDone {
+                    finish_reason: "stop".to_string(),
+                },
+            )
+            .await
+        });
+
+        assert!(matches!(
+            storage_rx.recv().await,
+            Some(StorageMessage::ResponseDone { .. })
+        ));
+        tokio::task::yield_now().await;
+        assert!(
+            !terminal_sender.is_finished(),
+            "terminal sender must be blocked behind buffered client output"
+        );
+        terminal_sender.abort();
+        assert!(terminal_sender
+            .await
+            .expect_err("terminal sender should be cancelled")
+            .is_cancelled());
+
+        assert!(matches!(
+            next_client_message_after_durable_completion(&mut client_rx),
+            StorageMessage::MessageStarted { item_id: replayed_id } if replayed_id == item_id
+        ));
+
+        assert!(matches!(
+            next_client_message_after_durable_completion(&mut client_rx),
+            StorageMessage::ContentDelta { item_id: replayed_id, delta }
+                if replayed_id == item_id && delta == "buffered output"
+        ));
+        assert!(matches!(
+            next_client_message_after_durable_completion(&mut client_rx),
+            StorageMessage::MessageDone { item_id: replayed_id, finish_reason }
+                if replayed_id == item_id && finish_reason == "stop"
+        ));
+        assert!(matches!(
+            next_client_message_after_durable_completion(&mut client_rx),
+            StorageMessage::ResponseDone { .. }
+        ));
+    }
+
+    #[test]
+    fn durable_storage_outcome_controls_the_client_cancellation_terminal() {
+        assert_eq!(
+            client_cancellation_terminal_decision(StorageCompletionDecision::Completed),
+            ClientCancellationTerminalDecision::ReplayCompleted
+        );
+        assert_eq!(
+            client_cancellation_terminal_decision(StorageCompletionDecision::Cancelled),
+            ClientCancellationTerminalDecision::EmitCancelled
+        );
+        assert_eq!(
+            client_cancellation_terminal_decision(StorageCompletionDecision::Error),
+            ClientCancellationTerminalDecision::EmitError
+        );
+    }
+
+    #[tokio::test]
+    async fn durable_completion_uses_an_already_queued_client_terminal_message() {
+        let (client_tx, mut client_rx) = mpsc::channel(2);
+        client_tx
+            .send(StorageMessage::Usage {
+                prompt_tokens: 3,
+                completion_tokens: 5,
+            })
+            .await
+            .expect("queue usage");
+        client_tx
+            .send(StorageMessage::ResponseDone {
+                finish_reason: "length".to_string(),
+            })
+            .await
+            .expect("queue terminal message");
+
+        assert!(matches!(
+            next_client_message_after_durable_completion(&mut client_rx),
+            StorageMessage::Usage {
+                prompt_tokens: 3,
+                completion_tokens: 5
+            }
+        ));
+        assert!(matches!(
+            next_client_message_after_durable_completion(&mut client_rx),
+            StorageMessage::ResponseDone { finish_reason } if finish_reason == "length"
+        ));
+    }
+
+    #[tokio::test]
     async fn transcript_delta_waits_for_saturated_client_channel() {
         let (storage_tx, mut storage_rx) = mpsc::channel(2);
         let (client_tx, mut client_rx) = mpsc::channel(1);
@@ -1124,20 +1241,38 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn response_completion_aborts_a_stalled_storage_worker_after_timeout() {
-        let handle = tokio::spawn(async {
-            std::future::pending::<()>().await;
+    async fn response_completion_keeps_waiting_after_storage_join_warning() {
+        let (release_storage, storage_released) = oneshot::channel();
+        let handle = tokio::spawn(async move {
+            storage_released.await.expect("release storage worker");
             StorageTaskOutcome::Completed
         });
         let abort_handle = handle.abort_handle();
         let mut storage_handle = Some(handle);
+        let mut waiter = tokio::spawn(async move {
+            let decision = await_storage_completion_with_warning_after(
+                &mut storage_handle,
+                Duration::from_millis(20),
+            )
+            .await;
+            (decision, storage_handle.is_none())
+        });
 
-        assert_eq!(
-            await_storage_completion_with_timeout(&mut storage_handle, Duration::from_millis(20),)
-                .await,
-            StorageCompletionDecision::Error
+        assert!(
+            tokio::time::timeout(Duration::from_millis(75), &mut waiter)
+                .await
+                .is_err(),
+            "storage waiter must remain pending after the warning threshold"
         );
-        assert!(storage_handle.is_none());
+        assert!(!abort_handle.is_finished());
+
+        release_storage.send(()).expect("release storage worker");
+        let (decision, handle_consumed) = tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("storage waiter should resume after release")
+            .expect("join storage waiter");
+        assert_eq!(decision, StorageCompletionDecision::Completed);
+        assert!(handle_consumed);
         assert!(abort_handle.is_finished());
     }
 
@@ -3612,6 +3747,23 @@ enum StorageCompletionDecision {
     Error,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClientCancellationTerminalDecision {
+    EmitCancelled,
+    ReplayCompleted,
+    EmitError,
+}
+
+fn client_cancellation_terminal_decision(
+    storage_completion: StorageCompletionDecision,
+) -> ClientCancellationTerminalDecision {
+    match storage_completion {
+        StorageCompletionDecision::Cancelled => ClientCancellationTerminalDecision::EmitCancelled,
+        StorageCompletionDecision::Completed => ClientCancellationTerminalDecision::ReplayCompleted,
+        StorageCompletionDecision::Error => ClientCancellationTerminalDecision::EmitError,
+    }
+}
+
 /// Wait for the storage worker to acknowledge the terminal response state.
 ///
 /// `ResponseDone` reaches the client and storage channels independently. The
@@ -3621,30 +3773,53 @@ enum StorageCompletionDecision {
 async fn await_storage_completion(
     storage_handle: &mut Option<tokio::task::JoinHandle<StorageTaskOutcome>>,
 ) -> StorageCompletionDecision {
-    await_storage_completion_with_timeout(storage_handle, RESPONSE_STORAGE_JOIN_TIMEOUT).await
+    await_storage_completion_with_warning_after(storage_handle, RESPONSE_STORAGE_JOIN_WARNING_AFTER)
+        .await
 }
 
-async fn await_storage_completion_with_timeout(
+async fn await_storage_completion_with_warning_after(
     storage_handle: &mut Option<tokio::task::JoinHandle<StorageTaskOutcome>>,
-    join_timeout: Duration,
+    warning_after: Duration,
 ) -> StorageCompletionDecision {
     let Some(mut handle) = storage_handle.take() else {
         return StorageCompletionDecision::Error;
     };
 
-    match tokio::time::timeout(join_timeout, &mut handle).await {
-        Ok(Ok(StorageTaskOutcome::Completed)) => StorageCompletionDecision::Completed,
-        Ok(Ok(StorageTaskOutcome::Cancelled)) => StorageCompletionDecision::Cancelled,
-        Ok(Ok(StorageTaskOutcome::Failed)) | Ok(Err(_)) => StorageCompletionDecision::Error,
+    let storage_outcome = match tokio::time::timeout(warning_after, &mut handle).await {
+        Ok(outcome) => outcome,
         Err(_) => {
-            error!("Timed out joining the Responses storage worker");
-            handle.abort();
-            // Diesel calls inside the task are synchronous, so Tokio abort is
-            // cooperative. Keep the failure path bounded rather than awaiting
-            // an indefinitely blocked database call after abort.
-            let _ = tokio::time::timeout(RESPONSE_STORAGE_ABORT_JOIN_TIMEOUT, handle).await;
-            StorageCompletionDecision::Error
+            warn!(
+                "Responses storage worker is still running after {} ms; continuing to wait for its authoritative terminal state",
+                warning_after.as_millis()
+            );
+            handle.await
         }
+    };
+
+    match storage_outcome {
+        Ok(StorageTaskOutcome::Completed) => StorageCompletionDecision::Completed,
+        Ok(StorageTaskOutcome::Cancelled) => StorageCompletionDecision::Cancelled,
+        Ok(StorageTaskOutcome::Failed) | Err(_) => StorageCompletionDecision::Error,
+    }
+}
+
+/// Once storage has durably completed, every nonterminal client projection is
+/// already buffered or consumed because producers await each client send before
+/// enqueueing `ResponseDone` for storage. Cancellation can interrupt the
+/// redundant client-side `ResponseDone` send after storage received its copy,
+/// so synthesize only that terminal marker after the buffered projection drains.
+fn next_client_message_after_durable_completion(
+    rx_client: &mut mpsc::Receiver<StorageMessage>,
+) -> StorageMessage {
+    match rx_client.try_recv() {
+        Ok(message @ StorageMessage::ResponseDone { .. }) => message,
+        Ok(StorageMessage::Cancelled | StorageMessage::Error(_))
+        | Err(mpsc::error::TryRecvError::Empty | mpsc::error::TryRecvError::Disconnected) => {
+            StorageMessage::ResponseDone {
+                finish_reason: "stop".to_string(),
+            }
+        }
+        Ok(message) => message,
     }
 }
 
@@ -4530,15 +4705,20 @@ async fn create_response_stream(
         let mut client_state = ClientResponseState::default();
         let mut total_prompt_tokens_used = 0i32;
         let mut total_completion_tokens = 0i32;
+        let mut durable_completion_pending = false;
         loop {
-            let msg = tokio::select! {
-                biased;
-                _ = response_execution.cancelled() => StorageMessage::Cancelled,
-                message = rx_client.recv() => {
-                    let Some(message) = message else {
-                        break;
-                    };
-                    message
+            let msg = if durable_completion_pending {
+                next_client_message_after_durable_completion(&mut rx_client)
+            } else {
+                tokio::select! {
+                    biased;
+                    _ = response_execution.cancelled() => StorageMessage::Cancelled,
+                    message = rx_client.recv() => {
+                        let Some(message) = message else {
+                            break;
+                        };
+                        message
+                    }
                 }
             };
             trace!("Client stream received message from upstream processor");
@@ -4702,7 +4882,12 @@ async fn create_response_stream(
                     yield Ok(ResponseEvent::OutputItemDone(reasoning_item_done).to_sse_event(&mut emitter).await);
                 }
                 StorageMessage::ResponseDone { finish_reason: _finish_reason } => {
-                    match await_storage_completion(&mut storage_handle).await {
+                    let storage_completion = if durable_completion_pending {
+                        StorageCompletionDecision::Completed
+                    } else {
+                        await_storage_completion(&mut storage_handle).await
+                    };
+                    match storage_completion {
                         StorageCompletionDecision::Completed => {}
                         StorageCompletionDecision::Cancelled => {
                             debug!(
@@ -4783,25 +4968,19 @@ async fn create_response_stream(
                 }
                 StorageMessage::Cancelled => {
                     debug!("Client stream received cancellation signal");
-                    match await_storage_completion(&mut storage_handle).await {
-                        StorageCompletionDecision::Cancelled => {}
-                        StorageCompletionDecision::Completed => {
-                            error!(
-                                "Storage completed response {} despite a client cancellation signal",
+                    match client_cancellation_terminal_decision(
+                        await_storage_completion(&mut storage_handle).await,
+                    ) {
+                        ClientCancellationTerminalDecision::EmitCancelled => {}
+                        ClientCancellationTerminalDecision::ReplayCompleted => {
+                            debug!(
+                                "Cancellation for response {} lost to durable completion; draining the client projection before emitting response.completed",
                                 response_uuid
                             );
-                            let error_event = ResponseErrorEvent {
-                                event_type: EVENT_RESPONSE_ERROR,
-                                error: ResponseError {
-                                    error_type: "stream_error".to_string(),
-                                    message: "Internal storage failure - response cancellation was not finalized".to_string(),
-                                },
-                            };
-                            drop(client_execution_guard.take());
-                            yield Ok(ResponseEvent::Error(error_event).to_sse_event(&mut emitter).await);
-                            break;
+                            durable_completion_pending = true;
+                            continue;
                         }
-                        StorageCompletionDecision::Error => {
+                        ClientCancellationTerminalDecision::EmitError => {
                             error!(
                                 "Storage did not acknowledge durable cancellation for response {}",
                                 response_uuid

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -20,6 +20,7 @@ use crate::{
         encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
         openai::{
             ensure_completion_model_access, get_chat_completion_response,
+            get_chat_completion_response_for_execution,
             get_chat_completion_response_for_expected_route, BillingContext, CompletionChunk,
             ServerSelectedCompletionRoute,
         },
@@ -37,7 +38,7 @@ use crate::{
             },
             prompt_token_budget, storage_task, tools, ContentPartBuilder, DeletedObjectResponse,
             MessageContent, MessageContentConverter, MessageContentPart, OutputItemBuilder,
-            ResponseBuilder, ResponseEvent, SseEventEmitter,
+            ResponseBuilder, ResponseEvent, ResponseExecution, SseEventEmitter, StorageTaskOutcome,
         },
     },
     ApiError, AppState,
@@ -63,15 +64,51 @@ use std::{
     collections::{HashMap, HashSet},
     convert::Infallible,
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::mpsc;
 use tracing::{debug, error, info, trace, warn};
 use uuid::Uuid;
 
 const RESPONSES_SSE_KEEPALIVE_INTERVAL_SECS: u64 = 1;
+const RESPONSE_CANCEL_ACK_TIMEOUT: Duration = Duration::from_secs(4);
+const RESPONSE_CANCEL_ACK_POLL_INTERVAL: Duration = Duration::from_millis(20);
+const RESPONSE_STORAGE_JOIN_TIMEOUT: Duration = Duration::from_secs(4);
+const RESPONSE_STORAGE_ABORT_JOIN_TIMEOUT: Duration = Duration::from_millis(100);
 const MAX_WEB_SEARCH_TOOL_TURNS_FREE: usize = 5;
 const MAX_WEB_SEARCH_TOOL_TURNS_PAID: usize = 30;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResponseCancellationAckDecision {
+    Wait,
+    Cancelled,
+    LostTerminalRace,
+}
+
+fn response_cancellation_ack_decision(status: ResponseStatus) -> ResponseCancellationAckDecision {
+    match status {
+        ResponseStatus::Cancelled => ResponseCancellationAckDecision::Cancelled,
+        ResponseStatus::Completed | ResponseStatus::Failed => {
+            ResponseCancellationAckDecision::LostTerminalRace
+        }
+        ResponseStatus::Queued | ResponseStatus::InProgress => {
+            ResponseCancellationAckDecision::Wait
+        }
+    }
+}
+
+async fn wait_for_local_response_execution_quiescence(
+    execution: Option<ResponseExecution>,
+    wait_timeout: Duration,
+) -> bool {
+    let Some(execution) = execution else {
+        return true;
+    };
+
+    tokio::time::timeout(wait_timeout, execution.wait_for_quiescence())
+        .await
+        .is_ok()
+}
 
 // Default functions for serde
 fn default_store() -> bool {
@@ -395,23 +432,27 @@ fn final_assistant_finish_reason(tools_enabled: bool, finish_reason: Option<Stri
 mod tests {
     use super::{
         append_streamed_tool_calls, apply_responses_model_defaults,
-        assistant_turn_finished_with_tool_call, build_internal_system_prompt_for_now,
+        assistant_turn_finished_with_tool_call, await_storage_completion,
+        await_storage_completion_with_timeout, build_internal_system_prompt_for_now,
         build_model_turn_request, build_provider_tools, final_assistant_finish_reason,
         finalize_first_model_tool_call, has_streamed_tool_call_entries, image_attachments,
         image_description_access, image_description_api_error, maple_kagi_web_search_prompt,
         model_turn_request_without_user_payload, resolve_responses_model,
-        resolve_responses_sampling, wait_for_response_cancellation, web_search_is_selected,
+        resolve_responses_sampling, response_cancellation_ack_decision, send_storage_message,
+        wait_for_local_response_execution_quiescence, web_search_is_selected,
         web_search_tool_turn_limit, web_search_tool_turn_limit_error,
         web_search_tool_turn_limit_reached, ClientResponseState, ConversationParam,
         ImageAttachment, ImageDescriptionFailureClass, ImageDescriptionInput,
         ImageDescriptionToolPair, InputMessage, MessageContent, MessageContentPart, MessageInput,
-        ResponsesCreateRequest, StorageMessage, StreamedToolCall, MAX_WEB_SEARCH_TOOL_TURNS_FREE,
+        ResponseCancellationAckDecision, ResponsesCreateRequest, StorageCompletionDecision,
+        StorageMessage, StreamedToolCall, MAX_WEB_SEARCH_TOOL_TURNS_FREE,
         MAX_WEB_SEARCH_TOOL_TURNS_PAID, READ_IMAGE_TOOL_NAME,
     };
-    use crate::web::responses::tools;
+    use crate::web::responses::{tools, StorageTaskOutcome};
     use crate::{
         billing::{BillingClient, ChatBillingAccess},
         model_config::{ModelAliasTargets, ModelPlan},
+        models::responses::ResponseStatus,
         ApiError,
     };
     use axum::{routing::get, Json, Router};
@@ -419,8 +460,8 @@ mod tests {
     use serde_json::json;
     use tokio::{
         net::TcpListener,
-        sync::{broadcast, mpsc},
-        time::{timeout, Duration},
+        sync::{mpsc, oneshot},
+        time::Duration,
     };
     use uuid::Uuid;
 
@@ -815,49 +856,232 @@ mod tests {
         assert!(!serialized.contains("request metadata"));
     }
 
-    #[tokio::test]
-    async fn wait_for_response_cancellation_ignores_unrelated_broadcasts() {
-        let response_uuid = Uuid::new_v4();
-        let unrelated_uuid = Uuid::new_v4();
-        let (cancel_tx, cancel_rx) = broadcast::channel(8);
-        let (storage_tx, mut storage_rx) = mpsc::channel(2);
-        let (client_tx, mut client_rx) = mpsc::channel(2);
+    #[test]
+    fn cancellation_ack_waits_only_for_nonterminal_statuses() {
+        assert_eq!(
+            response_cancellation_ack_decision(ResponseStatus::Queued),
+            ResponseCancellationAckDecision::Wait
+        );
+        assert_eq!(
+            response_cancellation_ack_decision(ResponseStatus::InProgress),
+            ResponseCancellationAckDecision::Wait
+        );
+        assert_eq!(
+            response_cancellation_ack_decision(ResponseStatus::Cancelled),
+            ResponseCancellationAckDecision::Cancelled
+        );
+        for status in [ResponseStatus::Completed, ResponseStatus::Failed] {
+            assert_eq!(
+                response_cancellation_ack_decision(status),
+                ResponseCancellationAckDecision::LostTerminalRace
+            );
+        }
+    }
 
-        let listener = tokio::spawn(wait_for_response_cancellation(
-            response_uuid,
-            cancel_rx,
-            storage_tx,
-            client_tx,
+    #[tokio::test]
+    async fn response_completion_waits_for_storage_acknowledgement() {
+        let (release_storage, storage_released) = oneshot::channel();
+        let storage_handle = tokio::spawn(async move {
+            storage_released.await.expect("release storage worker");
+            StorageTaskOutcome::Completed
+        });
+        let mut storage_handle = Some(storage_handle);
+        let (decision_tx, mut decision_rx) = oneshot::channel();
+
+        let waiter = tokio::spawn(async move {
+            let decision = await_storage_completion(&mut storage_handle).await;
+            decision_tx.send(decision).expect("send terminal decision");
+        });
+
+        tokio::task::yield_now().await;
+        assert!(matches!(
+            decision_rx.try_recv(),
+            Err(oneshot::error::TryRecvError::Empty)
         ));
 
-        cancel_tx.send(unrelated_uuid).unwrap();
-        assert!(
-            timeout(Duration::from_millis(25), storage_rx.recv())
-                .await
-                .is_err(),
-            "unrelated cancellation should not emit a storage cancellation"
+        release_storage.send(()).expect("release storage worker");
+        assert_eq!(
+            decision_rx.await.expect("receive terminal decision"),
+            StorageCompletionDecision::Completed
         );
-        assert!(
-            timeout(Duration::from_millis(25), client_rx.recv())
-                .await
-                .is_err(),
-            "unrelated cancellation should not emit a client cancellation"
-        );
-        assert!(
-            !listener.is_finished(),
-            "listener should continue after unrelated cancellation"
-        );
+        waiter.await.expect("join completion waiter");
+    }
 
-        cancel_tx.send(response_uuid).unwrap();
+    #[tokio::test]
+    async fn terminal_cancel_rejection_waits_for_local_execution_quiescence() {
+        let registry = crate::web::responses::ResponseExecutionRegistry::default();
+        let registration = registry
+            .register(Uuid::new_v4(), Uuid::new_v4())
+            .expect("register response execution");
+        let execution = registration.execution();
+        let child = execution.begin_task().expect("register child task");
+        drop(registration);
+
+        let mut waiter = Box::pin(wait_for_local_response_execution_quiescence(
+            Some(execution),
+            Duration::from_secs(1),
+        ));
+        assert!(tokio::time::timeout(Duration::from_millis(10), &mut waiter)
+            .await
+            .is_err());
+
+        drop(child);
+        assert!(tokio::time::timeout(Duration::from_millis(50), waiter)
+            .await
+            .expect("quiescence waiter should finish"));
+    }
+
+    #[tokio::test]
+    async fn terminal_storage_message_waits_for_saturated_client_channel() {
+        let (storage_tx, mut storage_rx) = mpsc::channel(2);
+        let (client_tx, mut client_rx) = mpsc::channel(1);
+        client_tx
+            .send(StorageMessage::ContentDelta {
+                item_id: Uuid::new_v4(),
+                delta: "queued output".to_string(),
+            })
+            .await
+            .expect("fill client channel");
+
+        let terminal_sender = tokio::spawn(async move {
+            send_storage_message(
+                &storage_tx,
+                &client_tx,
+                StorageMessage::ResponseDone {
+                    finish_reason: "stop".to_string(),
+                },
+            )
+            .await
+        });
+
         assert!(matches!(
             storage_rx.recv().await,
-            Some(StorageMessage::Cancelled)
+            Some(StorageMessage::ResponseDone { .. })
         ));
+        tokio::task::yield_now().await;
+        assert!(
+            !terminal_sender.is_finished(),
+            "terminal event must wait instead of being dropped while the client channel is full"
+        );
+
         assert!(matches!(
             client_rx.recv().await,
-            Some(StorageMessage::Cancelled)
+            Some(StorageMessage::ContentDelta { .. })
         ));
-        listener.await.unwrap();
+        terminal_sender
+            .await
+            .expect("join terminal sender")
+            .expect("send terminal message");
+        assert!(matches!(
+            client_rx.recv().await,
+            Some(StorageMessage::ResponseDone { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn transcript_delta_waits_for_saturated_client_channel() {
+        let (storage_tx, mut storage_rx) = mpsc::channel(2);
+        let (client_tx, mut client_rx) = mpsc::channel(1);
+        let queued_item_id = Uuid::new_v4();
+        let retained_item_id = Uuid::new_v4();
+        client_tx
+            .send(StorageMessage::ContentDelta {
+                item_id: queued_item_id,
+                delta: "already queued".to_string(),
+            })
+            .await
+            .expect("fill client channel");
+
+        let delta_sender = tokio::spawn(async move {
+            send_storage_message(
+                &storage_tx,
+                &client_tx,
+                StorageMessage::ContentDelta {
+                    item_id: retained_item_id,
+                    delta: "must not be dropped".to_string(),
+                },
+            )
+            .await
+        });
+
+        assert!(matches!(
+            storage_rx.recv().await,
+            Some(StorageMessage::ContentDelta { item_id, .. }) if item_id == retained_item_id
+        ));
+        tokio::task::yield_now().await;
+        assert!(
+            !delta_sender.is_finished(),
+            "transcript deltas must apply backpressure instead of being dropped"
+        );
+
+        assert!(matches!(
+            client_rx.recv().await,
+            Some(StorageMessage::ContentDelta { item_id, .. }) if item_id == queued_item_id
+        ));
+        delta_sender
+            .await
+            .expect("join delta sender")
+            .expect("send retained delta");
+        assert!(matches!(
+            client_rx.recv().await,
+            Some(StorageMessage::ContentDelta { item_id, .. }) if item_id == retained_item_id
+        ));
+    }
+
+    #[tokio::test]
+    async fn response_completion_maps_non_successful_storage_outcomes() {
+        for (outcome, expected) in [
+            (
+                StorageTaskOutcome::Cancelled,
+                StorageCompletionDecision::Cancelled,
+            ),
+            (StorageTaskOutcome::Failed, StorageCompletionDecision::Error),
+        ] {
+            let mut storage_handle = Some(tokio::spawn(async move { outcome }));
+            assert_eq!(
+                await_storage_completion(&mut storage_handle).await,
+                expected
+            );
+            assert!(storage_handle.is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn response_completion_fails_closed_for_missing_or_aborted_storage_worker() {
+        let mut missing_handle = None;
+        assert_eq!(
+            await_storage_completion(&mut missing_handle).await,
+            StorageCompletionDecision::Error
+        );
+
+        let handle = tokio::spawn(async {
+            std::future::pending::<()>().await;
+            StorageTaskOutcome::Completed
+        });
+        handle.abort();
+        let mut aborted_handle = Some(handle);
+        assert_eq!(
+            await_storage_completion(&mut aborted_handle).await,
+            StorageCompletionDecision::Error
+        );
+    }
+
+    #[tokio::test]
+    async fn response_completion_aborts_a_stalled_storage_worker_after_timeout() {
+        let handle = tokio::spawn(async {
+            std::future::pending::<()>().await;
+            StorageTaskOutcome::Completed
+        });
+        let abort_handle = handle.abort_handle();
+        let mut storage_handle = Some(handle);
+
+        assert_eq!(
+            await_storage_completion_with_timeout(&mut storage_handle, Duration::from_millis(20),)
+                .await,
+            StorageCompletionDecision::Error
+        );
+        assert!(storage_handle.is_none());
+        assert!(abort_handle.is_finished());
     }
 
     #[test]
@@ -2612,7 +2836,7 @@ struct PersistedData {
 /// * `user` - The user who owns the conversation
 /// * `user_key` - User's encryption key for metadata
 /// * `user_content` - The user's first message content
-async fn spawn_title_generation_task(
+fn spawn_title_generation_task(
     state: Arc<AppState>,
     conversation_id: i64,
     conversation_uuid: Uuid,
@@ -3184,9 +3408,9 @@ async fn execute_tool_call_and_wait(
             .await;
         return Err(ApiError::InternalServerError);
     }
-    if tx_client.try_send(tool_call_msg).is_err() {
+    if tx_client.send(tool_call_msg).await.is_err() {
         warn!(
-            "Client channel full or closed, skipping tool_call {} for response {}",
+            "Client channel closed before tool_call {} for response {}",
             tool_call_id, persisted.response.uuid
         );
     }
@@ -3260,9 +3484,9 @@ async fn execute_tool_call_and_wait(
             .await;
         return Err(ApiError::InternalServerError);
     }
-    if tx_client.try_send(tool_output_msg).is_err() {
+    if tx_client.send(tool_output_msg).await.is_err() {
         warn!(
-            "Client channel full or closed, skipping tool_output {} for tool_call {} on response {}",
+            "Client channel closed before tool_output {} for tool_call {} on response {}",
             tool_output_id, tool_call_id, persisted.response.uuid
         );
     }
@@ -3315,10 +3539,82 @@ async fn send_storage_message(
         error!("Storage channel closed unexpectedly");
         return Err(ApiError::InternalServerError);
     }
-    if tx_client.try_send(msg).is_err() {
-        warn!("Client channel full or closed");
+    // Every client item is part of the durable transcript projection. Apply
+    // bounded backpressure rather than dropping deltas or item-finalization
+    // events and then emitting a misleading response.completed.
+    if tx_client.send(msg).await.is_err() {
+        warn!("Client channel closed before response event");
     }
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StorageCompletionDecision {
+    Completed,
+    Cancelled,
+    Error,
+}
+
+/// Wait for the storage worker to acknowledge the terminal response state.
+///
+/// `ResponseDone` reaches the client and storage channels independently. The
+/// client must therefore join the storage worker before treating its copy as a
+/// durable `response.completed` event. A missing, failed, or panicked worker is
+/// fail-closed so callers never observe a false completion.
+async fn await_storage_completion(
+    storage_handle: &mut Option<tokio::task::JoinHandle<StorageTaskOutcome>>,
+) -> StorageCompletionDecision {
+    await_storage_completion_with_timeout(storage_handle, RESPONSE_STORAGE_JOIN_TIMEOUT).await
+}
+
+async fn await_storage_completion_with_timeout(
+    storage_handle: &mut Option<tokio::task::JoinHandle<StorageTaskOutcome>>,
+    join_timeout: Duration,
+) -> StorageCompletionDecision {
+    let Some(mut handle) = storage_handle.take() else {
+        return StorageCompletionDecision::Error;
+    };
+
+    match tokio::time::timeout(join_timeout, &mut handle).await {
+        Ok(Ok(StorageTaskOutcome::Completed)) => StorageCompletionDecision::Completed,
+        Ok(Ok(StorageTaskOutcome::Cancelled)) => StorageCompletionDecision::Cancelled,
+        Ok(Ok(StorageTaskOutcome::Failed)) | Ok(Err(_)) => StorageCompletionDecision::Error,
+        Err(_) => {
+            error!("Timed out joining the Responses storage worker");
+            handle.abort();
+            // Diesel calls inside the task are synchronous, so Tokio abort is
+            // cooperative. Keep the failure path bounded rather than awaiting
+            // an indefinitely blocked database call after abort.
+            let _ = tokio::time::timeout(RESPONSE_STORAGE_ABORT_JOIN_TIMEOUT, handle).await;
+            StorageCompletionDecision::Error
+        }
+    }
+}
+
+fn best_effort_fail_response_after_storage_error(
+    state: &AppState,
+    response_id: i64,
+    response_uuid: Uuid,
+) {
+    match state.db.update_response_status_if_current(
+        response_id,
+        ResponseStatus::InProgress,
+        ResponseStatus::Failed,
+        Some(Utc::now()),
+    ) {
+        Ok(true) => debug!(
+            "Marked response {} failed after storage worker error",
+            response_uuid
+        ),
+        Ok(false) => debug!(
+            "Response {} was already terminal after storage worker error",
+            response_uuid
+        ),
+        Err(e) => error!(
+            "Failed to mark response {} failed after storage worker error: {:?}",
+            response_uuid, e
+        ),
+    }
 }
 
 fn next_assistant_message_id(next_message_id: &mut Option<Uuid>) -> Uuid {
@@ -3386,6 +3682,7 @@ async fn ensure_message_started(
         StorageMessage::MessageStarted { item_id: id },
     )
     .await?;
+
     *current_message_id = Some(id);
     Ok(id)
 }
@@ -3406,6 +3703,7 @@ async fn stream_one_assistant_turn(
     conversation_uuid: Uuid,
     tool_turn_count: usize,
     prompt_token_estimate: usize,
+    response_execution: ResponseExecution,
 ) -> Result<AssistantTurnOutcome, ApiError> {
     let mut chat_request = build_model_turn_request(body, prompt_messages, tools_enabled);
 
@@ -3431,13 +3729,14 @@ async fn stream_one_assistant_turn(
         body.model.clone(),
     );
 
-    let mut completion = get_chat_completion_response(
+    let mut completion = get_chat_completion_response_for_execution(
         state,
         user,
         chat_request.take(),
         headers,
         billing_context,
         model_plan,
+        response_execution,
     )
     .await?;
 
@@ -3699,6 +3998,7 @@ async fn setup_completion_processor(
     tx_client: mpsc::Sender<StorageMessage>,
     tx_storage: mpsc::Sender<StorageMessage>,
     mut rx_tool_ack: mpsc::Receiver<Result<(), String>>,
+    response_execution: ResponseExecution,
 ) -> Result<crate::models::responses::Response, ApiError> {
     let tools_enabled = context.web_search_enabled;
     let mut prompt_messages = Arc::as_ref(&context.prompt_messages).clone();
@@ -3724,6 +4024,7 @@ async fn setup_completion_processor(
                 context.conversation.uuid,
                 tool_turn_count,
                 prompt_token_estimate,
+                response_execution.clone(),
             )
             .await?
             {
@@ -3770,55 +4071,11 @@ async fn setup_completion_processor(
     if let Err(e) = loop_result {
         let msg = StorageMessage::Error(format!("Streaming failed: {:?}", e));
         let _ = tx_storage.send(msg.clone()).await;
-        let _ = tx_client.try_send(msg);
+        let _ = tx_client.send(msg).await;
         return Err(e);
     }
 
     Ok(persisted.response.clone())
-}
-
-async fn wait_for_response_cancellation(
-    response_uuid: Uuid,
-    mut cancel_rx: broadcast::Receiver<Uuid>,
-    tx_storage: mpsc::Sender<StorageMessage>,
-    tx_client: mpsc::Sender<StorageMessage>,
-) {
-    loop {
-        match cancel_rx.recv().await {
-            Ok(cancelled_id) if cancelled_id == response_uuid => {
-                debug!(
-                    "Orchestrator: Received cancellation during phases 5-6 for response {}",
-                    response_uuid
-                );
-
-                let _ = tx_storage.send(StorageMessage::Cancelled).await;
-                let _ = tx_client.send(StorageMessage::Cancelled).await;
-
-                trace!("Orchestrator: Cancellation handled, exiting");
-                return;
-            }
-            Ok(cancelled_id) => {
-                trace!(
-                    "Orchestrator: ignoring cancellation for unrelated response {} while running response {}",
-                    cancelled_id,
-                    response_uuid
-                );
-            }
-            Err(broadcast::error::RecvError::Lagged(skipped)) => {
-                warn!(
-                    "Orchestrator: cancellation listener for response {} lagged by {} message(s)",
-                    response_uuid, skipped
-                );
-            }
-            Err(broadcast::error::RecvError::Closed) => {
-                warn!(
-                    "Orchestrator: cancellation channel closed while response {} was still running",
-                    response_uuid
-                );
-                std::future::pending::<()>().await;
-            }
-        }
-    }
 }
 
 async fn create_response_stream(
@@ -3942,6 +4199,77 @@ async fn create_response_stream(
     )
     .await?;
 
+    // Derive the response-item clock before starting any detached work. If the
+    // timestamp cannot advance, fail the newly persisted response explicitly
+    // rather than leaving an in_progress row with no execution owner.
+    let Some(first_response_item_created_at) = persisted
+        .last_item_created_at
+        .checked_add_signed(chrono::Duration::microseconds(1))
+    else {
+        best_effort_fail_response_after_storage_error(
+            &state,
+            persisted.response.id,
+            persisted.response.uuid,
+        );
+        return Err(ApiError::InternalServerError);
+    };
+
+    let response_execution_registration = state
+        .response_executions
+        .register(persisted.response.uuid, user.uuid)
+        .map_err(|_| {
+            error!(
+                "Duplicate live execution registration for response {}",
+                persisted.response.uuid
+            );
+            best_effort_fail_response_after_storage_error(
+                &state,
+                persisted.response.id,
+                persisted.response.uuid,
+            );
+            ApiError::InternalServerError
+        })?;
+    let response_execution = response_execution_registration.execution();
+    // Bridge registration into lazy SSE startup. This guard is acquired before
+    // the response ID can be exposed and is released only after storage and
+    // orchestrator ownership have both been installed.
+    let response_setup_guard = response_execution.begin_task().map_err(|_| {
+        error!("Response execution closed during initial task registration");
+        best_effort_fail_response_after_storage_error(
+            &state,
+            persisted.response.id,
+            persisted.response.uuid,
+        );
+        ApiError::InternalServerError
+    })?;
+    let storage_execution_guard = response_execution.begin_task().map_err(|_| {
+        error!("Response execution closed before storage ownership was installed");
+        best_effort_fail_response_after_storage_error(
+            &state,
+            persisted.response.id,
+            persisted.response.uuid,
+        );
+        ApiError::InternalServerError
+    })?;
+    let orchestrator_execution_guard = response_execution.begin_task().map_err(|_| {
+        error!("Response execution closed before orchestrator ownership was installed");
+        best_effort_fail_response_after_storage_error(
+            &state,
+            persisted.response.id,
+            persisted.response.uuid,
+        );
+        ApiError::InternalServerError
+    })?;
+    let client_execution_guard = response_execution.begin_task().map_err(|_| {
+        error!("Response execution closed before client-stream ownership was installed");
+        best_effort_fail_response_after_storage_error(
+            &state,
+            persisted.response.id,
+            persisted.response.uuid,
+        );
+        ApiError::InternalServerError
+    })?;
+
     // Check if first message and spawn title generation task
     let (user_count, assistant_count) =
         context
@@ -3960,6 +4288,9 @@ async fn create_response_stream(
     if user_count == 1 && assistant_count == 0 {
         let user_content =
             MessageContentConverter::extract_text_for_token_counting(&prepared.message_content);
+        // Conversation title generation has its own lifecycle. It is not part
+        // of the main response execution barrier, so Stop is never delayed by
+        // this best-effort metadata task.
         spawn_title_generation_task(
             state.clone(),
             context.conversation.id,
@@ -3967,8 +4298,7 @@ async fn create_response_stream(
             user.clone(),
             prepared.user_key,
             user_content,
-        )
-        .await;
+        );
     }
 
     // Capture variables needed inside the stream
@@ -3980,10 +4310,6 @@ async fn create_response_stream(
     let response_uuid = persisted.response.uuid;
     // Persist all generated response items on a single monotonic timestamp sequence that
     // begins immediately after the user message so retrieval order matches stream order.
-    let first_response_item_created_at = persisted
-        .last_item_created_at
-        .checked_add_signed(chrono::Duration::microseconds(1))
-        .ok_or(ApiError::InternalServerError)?;
     let conversation_id = context.conversation.id;
     let user_id = user.uuid;
     let user_key = prepared.user_key;
@@ -3993,7 +4319,125 @@ async fn create_response_stream(
     let image_descriptions_for_stream = Arc::new(image_descriptions);
     let model_turn_body = model_turn_request_without_user_payload(&body);
 
-    // Phases 4-6 now happen INSIDE the stream to start sending events ASAP
+    // Install every response-owned worker eagerly. An HTTP body is lazy and
+    // may be dropped before its first poll; leaving worker startup inside the
+    // SSE generator would strand the already-persisted response in_progress.
+    trace!("Phase 4: Creating dual streams and spawning storage task");
+    let (tx_storage, rx_storage) = mpsc::channel::<StorageMessage>(STORAGE_CHANNEL_BUFFER);
+    let (tx_client, mut rx_client) = mpsc::channel::<StorageMessage>(CLIENT_CHANNEL_BUFFER);
+
+    // These pairs are already durable. Queue them before the orchestrator can
+    // enqueue assistant output so client order matches persistence order.
+    for pair in image_descriptions_for_stream.iter() {
+        for message in pair.client_messages() {
+            let _ = tx_client.send(message).await;
+        }
+    }
+
+    let (tx_tool_ack, rx_tool_ack) = mpsc::channel::<Result<(), String>>(8);
+    let mut storage_handle = Some({
+        let db = state.db.clone();
+
+        tokio::spawn(async move {
+            let _storage_execution_guard = storage_execution_guard;
+            storage_task(
+                rx_storage,
+                Some(tx_tool_ack),
+                db,
+                response_id,
+                response_uuid,
+                first_response_item_created_at,
+                conversation_id,
+                user_id,
+                user_key,
+            )
+            .await
+        })
+    });
+
+    trace!("Spawning background orchestrator for phases 5-6");
+    let orchestrator_tx_client = tx_client.clone();
+    let orchestrator_tx_storage = tx_storage.clone();
+    let orchestrator_state = state.clone();
+    let orchestrator_user = user.clone();
+    let orchestrator_body = model_turn_body.clone();
+    let orchestrator_headers = headers.clone();
+    let orchestrator_response = response_for_stream.clone();
+    let orchestrator_metadata = decrypted_metadata.clone();
+    let orchestrator_last_item_created_at = persisted.last_item_created_at;
+    let orchestrator_conversation = conversation_for_stream.clone();
+    let orchestrator_prompt_messages = prompt_messages.clone();
+    let orchestrator_execution = response_execution.clone();
+
+    tokio::spawn(async move {
+        let _orchestrator_execution_guard = orchestrator_execution_guard;
+        trace!("Orchestrator: Starting phases 5-6 in background");
+
+        let cancelled = tokio::select! {
+            biased;
+            _ = orchestrator_execution.cancelled() => true,
+            _ = async {
+                trace!("Orchestrator: Setting up assistant/tool loop");
+
+                let context_for_completion = BuiltContext {
+                    conversation: orchestrator_conversation,
+                    prompt_messages: orchestrator_prompt_messages,
+                    total_prompt_tokens,
+                    web_search_enabled,
+                };
+
+                let persisted_for_completion = PersistedData {
+                    response: orchestrator_response.clone(),
+                    decrypted_metadata: orchestrator_metadata.clone(),
+                    last_item_created_at: orchestrator_last_item_created_at,
+                };
+
+                match setup_completion_processor(
+                    &orchestrator_state,
+                    &orchestrator_user,
+                    &orchestrator_body,
+                    model_plan,
+                    &context_for_completion,
+                    &user_key,
+                    assistant_message_id,
+                    &persisted_for_completion,
+                    &orchestrator_headers,
+                    orchestrator_tx_client.clone(),
+                    orchestrator_tx_storage.clone(),
+                    rx_tool_ack,
+                    orchestrator_execution.clone(),
+                )
+                .await
+                {
+                    Ok(_) => trace!("Orchestrator: Assistant/tool loop completed"),
+                    Err(e) => error!("Orchestrator: Assistant/tool loop failed: {:?}", e),
+                }
+            } => {
+                trace!("Orchestrator: Phases 5-6 completed normally");
+                false
+            }
+        };
+
+        if cancelled {
+            debug!(
+                "Orchestrator: stopping response {} before ordered storage cancellation",
+                response_uuid
+            );
+            // The non-selected completion future has been dropped, so no
+            // producer can enqueue more transcript messages. Storage drains
+            // every prior message before publishing durable cancellation.
+            let _ = orchestrator_tx_storage
+                .send(StorageMessage::Cancelled)
+                .await;
+        }
+    });
+
+    // All root lineages have been spawned. From this point quiescence means
+    // both owner setup and every response-owned child have finished.
+    drop(response_execution_registration);
+    drop(response_setup_guard);
+    let mut client_execution_guard = Some(client_execution_guard);
+
     trace!("Creating SSE event stream for client");
     let event_stream = async_stream::stream! {
         trace!("=== STARTING SSE STREAM ===");
@@ -4014,8 +4458,6 @@ async fn create_response_stream(
             sequence_number: emitter.sequence_number(),
         };
 
-        yield Ok(ResponseEvent::Created(created_event).to_sse_event(&mut emitter).await);
-
         // Event 2: response.in_progress
         let in_progress_event = ResponseInProgressEvent {
             event_type: EVENT_RESPONSE_IN_PROGRESS,
@@ -4023,126 +4465,25 @@ async fn create_response_stream(
             sequence_number: emitter.sequence_number(),
         };
 
+        yield Ok(ResponseEvent::Created(created_event).to_sse_event(&mut emitter).await);
         yield Ok(ResponseEvent::InProgress(in_progress_event).to_sse_event(&mut emitter).await);
-
-        // Phase 4: Create dual streams and spawn storage task
-        trace!("Phase 4: Creating dual streams and spawning storage task");
-        let (tx_storage, rx_storage) = mpsc::channel::<StorageMessage>(STORAGE_CHANNEL_BUFFER);
-        let (tx_client, mut rx_client) = mpsc::channel::<StorageMessage>(CLIENT_CHANNEL_BUFFER);
-
-        // These pairs are already durable. Queue them only for client emission,
-        // before the orchestrator can enqueue any assistant output.
-        for pair in image_descriptions_for_stream.iter() {
-            for message in pair.client_messages() {
-                let _ = tx_client.send(message).await;
-            }
-        }
-
-        // Create channel for tool persistence acknowledgments (supports multiple tool loops)
-        let (tx_tool_ack, rx_tool_ack) = mpsc::channel::<Result<(), String>>(8);
-
-        let _storage_handle = {
-            let db = state.db.clone();
-
-            tokio::spawn(async move {
-                storage_task(
-                    rx_storage,
-                    Some(tx_tool_ack),
-                    db,
-                    response_id,
-                    response_uuid,
-                    first_response_item_created_at,
-                    conversation_id,
-                    user_id,
-                    user_key,
-                )
-                .await;
-            })
-        };
-
-        // Spawn orchestrator task for phases 5-6 (runs in background, sends events to tx_client)
-        trace!("Spawning background orchestrator for phases 5-6");
-        let orchestrator_tx_client = tx_client.clone();
-        let orchestrator_tx_storage = tx_storage.clone();
-        let orchestrator_state = state.clone();
-        let orchestrator_user = user.clone();
-        let orchestrator_body = model_turn_body.clone();
-        let orchestrator_headers = headers.clone();
-        let orchestrator_response = response_for_stream.clone();
-        let orchestrator_metadata = decrypted_metadata.clone();
-        let orchestrator_last_item_created_at = persisted.last_item_created_at;
-        let orchestrator_conversation = conversation_for_stream.clone();
-        let orchestrator_prompt_messages = prompt_messages.clone();
-
-        tokio::spawn(async move {
-            trace!("Orchestrator: Starting phases 5-6 in background");
-
-            // Subscribe to cancellation broadcast. The endpoint lives on a separate
-            // request task, so each stream listens for its own response UUID.
-            let cancel_rx = orchestrator_state.cancellation_broadcast.subscribe();
-            let cancellation_listener = wait_for_response_cancellation(
-                response_uuid,
-                cancel_rx,
-                orchestrator_tx_storage.clone(),
-                orchestrator_tx_client.clone(),
-            );
-
-            // Run phases 5-6 with cancellation support
-            tokio::select! {
-                _ = async {
-                    // Phase 5-6: Run the normal assistant/tool loop
-                    trace!("Orchestrator: Setting up assistant/tool loop");
-
-                    let context_for_completion = BuiltContext {
-                        conversation: orchestrator_conversation,
-                        prompt_messages: orchestrator_prompt_messages,
-                        total_prompt_tokens,
-                        web_search_enabled,
-                    };
-
-                    let persisted_for_completion = PersistedData {
-                        response: orchestrator_response.clone(),
-                        decrypted_metadata: orchestrator_metadata.clone(),
-                        last_item_created_at: orchestrator_last_item_created_at,
-                    };
-
-                    match setup_completion_processor(
-                        &orchestrator_state,
-                        &orchestrator_user,
-                        &orchestrator_body,
-                        model_plan,
-                        &context_for_completion,
-                        &user_key,
-                        assistant_message_id,
-                        &persisted_for_completion,
-                        &orchestrator_headers,
-                        orchestrator_tx_client.clone(),
-                        orchestrator_tx_storage.clone(),
-                        rx_tool_ack,
-                    )
-                    .await
-                    {
-                        Ok(_) => {
-                            trace!("Orchestrator: Assistant/tool loop completed");
-                        }
-                        Err(e) => {
-                            error!("Orchestrator: Assistant/tool loop failed: {:?}", e);
-                        }
-                    }
-                } => {
-                    trace!("Orchestrator: Phases 5-6 completed normally");
-                }
-
-                _ = cancellation_listener => {}
-            }
-        });
 
         // NOW immediately start the event loop - it will receive events from orchestrator as they happen
         trace!("Starting event loop to receive messages from background tasks");
         let mut client_state = ClientResponseState::default();
         let mut total_prompt_tokens_used = 0i32;
         let mut total_completion_tokens = 0i32;
-        while let Some(msg) = rx_client.recv().await {
+        loop {
+            let msg = tokio::select! {
+                biased;
+                _ = response_execution.cancelled() => StorageMessage::Cancelled,
+                message = rx_client.recv() => {
+                    let Some(message) = message else {
+                        break;
+                    };
+                    message
+                }
+            };
             trace!("Client stream received message from upstream processor");
             match msg {
                 StorageMessage::MessageStarted { item_id } => {
@@ -4304,6 +4645,53 @@ async fn create_response_stream(
                     yield Ok(ResponseEvent::OutputItemDone(reasoning_item_done).to_sse_event(&mut emitter).await);
                 }
                 StorageMessage::ResponseDone { finish_reason: _finish_reason } => {
+                    match await_storage_completion(&mut storage_handle).await {
+                        StorageCompletionDecision::Completed => {}
+                        StorageCompletionDecision::Cancelled => {
+                            debug!(
+                                "Storage completed response {} as cancelled before the client terminal event",
+                                response_uuid
+                            );
+                            let cancelled_event = ResponseCancelledEvent {
+                                id: Uuid::new_v4().to_string(),
+                                event_type: EVENT_RESPONSE_CANCELLED,
+                                created_at: Utc::now().timestamp(),
+                                data: ResponseCancelledData {
+                                    id: response_uuid,
+                                },
+                            };
+                            // A terminal SSE event is also the client-visible
+                            // release point for response lifecycle fences. Do
+                            // not emit it until every process-local task owned
+                            // by the main response has exited.
+                            drop(client_execution_guard.take());
+                            response_execution.wait_for_quiescence().await;
+                            yield Ok(ResponseEvent::Cancelled(cancelled_event).to_sse_event(&mut emitter).await);
+                            break;
+                        }
+                        StorageCompletionDecision::Error => {
+                            error!(
+                                "Storage did not acknowledge durable completion for response {}",
+                                response_uuid
+                            );
+                            best_effort_fail_response_after_storage_error(
+                                &state,
+                                response_id,
+                                response_uuid,
+                            );
+                            let error_event = ResponseErrorEvent {
+                                event_type: EVENT_RESPONSE_ERROR,
+                                error: ResponseError {
+                                    error_type: "stream_error".to_string(),
+                                    message: "Internal storage failure - response was not completed".to_string(),
+                                },
+                            };
+                            drop(client_execution_guard.take());
+                            yield Ok(ResponseEvent::Error(error_event).to_sse_event(&mut emitter).await);
+                            break;
+                        }
+                    }
+
                     let usage = build_usage(
                         if total_prompt_tokens_used > 0 {
                             total_prompt_tokens_used
@@ -4326,6 +4714,8 @@ async fn create_response_stream(
                         sequence_number: emitter.sequence_number(),
                     };
 
+                    drop(client_execution_guard.take());
+                    response_execution.wait_for_quiescence().await;
                     yield Ok(ResponseEvent::Completed(completed_event).to_sse_event(&mut emitter).await);
                     break;
                 }
@@ -4336,6 +4726,47 @@ async fn create_response_stream(
                 }
                 StorageMessage::Cancelled => {
                     debug!("Client stream received cancellation signal");
+                    match await_storage_completion(&mut storage_handle).await {
+                        StorageCompletionDecision::Cancelled => {}
+                        StorageCompletionDecision::Completed => {
+                            error!(
+                                "Storage completed response {} despite a client cancellation signal",
+                                response_uuid
+                            );
+                            let error_event = ResponseErrorEvent {
+                                event_type: EVENT_RESPONSE_ERROR,
+                                error: ResponseError {
+                                    error_type: "stream_error".to_string(),
+                                    message: "Internal storage failure - response cancellation was not finalized".to_string(),
+                                },
+                            };
+                            drop(client_execution_guard.take());
+                            yield Ok(ResponseEvent::Error(error_event).to_sse_event(&mut emitter).await);
+                            break;
+                        }
+                        StorageCompletionDecision::Error => {
+                            error!(
+                                "Storage did not acknowledge durable cancellation for response {}",
+                                response_uuid
+                            );
+                            best_effort_fail_response_after_storage_error(
+                                &state,
+                                response_id,
+                                response_uuid,
+                            );
+                            let error_event = ResponseErrorEvent {
+                                event_type: EVENT_RESPONSE_ERROR,
+                                error: ResponseError {
+                                    error_type: "stream_error".to_string(),
+                                    message: "Internal storage failure - response cancellation was not finalized".to_string(),
+                                },
+                            };
+                            drop(client_execution_guard.take());
+                            yield Ok(ResponseEvent::Error(error_event).to_sse_event(&mut emitter).await);
+                            break;
+                        }
+                    }
+
                     // Send response.cancelled event
                     let cancelled_event = ResponseCancelledEvent {
                         id: Uuid::new_v4().to_string(),
@@ -4346,11 +4777,36 @@ async fn create_response_stream(
                         },
                     };
 
+                    drop(client_execution_guard.take());
+                    response_execution.wait_for_quiescence().await;
                     yield Ok(ResponseEvent::Cancelled(cancelled_event).to_sse_event(&mut emitter).await);
                     break;
                 }
                 StorageMessage::Error(error_msg) => {
                     error!("Client stream received error: {}", error_msg);
+                    let storage_decision = await_storage_completion(&mut storage_handle).await;
+                    if matches!(storage_decision, StorageCompletionDecision::Cancelled) {
+                        let cancelled_event = ResponseCancelledEvent {
+                            id: Uuid::new_v4().to_string(),
+                            event_type: EVENT_RESPONSE_CANCELLED,
+                            created_at: Utc::now().timestamp(),
+                            data: ResponseCancelledData {
+                                id: response_uuid,
+                            },
+                        };
+                        drop(client_execution_guard.take());
+                        response_execution.wait_for_quiescence().await;
+                        yield Ok(ResponseEvent::Cancelled(cancelled_event).to_sse_event(&mut emitter).await);
+                        break;
+                    }
+                    if matches!(storage_decision, StorageCompletionDecision::Error) {
+                        best_effort_fail_response_after_storage_error(
+                            &state,
+                            response_id,
+                            response_uuid,
+                        );
+                    }
+
                     // Send error event to client
                     let error_event = ResponseErrorEvent {
                         event_type: EVENT_RESPONSE_ERROR,
@@ -4360,6 +4816,7 @@ async fn create_response_stream(
                         },
                     };
 
+                    drop(client_execution_guard.take());
                     yield Ok(ResponseEvent::Error(error_event).to_sse_event(&mut emitter).await);
                     break;
                 }
@@ -4724,11 +5181,24 @@ async fn cancel_response(
             }
         })?;
 
-    // Only allow cancelling responses that have not reached a terminal state.
+    let local_execution = state.response_executions.execution_for_user(id, user.uuid);
+
+    // A terminal-status rejection is client-visible as an already-finished
+    // acknowledgement. If process-local work for that response is still
+    // draining, do not return that acknowledgement early.
     if !matches!(
         response.status,
         ResponseStatus::Queued | ResponseStatus::InProgress
     ) {
+        if !wait_for_local_response_execution_quiescence(
+            local_execution,
+            RESPONSE_CANCEL_ACK_TIMEOUT,
+        )
+        .await
+        {
+            warn!("Timed out waiting for terminal response {} to quiesce", id);
+            return Err(ApiError::ServiceUnavailable);
+        }
         debug!(
             "Cannot cancel response {} with status {:?}",
             id, response.status
@@ -4736,25 +5206,74 @@ async fn cancel_response(
         return Err(ApiError::BadRequest);
     }
 
-    // Update the response status in the database
-    let response = state.db.cancel_response(id, user.uuid).map_err(|e| {
-        debug!(
-            "Response {} not found for user {} during cancel: {:?}",
-            id, user.uuid, e
+    let execution = local_execution.ok_or_else(|| {
+        // A process-local registry cannot safely acknowledge a stale row
+        // from another process or a prior server lifetime.
+        warn!(
+            "No live execution owner can acknowledge cancellation for response {}",
+            id
         );
-        match e {
-            DBError::ResponsesError(ResponsesError::ResponseNotFound) => ApiError::NotFound,
-            DBError::ResponsesError(ResponsesError::Unauthorized) => ApiError::Unauthorized,
-            DBError::ResponsesError(ResponsesError::ValidationError) => ApiError::BadRequest,
-            _ => ApiError::InternalServerError,
-        }
+        ApiError::ServiceUnavailable
     })?;
 
-    // Broadcast cancellation signal to stream listeners after the DB transition
-    // succeeds so storage cannot race the endpoint and turn a valid cancel into
-    // a bad request.
-    debug!("Broadcasting cancellation signal for response {}", id);
-    let _ = state.cancellation_broadcast.send(id);
+    debug!("Signalling cancellation for response {}", id);
+    execution.cancel();
+
+    // Storage owns the terminal status transition. A cancelled row certifies
+    // pending transcript cleanup; the execution barrier below additionally
+    // certifies that storage, orchestrator, main-provider, and client-finalizer
+    // tasks owned by this response have exited. Usage publication and
+    // best-effort conversation-title work have independent lifecycles.
+    let wait_started = Instant::now();
+    let terminal_response = async {
+        loop {
+            let observed = state
+                .db
+                .get_response_by_uuid_and_user(id, user.uuid)
+                .map_err(|e| {
+                    error!(
+                        "Failed to observe cancellation acknowledgement for response {}: {:?}",
+                        id, e
+                    );
+                    ApiError::InternalServerError
+                })?;
+
+            match response_cancellation_ack_decision(observed.status) {
+                ResponseCancellationAckDecision::Cancelled => break Ok(observed),
+                ResponseCancellationAckDecision::LostTerminalRace => {
+                    debug!(
+                        "Cancellation for response {} lost to terminal status {:?}",
+                        id, observed.status
+                    );
+                    break Err(ApiError::BadRequest);
+                }
+                ResponseCancellationAckDecision::Wait => {}
+            }
+
+            if wait_started.elapsed() >= RESPONSE_CANCEL_ACK_TIMEOUT {
+                warn!(
+                    "Timed out waiting for durable cancellation acknowledgement for response {}",
+                    id
+                );
+                break Err(ApiError::ServiceUnavailable);
+            }
+            tokio::time::sleep(RESPONSE_CANCEL_ACK_POLL_INTERVAL).await;
+        }
+    }
+    .await;
+
+    let remaining = RESPONSE_CANCEL_ACK_TIMEOUT.saturating_sub(wait_started.elapsed());
+    if tokio::time::timeout(remaining, execution.wait_for_quiescence())
+        .await
+        .is_err()
+    {
+        warn!(
+            "Timed out waiting for execution quiescence for response {}",
+            id
+        );
+        return Err(ApiError::ServiceUnavailable);
+    }
+    let response = terminal_response?;
 
     // No usage or output for cancelled responses
     let retrieve_response = ResponsesRetrieveResponse {
@@ -4778,6 +5297,44 @@ async fn delete_response(
     Extension(session_id): Extension<Uuid>,
 ) -> Result<Json<EncryptedResponse<DeletedObjectResponse>>, ApiError> {
     debug!("Deleting response {} for user {}", id, user.uuid);
+
+    let existing = state
+        .db
+        .get_response_by_uuid_and_user(id, user.uuid)
+        .map_err(|e| {
+            debug!(
+                "Response {} not found for user {} before delete: {:?}",
+                id, user.uuid, e
+            );
+            match e {
+                DBError::ResponsesError(ResponsesError::ResponseNotFound) => ApiError::NotFound,
+                DBError::ResponsesError(ResponsesError::Unauthorized) => ApiError::Unauthorized,
+                _ => ApiError::InternalServerError,
+            }
+        })?;
+
+    if let Some(execution) = state.response_executions.execution_for_user(id, user.uuid) {
+        execution.cancel();
+        if tokio::time::timeout(RESPONSE_CANCEL_ACK_TIMEOUT, execution.wait_for_quiescence())
+            .await
+            .is_err()
+        {
+            warn!(
+                "Refusing to delete response {} before its execution quiesced",
+                id
+            );
+            return Err(ApiError::ServiceUnavailable);
+        }
+    } else if matches!(
+        existing.status,
+        ResponseStatus::Queued | ResponseStatus::InProgress
+    ) {
+        warn!(
+            "Refusing to delete active response {} without a local execution owner",
+            id
+        );
+        return Err(ApiError::ServiceUnavailable);
+    }
 
     // Delete the response (cascade will handle related records)
     state.db.delete_response(id, user.uuid).map_err(|e| {

--- a/src/web/responses/mod.rs
+++ b/src/web/responses/mod.rs
@@ -11,6 +11,7 @@ pub mod conversations;
 pub mod conversions;
 pub mod errors;
 pub mod events;
+mod execution;
 pub mod handlers;
 pub(crate) mod image_describer;
 pub mod instructions;
@@ -28,8 +29,11 @@ pub use context_builder::{build_prompt, build_prompt_with_token_reserve};
 pub use conversions::{ConversationItem, ConversationItemConverter, MessageContentConverter};
 pub use errors::error_mapping;
 pub use events::{ResponseEvent, SseEventEmitter};
+pub(crate) use execution::{
+    ResponseExecution, ResponseExecutionRegistry, ResponseExecutionTaskGuard,
+};
 pub use pagination::Paginator;
-pub use storage::storage_task;
+pub use storage::{storage_task, StorageTaskOutcome};
 // REMOVED: UpstreamStreamProcessor - no longer used with centralized billing architecture
 pub use types::{DeletedObjectResponse, MessageContent, MessageContentPart, NullableField};
 

--- a/src/web/responses/storage.rs
+++ b/src/web/responses/storage.rs
@@ -20,6 +20,26 @@ use uuid::Uuid;
 
 use super::handlers::StorageMessage;
 
+/// Terminal result of the per-response storage worker.
+///
+/// A `Completed` result is an acknowledgement that every queued response item
+/// was persisted successfully and the response status was durably advanced to
+/// `completed`. The streaming task must not emit `response.completed` for any
+/// other outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorageTaskOutcome {
+    Completed,
+    Cancelled,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TerminalStatusUpdate {
+    Updated,
+    AlreadyTerminal,
+    Failed,
+}
+
 #[derive(Default)]
 struct PendingAssistantMessage {
     content: String,
@@ -86,26 +106,65 @@ fn update_terminal_response_status(
     response_uuid: Uuid,
     status: ResponseStatus,
     reason: &str,
-) {
+) -> TerminalStatusUpdate {
     match db.update_response_status_if_current(
         response_id,
         ResponseStatus::InProgress,
         status,
         Some(Utc::now()),
     ) {
-        Ok(true) => {}
+        Ok(true) => TerminalStatusUpdate::Updated,
         Ok(false) => {
             debug!(
                 "Storage: skipped setting response {} ({}) to {:?} after {}; response was no longer in_progress",
                 response_id, response_uuid, status, reason
             );
+            TerminalStatusUpdate::AlreadyTerminal
         }
         Err(e) => {
             error!(
                 "Failed to update response {} ({}) status to {:?} after {}: {:?}",
                 response_id, response_uuid, status, reason, e
             );
+            TerminalStatusUpdate::Failed
         }
+    }
+}
+
+fn terminal_outcome_after_status_update<F, E>(
+    response_uuid: Uuid,
+    status_update: TerminalStatusUpdate,
+    updated_outcome: StorageTaskOutcome,
+    get_persisted_status: F,
+) -> StorageTaskOutcome
+where
+    F: FnOnce() -> Result<ResponseStatus, E>,
+    E: std::fmt::Debug,
+{
+    match status_update {
+        TerminalStatusUpdate::Updated => updated_outcome,
+        TerminalStatusUpdate::Failed => StorageTaskOutcome::Failed,
+        TerminalStatusUpdate::AlreadyTerminal => match get_persisted_status() {
+            Ok(ResponseStatus::Cancelled) => {
+                // A competing cancellation worker already completed the same
+                // durable terminal transition, so its result is authoritative.
+                StorageTaskOutcome::Cancelled
+            }
+            Ok(status) => {
+                error!(
+                    "Storage: response {} was {:?} after a terminal status update lost its in_progress compare-and-set",
+                    response_uuid, status
+                );
+                StorageTaskOutcome::Failed
+            }
+            Err(e) => {
+                error!(
+                    "Storage: failed to read response {} after a terminal status update lost its in_progress compare-and-set: {:?}",
+                    response_uuid, e
+                );
+                StorageTaskOutcome::Failed
+            }
+        },
     }
 }
 
@@ -252,7 +311,8 @@ async fn mark_pending_items_incomplete(
     pending_messages: &mut HashMap<Uuid, PendingAssistantMessage>,
     pending_reasoning: &mut HashMap<Uuid, PendingReasoningItem>,
     message_finish_reason: Option<String>,
-) {
+) -> bool {
+    let mut succeeded = true;
     for (item_id, pending) in pending_messages.drain() {
         if let Err(e) = finalize_assistant_message(
             db,
@@ -268,6 +328,7 @@ async fn mark_pending_items_incomplete(
                 "Failed to finalize pending assistant message {}: {}",
                 item_id, e
             );
+            succeeded = false;
         }
     }
 
@@ -279,8 +340,11 @@ async fn mark_pending_items_incomplete(
                 "Failed to finalize pending reasoning item {}: {}",
                 item_id, e
             );
+            succeeded = false;
         }
     }
+
+    succeeded
 }
 
 /// Main storage task that orchestrates per-item persistence.
@@ -295,11 +359,12 @@ pub async fn storage_task(
     conversation_id: i64,
     user_id: Uuid,
     user_key: SecretKey,
-) {
+) -> StorageTaskOutcome {
     let tool_ack = tool_persist_ack;
     let mut pending_messages: HashMap<Uuid, PendingAssistantMessage> = HashMap::new();
     let mut pending_reasoning: HashMap<Uuid, PendingReasoningItem> = HashMap::new();
     let mut next_item_created_at = first_item_created_at;
+    let mut persistence_failed = false;
 
     while let Some(msg) = rx.recv().await {
         match msg {
@@ -354,6 +419,7 @@ pub async fn storage_task(
                     created_at,
                 ) {
                     error!("{}", e);
+                    persistence_failed = true;
                 }
                 if let Err(e) = finalize_assistant_message(
                     &db,
@@ -366,6 +432,7 @@ pub async fn storage_task(
                 .await
                 {
                     error!("{}", e);
+                    persistence_failed = true;
                 }
             }
             StorageMessage::ReasoningStarted { item_id } => {
@@ -381,6 +448,7 @@ pub async fn storage_task(
                     created_at,
                 ) {
                     error!("{}", e);
+                    persistence_failed = true;
                 }
             }
             StorageMessage::ReasoningDelta { item_id, delta } => {
@@ -418,6 +486,7 @@ pub async fn storage_task(
                         reasoning_finalize_started.elapsed().as_millis(),
                         e
                     );
+                    persistence_failed = true;
                 } else {
                     debug!(
                         "Storage: finalized reasoning item {} for response {} in {} ms",
@@ -453,29 +522,50 @@ pub async fn storage_task(
                         None,
                     )
                     .await;
+                    persistence_failed = true;
                 }
-                update_terminal_response_status(
+                if persistence_failed {
+                    let status_update = update_terminal_response_status(
+                        &db,
+                        response_id,
+                        response_uuid,
+                        ResponseStatus::Failed,
+                        "response item persistence failure",
+                    );
+                    return terminal_outcome_after_status_update(
+                        response_uuid,
+                        status_update,
+                        StorageTaskOutcome::Failed,
+                        || {
+                            db.get_response_by_uuid_and_user(response_uuid, user_id)
+                                .map(|response| response.status)
+                        },
+                    );
+                }
+
+                let status_update = update_terminal_response_status(
                     &db,
                     response_id,
                     response_uuid,
                     ResponseStatus::Completed,
                     "ResponseDone",
                 );
-                return;
+                return terminal_outcome_after_status_update(
+                    response_uuid,
+                    status_update,
+                    StorageTaskOutcome::Completed,
+                    || {
+                        db.get_response_by_uuid_and_user(response_uuid, user_id)
+                            .map(|response| response.status)
+                    },
+                );
             }
             StorageMessage::Cancelled => {
                 debug!(
                     "Storage: cancellation received for response {} ({})",
                     response_id, response_uuid
                 );
-                update_terminal_response_status(
-                    &db,
-                    response_id,
-                    response_uuid,
-                    ResponseStatus::Cancelled,
-                    "cancellation",
-                );
-                mark_pending_items_incomplete(
+                let cleanup_succeeded = mark_pending_items_incomplete(
                     &db,
                     &user_key,
                     &mut pending_messages,
@@ -483,21 +573,52 @@ pub async fn storage_task(
                     Some(FINISH_REASON_CANCELLED.to_string()),
                 )
                 .await;
-                return;
+                // The cancelled database state is the endpoint's durability
+                // certificate. Publish it only after every pending item has
+                // been finalized, never before cleanup.
+                let (status, outcome, reason) = if cleanup_succeeded {
+                    (
+                        ResponseStatus::Cancelled,
+                        StorageTaskOutcome::Cancelled,
+                        "cancellation cleanup",
+                    )
+                } else {
+                    (
+                        ResponseStatus::Failed,
+                        StorageTaskOutcome::Failed,
+                        "cancellation cleanup failure",
+                    )
+                };
+                let status_update = update_terminal_response_status(
+                    &db,
+                    response_id,
+                    response_uuid,
+                    status,
+                    reason,
+                );
+                return terminal_outcome_after_status_update(
+                    response_uuid,
+                    status_update,
+                    outcome,
+                    || {
+                        db.get_response_by_uuid_and_user(response_uuid, user_id)
+                            .map(|response| response.status)
+                    },
+                );
             }
             StorageMessage::Error(error_msg) => {
                 error!(
                     "Storage: received error for response {} ({}): {}",
                     response_id, response_uuid, error_msg
                 );
-                update_terminal_response_status(
+                let status_update = update_terminal_response_status(
                     &db,
                     response_id,
                     response_uuid,
                     ResponseStatus::Failed,
                     "streaming error",
                 );
-                mark_pending_items_incomplete(
+                let cleanup_succeeded = mark_pending_items_incomplete(
                     &db,
                     &user_key,
                     &mut pending_messages,
@@ -505,7 +626,20 @@ pub async fn storage_task(
                     None,
                 )
                 .await;
-                return;
+                let outcome = terminal_outcome_after_status_update(
+                    response_uuid,
+                    status_update,
+                    StorageTaskOutcome::Failed,
+                    || {
+                        db.get_response_by_uuid_and_user(response_uuid, user_id)
+                            .map(|response| response.status)
+                    },
+                );
+                return if cleanup_succeeded {
+                    outcome
+                } else {
+                    StorageTaskOutcome::Failed
+                };
             }
             StorageMessage::ToolCall {
                 tool_call_id,
@@ -548,6 +682,7 @@ pub async fn storage_task(
                             tool_call_persist_started.elapsed().as_millis(),
                             e
                         );
+                        persistence_failed = true;
                         if let Some(ack) = &tool_ack {
                             let _ = ack.send(Err(e)).await;
                         }
@@ -599,6 +734,7 @@ pub async fn storage_task(
                             tool_output_persist_started.elapsed().as_millis(),
                             e
                         );
+                        persistence_failed = true;
                         if let Some(ack) = &tool_ack {
                             let _ = ack.send(Err(e)).await;
                         }
@@ -627,4 +763,89 @@ pub async fn storage_task(
         None,
     )
     .await;
+    StorageTaskOutcome::Failed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn successful_terminal_status_update_uses_requested_outcome() {
+        let outcome = terminal_outcome_after_status_update(
+            Uuid::new_v4(),
+            TerminalStatusUpdate::Updated,
+            StorageTaskOutcome::Completed,
+            || -> Result<ResponseStatus, &'static str> {
+                panic!("a successful compare-and-set must not reread response status")
+            },
+        );
+
+        assert_eq!(outcome, StorageTaskOutcome::Completed);
+
+        let failed_outcome = terminal_outcome_after_status_update(
+            Uuid::new_v4(),
+            TerminalStatusUpdate::Updated,
+            StorageTaskOutcome::Failed,
+            || -> Result<ResponseStatus, &'static str> {
+                panic!("a successful compare-and-set must not reread response status")
+            },
+        );
+        assert_eq!(failed_outcome, StorageTaskOutcome::Failed);
+    }
+
+    #[test]
+    fn cancelled_database_state_wins_completion_race() {
+        for updated_outcome in [StorageTaskOutcome::Completed, StorageTaskOutcome::Failed] {
+            let outcome = terminal_outcome_after_status_update(
+                Uuid::new_v4(),
+                TerminalStatusUpdate::AlreadyTerminal,
+                updated_outcome,
+                || Ok::<ResponseStatus, &'static str>(ResponseStatus::Cancelled),
+            );
+
+            assert_eq!(outcome, StorageTaskOutcome::Cancelled);
+        }
+    }
+
+    #[test]
+    fn completion_fails_closed_for_other_terminal_state_or_read_error() {
+        for status in [
+            ResponseStatus::Queued,
+            ResponseStatus::InProgress,
+            ResponseStatus::Completed,
+            ResponseStatus::Failed,
+        ] {
+            assert_eq!(
+                terminal_outcome_after_status_update(
+                    Uuid::new_v4(),
+                    TerminalStatusUpdate::AlreadyTerminal,
+                    StorageTaskOutcome::Completed,
+                    || Ok::<ResponseStatus, &'static str>(status),
+                ),
+                StorageTaskOutcome::Failed
+            );
+        }
+
+        assert_eq!(
+            terminal_outcome_after_status_update(
+                Uuid::new_v4(),
+                TerminalStatusUpdate::AlreadyTerminal,
+                StorageTaskOutcome::Completed,
+                || Err::<ResponseStatus, &'static str>("read failed"),
+            ),
+            StorageTaskOutcome::Failed
+        );
+        assert_eq!(
+            terminal_outcome_after_status_update(
+                Uuid::new_v4(),
+                TerminalStatusUpdate::Failed,
+                StorageTaskOutcome::Completed,
+                || -> Result<ResponseStatus, &'static str> {
+                    panic!("a failed compare-and-set must not be reread")
+                },
+            ),
+            StorageTaskOutcome::Failed
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- return the persisted Responses API ID with conversation items so clients can recover ownership after navigation or reconnects
- track each response's provider, orchestration, storage, and client-finalization work through one execution registry
- make cancel and exact-response delete wait for process-local quiescence and fail closed when this process cannot prove ownership
- publish completed/cancelled terminal events only after the response transcript and terminal state are durable
- when client cancellation loses a race to durable completion, drain the buffered client projection and emit the authoritative completed terminal instead of a false stream error
- treat the four-second storage-join threshold as a warning and continue waiting for the authoritative terminal outcome instead of aborting storage

## Why

Maple's client-side Chat queue promotes the next turn only after the active response reaches a trustworthy terminal state. Before this change, cancellation acknowledged a database status transition while provider/storage work could still be running.

This does **not** add a server-side message queue or steer/force-push behavior. It tightens the existing Responses execution and cancellation contract used by the client queue.

## Compatibility and boundaries

- The barrier is scoped to exact response execution. It does not claim an account-wide drain of unrelated title/image work or every detached accounting path.
- Execution ownership is process-local. If an active database row has no local owner, cancel/delete returns 503 because this process cannot distinguish a live foreign replica from a prior-lifetime orphan. Durable cross-process fencing/recovery is a follow-up; restart-orphaned rows require explicitly coordinated post-drain reconciliation.
- No leases, fencing, startup sweep, schema change, release, deployment, enclave, PCR, KMS, IAM, or production multi-replica validation is included in this PR.

## Validation

- Rust formatting and strict Clippy with warnings denied
- all-feature unit suite: 462 passed, 0 failed, 23 expected ignored
- focused Responses handler suite: 47 passed, 0 failed
- disposable PostgreSQL validation: 20 AEAD/database tests and 2 OAuth database tests passed with no skips
- managed OpenSecret workspace smoke against the companion Maple branch
- paid local Pro web GUI smoke with Kimi K3: queue, inline edit, remove, Stop retention, idle resume, and a separate normal completed response

## Companion client

Companion Maple PR: OpenSecretCloud/Maple#877.
