### PR TITLE
Add Transport V2 with V1-compatible session recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3096,6 +3096,7 @@ dependencies = [
  "tinfoil",
  "tokio",
  "tokio-stream",
+ "tower 0.5.2",
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tower-http = { version = "0.5.2", features = ["cors"] }
+tower = { version = "0.5", features = ["util"] }
 thiserror = "1.0.63"
 async-trait = "0.1.81"
 jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }

--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -1,0 +1,610 @@
+# OpenSecret Transport V2
+
+This document is the canonical wire contract for Transport V2. It describes
+the protocol implemented by `src/transport_v2/` and the V2-specific
+authentication paths. Older design notes are useful research, but are not
+normative when they disagree with this document or the source.
+
+Transport V2 is deliberately small:
+
+- one attested X25519 request/response establishes an identity-neutral session;
+- every logical request is one whole-request ChaCha20-Poly1305 envelope;
+- every request carries its own credential, when one is required;
+- a random request ID provides unordered, exact replay detection;
+- responses are ordered authenticated records with explicit finality; and
+- V1 remains a separate protocol with unchanged wire behavior.
+
+It does **not** use a principal-bound session, EHBP, DPoP, Binary HTTP,
+monotonic request counters, per-field signatures, or a custom memory scheduler.
+
+## Security boundary
+
+The TLS terminator, forwarding host, reverse proxy, and load balancer are not
+trusted with logical request or response contents. After session
+establishment, they can observe the V2 endpoint, session identifier, ciphertext
+lengths, timing, and connection behavior, but not the logical method, target,
+headers, credential, cache root, body, status, or response bytes.
+
+The client trusts session keys only after it has:
+
+1. authenticated the AWS Nitro attestation document, including its certificate
+   chain, COSE signature, validity time, and freshness challenge;
+2. applied its configured approved-PCR policy;
+3. checked all three transcript bindings in the document; and
+4. derived the same session identifier returned by the enclave.
+
+The approved-PCR policy is a client release policy, not a value supplied by the
+server or defined by this wire format. Production clients fail closed if it is
+not satisfied. An exact loopback development configuration may use the mock
+attestation path.
+
+An encryption session proves possession of transport keys. It never supplies a
+user, platform-user, project, or API-key identity. Application authentication
+and authorization still run for every logical request.
+
+## Byte conventions
+
+Unless specified otherwise:
+
+- integers are unsigned and big-endian;
+- byte concatenation is written `||`;
+- `0` in a derivation is one zero byte;
+- Base64 means canonical padded RFC 4648 standard Base64;
+- session and request IDs render as exactly 32 lowercase hexadecimal
+  characters; and
+- AEAD means ChaCha20-Poly1305 with its 16-byte authentication tag appended to
+  the ciphertext.
+
+Protocol labels are ASCII bytes exactly as printed below. They are not
+NUL-terminated except for the explicit separator byte.
+
+## 1. Establish an attested session
+
+The client generates a fresh 32-byte random challenge and ephemeral X25519 key
+pair, then sends:
+
+```http
+POST /v2/session
+Content-Type: application/json
+
+{
+  "version": 2,
+  "challenge": "<canonical Base64 of 32 bytes>",
+  "client_public_key": "<canonical Base64 of 32 bytes>"
+}
+```
+
+`Content-Type` must be exactly `application/json` without parameters. The JSON
+object rejects unknown or duplicate fields. The outer request has no query
+string, authorization, proxy authorization, cookie, or content encoding. Its
+actual body is limited to 4 KiB. `Content-Length` is optional; when present, it
+is only an early size check, and the actual bytes read remain authoritative.
+
+The enclave generates its own ephemeral X25519 key pair and returns plaintext
+JSON:
+
+```json
+{
+  "version": 2,
+  "session_id": "<32 lowercase hex characters>",
+  "attestation_document": "<Base64 Nitro attestation document>",
+  "expires_in_seconds": 3900
+}
+```
+
+The Nitro document must contain these exact bindings:
+
+| Nitro field | Required value |
+| --- | --- |
+| `nonce` | the client's 32-byte challenge |
+| `public_key` | the enclave's 32-byte ephemeral X25519 public key |
+| `user_data` | `"opensecret/transport-v2/session/v1/client-public-key" || 0 || client_public_key` |
+
+The client authenticates and approves the document **before** using the server
+public key. It then computes X25519 with its ephemeral private key and rejects
+the all-zero shared secret.
+
+### Session key schedule
+
+Let:
+
+```text
+transcript_hash = SHA-256(
+    "opensecret/transport-v2/session/v1" || 0 ||
+    challenge || client_public_key || server_public_key
+)
+
+PRK = HKDF-Extract-SHA256(
+    salt = challenge,
+    IKM  = X25519_shared_secret
+)
+```
+
+Derive three values with HKDF-Expand-SHA256:
+
+```text
+request_key  = Expand(PRK,
+    "opensecret/transport-v2/request-key/v1" || 0 || transcript_hash, 32)
+
+response_key = Expand(PRK,
+    "opensecret/transport-v2/response-key/v1" || 0 || transcript_hash, 32)
+
+session_id   = Expand(PRK,
+    "opensecret/transport-v2/session-id/v1" || 0 || transcript_hash, 16)
+```
+
+The client compares lowercase-hex `session_id` with the response and rejects a
+mismatch. It then erases the ephemeral private key, shared secret, transcript
+scratch values, and any unneeded derived-key copies.
+
+The server session has a fixed 3,900-second lifetime from creation. Activity
+does not extend it. Clients should retire it slightly early to account for
+establishment time and clock or network skew.
+
+## 2. Send a whole logical request
+
+All application operations use one outer endpoint:
+
+```http
+POST /v2/request
+Content-Type: application/octet-stream
+X-Session-Id: <32 lowercase hex session ID>
+
+<request record bytes>
+```
+
+`Content-Type` must be exactly `application/octet-stream` without parameters,
+and there must be exactly one `X-Session-Id`. The outer URI has no query string.
+Credentials, cookies, and content encoding are forbidden outside the
+ciphertext. Transfer framing such as an absent `Content-Length` or HTTP
+chunking is valid; the gateway always enforces the actual-body limit while
+reading.
+
+The client chooses a fresh, cryptographically random 16-byte `request_id` for
+every logical request. Requests may arrive in any order.
+
+### Request plaintext
+
+The AEAD plaintext is:
+
+```text
+metadata_length_u32 || metadata_json || raw_body
+```
+
+`metadata_json` is UTF-8 JSON with exactly these fields:
+
+```json
+{
+  "version": 2,
+  "credential": null,
+  "cache_namespace_root": null,
+  "method": "GET",
+  "target": "/v1/models?example=1",
+  "headers": [
+    { "name": "accept", "value": "application/json" }
+  ],
+  "body_present": false
+}
+```
+
+Object field order is immaterial, but unknown and duplicate fields are
+rejected. Canonical writers emit every field shown. The current decoder also
+treats an omitted `credential` or `cache_namespace_root` as `null`; clients
+must not rely on omitting any other field. Nested credential and header objects
+also reject unknown or duplicate fields. `body_present: false` requires an
+empty raw tail and means no logical body. `body_present: true` distinguishes a
+present empty body from an absent body.
+
+The method is an HTTP method token. The target is an origin-relative path with
+an optional query, starts with one `/`, has no scheme or authority, and contains
+neither a fragment nor a backslash. Logical header names are canonical
+lowercase HTTP names. Repeated headers are allowed and preserve their order.
+
+The following headers are controlled by the gateway and cannot appear as
+logical headers:
+
+```text
+authorization  proxy-authorization  cookie  set-cookie  host
+content-length transfer-encoding
+connection     keep-alive           te      trailer      upgrade
+forwarded      via                  x-forwarded-for
+x-forwarded-host x-forwarded-proto  x-session-id
+```
+
+`content-encoding` is also rejected on the outer request. It is not in the
+logical gateway-controlled list.
+
+### Credentials and anonymous-to-authenticated use
+
+`credential` is either `null` or an exact object:
+
+```json
+{ "kind": "bearer", "value": "<V2 access token>" }
+```
+
+The supported kinds are:
+
+- `bearer`: a V2 user or platform access token, as required by the route;
+- `api_key`: an inference-scoped OpenSecret API key; and
+- `resumption`: a V2 refresh token, accepted by the user or platform refresh
+  route instead of a refresh token in the logical body.
+
+The value is 1 to 16 KiB of visible non-space ASCII. A request that needs no
+identity, including registration, login, and session establishment, uses
+`null`. A successful login or registration returns V2 access and refresh tokens
+inside the encrypted response; subsequent authenticated requests carry the
+appropriate token inside their own envelope. The transport session itself does
+not change state during this transition.
+
+V2 user and platform access/refresh tokens have dedicated audiences that V1
+validators do not accept. Third-party JWT issuance remains an authenticated
+application operation; those tokens are outputs for external services, not V2
+transport credentials.
+
+### Provider cache root
+
+`cache_namespace_root` is either `null` or canonical padded Base64 of exactly
+32 client-random bytes. V2 chat-completion and Responses creation/inference
+requests require a root; stored-response control and read operations do not. A
+client keeps it stable across app restarts when it wants stable provider cache
+hits, but never sends it outside the encrypted envelope.
+
+After authenticating the request, the enclave derives:
+
+```text
+HMAC-SHA256(
+    key = cache_namespace_root,
+    data = "opensecret/provider-cache/tinfoil/user-cache-namespace/v1" || 0 ||
+           verified_user_uuid_bytes
+)
+```
+
+Only the hexadecimal derived value is supplied to Tinfoil as
+`user_cache_secret`. The raw root is not persisted by OpenSecret. Caller
+versions of provider-managed cache fields are removed; non-Tinfoil providers
+do not receive `user_cache_secret`, and Continuum retains its separate
+server-controlled cache isolation.
+
+### Request record encryption
+
+Treat the 32-byte directional `request_key` as an HKDF PRK and derive:
+
+```text
+request_subkey = HKDF-Expand-SHA256(
+    request_key,
+    "opensecret/transport-v2/request-subkey/v1" || 0 ||
+    session_id || request_id,
+    32
+)
+
+request_aad =
+    "opensecret/transport-v2/request-record/v1" || 0 ||
+    session_id || request_id
+```
+
+Encrypt the request plaintext with ChaCha20-Poly1305 using
+`request_subkey`, a 12-byte all-zero nonce, and `request_aad`. The wire record
+is:
+
+```text
+request_id || ciphertext_and_tag
+```
+
+The fixed nonce is safe only because every random request ID derives a distinct
+subkey. A client must never use the same request ID with different plaintext;
+canonical clients do not intentionally reuse an ID at all.
+
+### Replay admission
+
+After successful AEAD authentication and before application dispatch, the
+enclave atomically inserts `request_id` into that session's exact `HashSet`.
+There is no ordering assumption or highest-sequence window. Concurrent copies
+of one record have exactly one winner.
+
+A duplicate ID or exhausted per-session set is rejected before application
+side effects. Process-wide replay pressure returns a generic, non-latching
+capacity failure without permanently poisoning unrelated sessions. It does not
+make a resend safe. Replay entries disappear with the in-memory session; after
+an enclave restart the old session keys are also gone, so old ciphertext is
+not usable in a new session.
+
+## 3. Receive the logical response
+
+After a request is authenticated and replay-admitted, its response writer is
+derived directly from that same session and request ID. It is not selected by a
+second caller-controlled lookup.
+
+A successfully constructed admitted response uses:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/octet-stream
+Cache-Control: no-store
+X-Accel-Buffering: no
+
+<framed encrypted records>
+```
+
+Each outer frame is:
+
+```text
+ciphertext_length_u32 || ciphertext_and_tag
+```
+
+HTTP transport chunks are not record boundaries. A client parser must buffer
+across a fragmented length prefix or ciphertext and must also accept multiple
+complete frames coalesced into one HTTP chunk. It must enforce the record-size
+limit before allocating the declared ciphertext and reject EOF in a partial
+prefix or frame.
+
+The sequence number is implicit. It starts at zero and increments once for
+every encrypted record; it is not carried separately on the wire.
+
+Treat the 32-byte directional `response_key` as an HKDF PRK and derive one
+subkey for the request:
+
+```text
+response_subkey = HKDF-Expand-SHA256(
+    response_key,
+    "opensecret/transport-v2/response-subkey/v1" || 0 ||
+    session_id || request_id,
+    32
+)
+
+response_nonce = 0x00000000 || sequence_u64
+
+response_aad =
+    "opensecret/transport-v2/response-record/v1" || 0 ||
+    session_id || request_id || sequence_u64
+```
+
+Each plaintext response record begins with a one-byte tag:
+
+| Tag | Name | Remaining plaintext |
+| --- | --- | --- |
+| `0x01` | Start | strict JSON `{"status": <200..599>, "headers": [...]}` |
+| `0x02` | Chunk | raw logical response bytes, at most 64 KiB |
+| `0x03` | End | empty |
+| `0x04` | Error | strict JSON `{"code": "lowercase_machine_code"}` |
+
+The required grammar is:
+
+```text
+Start, zero or more Chunk records, exactly one of End or Error, then EOF
+```
+
+Every response, including a unary JSON or binary response, uses this grammar.
+SSE remains ordinary SSE bytes inside Chunk records; clients decrypt
+incrementally and expose the reconstructed logical stream to the application.
+An application body or stream-production failure after Start becomes an
+authenticated transport Error record. An ordinary application failure—such as
+an expired access credential—is instead a logical HTTP status, headers, and
+body beginning in the authenticated Start record. In particular, clients
+recognize `access_token_expired` only from the decrypted
+`x-opensecret-error-contract` and `x-opensecret-error-code` logical headers;
+matching outer headers are unauthenticated and must be ignored. EOF without a
+terminal record, a second Start, a record after the terminal, a sequence or
+AEAD failure, an invalid frame length, a redirect, a non-200 outer status, or a
+wrong outer content type is a transport failure and must fail closed.
+
+Before a request is authenticated and replay-admitted, the gateway can return a
+generic plaintext outer `400`, `413`, `415`, or `503`. Once admitted, ordinary
+application statuses and representable errors are carried in the encrypted
+Start record. A replay rejection is deliberately an outer generic error: the
+server does not encrypt a second response under a reused request subkey and
+sequence. A generic outer `503` is only a capacity signal; it is not proof that
+the request was safe to resend automatically.
+
+### Cryptographic interoperability fixture
+
+`crypto::tests::deterministic_key_and_record_vector` fixes the following
+synthetic KDF/record vector. The repeated-byte shared secret is supplied
+directly for this fixture; it is not an X25519 private key.
+
+```text
+challenge         = byte 0x11 repeated 32 times
+client_public_key = byte 0x22 repeated 32 times
+server_public_key = byte 0x33 repeated 32 times
+shared_secret     = byte 0x44 repeated 32 times
+
+session_id  = f7258fb103137c612baab47ced4a5a02
+request_key = 00f898a5f2dcd40a703f42221f2a2b842b7e97ed5a555caa362c4153a5e1c491
+response_key = e4fb003c5c829f5385531eebfdbd0ee3d8430a0bd71322e9f3e41ace915c3190
+
+request_id = byte 0x55 repeated 16 times
+plaintext  = "vector plaintext"
+record     = 55555555555555555555555555555555671f5c411205cb00f769e6b2705052b795e91f44516fc6165e16a152e686b209
+
+response request_id = byte 0x66 repeated 16 times
+sequence            = 0
+plaintext           = "vector response"
+ciphertext          = 25a2d5ed89864bd7b5e13c83eb49b1f314a70abf8bd7e871b706bb6768c9e1
+```
+
+## Limits and memory behavior
+
+These are byte and retained-state caps, not reservations:
+
+| Resource | Limit |
+| --- | ---: |
+| `/v2/session` request body | 4 KiB actual bytes |
+| Request metadata JSON | 128 KiB |
+| Logical request body | 50 MiB |
+| Encoded request plaintext | 52,559,876 bytes |
+| Raw encrypted request record | 52,559,908 bytes |
+| Credential | 16 KiB |
+| Method | 32 bytes |
+| Relative target | 16 KiB |
+| Logical request headers | 64 entries |
+| Response metadata JSON | 64 KiB |
+| Response Chunk | 64 KiB |
+| Encrypted response record | 65,553 bytes |
+| Logical response headers | 32 entries |
+| Error code | 64 bytes |
+| Session lifetime | 3,900 seconds, absolute |
+| Live sessions per enclave process | 2,097,152 |
+| Replay IDs per session | 1,048,576 |
+| Replay IDs per enclave process | 16,777,216 |
+| Pending OAuth states | 4,096 per provider for 10 minutes |
+
+The gateway allocates for bytes and state that actually arrive. It does not
+pre-reserve a maximum request, translate byte ceilings into concurrent-request
+permits, or hold a provider/storage permit for a stream. The session and replay
+limits allocate no entries up front.
+
+The request carrier is intentionally buffered once before decryption. During
+admission, a maximum request can briefly coexist as about 50.1 MiB of
+ciphertext and 50.1 MiB of plaintext (about 100.25 MiB total before ordinary
+HTTP and allocator overhead). Smaller requests use proportionally less. The
+decoded logical body slices the decrypted allocation rather than copying the
+50 MiB tail again.
+
+There is deliberately no transport-level aggregate reservation for in-flight
+bytes or concurrent requests. Concurrent maximum-size requests multiply that
+transient footprint, so ingress admission, memory observability, and horizontal
+capacity must keep such traffic within the enclave's real RAM. Likewise, the
+session and replay counts are hard safety ceilings rather than steady-state
+capacity promises; hash-table overhead makes their RAM cost greater than the
+raw identifier bytes.
+
+Responses are processed as bounded records. A long stream has no protocol-wide
+aggregate-byte or per-session response-record reservation. Once the response
+subkey is derived, the stream writer retains only that key plus its session ID,
+request ID, and sequence; it does not pin the complete session or replay set.
+
+Expired sessions are purged at least once per minute and on lookup. Live
+sessions are never evicted to make room for unauthenticated handshakes. A full
+session store or global replay set fails closed with `503`; dropping a session
+releases all of its retained replay IDs. Expiry prevents new admissions, but an
+already-admitted response or stream may finish after its session expires.
+
+## Redirect-based OAuth authorization-code binding
+
+V2 OAuth initiation and callback both travel through the encrypted request
+channel. The enclave stores each one-time OAuth state with the exact initiating
+V2 session and a provider-verifiable proof:
+
+- GitHub and Google authorization requests use a fresh PKCE S256 challenge;
+  the enclave retains the verifier and supplies it exactly once during the
+  token exchange.
+- Apple authorization requests use a fresh raw nonce retained only in enclave
+  memory. The authorization URL carries lowercase hex
+  `SHA-256(raw_nonce_ascii)`, and the signed token-endpoint ID token must contain
+  the same nonce value when verified from the retained raw nonce.
+
+The callback must use the initiating V2 session and matching state. A mismatch
+in state or session does not consume the legitimate state; a match is
+atomically consumed before provider exchange. A provider or network failure
+after that point requires a new OAuth attempt. Clients must therefore preserve
+the exact attested session across the browser redirect. The Apple front-channel
+ID token is not the proof used here; verification uses the signed ID token from
+the token endpoint. This redirect proof does not replace `/auth/apple/native`:
+that route verifies the submitted signed identity token and preserves its
+existing optional client-provided nonce behavior. V1 keeps its existing OAuth
+URL and state behavior.
+
+## Refresh, retry, and downgrade rules
+
+V2 refresh is a separate encrypted logical request to `/refresh` or
+`/platform/refresh`. It has no logical body and carries the refresh token as a
+`resumption` credential. A successful response replaces the client's stored V2
+access and refresh tokens.
+
+Refresh currently issues a new signed pair but does not consume or revoke the
+previous stateless refresh token. Do not describe this as one-time refresh-token
+rotation; revocation remains a separate application concern.
+
+Official clients use the access token's decoded expiry only as a scheduling
+hint. They refresh before sending a new operation when expiry is within 30
+seconds and coalesce concurrent refresh work for the same authentication
+revision. Authentication remains a server decision. If preflight refresh fails
+transiently, credentials are preserved and the original operation is not sent.
+
+No client layer automatically resends a logical request after its ciphertext
+may have left the client. A lost response is an ambiguous outcome: the
+operation may have completed and the request ID is already claimed. An
+authenticated `access_token_expired` response may trigger refresh for future
+operations, but the original operation is still returned as failed. Operations
+that need user-visible retry require their own application-level idempotency
+contract.
+
+V2 clients do not fall back to V1 when session establishment or a request
+fails. They reject redirects and unauthenticated outer responses. V1 and V2 use
+separate session stores, record formats, and internal token audiences. Existing
+raw API keys remain the same inference-only application capability across both
+transports; the transport does not rotate them.
+
+## Native application handoff
+
+Native handoff transfers authentication without placing access or refresh
+tokens in a deep link:
+
+1. The native client establishes a V2 session, chooses the random request ID
+   it will use for redemption, and retains both without sending the request yet.
+2. An already-authenticated V2 browser session requests
+   `/auth/native-handoff/grant` with that target session ID and request ID.
+3. OpenSecret returns an ES256K-signed compact JWT grant, valid for five
+   minutes (with 30 seconds of validation leeway), containing the user's
+   authenticated binding and the exact target session and request IDs. Its
+   claims are readable, so a client treats it as a short-lived capability
+   rather than encrypted data.
+4. The native client sends `/auth/native-handoff/redeem` under the prearranged
+   session and request ID, with the grant in the logical body and no credential
+   or cache root.
+5. OpenSecret verifies the grant, its times and audience, the exact transport
+   bindings, current user/project ownership, and the active seed wrap, then
+   returns fresh V2 access and refresh tokens encrypted to the native session.
+
+A copied grant cannot be redeemed from a different session or request. The
+session replay set prevents duplicate redemption within the live session.
+
+## V1 compatibility
+
+Transport V2 is an additive network boundary. Its decrypted logical methods,
+targets, headers, bodies, statuses, and streams are dispatched through the same
+application routers used by V1. A logical target such as `/v1/chat/completions`
+inside a V2 envelope is not a V1 transport request.
+
+The legacy attestation/session endpoints, outer bearer behavior, encrypted-body
+shape, response shape, OAuth behavior, and `SHA-256(user UUID)` Tinfoil cache
+namespace remain unchanged for released V1 clients. A new server therefore
+continues to serve old clients. New V2 clients speak only V2. Existing V1 user
+or platform JWT sessions require fresh V2 authentication rather than token
+migration; login, registration, OAuth, and native handoff are valid V2 entry
+paths, while existing raw inference-only API keys remain usable. V1 cache
+entries do not share the new V2 namespace, and V1 traffic does not gain V2's
+credential confidentiality, whole-request binding, or replay guarantees.
+
+## Rollout gates
+
+Before enabling V2 clients in production:
+
+1. Deploy the V2-capable backend first and prove released V1 clients still use
+   their unchanged paths.
+2. Build and verify the production EIF, publish the reviewed PCR evidence, and
+   confirm each client enforces the intended PCR policy before key derivation.
+3. Ensure `/v2/request` always reaches the enclave process that created its
+   session. The same constraint covers an OAuth callback because pending OAuth
+   state is also process-local. Enclave restart or loss requires a fresh
+   attestation and session, followed by an encrypted resumption request.
+4. Configure ingress to pass `application/octet-stream` bodies byte-for-byte,
+   permit at least 52,559,908 bytes if the full logical body limit is supported,
+   accept ordinary HTTP transfer framing, and stream responses without
+   buffering. Idle timeouts must accommodate provider streaming behavior.
+5. Keep HTTPS mandatory except for the exact loopback development carve-out;
+   do not follow redirects for either V2 endpoint.
+6. Exercise user, platform, API-key, refresh, bodyless mutation, binary, SSE,
+   OAuth-provider, native-handoff, replay, disconnect, and enclave-restart paths
+   through the pinned SDKs. Provider-backed and real-Nitro checks are distinct
+   from local mock/unit tests. Before Apple redirect OAuth is enabled, a real
+   provider smoke must confirm that the signed token-endpoint ID token carries
+   the requested nonce.
+7. Rate-limit public session creation and other unauthenticated admission at a
+   boundary that cannot be bypassed. The process-wide state counts are final
+   safety caps, not the primary abuse-control policy.
+8. Load-test concurrent large requests against the production enclave memory
+   profile and set operational admission and headroom accordingly. The
+   protocol intentionally has no custom aggregate memory reservation layer.
+9. Retain a coordinated rollback plan. Rolling the backend back below V2 after
+   publishing V2-only clients strands those clients; they intentionally do not
+   downgrade or transmit credentials over V1.

--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -66,6 +66,7 @@ pair, then sends:
 ```http
 POST /v2/session
 Content-Type: application/json
+X-OpenSecret-Routing-Key: <canonical padded Base64 challenge>
 
 {
   "version": 2,
@@ -88,7 +89,7 @@ JSON:
   "version": 2,
   "session_id": "<32 lowercase hex characters>",
   "attestation_document": "<Base64 Nitro attestation document>",
-  "expires_in_seconds": 3900
+  "expires_in_seconds": 3600
 }
 ```
 
@@ -137,9 +138,18 @@ The client compares lowercase-hex `session_id` with the response and rejects a
 mismatch. It then erases the ephemeral private key, shared secret, transcript
 scratch values, and any unneeded derived-key copies.
 
-The server session has a fixed 3,900-second lifetime from creation. Activity
+The server session has a fixed 3,600-second lifetime from creation. Activity
 does not extend it. Clients should retire it slightly early to account for
 establishment time and clock or network skew.
+
+`X-OpenSecret-Routing-Key` is the exact canonical Base64 encoding of the
+32-byte client challenge. It is public, random per session, and carries no
+credential, identity, or authority. The enclave requires it to match the
+challenge during session creation and the stored session on later requests.
+The challenge is already authenticated by Nitro attestation and included in
+the session key transcript, so no separate routing-key cryptography exists.
+Its purpose is to let a stateful load balancer select the same enclave for the
+initial handshake and every request that follows.
 
 ## 2. Send a whole logical request
 
@@ -149,12 +159,14 @@ All application operations use one outer endpoint:
 POST /v2/request
 Content-Type: application/octet-stream
 X-Session-Id: <32 lowercase hex session ID>
+X-OpenSecret-Routing-Key: <canonical padded Base64 session routing key>
 
 <request record bytes>
 ```
 
 `Content-Type` must be exactly `application/octet-stream` without parameters,
-and there must be exactly one `X-Session-Id`. The outer URI has no query string.
+and there must be exactly one `X-Session-Id` and one
+`X-OpenSecret-Routing-Key`. The outer URI has no query string.
 Credentials, cookies, and content encoding are forbidden outside the
 ciphertext. Transfer framing such as an absent `Content-Length` or HTTP
 chunking is valid; the gateway always enforces the actual-body limit while
@@ -208,7 +220,8 @@ authorization  proxy-authorization  cookie  set-cookie  host
 content-length transfer-encoding
 connection     keep-alive           te      trailer      upgrade
 forwarded      via                  x-forwarded-for
-x-forwarded-host x-forwarded-proto  x-session-id
+x-forwarded-host x-forwarded-proto  x-opensecret-routing-key
+x-session-id
 ```
 
 `content-encoding` is also rejected on the outer request. It is not in the
@@ -441,7 +454,7 @@ These are byte and retained-state caps, not reservations:
 | Encrypted response record | 65,553 bytes |
 | Logical response headers | 32 entries |
 | Error code | 64 bytes |
-| Session lifetime | 3,900 seconds, absolute |
+| Session lifetime | 3,600 seconds, absolute |
 | Live sessions per enclave process | 2,097,152 |
 | Replay IDs per session | 1,048,576 |
 | Replay IDs per enclave process | 16,777,216 |
@@ -584,9 +597,22 @@ Before enabling V2 clients in production:
 2. Build and verify the production EIF, publish the reviewed PCR evidence, and
    confirm each client enforces the intended PCR policy before key derivation.
 3. Ensure `/v2/request` always reaches the enclave process that created its
-   session. The same constraint covers an OAuth callback because pending OAuth
-   state is also process-local. Enclave restart or loss requires a fresh
-   attestation and session, followed by an encrypted resumption request.
+   session. Preserve the load balancer's existing cookie affinity as the
+   default for released V1 clients. Add a [custom load-balancing
+   rule](https://developers.cloudflare.com/load-balancing/additional-options/load-balancing-rules/)
+   matching `starts_with(http.request.uri.path, "/v2/")` that overrides only
+   those requests to [HTTP-header session
+   affinity](https://developers.cloudflare.com/load-balancing/understand-basics/session-affinity/)
+   on `x-opensecret-routing-key`, requires that header, and uses the maximum
+   3,600-second idle TTL. Canonical clients retire the absolute 3,600-second
+   enclave session 30 seconds early, before an otherwise-idle affinity entry
+   can expire. Global replacement of cookie affinity would break released V1
+   clients, while cookie affinity alone is insufficient for V2 because V2
+   deliberately omits credentials and rejects outer cookies. Header affinity
+   also cannot use Cloudflare's sticky zero-downtime failover; an origin loss
+   therefore requires a fresh attestation and session, followed by an
+   encrypted resumption request. The same affinity constraint covers an OAuth
+   callback because pending OAuth state is also process-local.
 4. Configure ingress to pass `application/octet-stream` bodies byte-for-byte,
    permit at least 52,559,908 bytes if the full logical body limit is supported,
    accept ordinary HTTP transfer framing, and stream responses without
@@ -599,9 +625,11 @@ Before enabling V2 clients in production:
    from local mock/unit tests. Before Apple redirect OAuth is enabled, a real
    provider smoke must confirm that the signed token-endpoint ID token carries
    the requested nonce.
-7. Rate-limit public session creation and other unauthenticated admission at a
-   boundary that cannot be bypassed. The process-wide state counts are final
-   safety caps, not the primary abuse-control policy.
+7. Restrict direct origin ingress to Cloudflare, or enforce equivalent
+   connection, upload-time, and request-rate controls at every origin-local
+   boundary. Rate-limit public session creation and other unauthenticated
+   admission where those controls cannot be bypassed. The process-wide state
+   counts are final safety caps, not the primary abuse-control policy.
 8. Load-test concurrent large requests against the production enclave memory
    profile and set operational admission and headroom accordingly. The
    protocol intentionally has no custom aggregate memory reservation layer.

--- a/docs/transport-v2-protocol.md
+++ b/docs/transport-v2-protocol.md
@@ -149,7 +149,9 @@ challenge during session creation and the stored session on later requests.
 The challenge is already authenticated by Nitro attestation and included in
 the session key transcript, so no separate routing-key cryptography exists.
 Its purpose is to let a stateful load balancer select the same enclave for the
-initial handshake and every request that follows.
+initial handshake and every request that follows when using HTTP-header
+affinity. The wire header remains required with a single origin or DNS-only
+routing, even when that routing layer does not inspect HTTP headers.
 
 ## 2. Send a whole logical request
 
@@ -395,10 +397,12 @@ an expired access credential—is instead a logical HTTP status, headers, and
 body beginning in the authenticated Start record. In particular, clients
 recognize `access_token_expired` only from the decrypted
 `x-opensecret-error-contract` and `x-opensecret-error-code` logical headers;
-matching outer headers are unauthenticated and must be ignored. EOF without a
+matching outer headers cannot trigger access-token refresh. EOF without a
 terminal record, a second Start, a record after the terminal, a sequence or
 AEAD failure, an invalid frame length, a redirect, a non-200 outer status, or a
-wrong outer content type is a transport failure and must fail closed.
+wrong outer content type is a transport failure. Clients fail closed except
+for the narrowly marked session-recovery response described below; response
+AEAD or framing failures never qualify for automatic recovery.
 
 Before a request is authenticated and replay-admitted, the gateway can return a
 generic plaintext outer `400`, `413`, `415`, or `503`. Once admitted, ordinary
@@ -407,6 +411,22 @@ Start record. A replay rejection is deliberately an outer generic error: the
 server does not encrypt a second response under a reused request subkey and
 sequence. A generic outer `503` is only a capacity signal; it is not proof that
 the request was safe to resend automatically.
+
+Two pre-dispatch failures use outer HTTP `400` with the existing
+`x-opensecret-error-contract: 1` header and one exact
+`x-opensecret-error-code` value:
+
+| Code | Server condition |
+| --- | --- |
+| `session_not_found` | The requested session is actually missing or expired |
+| `request_decryption_failed` | AEAD authentication of the incoming request fails |
+
+The gateway emits these codes only before application dispatch. A routing-key
+mismatch for an existing session, record length/encoding errors, malformed
+envelopes, replay rejection, capacity failures, and ordinary application errors
+do not receive these recovery markers. These
+outer headers are unauthenticated hints, not evidence the original request
+never executed; see the retry rules below.
 
 ### Cryptographic interoperability fixture
 
@@ -460,10 +480,11 @@ These are byte and retained-state caps, not reservations:
 | Replay IDs per enclave process | 16,777,216 |
 | Pending OAuth states | 4,096 per provider for 10 minutes |
 
-The gateway allocates for bytes and state that actually arrive. It does not
-pre-reserve a maximum request, translate byte ceilings into concurrent-request
-permits, or hold a provider/storage permit for a stream. The session and replay
-limits allocate no entries up front.
+These body, session, and replay caps are active defaults, not optional
+deployment settings. The gateway allocates for bytes and state that actually
+arrive. It does not pre-reserve a maximum request, translate byte ceilings into
+concurrent-request permits, or hold a provider/storage permit for a stream. The
+session and replay limits allocate no entries up front.
 
 The request carrier is intentionally buffered once before decryption. During
 admission, a maximum request can briefly coexist as about 50.1 MiB of
@@ -533,17 +554,34 @@ seconds and coalesce concurrent refresh work for the same authentication
 revision. Authentication remains a server decision. If preflight refresh fails
 transiently, credentials are preserved and the original operation is not sent.
 
-No client layer automatically resends a logical request after its ciphertext
-may have left the client. A lost response is an ambiguous outcome: the
-operation may have completed and the request ID is already claimed. An
-authenticated `access_token_expired` response may trigger refresh for future
-operations, but the original operation is still returned as failed. Operations
-that need user-visible retry require their own application-level idempotency
-contract.
+Managed SDK requests allow one automatic resend of the original logical
+operation after a fresh, verified attestation handshake, and only when the
+first attempt returns outer HTTP `400`, exactly
+`x-opensecret-error-contract: 1`, and exactly one of the two recovery codes
+above. The resend uses the new session and a fresh request ID; a second failure
+is returned to the caller. This applies to ordinary managed requests including
+mutations and inference, not just reads.
+
+This deliberately matches V1's best-effort session recovery behavior. An
+untrusted intermediary can let the original request execute, replace its
+response with a forged recovery hint, and cause the client to submit the
+operation again under a new session. The per-session replay set cannot prevent
+that second execution: cross-session at-most-once execution is not guaranteed.
+Operations needing that guarantee require application-level idempotency.
+
+There is no automatic resend for client-side response AEAD or framing failures,
+network failures or timeouts, partial streams, redirects, generic outer `400`
+or `503`, or ordinary application errors. An authenticated
+`access_token_expired` response may trigger refresh for future operations, but
+the original operation is still returned as failed. A lost response remains an
+ambiguous outcome. Prepared native-handoff redemption and session-bound OAuth
+callbacks cannot move to a fresh session; their flows must restart instead.
 
 V2 clients do not fall back to V1 when session establishment or a request
-fails. They reject redirects and unauthenticated outer responses. V1 and V2 use
-separate session stores, record formats, and internal token audiences. Existing
+fails. The narrow recovery hints never authenticate response content or permit
+plaintext credentials; logical credentials remain inside the encrypted resend.
+V1 and V2 use separate session stores, record formats, and internal token
+audiences. Existing
 raw API keys remain the same inference-only application capability across both
 transports; the transport does not rotate them.
 
@@ -570,6 +608,8 @@ tokens in a deep link:
 
 A copied grant cannot be redeemed from a different session or request. The
 session replay set prevents duplicate redemption within the live session.
+Prepared redemption does not use managed session-recovery retries: losing its
+bound session requires a new handoff and grant.
 
 ## V1 compatibility
 
@@ -587,6 +627,8 @@ migration; login, registration, OAuth, and native handoff are valid V2 entry
 paths, while existing raw inference-only API keys remain usable. V1 cache
 entries do not share the new V2 namespace, and V1 traffic does not gain V2's
 credential confidentiality, whole-request binding, or replay guarantees.
+This transport change adds no database migration, schema backfill, runtime
+environment variable, deployed secret, or additional service.
 
 ## Rollout gates
 
@@ -596,9 +638,14 @@ Before enabling V2 clients in production:
    their unchanged paths.
 2. Build and verify the production EIF, publish the reviewed PCR evidence, and
    confirm each client enforces the intended PCR policy before key derivation.
-3. Ensure `/v2/request` always reaches the enclave process that created its
-   session. Preserve the load balancer's existing cookie affinity as the
-   default for released V1 clients. Add a [custom load-balancing
+3. Keep each V2 session's normal traffic on the enclave process that created
+   it. A single origin or stable [DNS-only
+   persistence](https://developers.cloudflare.com/load-balancing/additional-options/dns-persistence/)
+   can meet this requirement; HTTP-header affinity does not apply in DNS-only
+   mode. Verify the actual topology and persistence rather than inferring it
+   from a hostname. For a proxied HTTP deployment whose multiple origins rely
+   on cookie affinity, preserve the existing cookie policy for V1 and add a
+   [custom load-balancing
    rule](https://developers.cloudflare.com/load-balancing/additional-options/load-balancing-rules/)
    matching `starts_with(http.request.uri.path, "/v2/")` that overrides only
    those requests to [HTTP-header session
@@ -610,9 +657,10 @@ Before enabling V2 clients in production:
    clients, while cookie affinity alone is insufficient for V2 because V2
    deliberately omits credentials and rejects outer cookies. Header affinity
    also cannot use Cloudflare's sticky zero-downtime failover; an origin loss
-   therefore requires a fresh attestation and session, followed by an
-   encrypted resumption request. The same affinity constraint covers an OAuth
-   callback because pending OAuth state is also process-local.
+   therefore requires a fresh attestation and session. Only the marked outer
+   `400` recovery cases permit one automatic resend; network failure alone
+   does not. Session-bound OAuth callbacks and prepared native handoffs must
+   restart because their state cannot move to the replacement session.
 4. Configure ingress to pass `application/octet-stream` bodies byte-for-byte,
    permit at least 52,559,908 bytes if the full logical body limit is supported,
    accept ordinary HTTP transfer framing, and stream responses without

--- a/src/apple_signin.rs
+++ b/src/apple_signin.rs
@@ -181,7 +181,9 @@ impl AppleJwtVerifier {
         if let Some(expected) = expected_nonce {
             match &token_data.claims.nonce {
                 Some(token_nonce) => {
-                    // Apple stores SHA256 hash of the nonce in the token
+                    // OpenSecret retains the raw nonce while the client sends
+                    // SHA256(raw nonce) to Apple. Apple returns that supplied
+                    // value in the signed token.
                     use sha2::{Digest, Sha256};
                     let mut hasher = Sha256::new();
                     hasher.update(expected.as_bytes());

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -11,7 +11,7 @@ use axum::{
     response::IntoResponse,
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, Utc};
 use jwt_compact::{alg::Es256k, prelude::*, AlgorithmExt};
 use secp256k1::{All, PublicKey, Secp256k1, SecretKey};
 use serde::{Deserialize, Serialize};
@@ -27,7 +27,10 @@ use url::Url;
 
 use crate::models::{platform_users::PlatformUser, users::User};
 use crate::{
-    transport_v2::envelope::{Credential, CredentialKind},
+    transport_v2::{
+        crypto::SessionId,
+        envelope::{Credential, CredentialKind, RequestId},
+    },
     web::encryption_middleware::TransportSession,
 };
 
@@ -47,6 +50,13 @@ pub const TRANSPORT_V2_PLATFORM_ACCESS: &str =
     "urn:opensecret:internal:transport-v2:platform:access-token";
 pub const TRANSPORT_V2_PLATFORM_REFRESH: &str =
     "urn:opensecret:internal:transport-v2:platform:refresh-token";
+pub const TRANSPORT_V2_NATIVE_HANDOFF: &str =
+    "urn:opensecret:internal:transport-v2:user:native-handoff";
+const TRANSPORT_V2_ISSUER: &str = "urn:opensecret:transport-v2";
+const TRANSPORT_V2_VERSION: u8 = 2;
+const TRANSPORT_V2_NATIVE_HANDOFF_TTL: Duration = Duration::minutes(5);
+const TRANSPORT_V2_NATIVE_HANDOFF_CLOCK_LEEWAY: Duration = Duration::seconds(30);
+pub(crate) const TRANSPORT_V2_NATIVE_HANDOFF_MAX_BYTES: usize = 4 * 1024;
 
 pub const USER_TOKEN_FORMAT_V2: u8 = 2;
 
@@ -80,6 +90,32 @@ impl TokenType {
 #[derive(Debug, Clone)]
 pub struct NewToken {
     pub token: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct NativeHandoffClaims {
+    sub: String,
+    iss: String,
+    aud: String,
+    version: u8,
+    kind: String,
+    #[serde(rename = "tf")]
+    token_format: u8,
+    #[serde(rename = "am")]
+    auth_method: String,
+    #[serde(rename = "pid")]
+    project_id: i32,
+    #[serde(rename = "ab")]
+    auth_binding: String,
+    #[serde(rename = "sid")]
+    target_session_id: String,
+    #[serde(rename = "rid")]
+    request_id: String,
+}
+
+pub(crate) struct IssuedNativeHandoffGrant {
+    pub(crate) grant: String,
+    pub(crate) expires_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Clone)]
@@ -210,7 +246,7 @@ impl AuthContext {
 impl TokenType {
     pub fn validate_third_party_audience(aud: &str) -> Result<(), ApiError> {
         // Validate third party audience can't use our internal audience types
-        const RESERVED_AUDIENCES: [&str; 8] = [
+        const RESERVED_AUDIENCES: [&str; 9] = [
             USER_ACCESS,
             USER_REFRESH,
             PLATFORM_ACCESS,
@@ -219,6 +255,7 @@ impl TokenType {
             TRANSPORT_V2_USER_REFRESH,
             TRANSPORT_V2_PLATFORM_ACCESS,
             TRANSPORT_V2_PLATFORM_REFRESH,
+            TRANSPORT_V2_NATIVE_HANDOFF,
         ];
 
         // 1. Check for reserved audiences
@@ -617,6 +654,184 @@ impl NewToken {
             token: token_string,
         })
     }
+}
+
+pub(crate) fn issue_native_handoff_grant(
+    user: &User,
+    auth_context: &AuthContext,
+    target_session_id: SessionId,
+    request_id: RequestId,
+    app_state: &AppState,
+) -> Result<IssuedNativeHandoffGrant, ApiError> {
+    if user.project_id != auth_context.project_id {
+        return Err(ApiError::BadRequest);
+    }
+    issue_native_handoff_grant_with_keys(
+        user.get_id(),
+        auth_context,
+        target_session_id,
+        request_id,
+        &app_state.config.jwt_keys,
+        Utc::now(),
+    )
+}
+
+fn issue_native_handoff_grant_with_keys(
+    user_id: Uuid,
+    auth_context: &AuthContext,
+    target_session_id: SessionId,
+    request_id: RequestId,
+    jwt_keys: &JwtKeys,
+    issued_at: DateTime<Utc>,
+) -> Result<IssuedNativeHandoffGrant, ApiError> {
+    let expiration = issued_at + TRANSPORT_V2_NATIVE_HANDOFF_TTL;
+    let custom_claims = NativeHandoffClaims {
+        sub: user_id.to_string(),
+        iss: TRANSPORT_V2_ISSUER.to_owned(),
+        aud: TRANSPORT_V2_NATIVE_HANDOFF.to_owned(),
+        version: TRANSPORT_V2_VERSION,
+        kind: "native_handoff".to_owned(),
+        token_format: auth_context.token_format,
+        auth_method: auth_context.method.as_str().to_owned(),
+        project_id: auth_context.project_id,
+        auth_binding: URL_SAFE_NO_PAD.encode(auth_context.auth_binding),
+        target_session_id: target_session_id.to_string(),
+        request_id: request_id.to_string(),
+    };
+    let mut claims = Claims::new(custom_claims);
+    claims.issued_at = Some(issued_at);
+    claims.not_before = Some(issued_at);
+    claims.expiration = Some(expiration);
+
+    let grant = Es256k::<Sha256>::new(jwt_keys.secp.clone())
+        .token(
+            &Header::empty().with_token_type("JWT"),
+            &claims,
+            &jwt_keys.signing_key,
+        )
+        .map_err(|error| {
+            tracing::error!(?error, "failed to create transport-v2 native handoff grant");
+            ApiError::InternalServerError
+        })?;
+    if !is_canonical_compact_jwt(&grant) {
+        tracing::error!("issued transport-v2 native handoff grant exceeded its wire contract");
+        return Err(ApiError::InternalServerError);
+    }
+
+    Ok(IssuedNativeHandoffGrant {
+        grant,
+        expires_at: expiration,
+    })
+}
+
+pub(crate) fn validate_native_handoff_grant(
+    grant: &str,
+    expected_session_id: SessionId,
+    expected_request_id: RequestId,
+    app_state: &AppState,
+) -> Result<(Uuid, AuthContext), ApiError> {
+    validate_native_handoff_grant_with_keys(
+        grant,
+        expected_session_id,
+        expected_request_id,
+        &app_state.config.jwt_keys,
+        Utc::now(),
+    )
+}
+
+fn validate_native_handoff_grant_with_keys(
+    grant: &str,
+    expected_session_id: SessionId,
+    expected_request_id: RequestId,
+    jwt_keys: &JwtKeys,
+    now: DateTime<Utc>,
+) -> Result<(Uuid, AuthContext), ApiError> {
+    if !is_canonical_compact_jwt(grant) {
+        return Err(ApiError::InvalidJwt);
+    }
+    let untrusted = UntrustedToken::new(grant).map_err(|_| ApiError::InvalidJwt)?;
+    let public_key = jwt_keys.public_key();
+    let token: Token<NativeHandoffClaims> = Es256k::<Sha256>::new(jwt_keys.secp.clone())
+        .validator(&public_key)
+        .validate(&untrusted)
+        .map_err(|_| ApiError::InvalidJwt)?;
+    let claims = token.claims();
+    if claims.custom.iss != TRANSPORT_V2_ISSUER
+        || claims.custom.aud != TRANSPORT_V2_NATIVE_HANDOFF
+        || claims.custom.version != TRANSPORT_V2_VERSION
+        || claims.custom.kind != "native_handoff"
+        || claims.custom.target_session_id != expected_session_id.to_string()
+        || claims.custom.request_id != expected_request_id.to_string()
+    {
+        return Err(ApiError::InvalidJwt);
+    }
+    validate_native_handoff_times(claims, now)?;
+
+    let user_id = Uuid::parse_str(&claims.custom.sub).map_err(|_| ApiError::InvalidJwt)?;
+    if user_id.is_nil() || user_id.to_string() != claims.custom.sub {
+        return Err(ApiError::InvalidJwt);
+    }
+    let auth_context = AuthContext::from_claims(&CustomClaims {
+        sub: claims.custom.sub.clone(),
+        aud: Some(claims.custom.aud.clone()),
+        azp: None,
+        role: None,
+        token_format: Some(claims.custom.token_format),
+        auth_method: Some(claims.custom.auth_method.clone()),
+        project_id: Some(claims.custom.project_id),
+        auth_binding: Some(claims.custom.auth_binding.clone()),
+    })?;
+    Ok((user_id, auth_context))
+}
+
+fn validate_native_handoff_times<T>(
+    claims: &Claims<T>,
+    now: DateTime<Utc>,
+) -> Result<(), ApiError> {
+    let time_options = TimeOptions::new(TRANSPORT_V2_NATIVE_HANDOFF_CLOCK_LEEWAY, move || now);
+    claims
+        .validate_expiration(&time_options)
+        .and_then(|claims| claims.validate_maturity(&time_options))
+        .map_err(|_| ApiError::InvalidJwt)?;
+
+    let issued_at = claims.issued_at.ok_or(ApiError::InvalidJwt)?;
+    let not_before = claims.not_before.ok_or(ApiError::InvalidJwt)?;
+    let expiration = claims.expiration.ok_or(ApiError::InvalidJwt)?;
+    let latest_issuance = now + TRANSPORT_V2_NATIVE_HANDOFF_CLOCK_LEEWAY;
+    if issued_at != not_before
+        || issued_at > latest_issuance
+        || expiration <= issued_at
+        || expiration - issued_at > TRANSPORT_V2_NATIVE_HANDOFF_TTL
+    {
+        return Err(ApiError::InvalidJwt);
+    }
+    Ok(())
+}
+
+fn is_canonical_compact_jwt(value: &str) -> bool {
+    if value.is_empty() || value.len() > TRANSPORT_V2_NATIVE_HANDOFF_MAX_BYTES {
+        return false;
+    }
+    let mut segments = value.split('.');
+    let canonical_segment = |segment: &str| {
+        if segment.is_empty()
+            || !segment
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+        {
+            return false;
+        }
+        URL_SAFE_NO_PAD
+            .decode(segment)
+            .is_ok_and(|decoded| URL_SAFE_NO_PAD.encode(decoded) == segment)
+    };
+    matches!(
+        (segments.next(), segments.next(), segments.next(), segments.next()),
+        (Some(header), Some(payload), Some(signature), None)
+            if canonical_segment(header)
+                && canonical_segment(payload)
+                && canonical_segment(signature)
+    )
 }
 
 pub async fn generate_jwt_secret(
@@ -1035,6 +1250,100 @@ mod tests {
                 "internal V2 audiences must remain outside V1's existing third-party audience space"
             );
         }
+    }
+
+    #[test]
+    fn native_handoff_grant_is_exactly_session_request_and_key_bound() {
+        let trusted_keys = test_keys(7);
+        let other_keys = test_keys(8);
+        let user_id = Uuid::from_u128(7);
+        let auth_context = AuthContext::new(AuthMethod::Password, 42, [0x33; 32]);
+        let session_id = SessionId::from_bytes([0x44; 16]);
+        let request_id = RequestId::from_bytes([0x55; 16]);
+        let now = Utc::now();
+        let issued = issue_native_handoff_grant_with_keys(
+            user_id,
+            &auth_context,
+            session_id,
+            request_id,
+            &trusted_keys,
+            now,
+        )
+        .unwrap();
+
+        assert_eq!(
+            validate_native_handoff_grant_with_keys(
+                &issued.grant,
+                session_id,
+                request_id,
+                &trusted_keys,
+                now,
+            )
+            .unwrap(),
+            (user_id, auth_context)
+        );
+        assert!(validate_native_handoff_grant_with_keys(
+            &issued.grant,
+            SessionId::from_bytes([0x45; 16]),
+            request_id,
+            &trusted_keys,
+            now,
+        )
+        .is_err());
+        assert!(validate_native_handoff_grant_with_keys(
+            &issued.grant,
+            session_id,
+            RequestId::from_bytes([0x56; 16]),
+            &trusted_keys,
+            now,
+        )
+        .is_err());
+        assert!(validate_native_handoff_grant_with_keys(
+            &issued.grant,
+            session_id,
+            request_id,
+            &other_keys,
+            now,
+        )
+        .is_err());
+        assert!(TokenType::validate_third_party_audience(TRANSPORT_V2_NATIVE_HANDOFF).is_err());
+        assert!(
+            TRANSPORT_V2_NATIVE_HANDOFF.len() > 50,
+            "the handoff audience must remain outside V1's existing third-party audience space"
+        );
+    }
+
+    #[test]
+    fn native_handoff_grant_rejects_expired_and_noncanonical_wire_values() {
+        let keys = test_keys(9);
+        let auth_context = AuthContext::new(AuthMethod::OAuth, 3, [0x66; 32]);
+        let session_id = SessionId::from_bytes([0x77; 16]);
+        let request_id = RequestId::from_bytes([0x88; 16]);
+        let now = Utc::now();
+        let expired = issue_native_handoff_grant_with_keys(
+            Uuid::from_u128(9),
+            &auth_context,
+            session_id,
+            request_id,
+            &keys,
+            now - Duration::minutes(10),
+        )
+        .unwrap();
+        assert!(validate_native_handoff_grant_with_keys(
+            &expired.grant,
+            session_id,
+            request_id,
+            &keys,
+            now,
+        )
+        .is_err());
+
+        let mut padded = expired.grant;
+        padded.push('=');
+        assert!(!is_canonical_compact_jwt(&padded));
+        assert!(!is_canonical_compact_jwt(
+            &"x".repeat(TRANSPORT_V2_NATIVE_HANDOFF_MAX_BYTES + 1)
+        ));
     }
 
     #[test]

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -26,12 +26,27 @@ use jsonwebtoken::{
 use url::Url;
 
 use crate::models::{platform_users::PlatformUser, users::User};
+use crate::{
+    transport_v2::envelope::{Credential, CredentialKind},
+    web::encryption_middleware::TransportSession,
+};
 
 pub const USER_ACCESS: &str = "access";
 pub const USER_REFRESH: &str = "refresh";
 
 pub const PLATFORM_ACCESS: &str = "platform_access";
 pub const PLATFORM_REFRESH: &str = "platform_refresh";
+// Every internal Transport V2 audience intentionally exceeds the existing
+// 50-byte third-party audience limit. Reserving these values therefore does
+// not newly reject any audience that a V1 caller could issue before Transport
+// V2 existed.
+pub const TRANSPORT_V2_USER_ACCESS: &str = "urn:opensecret:internal:transport-v2:user:access-token";
+pub const TRANSPORT_V2_USER_REFRESH: &str =
+    "urn:opensecret:internal:transport-v2:user:refresh-token";
+pub const TRANSPORT_V2_PLATFORM_ACCESS: &str =
+    "urn:opensecret:internal:transport-v2:platform:access-token";
+pub const TRANSPORT_V2_PLATFORM_REFRESH: &str =
+    "urn:opensecret:internal:transport-v2:platform:refresh-token";
 
 pub const USER_TOKEN_FORMAT_V2: u8 = 2;
 
@@ -39,7 +54,27 @@ pub const USER_TOKEN_FORMAT_V2: u8 = 2;
 pub enum TokenType {
     Access,
     Refresh,
+    TransportV2Access,
+    TransportV2Refresh,
     ThirdParty { aud: Option<String>, azp: String },
+}
+
+impl TokenType {
+    pub(crate) const fn access_for_transport(is_transport_v2: bool) -> Self {
+        if is_transport_v2 {
+            Self::TransportV2Access
+        } else {
+            Self::Access
+        }
+    }
+
+    pub(crate) const fn refresh_for_transport(is_transport_v2: bool) -> Self {
+        if is_transport_v2 {
+            Self::TransportV2Refresh
+        } else {
+            Self::Refresh
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -175,8 +210,16 @@ impl AuthContext {
 impl TokenType {
     pub fn validate_third_party_audience(aud: &str) -> Result<(), ApiError> {
         // Validate third party audience can't use our internal audience types
-        const RESERVED_AUDIENCES: [&str; 4] =
-            [USER_ACCESS, USER_REFRESH, PLATFORM_ACCESS, PLATFORM_REFRESH];
+        const RESERVED_AUDIENCES: [&str; 8] = [
+            USER_ACCESS,
+            USER_REFRESH,
+            PLATFORM_ACCESS,
+            PLATFORM_REFRESH,
+            TRANSPORT_V2_USER_ACCESS,
+            TRANSPORT_V2_USER_REFRESH,
+            TRANSPORT_V2_PLATFORM_ACCESS,
+            TRANSPORT_V2_PLATFORM_REFRESH,
+        ];
 
         // 1. Check for reserved audiences
         if RESERVED_AUDIENCES.contains(&aud) {
@@ -367,7 +410,10 @@ impl NewToken {
                     Duration::hours(1),
                 )
             }
-            TokenType::Access | TokenType::Refresh => {
+            TokenType::Access
+            | TokenType::Refresh
+            | TokenType::TransportV2Access
+            | TokenType::TransportV2Refresh => {
                 tracing::error!("User access/refresh tokens require AuthContext");
                 return Err(ApiError::BadRequest);
             }
@@ -442,6 +488,14 @@ impl NewToken {
                 Some(USER_REFRESH.to_string()),
                 Duration::days(app_state.config.refresh_token_maxage),
             ),
+            TokenType::TransportV2Access => (
+                Some(TRANSPORT_V2_USER_ACCESS.to_string()),
+                Duration::minutes(app_state.config.access_token_maxage),
+            ),
+            TokenType::TransportV2Refresh => (
+                Some(TRANSPORT_V2_USER_REFRESH.to_string()),
+                Duration::days(app_state.config.refresh_token_maxage),
+            ),
             TokenType::ThirdParty { .. } => {
                 return Err(ApiError::BadRequest);
             }
@@ -502,6 +556,16 @@ impl NewToken {
             ),
             TokenType::Refresh => (
                 PLATFORM_REFRESH.to_string(),
+                None,
+                Duration::days(app_state.config.refresh_token_maxage),
+            ),
+            TokenType::TransportV2Access => (
+                TRANSPORT_V2_PLATFORM_ACCESS.to_string(),
+                None,
+                Duration::minutes(app_state.config.access_token_maxage),
+            ),
+            TokenType::TransportV2Refresh => (
+                TRANSPORT_V2_PLATFORM_REFRESH.to_string(),
                 None,
                 Duration::days(app_state.config.refresh_token_maxage),
             ),
@@ -584,20 +648,36 @@ pub async fn validate_jwt(
     mut req: Request<Body>,
     next: Next,
 ) -> impl IntoResponse {
-    let token = match req
-        .headers()
-        .get(header::AUTHORIZATION)
-        .and_then(|auth_header| auth_header.to_str().ok())
-        .and_then(|auth_value| auth_value.strip_prefix("Bearer ").map(ToString::to_string))
-    {
-        Some(token) => token,
-        None => return ApiError::InvalidJwt.into_response(),
+    let is_transport_v2 = req
+        .extensions()
+        .get::<TransportSession>()
+        .is_some_and(TransportSession::is_v2);
+    let token = if is_transport_v2 {
+        match req.extensions().get::<Credential>() {
+            Some(credential) if credential.kind() == CredentialKind::Bearer => credential.value(),
+            _ => return ApiError::InvalidJwt.into_response(),
+        }
+    } else {
+        match req
+            .headers()
+            .get(header::AUTHORIZATION)
+            .and_then(|auth_header| auth_header.to_str().ok())
+            .and_then(|auth_value| auth_value.strip_prefix("Bearer "))
+        {
+            Some(token) => token,
+            None => return ApiError::InvalidJwt.into_response(),
+        }
     };
 
     tracing::trace!("Validating JWT");
 
+    let expected_audience = if is_transport_v2 {
+        TRANSPORT_V2_USER_ACCESS
+    } else {
+        USER_ACCESS
+    };
     let (claims, access_token_expired) =
-        match validate_access_token_for_auth(&token, &data, USER_ACCESS) {
+        match validate_access_token_for_auth(token, &data, expected_audience) {
             Ok(validation) => validation,
             Err(_) => return ApiError::InvalidJwt.into_response(),
         };
@@ -650,20 +730,36 @@ pub async fn validate_platform_jwt(
     mut req: Request<Body>,
     next: Next,
 ) -> impl IntoResponse {
-    let token = match req
-        .headers()
-        .get(header::AUTHORIZATION)
-        .and_then(|auth_header| auth_header.to_str().ok())
-        .and_then(|auth_value| auth_value.strip_prefix("Bearer ").map(ToString::to_string))
-    {
-        Some(token) => token,
-        None => return ApiError::InvalidJwt.into_response(),
+    let is_transport_v2 = req
+        .extensions()
+        .get::<TransportSession>()
+        .is_some_and(TransportSession::is_v2);
+    let token = if is_transport_v2 {
+        match req.extensions().get::<Credential>() {
+            Some(credential) if credential.kind() == CredentialKind::Bearer => credential.value(),
+            _ => return ApiError::InvalidJwt.into_response(),
+        }
+    } else {
+        match req
+            .headers()
+            .get(header::AUTHORIZATION)
+            .and_then(|auth_header| auth_header.to_str().ok())
+            .and_then(|auth_value| auth_value.strip_prefix("Bearer "))
+        {
+            Some(token) => token,
+            None => return ApiError::InvalidJwt.into_response(),
+        }
     };
 
     tracing::trace!("Validating platform JWT");
 
+    let expected_audience = if is_transport_v2 {
+        TRANSPORT_V2_PLATFORM_ACCESS
+    } else {
+        PLATFORM_ACCESS
+    };
     let (claims, access_token_expired) =
-        match validate_access_token_for_auth(&token, &data, PLATFORM_ACCESS) {
+        match validate_access_token_for_auth(token, &data, expected_audience) {
             Ok(validation) => validation,
             Err(_) => return ApiError::InvalidJwt.into_response(),
         };
@@ -726,7 +822,10 @@ fn validate_token_with_keys(
 }
 
 fn is_access_token_audience(audience: &str) -> bool {
-    audience == USER_ACCESS || audience == PLATFORM_ACCESS
+    matches!(
+        audience,
+        USER_ACCESS | PLATFORM_ACCESS | TRANSPORT_V2_USER_ACCESS | TRANSPORT_V2_PLATFORM_ACCESS
+    )
 }
 
 fn validate_token_with_keys_for_auth(
@@ -893,6 +992,49 @@ mod tests {
             validate_token_with_keys(&platform_access, &keys, PLATFORM_ACCESS),
             Err(ApiError::AccessTokenExpired)
         ));
+    }
+
+    #[test]
+    fn token_audiences_are_exactly_separated_across_transport_and_principal_kinds() {
+        let keys = test_keys(6);
+        let audiences = [
+            USER_ACCESS,
+            USER_REFRESH,
+            PLATFORM_ACCESS,
+            PLATFORM_REFRESH,
+            TRANSPORT_V2_USER_ACCESS,
+            TRANSPORT_V2_USER_REFRESH,
+            TRANSPORT_V2_PLATFORM_ACCESS,
+            TRANSPORT_V2_PLATFORM_REFRESH,
+        ];
+
+        for issued_audience in audiences {
+            let token = signed_test_token(
+                &keys,
+                issued_audience,
+                Some(Utc::now() + Duration::minutes(5)),
+            );
+            for expected_audience in audiences {
+                let result = validate_token_with_keys(&token, &keys, expected_audience);
+                assert_eq!(
+                    result.is_ok(),
+                    issued_audience == expected_audience,
+                    "token for {issued_audience} was validated as {expected_audience}"
+                );
+            }
+        }
+
+        for transport_v2_audience in [
+            TRANSPORT_V2_USER_ACCESS,
+            TRANSPORT_V2_USER_REFRESH,
+            TRANSPORT_V2_PLATFORM_ACCESS,
+            TRANSPORT_V2_PLATFORM_REFRESH,
+        ] {
+            assert!(
+                transport_v2_audience.len() > 50,
+                "internal V2 audiences must remain outside V1's existing third-party audience space"
+            );
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,8 @@ mod models;
 mod oauth;
 mod os_flags;
 mod private_key;
+#[allow(dead_code)] // Used by the dormant Transport V2 core in this stack layer.
+mod provider_cache;
 mod provider_client;
 mod provider_routing;
 mod proxy_config;
@@ -122,6 +124,8 @@ mod security_invariants;
 mod seed_wrapping;
 mod sqs;
 mod tokens;
+#[allow(dead_code)] // Transport V2 is wired by the next stacked change.
+mod transport_v2;
 mod web;
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,8 +23,8 @@ use crate::web::openai_auth::{validate_openai_auth, validate_optional_openai_aut
 use crate::web::platform_login_routes;
 use crate::web::{
     conversation_projects_routes, conversations_routes, health_routes_with_state,
-    instructions_routes, login_routes, oauth_routes, openai_models_routes, openai_routes,
-    protected_routes, responses_routes, web_routes,
+    instructions_routes, login_routes, native_handoff_routes, oauth_routes, openai_models_routes,
+    openai_routes, protected_routes, responses_routes, web_routes,
 };
 use crate::{attestation_routes::SessionState, web::platform_routes};
 use bounded_ttl_cache::BoundedTtlCache;
@@ -3913,6 +3913,7 @@ async fn main() -> Result<(), Error> {
     let v2_application = application
         .clone()
         .merge(health_routes_with_state(app_state.clone()))
+        .merge(native_handoff_routes(app_state.clone()))
         .layer(from_fn(add_error_contract_header));
     let transport_v2_gateway =
         transport_v2::gateway::TransportV2Gateway::new(app_state.clone(), v2_application);

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ use axum::{
     http::{HeaderName, HeaderValue, StatusCode},
     middleware::{from_fn, from_fn_with_state, Next},
     response::{IntoResponse, Response},
-    Json,
+    Json, Router,
 };
 use base64::engine::general_purpose;
 use base64::Engine as _;
@@ -124,7 +124,7 @@ mod security_invariants;
 mod seed_wrapping;
 mod sqs;
 mod tokens;
-#[allow(dead_code)] // Transport V2 is wired by the next stacked change.
+#[allow(dead_code)] // Includes client-side vector helpers shared with the SDK implementation.
 mod transport_v2;
 mod web;
 
@@ -3514,6 +3514,48 @@ async fn retrieve_kagi_api_key(
     }
 }
 
+fn application_routes(app_state: Arc<AppState>) -> Router<()> {
+    protected_routes(app_state.clone())
+        .route_layer(from_fn_with_state(app_state.clone(), validate_jwt))
+        .merge(login_routes(app_state.clone()))
+        .merge(
+            openai_routes(app_state.clone())
+                .route_layer(from_fn_with_state(app_state.clone(), validate_openai_auth)),
+        )
+        .merge(
+            openai_models_routes(app_state.clone()).route_layer(from_fn_with_state(
+                app_state.clone(),
+                validate_optional_openai_auth,
+            )),
+        )
+        .merge(
+            responses_routes(app_state.clone())
+                .route_layer(from_fn_with_state(app_state.clone(), validate_jwt)),
+        )
+        .merge(
+            web_routes(app_state.clone())
+                .route_layer(from_fn_with_state(app_state.clone(), validate_jwt)),
+        )
+        .merge(
+            conversations_routes(app_state.clone())
+                .route_layer(from_fn_with_state(app_state.clone(), validate_jwt)),
+        )
+        .merge(
+            conversation_projects_routes(app_state.clone())
+                .route_layer(from_fn_with_state(app_state.clone(), validate_jwt)),
+        )
+        .merge(
+            instructions_routes(app_state.clone())
+                .route_layer(from_fn_with_state(app_state.clone(), validate_jwt)),
+        )
+        .merge(oauth_routes(app_state.clone()))
+        .merge(platform_login_routes(app_state.clone()))
+        .merge(
+            platform_routes(app_state.clone())
+                .route_layer(from_fn_with_state(app_state.clone(), validate_platform_jwt)),
+        )
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     dotenv::dotenv().ok();
@@ -3867,47 +3909,18 @@ async fn main() -> Result<(), Error> {
         // allow requests from any origin
         .allow_origin(Any);
 
-    let app = protected_routes(app_state.clone())
-        .route_layer(from_fn_with_state(app_state.clone(), validate_jwt))
+    let application = application_routes(app_state.clone());
+    let v2_application = application
+        .clone()
         .merge(health_routes_with_state(app_state.clone()))
-        .merge(login_routes(app_state.clone()))
-        .merge(
-            openai_routes(app_state.clone())
-                .route_layer(from_fn_with_state(app_state.clone(), validate_openai_auth)),
-        )
-        .merge(
-            openai_models_routes(app_state.clone()).route_layer(from_fn_with_state(
-                app_state.clone(),
-                validate_optional_openai_auth,
-            )),
-        )
-        .merge(
-            responses_routes(app_state.clone())
-                .route_layer(from_fn_with_state(app_state.clone(), validate_jwt)),
-        )
-        .merge(
-            web_routes(app_state.clone())
-                .route_layer(from_fn_with_state(app_state.clone(), validate_jwt)),
-        )
-        .merge(
-            conversations_routes(app_state.clone())
-                .route_layer(from_fn_with_state(app_state.clone(), validate_jwt)),
-        )
-        .merge(
-            conversation_projects_routes(app_state.clone())
-                .route_layer(from_fn_with_state(app_state.clone(), validate_jwt)),
-        )
-        .merge(
-            instructions_routes(app_state.clone())
-                .route_layer(from_fn_with_state(app_state.clone(), validate_jwt)),
-        )
+        .layer(from_fn(add_error_contract_header));
+    let transport_v2_gateway =
+        transport_v2::gateway::TransportV2Gateway::new(app_state.clone(), v2_application);
+
+    let app = application
+        .merge(health_routes_with_state(app_state.clone()))
         .merge(attestation_routes::router(app_state.clone()))
-        .merge(oauth_routes(app_state.clone()))
-        .merge(platform_login_routes(app_state.clone()))
-        .merge(
-            platform_routes(app_state.clone())
-                .route_layer(from_fn_with_state(app_state.clone(), validate_platform_jwt)),
-        )
+        .merge(transport_v2_gateway.router())
         .layer(cors)
         .layer(from_fn(add_error_contract_header));
 
@@ -3921,6 +3934,9 @@ async fn main() -> Result<(), Error> {
         result = axum::serve(listener, app.into_make_service()) => Ok(result?),
         _ = secret_cache_maintenance::run(app_state) => {
             unreachable!("secret cache maintenance runs until the server stops")
+        }
+        _ = transport_v2_gateway.run_maintenance() => {
+            unreachable!("transport-v2 session maintenance runs until the server stops")
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1715,7 +1715,7 @@ impl AppState {
 
         let encrypted_pw = encrypt_with_key(&secret_key, password_hash.as_bytes()).await;
 
-        tracing::debug!("registering new user: {:?}", creds.email);
+        tracing::debug!("Registering new user");
 
         // Generate private key for new user
         let user_seed_words = generate_twelve_word_seed(self.aws_credential_manager.clone())
@@ -1731,7 +1731,7 @@ impl AppState {
             user_seed_words.as_bytes(),
         )?;
 
-        tracing::info!("registered new user: {:?} {:?}", user.email, user.uuid);
+        tracing::info!("Registered new user: {}", user.uuid);
 
         Ok(user)
     }
@@ -2126,7 +2126,7 @@ impl AppState {
             Err(DBError::UserNotFound) => {
                 // User doesn't exist, but we don't want to reveal this information
                 // So we'll just log it and return as if everything was successful
-                debug!("Password reset requested for non-existent email: {}", email);
+                debug!("Password reset requested for nonexistent user");
             }
             Err(e) => {
                 // For other errors, we should still log them but not expose them to the user
@@ -2299,10 +2299,7 @@ impl AppState {
             Ok(None) => {
                 // User doesn't exist, but we don't want to reveal this information
                 // So we'll just log it and return as if everything was successful
-                debug!(
-                    "Password reset requested for non-existent platform email: {}",
-                    email
-                );
+                debug!("Password reset requested for nonexistent platform user");
             }
             Err(e) => {
                 // For other errors, we should still log them but not expose them to the user
@@ -2631,7 +2628,7 @@ impl AppState {
         let platform_user = match self.db.get_platform_user_by_email(email)? {
             Some(user) => user,
             None => {
-                warn!("Could not find platform user by email: {email}");
+                warn!("Could not find platform user by provided login identifier");
                 return Ok(None);
             }
         };

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -2,17 +2,23 @@ use crate::db::DBConnection;
 use crate::models::oauth::NewOAuthProvider;
 use crate::Error;
 use async_trait::async_trait;
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use oauth2::{
     basic::BasicClient as OAuthBasicClient, AuthUrl, ClientId, ClientSecret, CsrfToken,
-    EndpointNotSet, EndpointSet, RedirectUrl, Scope, TokenUrl,
+    EndpointNotSet, EndpointSet, PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, Scope, TokenUrl,
 };
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 use tracing::{debug, error, info};
 use uuid::Uuid;
+use zeroize::Zeroizing;
+
+use crate::transport_v2::crypto::SessionId;
 
 // OAuth redirects normally complete within seconds. Ten minutes leaves room for a user to
 // authenticate without retaining abandoned CSRF state for the encrypted session lifetime.
@@ -44,7 +50,60 @@ struct OAuthStateStoreInner {
 #[derive(Debug)]
 struct StoredOAuthState {
     state: OAuthState,
+    binding: OAuthStateBinding,
     expires_at: Instant,
+}
+
+/// Server-only binding for an OAuth authorization round trip.
+///
+/// V1 preserves its existing state semantics. V2 binds the one-time callback
+/// state to the attested transport session that initiated the redirect, so
+/// copied provider callback parameters cannot authenticate another session.
+#[derive(Debug)]
+enum OAuthStateBinding {
+    LegacyV1,
+    TransportV2 {
+        session_id: SessionId,
+        code_binding: OAuthCodeBinding,
+    },
+}
+
+/// Provider-verifiable binding between one V2 authorization response and the
+/// enclave session that initiated it.
+///
+/// GitHub and Google bind the authorization code to a one-time PKCE verifier.
+/// Apple does not advertise PKCE, so its signed ID token carries a nonce
+/// generated independently and stored alongside the state and V2 session.
+pub(crate) enum OAuthCodeBinding {
+    Pkce(PkceCodeVerifier),
+    AppleNonce(Zeroizing<String>),
+}
+
+fn new_pkce_binding() -> (PkceCodeChallenge, OAuthCodeBinding) {
+    let (challenge, verifier) = PkceCodeChallenge::new_random_sha256();
+    (challenge, OAuthCodeBinding::Pkce(verifier))
+}
+
+fn new_apple_nonce() -> (String, OAuthCodeBinding) {
+    let raw_nonce = Zeroizing::new(URL_SAFE_NO_PAD.encode(crate::encrypt::generate_random::<32>()));
+    let public_nonce = hex::encode(Sha256::digest(raw_nonce.as_bytes()));
+    (public_nonce, OAuthCodeBinding::AppleNonce(raw_nonce))
+}
+
+impl fmt::Debug for OAuthCodeBinding {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Pkce(_) => formatter.write_str("Pkce([redacted])"),
+            Self::AppleNonce(_) => formatter.write_str("AppleNonce([redacted])"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct BoundOAuthAuthorization {
+    pub(crate) auth_url: String,
+    pub(crate) csrf_token: CsrfToken,
+    pub(crate) code_binding: OAuthCodeBinding,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
@@ -70,13 +129,50 @@ impl OAuthStateStore {
         csrf_token: &str,
         state: OAuthState,
     ) -> Result<(), OAuthStateCapacityError> {
-        self.store_at(csrf_token, state, Instant::now()).await
+        self.store_with_binding(
+            csrf_token,
+            state,
+            OAuthStateBinding::LegacyV1,
+            Instant::now(),
+        )
+        .await
     }
 
+    async fn store_for_session(
+        &self,
+        csrf_token: &str,
+        state: OAuthState,
+        session_id: SessionId,
+        code_binding: OAuthCodeBinding,
+    ) -> Result<(), OAuthStateCapacityError> {
+        self.store_with_binding(
+            csrf_token,
+            state,
+            OAuthStateBinding::TransportV2 {
+                session_id,
+                code_binding,
+            },
+            Instant::now(),
+        )
+        .await
+    }
+
+    #[cfg(test)]
     async fn store_at(
         &self,
         csrf_token: &str,
         state: OAuthState,
+        now: Instant,
+    ) -> Result<(), OAuthStateCapacityError> {
+        self.store_with_binding(csrf_token, state, OAuthStateBinding::LegacyV1, now)
+            .await
+    }
+
+    async fn store_with_binding(
+        &self,
+        csrf_token: &str,
+        state: OAuthState,
+        binding: OAuthStateBinding,
         now: Instant,
     ) -> Result<(), OAuthStateCapacityError> {
         let mut inner = self.inner.lock().await;
@@ -92,6 +188,7 @@ impl OAuthStateStore {
             csrf_token.to_string(),
             StoredOAuthState {
                 state,
+                binding,
                 expires_at: now
                     .checked_add(self.ttl)
                     .expect("OAuth state TTL must fit in Instant"),
@@ -101,23 +198,58 @@ impl OAuthStateStore {
     }
 
     async fn consume(&self, state: &OAuthState) -> bool {
-        self.consume_at(state, Instant::now()).await
+        self.take_with_binding(state, None, Instant::now())
+            .await
+            .is_some()
     }
 
+    async fn consume_for_session(
+        &self,
+        state: &OAuthState,
+        session_id: SessionId,
+    ) -> Option<OAuthCodeBinding> {
+        let stored_state = self
+            .take_with_binding(state, Some(session_id), Instant::now())
+            .await?;
+        match stored_state.binding {
+            OAuthStateBinding::TransportV2 { code_binding, .. } => Some(code_binding),
+            OAuthStateBinding::LegacyV1 => None,
+        }
+    }
+
+    #[cfg(test)]
     async fn consume_at(&self, state: &OAuthState, now: Instant) -> bool {
+        self.take_with_binding(state, None, now).await.is_some()
+    }
+
+    async fn take_with_binding(
+        &self,
+        state: &OAuthState,
+        session_id: Option<SessionId>,
+        now: Instant,
+    ) -> Option<StoredOAuthState> {
         let mut inner = self.inner.lock().await;
         inner
             .entries
             .retain(|_, stored_state| stored_state.expires_at > now);
 
-        let matches = inner
-            .entries
-            .get(&state.csrf_token)
-            .is_some_and(|stored_state| stored_state.state == *state);
-        if matches {
-            inner.entries.remove(&state.csrf_token);
-        }
+        let matches = inner.entries.get(&state.csrf_token).is_some_and(|stored| {
+            stored.state == *state
+                && match (&stored.binding, session_id) {
+                    (OAuthStateBinding::LegacyV1, None) => true,
+                    (
+                        OAuthStateBinding::TransportV2 {
+                            session_id: stored_session,
+                            ..
+                        },
+                        Some(expected_session),
+                    ) => *stored_session == expected_session,
+                    _ => false,
+                }
+        });
         matches
+            .then(|| inner.entries.remove(&state.csrf_token))
+            .flatten()
     }
 
     #[cfg(test)]
@@ -188,16 +320,22 @@ impl GithubProvider {
         (auth_url.to_string(), csrf_token)
     }
 
-    pub async fn store_state(
+    pub(crate) async fn generate_bound_authorize_url(
         &self,
-        csrf_token: &str,
-        state: OAuthState,
-    ) -> Result<(), OAuthStateCapacityError> {
-        self.state_store.store(csrf_token, state).await
-    }
+        client: &BasicClient,
+    ) -> BoundOAuthAuthorization {
+        let (challenge, binding) = new_pkce_binding();
+        let (auth_url, csrf_token) = client
+            .authorize_url(CsrfToken::new_random)
+            .add_scope(Scope::new("user:email".to_string()))
+            .set_pkce_challenge(challenge)
+            .url();
 
-    pub async fn consume_state(&self, state: &OAuthState) -> bool {
-        self.state_store.consume(state).await
+        BoundOAuthAuthorization {
+            auth_url: auth_url.to_string(),
+            csrf_token,
+            code_binding: binding,
+        }
     }
 
     async fn ensure_provider_exists(
@@ -293,16 +431,23 @@ impl GoogleProvider {
         (auth_url.to_string(), csrf_token)
     }
 
-    pub async fn store_state(
+    pub(crate) async fn generate_bound_authorize_url(
         &self,
-        csrf_token: &str,
-        state: OAuthState,
-    ) -> Result<(), OAuthStateCapacityError> {
-        self.state_store.store(csrf_token, state).await
-    }
+        client: &BasicClient,
+    ) -> BoundOAuthAuthorization {
+        let (challenge, binding) = new_pkce_binding();
+        let (auth_url, csrf_token) = client
+            .authorize_url(CsrfToken::new_random)
+            .add_scope(Scope::new("email".to_string()))
+            .add_scope(Scope::new("profile".to_string()))
+            .set_pkce_challenge(challenge)
+            .url();
 
-    pub async fn consume_state(&self, state: &OAuthState) -> bool {
-        self.state_store.consume(state).await
+        BoundOAuthAuthorization {
+            auth_url: auth_url.to_string(),
+            csrf_token,
+            code_binding: binding,
+        }
     }
 
     async fn ensure_provider_exists(
@@ -403,16 +548,25 @@ impl AppleProvider {
         (auth_url.to_string(), csrf_token)
     }
 
-    pub async fn store_state(
+    pub(crate) async fn generate_bound_authorize_url(
         &self,
-        csrf_token: &str,
-        state: OAuthState,
-    ) -> Result<(), OAuthStateCapacityError> {
-        self.state_store.store(csrf_token, state).await
-    }
+        client: &BasicClient,
+    ) -> BoundOAuthAuthorization {
+        let (nonce, binding) = new_apple_nonce();
+        let (auth_url, csrf_token) = client
+            .authorize_url(CsrfToken::new_random)
+            .add_scope(Scope::new("name".to_string()))
+            .add_scope(Scope::new("email".to_string()))
+            .add_extra_param("response_type", "code id_token")
+            .add_extra_param("response_mode", "form_post")
+            .add_extra_param("nonce", nonce)
+            .url();
 
-    pub async fn consume_state(&self, state: &OAuthState) -> bool {
-        self.state_store.consume(state).await
+        BoundOAuthAuthorization {
+            auth_url: auth_url.to_string(),
+            csrf_token,
+            code_binding: binding,
+        }
     }
 
     async fn ensure_provider_exists(
@@ -467,7 +621,19 @@ pub trait OAuthProvider: Send + Sync + 'static {
         csrf_token: &str,
         state: OAuthState,
     ) -> Result<(), OAuthStateCapacityError>;
+    async fn store_state_for_session(
+        &self,
+        csrf_token: &str,
+        state: OAuthState,
+        session_id: SessionId,
+        code_binding: OAuthCodeBinding,
+    ) -> Result<(), OAuthStateCapacityError>;
     async fn consume_state(&self, state: &OAuthState) -> bool;
+    async fn consume_state_for_session(
+        &self,
+        state: &OAuthState,
+        session_id: SessionId,
+    ) -> Option<OAuthCodeBinding>;
     async fn build_client(
         &self,
         client_id: String,
@@ -511,11 +677,33 @@ impl OAuthProvider for GithubProvider {
         csrf_token: &str,
         state: OAuthState,
     ) -> Result<(), OAuthStateCapacityError> {
-        self.store_state(csrf_token, state).await
+        self.state_store.store(csrf_token, state).await
+    }
+
+    async fn store_state_for_session(
+        &self,
+        csrf_token: &str,
+        state: OAuthState,
+        session_id: SessionId,
+        code_binding: OAuthCodeBinding,
+    ) -> Result<(), OAuthStateCapacityError> {
+        self.state_store
+            .store_for_session(csrf_token, state, session_id, code_binding)
+            .await
     }
 
     async fn consume_state(&self, state: &OAuthState) -> bool {
-        self.consume_state(state).await
+        self.state_store.consume(state).await
+    }
+
+    async fn consume_state_for_session(
+        &self,
+        state: &OAuthState,
+        session_id: SessionId,
+    ) -> Option<OAuthCodeBinding> {
+        self.state_store
+            .consume_for_session(state, session_id)
+            .await
     }
 
     async fn build_client(
@@ -544,11 +732,33 @@ impl OAuthProvider for GoogleProvider {
         csrf_token: &str,
         state: OAuthState,
     ) -> Result<(), OAuthStateCapacityError> {
-        self.store_state(csrf_token, state).await
+        self.state_store.store(csrf_token, state).await
+    }
+
+    async fn store_state_for_session(
+        &self,
+        csrf_token: &str,
+        state: OAuthState,
+        session_id: SessionId,
+        code_binding: OAuthCodeBinding,
+    ) -> Result<(), OAuthStateCapacityError> {
+        self.state_store
+            .store_for_session(csrf_token, state, session_id, code_binding)
+            .await
     }
 
     async fn consume_state(&self, state: &OAuthState) -> bool {
-        self.consume_state(state).await
+        self.state_store.consume(state).await
+    }
+
+    async fn consume_state_for_session(
+        &self,
+        state: &OAuthState,
+        session_id: SessionId,
+    ) -> Option<OAuthCodeBinding> {
+        self.state_store
+            .consume_for_session(state, session_id)
+            .await
     }
 
     async fn build_client(
@@ -577,11 +787,33 @@ impl OAuthProvider for AppleProvider {
         csrf_token: &str,
         state: OAuthState,
     ) -> Result<(), OAuthStateCapacityError> {
-        self.store_state(csrf_token, state).await
+        self.state_store.store(csrf_token, state).await
+    }
+
+    async fn store_state_for_session(
+        &self,
+        csrf_token: &str,
+        state: OAuthState,
+        session_id: SessionId,
+        code_binding: OAuthCodeBinding,
+    ) -> Result<(), OAuthStateCapacityError> {
+        self.state_store
+            .store_for_session(csrf_token, state, session_id, code_binding)
+            .await
     }
 
     async fn consume_state(&self, state: &OAuthState) -> bool {
-        self.consume_state(state).await
+        self.state_store.consume(state).await
+    }
+
+    async fn consume_state_for_session(
+        &self,
+        state: &OAuthState,
+        session_id: SessionId,
+    ) -> Option<OAuthCodeBinding> {
+        self.state_store
+            .consume_for_session(state, session_id)
+            .await
     }
 
     async fn build_client(
@@ -605,6 +837,25 @@ mod tests {
             csrf_token: csrf_token.to_string(),
             client_id: Uuid::from_u128(client_id),
         }
+    }
+
+    fn assert_pkce_authorization(authorization: &BoundOAuthAuthorization) {
+        let parameters: HashMap<_, _> = url::Url::parse(&authorization.auth_url)
+            .unwrap()
+            .query_pairs()
+            .into_owned()
+            .collect();
+        assert_eq!(
+            parameters.get("code_challenge_method").map(String::as_str),
+            Some("S256")
+        );
+        let OAuthCodeBinding::Pkce(verifier) = &authorization.code_binding else {
+            panic!("V2 authorization must retain a PKCE verifier");
+        };
+        assert_eq!(
+            parameters.get("code_challenge").map(String::as_str),
+            Some(PkceCodeChallenge::from_code_verifier_sha256(verifier).as_str())
+        );
     }
 
     #[tokio::test]
@@ -714,6 +965,143 @@ mod tests {
 
         assert!(!store.consume_at(&mismatched, now).await);
         assert!(store.consume_at(&valid, now).await);
+    }
+
+    #[tokio::test]
+    async fn oauth_state_protocol_and_v2_session_binding_are_non_consuming_on_mismatch() {
+        let store = OAuthStateStore::with_limits(Duration::from_secs(60), 2);
+        let now = Instant::now();
+        let v2_state = state("v2-state", 1);
+        let initiating_session = SessionId::from_bytes([10; 16]);
+        let other_session = SessionId::from_bytes([11; 16]);
+
+        store
+            .store_with_binding(
+                &v2_state.csrf_token,
+                v2_state.clone(),
+                OAuthStateBinding::TransportV2 {
+                    session_id: initiating_session,
+                    code_binding: OAuthCodeBinding::AppleNonce(Zeroizing::new(
+                        "raw-nonce".to_string(),
+                    )),
+                },
+                now,
+            )
+            .await
+            .unwrap();
+
+        assert!(!store.consume_at(&v2_state, now).await);
+        assert!(store
+            .take_with_binding(&v2_state, Some(other_session), now)
+            .await
+            .is_none());
+        let consumed = store
+            .take_with_binding(&v2_state, Some(initiating_session), now)
+            .await
+            .unwrap();
+        let OAuthStateBinding::TransportV2 {
+            code_binding: OAuthCodeBinding::AppleNonce(raw_nonce),
+            ..
+        } = consumed.binding
+        else {
+            panic!("expected an Apple nonce binding");
+        };
+        assert_eq!(raw_nonce.as_str(), "raw-nonce");
+
+        let v1_state = state("v1-state", 2);
+        store
+            .store_at(&v1_state.csrf_token, v1_state.clone(), now)
+            .await
+            .unwrap();
+        assert!(store
+            .take_with_binding(&v1_state, Some(initiating_session), now)
+            .await
+            .is_none());
+        assert!(store.consume_at(&v1_state, now).await);
+    }
+
+    #[tokio::test]
+    async fn v2_authorization_urls_bind_codes_without_changing_v1_urls() {
+        let github = GithubProvider {
+            auth_url: "https://github.example/authorize".to_string(),
+            token_url: "https://github.example/token".to_string(),
+            user_info_url: "https://github.example/user".to_string(),
+            state_store: OAuthStateStore::new(),
+        };
+        let github_client = github
+            .build_client(
+                "github-client".to_string(),
+                "github-secret".to_string(),
+                "https://maple.example/callback".to_string(),
+            )
+            .await
+            .unwrap();
+
+        let legacy_url = github.generate_authorize_url(&github_client).await.0;
+        let legacy_parameters: HashMap<_, _> = url::Url::parse(&legacy_url)
+            .unwrap()
+            .query_pairs()
+            .into_owned()
+            .collect();
+        assert!(!legacy_parameters.contains_key("code_challenge"));
+        assert!(!legacy_parameters.contains_key("code_challenge_method"));
+
+        let bound = github.generate_bound_authorize_url(&github_client).await;
+        assert_pkce_authorization(&bound);
+
+        let google = GoogleProvider {
+            auth_url: "https://google.example/authorize".to_string(),
+            token_url: "https://google.example/token".to_string(),
+            user_info_url: "https://google.example/user".to_string(),
+            state_store: OAuthStateStore::new(),
+        };
+        let google_client = google
+            .build_client(
+                "google-client".to_string(),
+                "google-secret".to_string(),
+                "https://maple.example/callback".to_string(),
+            )
+            .await
+            .unwrap();
+        let bound = google.generate_bound_authorize_url(&google_client).await;
+        assert_pkce_authorization(&bound);
+
+        let apple = AppleProvider {
+            auth_url: "https://apple.example/authorize".to_string(),
+            token_url: "https://apple.example/token".to_string(),
+            jwks_url: "https://apple.example/keys".to_string(),
+            state_store: OAuthStateStore::new(),
+        };
+        let apple_client = apple
+            .build_client(
+                "apple-client".to_string(),
+                "apple-secret".to_string(),
+                "https://maple.example/callback".to_string(),
+            )
+            .await
+            .unwrap();
+        let legacy_url = apple.generate_authorize_url(&apple_client).await.0;
+        let legacy_parameters: HashMap<_, _> = url::Url::parse(&legacy_url)
+            .unwrap()
+            .query_pairs()
+            .into_owned()
+            .collect();
+        assert!(!legacy_parameters.contains_key("nonce"));
+
+        let bound = apple.generate_bound_authorize_url(&apple_client).await;
+        let parameters: HashMap<_, _> = url::Url::parse(&bound.auth_url)
+            .unwrap()
+            .query_pairs()
+            .into_owned()
+            .collect();
+        let OAuthCodeBinding::AppleNonce(raw_nonce) = &bound.code_binding else {
+            panic!("Apple V2 authorization must retain the raw nonce");
+        };
+        let expected_nonce = hex::encode(Sha256::digest(raw_nonce.as_bytes()));
+        assert_eq!(
+            parameters.get("nonce").map(String::as_str),
+            Some(expected_nonce.as_str())
+        );
     }
 
     #[tokio::test]

--- a/src/provider_cache.rs
+++ b/src/provider_cache.rs
@@ -1,0 +1,166 @@
+use std::{fmt, sync::Arc};
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use hmac::{Hmac, Mac};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use sha2::Sha256;
+use uuid::Uuid;
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
+
+pub(crate) const CACHE_NAMESPACE_ROOT_BYTES: usize = 32;
+const CACHE_NAMESPACE_ROOT_BASE64_BYTES: usize = 44;
+const TINFOIL_CACHE_NAMESPACE_V1_LABEL: &[u8] =
+    b"opensecret/provider-cache/tinfoil/user-cache-namespace/v1";
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Client-generated secret material used to derive a provider cache namespace.
+///
+/// V2 carries this value only inside the encrypted request envelope. The
+/// forwarding host never sees it, and the enclave does not persist it.
+#[derive(Clone, Eq, PartialEq, Zeroize, ZeroizeOnDrop)]
+pub(crate) struct CacheNamespaceRoot([u8; CACHE_NAMESPACE_ROOT_BYTES]);
+
+impl CacheNamespaceRoot {
+    #[cfg(test)]
+    pub(crate) const fn from_bytes(bytes: [u8; CACHE_NAMESPACE_ROOT_BYTES]) -> Self {
+        Self(bytes)
+    }
+
+    const fn as_bytes(&self) -> &[u8; CACHE_NAMESPACE_ROOT_BYTES] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for CacheNamespaceRoot {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("CacheNamespaceRoot([REDACTED])")
+    }
+}
+
+impl Serialize for CacheNamespaceRoot {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let encoded = Zeroizing::new(STANDARD.encode(self.0));
+        serializer.serialize_str(encoded.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for CacheNamespaceRoot {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct CacheNamespaceRootVisitor;
+
+        impl de::Visitor<'_> for CacheNamespaceRootVisitor {
+            type Value = CacheNamespaceRoot;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("canonical padded base64 encoding of exactly 32 bytes")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                if value.len() != CACHE_NAMESPACE_ROOT_BASE64_BYTES {
+                    return Err(E::custom("cache namespace root must decode to 32 bytes"));
+                }
+
+                let mut decoded = Zeroizing::new([0_u8; CACHE_NAMESPACE_ROOT_BYTES]);
+                let decoded_bytes = STANDARD
+                    .decode_slice(value.as_bytes(), &mut decoded[..])
+                    .map_err(|_| E::custom("invalid base64 cache namespace root"))?;
+                if decoded_bytes != CACHE_NAMESPACE_ROOT_BYTES {
+                    return Err(E::custom("cache namespace root must decode to 32 bytes"));
+                }
+
+                let mut canonical = Zeroizing::new([0_u8; CACHE_NAMESPACE_ROOT_BASE64_BYTES]);
+                let encoded_bytes = STANDARD
+                    .encode_slice(&decoded[..], &mut canonical[..])
+                    .map_err(|_| E::custom("invalid cache namespace root"))?;
+                if encoded_bytes != value.len() || &canonical[..encoded_bytes] != value.as_bytes() {
+                    return Err(E::custom("non-canonical base64 cache namespace root"));
+                }
+
+                Ok(CacheNamespaceRoot(*decoded))
+            }
+        }
+
+        deserializer.deserialize_str(CacheNamespaceRootVisitor)
+    }
+}
+
+#[derive(Eq, PartialEq, Zeroize, ZeroizeOnDrop)]
+struct DerivedCacheNamespaceBytes([u8; 32]);
+
+/// Provider-facing cache namespace derived only after the enclave verifies the
+/// request's user identity.
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) struct DerivedCacheNamespace(Arc<DerivedCacheNamespaceBytes>);
+
+impl DerivedCacheNamespace {
+    pub(crate) fn tinfoil_user_cache_secret(&self) -> String {
+        hex::encode(self.0.as_ref().0)
+    }
+}
+
+impl fmt::Debug for DerivedCacheNamespace {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("DerivedCacheNamespace([REDACTED])")
+    }
+}
+
+pub(crate) fn derive_tinfoil_cache_namespace(
+    root: &CacheNamespaceRoot,
+    verified_user_id: Uuid,
+) -> DerivedCacheNamespace {
+    let mut hmac = HmacSha256::new_from_slice(root.as_bytes())
+        .expect("HMAC-SHA256 accepts cache namespace roots of any length");
+    hmac.update(TINFOIL_CACHE_NAMESPACE_V1_LABEL);
+    hmac.update(&[0]);
+    hmac.update(verified_user_id.as_bytes());
+
+    let bytes = Zeroizing::new(<[u8; 32]>::from(hmac.finalize().into_bytes()));
+    DerivedCacheNamespace(Arc::new(DerivedCacheNamespaceBytes(*bytes)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_root_wire_encoding_is_canonical_and_redacted() {
+        let root = CacheNamespaceRoot::from_bytes([0x5a; 32]);
+        let encoded = serde_json::to_string(&root).unwrap();
+        let decoded: CacheNamespaceRoot = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, root);
+        assert_eq!(format!("{root:?}"), "CacheNamespaceRoot([REDACTED])");
+
+        let unpadded = encoded.replace('=', "");
+        assert!(serde_json::from_str::<CacheNamespaceRoot>(&unpadded).is_err());
+        let wrong_length = format!("\"{}\"", STANDARD.encode([0x5a; 31]));
+        assert!(serde_json::from_str::<CacheNamespaceRoot>(&wrong_length).is_err());
+    }
+
+    #[test]
+    fn derivation_is_stable_but_separated_by_user_and_root() {
+        let root = CacheNamespaceRoot::from_bytes([0x42; 32]);
+        let user = Uuid::from_u128(1);
+        let first = derive_tinfoil_cache_namespace(&root, user);
+        assert_eq!(first, derive_tinfoil_cache_namespace(&root, user));
+        assert_ne!(
+            first,
+            derive_tinfoil_cache_namespace(&root, Uuid::from_u128(2))
+        );
+        assert_ne!(
+            first,
+            derive_tinfoil_cache_namespace(&CacheNamespaceRoot::from_bytes([0x24; 32]), user)
+        );
+        assert_eq!(first.tinfoil_user_cache_secret().len(), 64);
+        assert_eq!(format!("{first:?}"), "DerivedCacheNamespace([REDACTED])");
+    }
+}

--- a/src/security_invariants.rs
+++ b/src/security_invariants.rs
@@ -362,8 +362,8 @@ fn refresh_route_preserves_signed_auth_context_without_recomputing_binding() {
     for required_pattern in [
         "AuthContext::from_claims(&claims)",
         "verify_seed_wrap_for_auth_context(&user, &auth_context)",
-        "NewToken::new_with_auth_context(&user, TokenType::Access, &data, &auth_context)",
-        "NewToken::new_with_auth_context(&user, TokenType::Refresh, &data, &auth_context)",
+        "TokenType::access_for_transport(session_id.is_v2())",
+        "TokenType::refresh_for_transport(session_id.is_v2())",
     ] {
         assert!(
             refresh_body.contains(required_pattern),
@@ -714,8 +714,8 @@ fn password_credential_lifecycle_rewraps_seed_and_reissues_tokens() {
         ".update_user_password_and_seed_wrap(",
         "&auth_context",
         "NewToken::new_with_auth_context(",
-        "TokenType::Access",
-        "TokenType::Refresh",
+        "TokenType::access_for_transport(session_id.is_v2())",
+        "TokenType::refresh_for_transport(session_id.is_v2())",
         "&new_auth_context",
     ] {
         assert!(
@@ -911,8 +911,8 @@ fn password_registration_and_login_issue_tokens_only_after_seed_wrap_verificatio
     for required_pattern in [
         ".authenticate_user(",
         "NewToken::new_with_auth_context(",
-        "TokenType::Access",
-        "TokenType::Refresh",
+        "TokenType::access_for_transport(is_transport_v2)",
+        "TokenType::refresh_for_transport(is_transport_v2)",
         "&authenticated_user.auth_context",
     ] {
         assert!(

--- a/src/security_invariants.rs
+++ b/src/security_invariants.rs
@@ -176,36 +176,6 @@ fn openai_compatible_routes_do_not_request_user_storage_keys() {
 }
 
 #[test]
-fn response_encryption_routes_through_transport_session() {
-    let web_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/web");
-
-    let mut direct_session_encryption = Vec::new();
-    collect_pattern_matches(
-        &web_root,
-        ".encrypt_session_data(",
-        &mut direct_session_encryption,
-    );
-    assert_eq!(
-        direct_session_encryption.len(),
-        1,
-        "response encryption must stay centralized in TransportSession:\n{}",
-        direct_session_encryption.join("\n")
-    );
-    assert!(
-        direct_session_encryption[0].contains("encryption_middleware.rs"),
-        "the sole legacy session-encryption delegate must live in encryption_middleware.rs"
-    );
-
-    let mut bare_session_extensions = Vec::new();
-    collect_pattern_matches(&web_root, "Extension<Uuid>", &mut bare_session_extensions);
-    assert!(
-        bare_session_extensions.is_empty(),
-        "handlers must receive TransportSession rather than a bare session UUID:\n{}",
-        bare_session_extensions.join("\n")
-    );
-}
-
-#[test]
 fn models_route_allows_optional_identity_but_requires_session_e2ee() {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let main_source = fs::read_to_string(manifest_dir.join("src/main.rs"))

--- a/src/security_invariants.rs
+++ b/src/security_invariants.rs
@@ -176,6 +176,36 @@ fn openai_compatible_routes_do_not_request_user_storage_keys() {
 }
 
 #[test]
+fn response_encryption_routes_through_transport_session() {
+    let web_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/web");
+
+    let mut direct_session_encryption = Vec::new();
+    collect_pattern_matches(
+        &web_root,
+        ".encrypt_session_data(",
+        &mut direct_session_encryption,
+    );
+    assert_eq!(
+        direct_session_encryption.len(),
+        1,
+        "response encryption must stay centralized in TransportSession:\n{}",
+        direct_session_encryption.join("\n")
+    );
+    assert!(
+        direct_session_encryption[0].contains("encryption_middleware.rs"),
+        "the sole legacy session-encryption delegate must live in encryption_middleware.rs"
+    );
+
+    let mut bare_session_extensions = Vec::new();
+    collect_pattern_matches(&web_root, "Extension<Uuid>", &mut bare_session_extensions);
+    assert!(
+        bare_session_extensions.is_empty(),
+        "handlers must receive TransportSession rather than a bare session UUID:\n{}",
+        bare_session_extensions.join("\n")
+    );
+}
+
+#[test]
 fn models_route_allows_optional_identity_but_requires_session_e2ee() {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let main_source = fs::read_to_string(manifest_dir.join("src/main.rs"))
@@ -200,7 +230,7 @@ fn models_route_allows_optional_identity_but_requires_session_e2ee() {
     let handler_body = extract_function_body(&openai_source, "async fn proxy_models");
     assert!(
         openai_source.contains(
-            "async fn proxy_models(\n    State(state): State<Arc<AppState>>,\n    axum::Extension(session_id): axum::Extension<Uuid>,\n    user: Option<axum::Extension<User>>"
+            "async fn proxy_models(\n    State(state): State<Arc<AppState>>,\n    axum::Extension(session_id): axum::Extension<TransportSession>,\n    user: Option<axum::Extension<User>>"
         )
             && handler_body.contains("encrypt_response(&state, &session_id, &models_response)"),
         "the models handler must require session E2EE while allowing optional identity"

--- a/src/transport_v2/crypto.rs
+++ b/src/transport_v2/crypto.rs
@@ -1,0 +1,633 @@
+use std::{fmt, str::FromStr};
+
+use chacha20poly1305::{
+    aead::{Aead, Payload},
+    ChaCha20Poly1305, KeyInit, Nonce,
+};
+use hkdf::Hkdf;
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
+use x25519_dalek::{EphemeralSecret, PublicKey};
+use zeroize::ZeroizeOnDrop;
+
+use super::envelope::{RequestId, REQUEST_ID_BYTES};
+
+pub(crate) const HANDSHAKE_CHALLENGE_BYTES: usize = 32;
+pub(crate) const X25519_PUBLIC_KEY_BYTES: usize = 32;
+pub(crate) const SESSION_ID_BYTES: usize = 16;
+pub(crate) const RECORD_NONCE_BYTES: usize = 12;
+pub(crate) const RECORD_TAG_BYTES: usize = 16;
+pub(crate) const MIN_REQUEST_RECORD_BYTES: usize = REQUEST_ID_BYTES + RECORD_TAG_BYTES;
+pub(crate) const MIN_RESPONSE_RECORD_BYTES: usize = RECORD_TAG_BYTES;
+
+const HANDSHAKE_DOMAIN: &[u8] = b"opensecret/transport-v2/session/v1";
+const ATTESTATION_USER_DATA_DOMAIN: &[u8] = b"opensecret/transport-v2/session/v1/client-public-key";
+const REQUEST_KEY_INFO: &[u8] = b"opensecret/transport-v2/request-key/v1";
+const RESPONSE_KEY_INFO: &[u8] = b"opensecret/transport-v2/response-key/v1";
+const SESSION_ID_INFO: &[u8] = b"opensecret/transport-v2/session-id/v1";
+const REQUEST_SUBKEY_INFO: &[u8] = b"opensecret/transport-v2/request-subkey/v1";
+const RESPONSE_SUBKEY_INFO: &[u8] = b"opensecret/transport-v2/response-subkey/v1";
+const REQUEST_RECORD_DOMAIN: &[u8] = b"opensecret/transport-v2/request-record/v1";
+const RESPONSE_RECORD_DOMAIN: &[u8] = b"opensecret/transport-v2/response-record/v1";
+
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+#[error("transport-v2 session ID must be exactly 32 lowercase hexadecimal characters")]
+pub(crate) struct SessionIdParseError;
+
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub(crate) enum CryptoError {
+    #[error("non-contributory X25519 shared secret")]
+    NonContributoryKey,
+    #[error("transport-v2 key derivation failed")]
+    KeyDerivation,
+    #[error("transport-v2 record is truncated")]
+    TruncatedRecord,
+    #[error("transport-v2 record encryption failed")]
+    Encryption,
+    #[error("transport-v2 record authentication failed")]
+    Authentication,
+    #[error("transport-v2 response sequence is exhausted")]
+    SequenceExhausted,
+}
+
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+pub(crate) struct SessionId([u8; SESSION_ID_BYTES]);
+
+impl SessionId {
+    pub(crate) const fn from_bytes(bytes: [u8; SESSION_ID_BYTES]) -> Self {
+        Self(bytes)
+    }
+
+    pub(crate) const fn as_bytes(&self) -> &[u8; SESSION_ID_BYTES] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for SessionId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SessionId(")?;
+        formatter.write_str(&hex::encode(self.0))?;
+        formatter.write_str(")")
+    }
+}
+
+impl fmt::Display for SessionId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&hex::encode(self.0))
+    }
+}
+
+impl FromStr for SessionId {
+    type Err = SessionIdParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let encoded = value.as_bytes();
+        if encoded.len() != SESSION_ID_BYTES * 2
+            || !encoded
+                .iter()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+        {
+            return Err(SessionIdParseError);
+        }
+
+        let mut decoded = [0; SESSION_ID_BYTES];
+        hex::decode_to_slice(encoded, &mut decoded).map_err(|_| SessionIdParseError)?;
+        Ok(Self(decoded))
+    }
+}
+
+/// Values that a client verifies in one Nitro attestation document before it
+/// treats derived transport keys as belonging to an approved enclave.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct HandshakeTranscript {
+    challenge: [u8; HANDSHAKE_CHALLENGE_BYTES],
+    client_public_key: [u8; X25519_PUBLIC_KEY_BYTES],
+    server_public_key: [u8; X25519_PUBLIC_KEY_BYTES],
+}
+
+impl HandshakeTranscript {
+    pub(crate) const fn new(
+        challenge: [u8; HANDSHAKE_CHALLENGE_BYTES],
+        client_public_key: [u8; X25519_PUBLIC_KEY_BYTES],
+        server_public_key: [u8; X25519_PUBLIC_KEY_BYTES],
+    ) -> Self {
+        Self {
+            challenge,
+            client_public_key,
+            server_public_key,
+        }
+    }
+
+    pub(crate) const fn challenge(&self) -> &[u8; HANDSHAKE_CHALLENGE_BYTES] {
+        &self.challenge
+    }
+
+    pub(crate) const fn client_public_key(&self) -> &[u8; X25519_PUBLIC_KEY_BYTES] {
+        &self.client_public_key
+    }
+
+    pub(crate) const fn server_public_key(&self) -> &[u8; X25519_PUBLIC_KEY_BYTES] {
+        &self.server_public_key
+    }
+
+    fn digest(&self) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(HANDSHAKE_DOMAIN);
+        hasher.update([0]);
+        hasher.update(self.challenge);
+        hasher.update(self.client_public_key);
+        hasher.update(self.server_public_key);
+        hasher.finalize().into()
+    }
+}
+
+/// Exact user-data bytes placed in the attestation document. The document's
+/// nonce carries the challenge and its public-key field carries the server key.
+pub(crate) fn attestation_user_data(client_public_key: &[u8; X25519_PUBLIC_KEY_BYTES]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(ATTESTATION_USER_DATA_DOMAIN.len() + 1 + 32);
+    bytes.extend_from_slice(ATTESTATION_USER_DATA_DOMAIN);
+    bytes.push(0);
+    bytes.extend_from_slice(client_public_key);
+    bytes
+}
+
+#[derive(ZeroizeOnDrop)]
+struct TrafficKey([u8; 32]);
+
+/// Directional keys plus the public identifier derived from one verified
+/// attested X25519 transcript. Raw key material is never exposed by this type.
+#[derive(ZeroizeOnDrop)]
+pub(crate) struct SessionSecrets {
+    #[zeroize(skip)]
+    session_id: SessionId,
+    request_key: TrafficKey,
+    response_key: TrafficKey,
+}
+
+/// The sole writer for one admitted request's encrypted response.
+///
+/// A per-request subkey lets every response start at sequence zero without a
+/// session-wide response-record counter. This type never rewinds its sequence,
+/// even if an encryption attempt fails.
+#[derive(ZeroizeOnDrop)]
+pub(crate) struct ResponseSealer {
+    #[zeroize(skip)]
+    session_id: SessionId,
+    #[zeroize(skip)]
+    request_id: RequestId,
+    key: TrafficKey,
+    #[zeroize(skip)]
+    next_sequence: u64,
+}
+
+impl fmt::Debug for ResponseSealer {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ResponseSealer")
+            .field("session_id", &self.session_id)
+            .field("request_id", &self.request_id)
+            .field("next_sequence", &self.next_sequence)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ResponseSealer {
+    pub(crate) fn seal_next(&mut self, plaintext: &[u8]) -> Result<Vec<u8>, CryptoError> {
+        let sequence = self.next_sequence;
+        self.next_sequence = self
+            .next_sequence
+            .checked_add(1)
+            .ok_or(CryptoError::SequenceExhausted)?;
+        seal_detached_nonce(
+            &self.key,
+            &response_aad(self.session_id, self.request_id, sequence),
+            response_nonce(sequence),
+            plaintext,
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn next_sequence(&self) -> u64 {
+        self.next_sequence
+    }
+}
+
+impl fmt::Debug for SessionSecrets {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SessionSecrets")
+            .field("session_id", &self.session_id)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SessionSecrets {
+    pub(crate) const fn session_id(&self) -> SessionId {
+        self.session_id
+    }
+
+    pub(crate) fn encrypt_request(
+        &self,
+        request_id: RequestId,
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, CryptoError> {
+        let key = derive_record_subkey(
+            &self.request_key,
+            REQUEST_SUBKEY_INFO,
+            self.session_id,
+            request_id,
+        )?;
+        let ciphertext = seal_detached_nonce(
+            &key,
+            &request_aad(self.session_id, request_id),
+            [0; RECORD_NONCE_BYTES],
+            plaintext,
+        )?;
+        let mut record = Vec::with_capacity(REQUEST_ID_BYTES + ciphertext.len());
+        record.extend_from_slice(request_id.as_bytes());
+        record.extend_from_slice(&ciphertext);
+        Ok(record)
+    }
+
+    pub(crate) fn decrypt_request(
+        &self,
+        record: &[u8],
+    ) -> Result<(RequestId, Vec<u8>), CryptoError> {
+        if record.len() < MIN_REQUEST_RECORD_BYTES {
+            return Err(CryptoError::TruncatedRecord);
+        }
+        let request_id = RequestId::from_bytes(
+            record[..REQUEST_ID_BYTES]
+                .try_into()
+                .map_err(|_| CryptoError::TruncatedRecord)?,
+        );
+        let key = derive_record_subkey(
+            &self.request_key,
+            REQUEST_SUBKEY_INFO,
+            self.session_id,
+            request_id,
+        )?;
+        let plaintext = open_detached_nonce(
+            &key,
+            &request_aad(self.session_id, request_id),
+            [0; RECORD_NONCE_BYTES],
+            &record[REQUEST_ID_BYTES..],
+        )?;
+        Ok((request_id, plaintext))
+    }
+
+    pub(super) fn response_sealer(
+        &self,
+        request_id: RequestId,
+    ) -> Result<ResponseSealer, CryptoError> {
+        Ok(ResponseSealer {
+            session_id: self.session_id,
+            request_id,
+            key: derive_record_subkey(
+                &self.response_key,
+                RESPONSE_SUBKEY_INFO,
+                self.session_id,
+                request_id,
+            )?,
+            next_sequence: 0,
+        })
+    }
+
+    pub(crate) fn decrypt_response(
+        &self,
+        request_id: RequestId,
+        sequence: u64,
+        record: &[u8],
+    ) -> Result<Vec<u8>, CryptoError> {
+        let key = derive_record_subkey(
+            &self.response_key,
+            RESPONSE_SUBKEY_INFO,
+            self.session_id,
+            request_id,
+        )?;
+        open_detached_nonce(
+            &key,
+            &response_aad(self.session_id, request_id, sequence),
+            response_nonce(sequence),
+            record,
+        )
+    }
+
+    #[cfg(test)]
+    fn request_key_bytes(&self) -> &[u8; 32] {
+        &self.request_key.0
+    }
+
+    #[cfg(test)]
+    fn response_key_bytes(&self) -> &[u8; 32] {
+        &self.response_key.0
+    }
+}
+
+pub(crate) fn derive_server_session(
+    server_secret: EphemeralSecret,
+    transcript: &HandshakeTranscript,
+) -> Result<SessionSecrets, CryptoError> {
+    let client_public_key = PublicKey::from(*transcript.client_public_key());
+    derive_session_secrets(
+        server_secret.diffie_hellman(&client_public_key).as_bytes(),
+        transcript,
+    )
+}
+
+pub(crate) fn derive_client_session(
+    client_secret: EphemeralSecret,
+    transcript: &HandshakeTranscript,
+) -> Result<SessionSecrets, CryptoError> {
+    let server_public_key = PublicKey::from(*transcript.server_public_key());
+    derive_session_secrets(
+        client_secret.diffie_hellman(&server_public_key).as_bytes(),
+        transcript,
+    )
+}
+
+fn derive_session_secrets(
+    shared_secret: &[u8; 32],
+    transcript: &HandshakeTranscript,
+) -> Result<SessionSecrets, CryptoError> {
+    if bool::from(shared_secret.ct_eq(&[0; 32])) {
+        return Err(CryptoError::NonContributoryKey);
+    }
+
+    let transcript_digest = transcript.digest();
+    let hkdf = Hkdf::<Sha256>::new(Some(transcript.challenge()), shared_secret);
+    let mut request_key = [0; 32];
+    let mut response_key = [0; 32];
+    let mut session_id = [0; SESSION_ID_BYTES];
+    hkdf.expand(
+        &key_info(REQUEST_KEY_INFO, &transcript_digest),
+        &mut request_key,
+    )
+    .map_err(|_| CryptoError::KeyDerivation)?;
+    hkdf.expand(
+        &key_info(RESPONSE_KEY_INFO, &transcript_digest),
+        &mut response_key,
+    )
+    .map_err(|_| CryptoError::KeyDerivation)?;
+    hkdf.expand(
+        &key_info(SESSION_ID_INFO, &transcript_digest),
+        &mut session_id,
+    )
+    .map_err(|_| CryptoError::KeyDerivation)?;
+
+    Ok(SessionSecrets {
+        session_id: SessionId(session_id),
+        request_key: TrafficKey(request_key),
+        response_key: TrafficKey(response_key),
+    })
+}
+
+fn key_info(label: &[u8], transcript_digest: &[u8; 32]) -> Vec<u8> {
+    let mut info = Vec::with_capacity(label.len() + 1 + transcript_digest.len());
+    info.extend_from_slice(label);
+    info.push(0);
+    info.extend_from_slice(transcript_digest);
+    info
+}
+
+fn derive_record_subkey(
+    base_key: &TrafficKey,
+    label: &[u8],
+    session_id: SessionId,
+    request_id: RequestId,
+) -> Result<TrafficKey, CryptoError> {
+    let hkdf = Hkdf::<Sha256>::from_prk(&base_key.0).map_err(|_| CryptoError::KeyDerivation)?;
+    let mut info = Vec::with_capacity(label.len() + 1 + SESSION_ID_BYTES + REQUEST_ID_BYTES);
+    info.extend_from_slice(label);
+    info.push(0);
+    info.extend_from_slice(session_id.as_bytes());
+    info.extend_from_slice(request_id.as_bytes());
+
+    let mut key = [0; 32];
+    hkdf.expand(&info, &mut key)
+        .map_err(|_| CryptoError::KeyDerivation)?;
+    Ok(TrafficKey(key))
+}
+
+fn request_aad(session_id: SessionId, request_id: RequestId) -> Vec<u8> {
+    let mut aad =
+        Vec::with_capacity(REQUEST_RECORD_DOMAIN.len() + 1 + SESSION_ID_BYTES + REQUEST_ID_BYTES);
+    aad.extend_from_slice(REQUEST_RECORD_DOMAIN);
+    aad.push(0);
+    aad.extend_from_slice(session_id.as_bytes());
+    aad.extend_from_slice(request_id.as_bytes());
+    aad
+}
+
+fn response_aad(session_id: SessionId, request_id: RequestId, sequence: u64) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(
+        RESPONSE_RECORD_DOMAIN.len() + 1 + SESSION_ID_BYTES + 16 + std::mem::size_of::<u64>(),
+    );
+    aad.extend_from_slice(RESPONSE_RECORD_DOMAIN);
+    aad.push(0);
+    aad.extend_from_slice(session_id.as_bytes());
+    aad.extend_from_slice(request_id.as_bytes());
+    aad.extend_from_slice(&sequence.to_be_bytes());
+    aad
+}
+
+fn response_nonce(sequence: u64) -> [u8; RECORD_NONCE_BYTES] {
+    let mut nonce = [0; RECORD_NONCE_BYTES];
+    nonce[4..].copy_from_slice(&sequence.to_be_bytes());
+    nonce
+}
+
+fn seal_detached_nonce(
+    key: &TrafficKey,
+    aad: &[u8],
+    nonce: [u8; RECORD_NONCE_BYTES],
+    plaintext: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    let cipher = ChaCha20Poly1305::new((&key.0).into());
+    let ciphertext = cipher
+        .encrypt(
+            Nonce::from_slice(&nonce),
+            Payload {
+                msg: plaintext,
+                aad,
+            },
+        )
+        .map_err(|_| CryptoError::Encryption)?;
+    Ok(ciphertext)
+}
+
+fn open_detached_nonce(
+    key: &TrafficKey,
+    aad: &[u8],
+    nonce: [u8; RECORD_NONCE_BYTES],
+    record: &[u8],
+) -> Result<Vec<u8>, CryptoError> {
+    if record.len() < RECORD_TAG_BYTES {
+        return Err(CryptoError::TruncatedRecord);
+    }
+    ChaCha20Poly1305::new((&key.0).into())
+        .decrypt(Nonce::from_slice(&nonce), Payload { msg: record, aad })
+        .map_err(|_| CryptoError::Authentication)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand_core::OsRng;
+
+    fn transcript() -> HandshakeTranscript {
+        HandshakeTranscript::new([0x11; 32], [0x22; 32], [0x33; 32])
+    }
+
+    fn secrets(seed: u8) -> SessionSecrets {
+        derive_session_secrets(&[seed; 32], &transcript()).unwrap()
+    }
+
+    #[test]
+    fn one_round_x25519_derives_identical_directional_keys() {
+        let client_secret = EphemeralSecret::random_from_rng(OsRng);
+        let client_public = PublicKey::from(&client_secret).to_bytes();
+        let server_secret = EphemeralSecret::random_from_rng(OsRng);
+        let server_public = PublicKey::from(&server_secret).to_bytes();
+        let transcript = HandshakeTranscript::new([7; 32], client_public, server_public);
+
+        let client = derive_client_session(client_secret, &transcript).unwrap();
+        let server = derive_server_session(server_secret, &transcript).unwrap();
+
+        assert_eq!(client.session_id(), server.session_id());
+        assert_eq!(client.request_key_bytes(), server.request_key_bytes());
+        assert_eq!(client.response_key_bytes(), server.response_key_bytes());
+    }
+
+    #[test]
+    fn attestation_fields_and_transcript_changes_are_bound() {
+        let expected = [
+            ATTESTATION_USER_DATA_DOMAIN,
+            &[0],
+            &[0x22; X25519_PUBLIC_KEY_BYTES],
+        ]
+        .concat();
+        assert_eq!(attestation_user_data(&[0x22; 32]), expected);
+
+        let original = secrets(0x44);
+        let changed = derive_session_secrets(
+            &[0x44; 32],
+            &HandshakeTranscript::new([0x10; 32], [0x22; 32], [0x33; 32]),
+        )
+        .unwrap();
+        assert_ne!(original.session_id(), changed.session_id());
+        assert_ne!(original.request_key_bytes(), changed.request_key_bytes());
+    }
+
+    #[test]
+    fn session_ids_have_one_canonical_wire_encoding() {
+        let session_id = SessionId::from_bytes([0xab; SESSION_ID_BYTES]);
+        let encoded = session_id.to_string();
+        assert_eq!(encoded, "abababababababababababababababab");
+        assert_eq!(SessionId::from_str(&encoded), Ok(session_id));
+        assert_eq!(
+            SessionId::from_str(&encoded.to_uppercase()),
+            Err(SessionIdParseError)
+        );
+        assert_eq!(SessionId::from_str("ab"), Err(SessionIdParseError));
+    }
+
+    #[test]
+    fn deterministic_key_and_record_vector() {
+        let secrets = secrets(0x44);
+        assert_eq!(
+            hex::encode(secrets.session_id().as_bytes()),
+            "f7258fb103137c612baab47ced4a5a02"
+        );
+        assert_eq!(
+            hex::encode(secrets.request_key_bytes()),
+            "00f898a5f2dcd40a703f42221f2a2b842b7e97ed5a555caa362c4153a5e1c491"
+        );
+        assert_eq!(
+            hex::encode(secrets.response_key_bytes()),
+            "e4fb003c5c829f5385531eebfdbd0ee3d8430a0bd71322e9f3e41ace915c3190"
+        );
+        let record = secrets
+            .encrypt_request(RequestId::from_bytes([0x55; 16]), b"vector plaintext")
+            .unwrap();
+        assert_eq!(
+            hex::encode(record),
+            "55555555555555555555555555555555671f5c411205cb00f769e6b2705052b795e91f44516fc6165e16a152e686b209"
+        );
+
+        let mut response = secrets
+            .response_sealer(RequestId::from_bytes([0x66; 16]))
+            .unwrap();
+        let record = response.seal_next(b"vector response").unwrap();
+        assert_eq!(
+            hex::encode(record),
+            "25a2d5ed89864bd7b5e13c83eb49b1f314a70abf8bd7e871b706bb6768c9e1"
+        );
+    }
+
+    #[test]
+    fn request_and_response_records_round_trip() {
+        let secrets = secrets(0x44);
+        let request_id = RequestId::from_bytes([9; 16]);
+        let request = secrets.encrypt_request(request_id, b"request").unwrap();
+        assert_eq!(
+            secrets.decrypt_request(&request).unwrap(),
+            (request_id, b"request".to_vec())
+        );
+
+        let mut sealer = secrets.response_sealer(request_id).unwrap();
+        for sequence in 0..7 {
+            let record = sealer.seal_next(b"earlier chunk").unwrap();
+            assert_eq!(
+                secrets
+                    .decrypt_response(request_id, sequence, &record)
+                    .unwrap(),
+                b"earlier chunk"
+            );
+        }
+        let response = sealer.seal_next(b"response chunk").unwrap();
+        assert_eq!(sealer.next_sequence(), 8);
+        assert_eq!(
+            secrets.decrypt_response(request_id, 7, &response).unwrap(),
+            b"response chunk"
+        );
+    }
+
+    #[test]
+    fn records_cannot_be_transplanted() {
+        let first = secrets(0x44);
+        let second = secrets(0x45);
+        let request = first
+            .encrypt_request(RequestId::from_bytes([3; 16]), b"request")
+            .unwrap();
+        assert_eq!(
+            second.decrypt_request(&request),
+            Err(CryptoError::Authentication)
+        );
+
+        let first_request = RequestId::from_bytes([1; 16]);
+        let other_request = RequestId::from_bytes([2; 16]);
+        let mut sealer = first.response_sealer(first_request).unwrap();
+        let response = sealer.seal_next(b"response").unwrap();
+        assert_eq!(
+            first.decrypt_response(other_request, 0, &response),
+            Err(CryptoError::Authentication)
+        );
+        assert_eq!(
+            first.decrypt_response(first_request, 1, &response),
+            Err(CryptoError::Authentication)
+        );
+    }
+
+    #[test]
+    fn rejects_non_contributory_shared_secret_and_truncated_records() {
+        assert_eq!(
+            derive_session_secrets(&[0; 32], &transcript()).unwrap_err(),
+            CryptoError::NonContributoryKey
+        );
+        assert_eq!(
+            secrets(0x44).decrypt_request(&[0; MIN_REQUEST_RECORD_BYTES - 1]),
+            Err(CryptoError::TruncatedRecord)
+        );
+    }
+}

--- a/src/transport_v2/envelope.rs
+++ b/src/transport_v2/envelope.rs
@@ -1,0 +1,739 @@
+use std::{fmt, str::FromStr};
+
+use axum::{
+    body::Bytes,
+    http::{HeaderName, HeaderValue, Method, Uri},
+};
+use rand_core::{OsRng, RngCore};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use zeroize::Zeroize;
+
+use crate::provider_cache::CacheNamespaceRoot;
+
+pub(crate) const VERSION: u8 = 2;
+pub(crate) const REQUEST_ID_BYTES: usize = 16;
+pub(crate) const METADATA_LENGTH_BYTES: usize = 4;
+pub(crate) const MAX_METADATA_BYTES: usize = 128 * 1024;
+pub(crate) const MAX_BODY_BYTES: usize = 50 * 1024 * 1024;
+pub(crate) const MAX_ENCODED_REQUEST_BYTES: usize =
+    METADATA_LENGTH_BYTES + MAX_METADATA_BYTES + MAX_BODY_BYTES;
+pub(crate) const MAX_CREDENTIAL_BYTES: usize = 16 * 1024;
+pub(crate) const MAX_METHOD_BYTES: usize = 32;
+pub(crate) const MAX_TARGET_BYTES: usize = 16 * 1024;
+pub(crate) const MAX_HEADER_COUNT: usize = 64;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum EnvelopeError {
+    #[error("transport-v2 request envelope is truncated")]
+    Truncated,
+    #[error("transport-v2 request envelope exceeds its byte limit")]
+    EnvelopeTooLarge,
+    #[error("transport-v2 request metadata exceeds its byte limit")]
+    MetadataTooLarge,
+    #[error("transport-v2 request body exceeds its byte limit")]
+    BodyTooLarge,
+    #[error("transport-v2 request metadata is invalid")]
+    InvalidMetadata(#[source] serde_json::Error),
+    #[error("transport-v2 request version must be exactly 2")]
+    InvalidVersion,
+    #[error("transport-v2 request body presence does not match its metadata")]
+    BodyPresenceMismatch,
+    #[error("transport-v2 credential is invalid")]
+    InvalidCredential,
+    #[error("transport-v2 method is invalid")]
+    InvalidMethod,
+    #[error("transport-v2 relative target is invalid")]
+    InvalidTarget,
+    #[error("transport-v2 request has too many logical headers")]
+    TooManyHeaders,
+    #[error("transport-v2 logical header name is invalid")]
+    InvalidHeaderName,
+    #[error("transport-v2 logical header value is invalid")]
+    InvalidHeaderValue,
+    #[error("transport-v2 logical header is controlled by the gateway")]
+    GatewayControlledHeader,
+}
+
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct RequestId([u8; REQUEST_ID_BYTES]);
+
+impl RequestId {
+    pub(crate) const fn from_bytes(bytes: [u8; REQUEST_ID_BYTES]) -> Self {
+        Self(bytes)
+    }
+
+    pub(crate) fn random() -> Self {
+        let mut bytes = [0; REQUEST_ID_BYTES];
+        OsRng.fill_bytes(&mut bytes);
+        Self(bytes)
+    }
+
+    pub(crate) const fn as_bytes(&self) -> &[u8; REQUEST_ID_BYTES] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for RequestId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("RequestId(")?;
+        formatter.write_str(&hex::encode(self.0))?;
+        formatter.write_str(")")
+    }
+}
+
+impl fmt::Display for RequestId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&hex::encode(self.0))
+    }
+}
+
+impl Serialize for RequestId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&hex::encode(self.0))
+    }
+}
+
+impl<'de> Deserialize<'de> for RequestId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct RequestIdVisitor;
+
+        impl de::Visitor<'_> for RequestIdVisitor {
+            type Value = RequestId;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("exactly 32 lowercase hexadecimal characters")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let encoded = value.as_bytes();
+                if encoded.len() != REQUEST_ID_BYTES * 2
+                    || !encoded
+                        .iter()
+                        .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+                {
+                    return Err(E::custom("request ID is not canonical lowercase hex"));
+                }
+                let mut decoded = [0; REQUEST_ID_BYTES];
+                hex::decode_to_slice(encoded, &mut decoded)
+                    .map_err(|_| E::custom("request ID is not valid hex"))?;
+                Ok(RequestId(decoded))
+            }
+        }
+
+        deserializer.deserialize_str(RequestIdVisitor)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CredentialKind {
+    Bearer,
+    ApiKey,
+    Resumption,
+}
+
+#[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Credential {
+    kind: CredentialKind,
+    value: String,
+}
+
+impl Credential {
+    pub(crate) fn new(kind: CredentialKind, value: String) -> Result<Self, EnvelopeError> {
+        let credential = Self { kind, value };
+        validate_credential(&credential)?;
+        Ok(credential)
+    }
+
+    pub(crate) const fn kind(&self) -> CredentialKind {
+        self.kind
+    }
+
+    pub(crate) fn value(&self) -> &str {
+        &self.value
+    }
+}
+
+impl fmt::Debug for Credential {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Credential")
+            .field("kind", &self.kind)
+            .field("value_bytes", &self.value.len())
+            .finish()
+    }
+}
+
+impl Drop for Credential {
+    fn drop(&mut self) {
+        self.value.zeroize();
+    }
+}
+
+#[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct LogicalHeader {
+    name: String,
+    value: String,
+}
+
+impl LogicalHeader {
+    pub(crate) fn new(name: String, value: String) -> Result<Self, EnvelopeError> {
+        let header = Self { name, value };
+        validate_header(&header)?;
+        Ok(header)
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(crate) fn value(&self) -> &str {
+        &self.value
+    }
+}
+
+impl fmt::Debug for LogicalHeader {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LogicalHeader")
+            .field("name", &self.name)
+            .field("value_bytes", &self.value.len())
+            .finish()
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RequestMetadata {
+    version: u8,
+    credential: Option<Credential>,
+    cache_namespace_root: Option<CacheNamespaceRoot>,
+    method: String,
+    target: String,
+    headers: Vec<LogicalHeader>,
+    body_present: bool,
+}
+
+pub(crate) struct RequestEnvelope {
+    request_id: RequestId,
+    credential: Option<Credential>,
+    cache_namespace_root: Option<CacheNamespaceRoot>,
+    method: String,
+    target: String,
+    headers: Vec<LogicalHeader>,
+    body: Option<Bytes>,
+}
+
+impl fmt::Debug for RequestEnvelope {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RequestEnvelope")
+            .field("request_id", &self.request_id)
+            .field("credential", &self.credential)
+            .field(
+                "cache_namespace_root_present",
+                &self.cache_namespace_root.is_some(),
+            )
+            .field("method", &self.method)
+            .field("target_bytes", &self.target.len())
+            .field("header_count", &self.headers.len())
+            .field("body_bytes", &self.body.as_ref().map(Bytes::len))
+            .finish()
+    }
+}
+
+impl RequestEnvelope {
+    pub(crate) fn new(
+        request_id: RequestId,
+        credential: Option<Credential>,
+        cache_namespace_root: Option<CacheNamespaceRoot>,
+        method: String,
+        target: String,
+        headers: Vec<LogicalHeader>,
+        body: Option<Vec<u8>>,
+    ) -> Result<Self, EnvelopeError> {
+        Self::from_parts(
+            request_id,
+            credential,
+            cache_namespace_root,
+            method,
+            target,
+            headers,
+            body.map(Bytes::from),
+        )
+    }
+
+    fn from_parts(
+        request_id: RequestId,
+        credential: Option<Credential>,
+        cache_namespace_root: Option<CacheNamespaceRoot>,
+        method: String,
+        target: String,
+        headers: Vec<LogicalHeader>,
+        body: Option<Bytes>,
+    ) -> Result<Self, EnvelopeError> {
+        let envelope = Self {
+            request_id,
+            credential,
+            cache_namespace_root,
+            method,
+            target,
+            headers,
+            body,
+        };
+        envelope.validate()?;
+        Ok(envelope)
+    }
+
+    pub(crate) const fn request_id(&self) -> RequestId {
+        self.request_id
+    }
+
+    pub(crate) fn credential(&self) -> Option<&Credential> {
+        self.credential.as_ref()
+    }
+
+    pub(crate) fn cache_namespace_root(&self) -> Option<&CacheNamespaceRoot> {
+        self.cache_namespace_root.as_ref()
+    }
+
+    pub(crate) fn method(&self) -> &str {
+        &self.method
+    }
+
+    pub(crate) fn target(&self) -> &str {
+        &self.target
+    }
+
+    pub(crate) fn headers(&self) -> &[LogicalHeader] {
+        &self.headers
+    }
+
+    pub(crate) fn body(&self) -> Option<&[u8]> {
+        self.body.as_deref()
+    }
+
+    pub(crate) fn into_body(mut self) -> Option<Bytes> {
+        self.body.take()
+    }
+
+    /// Encodes bounded JSON metadata followed by the raw body bytes. The raw
+    /// tail avoids base64 expansion and a second large decoded-body allocation.
+    pub(crate) fn encode(&self) -> Result<Vec<u8>, EnvelopeError> {
+        self.validate()?;
+        let metadata = RequestMetadata {
+            version: VERSION,
+            credential: self.credential.clone(),
+            cache_namespace_root: self.cache_namespace_root.clone(),
+            method: self.method.clone(),
+            target: self.target.clone(),
+            headers: self.headers.clone(),
+            body_present: self.body.is_some(),
+        };
+        let encoded_metadata =
+            serde_json::to_vec(&metadata).map_err(EnvelopeError::InvalidMetadata)?;
+        if encoded_metadata.len() > MAX_METADATA_BYTES {
+            return Err(EnvelopeError::MetadataTooLarge);
+        }
+        let body = self.body.as_deref().unwrap_or_default();
+        validate_body_len(body.len())?;
+
+        let mut encoded =
+            Vec::with_capacity(METADATA_LENGTH_BYTES + encoded_metadata.len() + body.len());
+        encoded.extend_from_slice(&(encoded_metadata.len() as u32).to_be_bytes());
+        encoded.extend_from_slice(&encoded_metadata);
+        encoded.extend_from_slice(body);
+        Ok(encoded)
+    }
+
+    pub(crate) fn decode(request_id: RequestId, encoded: &[u8]) -> Result<Self, EnvelopeError> {
+        Self::decode_owned(request_id, encoded.to_vec())
+    }
+
+    /// Decodes a decrypted record while retaining its allocation behind a
+    /// reference-counted byte slice. The logical body therefore does not need
+    /// a second maximum-sized copy.
+    pub(crate) fn decode_owned(
+        request_id: RequestId,
+        encoded: Vec<u8>,
+    ) -> Result<Self, EnvelopeError> {
+        Self::decode_bytes(request_id, Bytes::from(encoded))
+    }
+
+    fn decode_bytes(request_id: RequestId, encoded: Bytes) -> Result<Self, EnvelopeError> {
+        if encoded.len() < METADATA_LENGTH_BYTES {
+            return Err(EnvelopeError::Truncated);
+        }
+        if encoded.len() > MAX_ENCODED_REQUEST_BYTES {
+            return Err(EnvelopeError::EnvelopeTooLarge);
+        }
+
+        let metadata_len = u32::from_be_bytes(
+            encoded[..METADATA_LENGTH_BYTES]
+                .try_into()
+                .map_err(|_| EnvelopeError::Truncated)?,
+        ) as usize;
+        if metadata_len > MAX_METADATA_BYTES {
+            return Err(EnvelopeError::MetadataTooLarge);
+        }
+        let metadata_end = METADATA_LENGTH_BYTES
+            .checked_add(metadata_len)
+            .ok_or(EnvelopeError::EnvelopeTooLarge)?;
+        if metadata_end > encoded.len() {
+            return Err(EnvelopeError::Truncated);
+        }
+
+        let metadata: RequestMetadata =
+            serde_json::from_slice(&encoded[METADATA_LENGTH_BYTES..metadata_end])
+                .map_err(EnvelopeError::InvalidMetadata)?;
+        if metadata.version != VERSION {
+            return Err(EnvelopeError::InvalidVersion);
+        }
+
+        let body_bytes = encoded.slice(metadata_end..);
+        validate_body_len(body_bytes.len())?;
+        let body = match (metadata.body_present, body_bytes.is_empty()) {
+            (true, _) => Some(body_bytes),
+            (false, true) => None,
+            (false, false) => return Err(EnvelopeError::BodyPresenceMismatch),
+        };
+
+        Self::from_parts(
+            request_id,
+            metadata.credential,
+            metadata.cache_namespace_root,
+            metadata.method,
+            metadata.target,
+            metadata.headers,
+            body,
+        )
+    }
+
+    fn validate(&self) -> Result<(), EnvelopeError> {
+        if let Some(credential) = &self.credential {
+            validate_credential(credential)?;
+        }
+        validate_method(&self.method)?;
+        validate_target(&self.target)?;
+        validate_headers(&self.headers)?;
+        validate_body_len(self.body.as_ref().map_or(0, Bytes::len))
+    }
+}
+
+fn validate_credential(credential: &Credential) -> Result<(), EnvelopeError> {
+    let value = credential.value.as_bytes();
+    if value.is_empty()
+        || value.len() > MAX_CREDENTIAL_BYTES
+        || !value.iter().all(|byte| matches!(byte, 0x21..=0x7e))
+    {
+        return Err(EnvelopeError::InvalidCredential);
+    }
+    Ok(())
+}
+
+fn validate_method(method: &str) -> Result<(), EnvelopeError> {
+    if method.is_empty()
+        || method.len() > MAX_METHOD_BYTES
+        || Method::from_bytes(method.as_bytes()).is_err()
+    {
+        return Err(EnvelopeError::InvalidMethod);
+    }
+    Ok(())
+}
+
+fn validate_target(target: &str) -> Result<(), EnvelopeError> {
+    if target.is_empty()
+        || target.len() > MAX_TARGET_BYTES
+        || !target.starts_with('/')
+        || target.starts_with("//")
+        || target.contains(['#', '\\'])
+    {
+        return Err(EnvelopeError::InvalidTarget);
+    }
+    let uri = Uri::from_str(target).map_err(|_| EnvelopeError::InvalidTarget)?;
+    if uri.scheme().is_some()
+        || uri.authority().is_some()
+        || uri
+            .path_and_query()
+            .is_none_or(|path_and_query| path_and_query.as_str() != target)
+    {
+        return Err(EnvelopeError::InvalidTarget);
+    }
+    Ok(())
+}
+
+fn validate_headers(headers: &[LogicalHeader]) -> Result<(), EnvelopeError> {
+    if headers.len() > MAX_HEADER_COUNT {
+        return Err(EnvelopeError::TooManyHeaders);
+    }
+
+    for header in headers {
+        validate_header(header)?;
+    }
+    Ok(())
+}
+
+fn validate_header(header: &LogicalHeader) -> Result<(), EnvelopeError> {
+    let parsed_name = HeaderName::from_bytes(header.name.as_bytes())
+        .map_err(|_| EnvelopeError::InvalidHeaderName)?;
+    if parsed_name.as_str() != header.name {
+        return Err(EnvelopeError::InvalidHeaderName);
+    }
+    if is_gateway_controlled_header(parsed_name.as_str()) {
+        return Err(EnvelopeError::GatewayControlledHeader);
+    }
+    HeaderValue::from_str(&header.value).map_err(|_| EnvelopeError::InvalidHeaderValue)?;
+    Ok(())
+}
+
+fn is_gateway_controlled_header(name: &str) -> bool {
+    matches!(
+        name,
+        "authorization"
+            | "proxy-authorization"
+            | "cookie"
+            | "set-cookie"
+            | "host"
+            | "content-length"
+            | "transfer-encoding"
+            | "connection"
+            | "keep-alive"
+            | "te"
+            | "trailer"
+            | "upgrade"
+            | "forwarded"
+            | "via"
+            | "x-forwarded-for"
+            | "x-forwarded-host"
+            | "x-forwarded-proto"
+            | "x-session-id"
+    )
+}
+
+fn validate_body_len(body_len: usize) -> Result<(), EnvelopeError> {
+    if body_len > MAX_BODY_BYTES {
+        Err(EnvelopeError::BodyTooLarge)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(body: Option<Vec<u8>>) -> RequestEnvelope {
+        RequestEnvelope::new(
+            RequestId::from_bytes([0x11; 16]),
+            Some(
+                Credential::new(CredentialKind::Bearer, "header.payload.signature".into()).unwrap(),
+            ),
+            Some(CacheNamespaceRoot::from_bytes([0x22; 32])),
+            "POST".into(),
+            "/v1/chat/completions?trace=1".into(),
+            vec![LogicalHeader::new("content-type".into(), "application/json".into()).unwrap()],
+            body,
+        )
+        .unwrap()
+    }
+
+    fn wire(metadata: &str, body: &[u8]) -> Vec<u8> {
+        let mut encoded = Vec::new();
+        encoded.extend_from_slice(&(metadata.len() as u32).to_be_bytes());
+        encoded.extend_from_slice(metadata.as_bytes());
+        encoded.extend_from_slice(body);
+        encoded
+    }
+
+    fn decode(encoded: &[u8]) -> Result<RequestEnvelope, EnvelopeError> {
+        RequestEnvelope::decode(RequestId::from_bytes([0x11; 16]), encoded)
+    }
+
+    #[test]
+    fn raw_body_round_trip_has_no_base64_expansion() {
+        let body = vec![0, 1, 2, 3, 0xfe, 0xff];
+        let envelope = sample(Some(body.clone()));
+        let encoded = envelope.encode().unwrap();
+        assert!(encoded.ends_with(&body));
+
+        let decoded = decode(&encoded).unwrap();
+        assert_eq!(decoded.request_id(), envelope.request_id());
+        assert_eq!(decoded.method(), "POST");
+        assert_eq!(decoded.target(), "/v1/chat/completions?trace=1");
+        assert_eq!(decoded.body(), Some(body.as_slice()));
+        assert_eq!(decoded.credential().unwrap().kind(), CredentialKind::Bearer);
+        assert_eq!(
+            decoded.credential().unwrap().value(),
+            "header.payload.signature"
+        );
+        assert!(decoded.cache_namespace_root().is_some());
+        assert!(!format!("{decoded:?}").contains("IiIi"));
+    }
+
+    #[test]
+    fn absent_and_present_empty_bodies_remain_distinct() {
+        let absent = decode(&sample(None).encode().unwrap()).unwrap();
+        let empty = decode(&sample(Some(Vec::new())).encode().unwrap()).unwrap();
+        assert_eq!(absent.body(), None);
+        assert_eq!(empty.body(), Some([].as_slice()));
+    }
+
+    #[test]
+    fn strict_metadata_rejects_unknown_duplicate_and_wrong_version_fields() {
+        let base = r#"{"version":2,"credential":null,"cache_namespace_root":null,"method":"GET","target":"/health-check","headers":[],"body_present":false}"#;
+        assert!(decode(&wire(base, &[])).is_ok());
+
+        let unknown = base.replace(
+            "\"body_present\":false",
+            "\"body_present\":false,\"extra\":1",
+        );
+        assert!(matches!(
+            decode(&wire(&unknown, &[])),
+            Err(EnvelopeError::InvalidMetadata(_))
+        ));
+
+        let duplicate = base.replacen("\"version\":2", "\"version\":2,\"version\":2", 1);
+        assert!(matches!(
+            decode(&wire(&duplicate, &[])),
+            Err(EnvelopeError::InvalidMetadata(_))
+        ));
+
+        let wrong_version = base.replacen("\"version\":2", "\"version\":1", 1);
+        assert!(matches!(
+            decode(&wire(&wrong_version, &[])),
+            Err(EnvelopeError::InvalidVersion)
+        ));
+    }
+
+    #[test]
+    fn body_presence_and_prefix_are_strict() {
+        let no_body = r#"{"version":2,"credential":null,"cache_namespace_root":null,"method":"GET","target":"/health-check","headers":[],"body_present":false}"#;
+        assert!(matches!(
+            decode(&wire(no_body, b"unexpected")),
+            Err(EnvelopeError::BodyPresenceMismatch)
+        ));
+        assert!(matches!(decode(&[0, 0, 0]), Err(EnvelopeError::Truncated)));
+
+        let mut length_past_end = Vec::from(100_u32.to_be_bytes());
+        length_past_end.extend_from_slice(b"{}");
+        assert!(matches!(
+            decode(&length_past_end),
+            Err(EnvelopeError::Truncated)
+        ));
+    }
+
+    #[test]
+    fn only_relative_targets_and_non_gateway_headers_are_admitted() {
+        for target in [
+            "https://example.com/private",
+            "relative",
+            "//example.com/private",
+            "/safe#ignored",
+            "/safe\\ignored",
+        ] {
+            assert!(matches!(
+                RequestEnvelope::new(
+                    RequestId::random(),
+                    None,
+                    None,
+                    "GET".into(),
+                    target.into(),
+                    vec![],
+                    None,
+                ),
+                Err(EnvelopeError::InvalidTarget)
+            ));
+        }
+
+        for name in [
+            "authorization",
+            "cookie",
+            "host",
+            "transfer-encoding",
+            "x-forwarded-for",
+            "x-session-id",
+        ] {
+            assert!(matches!(
+                LogicalHeader::new(name.into(), "value".into()),
+                Err(EnvelopeError::GatewayControlledHeader)
+            ));
+        }
+        assert!(LogicalHeader::new("openai-beta".into(), "responses=v1".into()).is_ok());
+    }
+
+    #[test]
+    fn malformed_credentials_methods_and_headers_are_rejected() {
+        assert!(Credential::new(CredentialKind::Bearer, String::new()).is_err());
+        assert!(Credential::new(CredentialKind::ApiKey, "contains space".into()).is_err());
+        assert!(matches!(
+            RequestEnvelope::new(
+                RequestId::random(),
+                None,
+                None,
+                "not a method".into(),
+                "/v1/models".into(),
+                vec![],
+                None,
+            ),
+            Err(EnvelopeError::InvalidMethod)
+        ));
+        assert!(LogicalHeader::new("Content-Type".into(), "application/json".into()).is_err());
+        assert!(LogicalHeader::new("x-value".into(), "line\nbreak".into()).is_err());
+    }
+
+    #[test]
+    fn repeated_logical_headers_round_trip_in_order() {
+        let headers = vec![
+            LogicalHeader::new("x-repeat".into(), "first".into()).unwrap(),
+            LogicalHeader::new("x-repeat".into(), "second".into()).unwrap(),
+        ];
+        let envelope = RequestEnvelope::new(
+            RequestId::from_bytes([0x55; 16]),
+            None,
+            None,
+            "GET".into(),
+            "/v1/models".into(),
+            headers.clone(),
+            None,
+        )
+        .unwrap();
+
+        let decoded =
+            RequestEnvelope::decode(envelope.request_id(), &envelope.encode().unwrap()).unwrap();
+        assert_eq!(decoded.headers(), headers);
+    }
+
+    #[test]
+    fn all_limits_are_explicit_and_checked_without_preallocating_their_maxima() {
+        assert_eq!(MAX_METADATA_BYTES, 128 * 1024);
+        assert_eq!(MAX_BODY_BYTES, 50 * 1024 * 1024);
+        assert_eq!(MAX_ENCODED_REQUEST_BYTES, 52_559_876);
+        assert_eq!(MAX_CREDENTIAL_BYTES, 16 * 1024);
+        assert_eq!(MAX_METHOD_BYTES, 32);
+        assert_eq!(MAX_TARGET_BYTES, 16 * 1024);
+        assert_eq!(MAX_HEADER_COUNT, 64);
+        assert!(matches!(
+            validate_body_len(MAX_BODY_BYTES + 1),
+            Err(EnvelopeError::BodyTooLarge)
+        ));
+    }
+
+    #[test]
+    fn request_ids_are_full_width_and_randomly_generated() {
+        let first = RequestId::random();
+        let second = RequestId::random();
+        assert_eq!(first.as_bytes().len(), REQUEST_ID_BYTES);
+        assert_ne!(first, second);
+    }
+}

--- a/src/transport_v2/envelope.rs
+++ b/src/transport_v2/envelope.rs
@@ -537,6 +537,7 @@ fn is_gateway_controlled_header(name: &str) -> bool {
             | "x-forwarded-for"
             | "x-forwarded-host"
             | "x-forwarded-proto"
+            | "x-opensecret-routing-key"
             | "x-session-id"
     )
 }
@@ -682,6 +683,7 @@ mod tests {
             "host",
             "transfer-encoding",
             "x-forwarded-for",
+            "x-opensecret-routing-key",
             "x-session-id",
         ] {
             assert!(matches!(

--- a/src/transport_v2/envelope.rs
+++ b/src/transport_v2/envelope.rs
@@ -235,6 +235,15 @@ pub(crate) struct RequestEnvelope {
     body: Option<Bytes>,
 }
 
+pub(crate) struct RequestEnvelopeParts {
+    pub(crate) credential: Option<Credential>,
+    pub(crate) cache_namespace_root: Option<CacheNamespaceRoot>,
+    pub(crate) method: String,
+    pub(crate) target: String,
+    pub(crate) headers: Vec<LogicalHeader>,
+    pub(crate) body: Option<Bytes>,
+}
+
 impl fmt::Debug for RequestEnvelope {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
@@ -326,6 +335,17 @@ impl RequestEnvelope {
 
     pub(crate) fn into_body(mut self) -> Option<Bytes> {
         self.body.take()
+    }
+
+    pub(crate) fn into_parts(mut self) -> RequestEnvelopeParts {
+        RequestEnvelopeParts {
+            credential: self.credential.take(),
+            cache_namespace_root: self.cache_namespace_root.take(),
+            method: std::mem::take(&mut self.method),
+            target: std::mem::take(&mut self.target),
+            headers: std::mem::take(&mut self.headers),
+            body: self.body.take(),
+        }
     }
 
     /// Encodes bounded JSON metadata followed by the raw body bytes. The raw

--- a/src/transport_v2/framing.rs
+++ b/src/transport_v2/framing.rs
@@ -119,7 +119,7 @@ impl ResponseRecord {
     }
 
     #[cfg(test)]
-    fn decode(encoded: &[u8]) -> Result<Self, FramingError> {
+    pub(crate) fn decode(encoded: &[u8]) -> Result<Self, FramingError> {
         let (&tag, payload) = encoded.split_first().ok_or(FramingError::Truncated)?;
         match tag {
             START_TAG => {

--- a/src/transport_v2/framing.rs
+++ b/src/transport_v2/framing.rs
@@ -1,0 +1,294 @@
+use axum::body::Bytes;
+use serde::{Deserialize, Serialize};
+
+use super::{
+    crypto::RECORD_TAG_BYTES,
+    envelope::{EnvelopeError, LogicalHeader},
+};
+
+pub(crate) const MAX_RESPONSE_CHUNK_BYTES: usize = 64 * 1024;
+pub(crate) const MAX_RESPONSE_METADATA_BYTES: usize = 64 * 1024;
+pub(crate) const MAX_RESPONSE_ERROR_CODE_BYTES: usize = 64;
+pub(crate) const MAX_RESPONSE_RECORD_PLAINTEXT_BYTES: usize = 1 + MAX_RESPONSE_CHUNK_BYTES;
+pub(crate) const MAX_RESPONSE_RECORD_CIPHERTEXT_BYTES: usize =
+    MAX_RESPONSE_RECORD_PLAINTEXT_BYTES + RECORD_TAG_BYTES;
+pub(crate) const CIPHERTEXT_LENGTH_BYTES: usize = 4;
+
+const START_TAG: u8 = 1;
+const CHUNK_TAG: u8 = 2;
+const END_TAG: u8 = 3;
+const ERROR_TAG: u8 = 4;
+const MAX_RESPONSE_HEADER_COUNT: usize = 32;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum FramingError {
+    #[error("transport-v2 response record is truncated")]
+    Truncated,
+    #[error("transport-v2 response record is too large")]
+    RecordTooLarge,
+    #[error("transport-v2 response record tag is invalid")]
+    InvalidTag,
+    #[error("transport-v2 response metadata is invalid")]
+    InvalidMetadata(#[source] serde_json::Error),
+    #[error("transport-v2 response status is invalid")]
+    InvalidStatus,
+    #[error("transport-v2 response has too many headers")]
+    TooManyHeaders,
+    #[error("transport-v2 response header is invalid")]
+    InvalidHeader(#[source] EnvelopeError),
+    #[error("transport-v2 response error code is invalid")]
+    InvalidErrorCode,
+    #[error("transport-v2 response terminal record has trailing bytes")]
+    TrailingBytes,
+    #[error("transport-v2 ciphertext frame length is invalid")]
+    InvalidCiphertextLength,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ResponseStart {
+    status: u16,
+    headers: Vec<LogicalHeader>,
+}
+
+impl ResponseStart {
+    pub(crate) fn new(status: u16, headers: Vec<LogicalHeader>) -> Result<Self, FramingError> {
+        let start = Self { status, headers };
+        start.validate()?;
+        Ok(start)
+    }
+
+    pub(crate) const fn status(&self) -> u16 {
+        self.status
+    }
+
+    pub(crate) fn headers(&self) -> &[LogicalHeader] {
+        &self.headers
+    }
+
+    fn validate(&self) -> Result<(), FramingError> {
+        if !(200..=599).contains(&self.status) {
+            return Err(FramingError::InvalidStatus);
+        }
+        if self.headers.len() > MAX_RESPONSE_HEADER_COUNT {
+            return Err(FramingError::TooManyHeaders);
+        }
+        for header in &self.headers {
+            LogicalHeader::new(header.name().to_owned(), header.value().to_owned())
+                .map_err(FramingError::InvalidHeader)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+struct ResponseFailure {
+    code: String,
+}
+
+pub(crate) enum ResponseRecord {
+    Start(ResponseStart),
+    Chunk(Bytes),
+    End,
+    Error { code: String },
+}
+
+impl ResponseRecord {
+    pub(crate) fn encode(&self) -> Result<Vec<u8>, FramingError> {
+        match self {
+            Self::Start(start) => {
+                start.validate()?;
+                encode_metadata(START_TAG, start)
+            }
+            Self::Chunk(bytes) => {
+                if bytes.len() > MAX_RESPONSE_CHUNK_BYTES {
+                    return Err(FramingError::RecordTooLarge);
+                }
+                let mut encoded = Vec::with_capacity(1 + bytes.len());
+                encoded.push(CHUNK_TAG);
+                encoded.extend_from_slice(bytes);
+                Ok(encoded)
+            }
+            Self::End => Ok(vec![END_TAG]),
+            Self::Error { code } => {
+                validate_error_code(code)?;
+                encode_metadata(ERROR_TAG, &ResponseFailure { code: code.clone() })
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn decode(encoded: &[u8]) -> Result<Self, FramingError> {
+        let (&tag, payload) = encoded.split_first().ok_or(FramingError::Truncated)?;
+        match tag {
+            START_TAG => {
+                let start: ResponseStart = decode_metadata(payload)?;
+                start.validate()?;
+                Ok(Self::Start(start))
+            }
+            CHUNK_TAG => {
+                if payload.len() > MAX_RESPONSE_CHUNK_BYTES {
+                    return Err(FramingError::RecordTooLarge);
+                }
+                Ok(Self::Chunk(Bytes::copy_from_slice(payload)))
+            }
+            END_TAG if payload.is_empty() => Ok(Self::End),
+            END_TAG => Err(FramingError::TrailingBytes),
+            ERROR_TAG => {
+                let failure: ResponseFailure = decode_metadata(payload)?;
+                validate_error_code(&failure.code)?;
+                Ok(Self::Error { code: failure.code })
+            }
+            _ => Err(FramingError::InvalidTag),
+        }
+    }
+}
+
+pub(crate) fn frame_ciphertext(ciphertext: &[u8]) -> Result<Vec<u8>, FramingError> {
+    if ciphertext.len() < RECORD_TAG_BYTES
+        || ciphertext.len() > MAX_RESPONSE_RECORD_CIPHERTEXT_BYTES
+    {
+        return Err(FramingError::InvalidCiphertextLength);
+    }
+    let length =
+        u32::try_from(ciphertext.len()).map_err(|_| FramingError::InvalidCiphertextLength)?;
+    let mut framed = Vec::with_capacity(CIPHERTEXT_LENGTH_BYTES + ciphertext.len());
+    framed.extend_from_slice(&length.to_be_bytes());
+    framed.extend_from_slice(ciphertext);
+    Ok(framed)
+}
+
+fn encode_metadata<T: Serialize>(tag: u8, value: &T) -> Result<Vec<u8>, FramingError> {
+    let metadata = serde_json::to_vec(value).map_err(FramingError::InvalidMetadata)?;
+    if metadata.len() > MAX_RESPONSE_METADATA_BYTES
+        || metadata.len() + 1 > MAX_RESPONSE_RECORD_PLAINTEXT_BYTES
+    {
+        return Err(FramingError::RecordTooLarge);
+    }
+    let mut encoded = Vec::with_capacity(1 + metadata.len());
+    encoded.push(tag);
+    encoded.extend_from_slice(&metadata);
+    Ok(encoded)
+}
+
+#[cfg(test)]
+fn decode_metadata<T: for<'de> Deserialize<'de>>(encoded: &[u8]) -> Result<T, FramingError> {
+    if encoded.len() > MAX_RESPONSE_METADATA_BYTES {
+        return Err(FramingError::RecordTooLarge);
+    }
+    serde_json::from_slice(encoded).map_err(FramingError::InvalidMetadata)
+}
+
+fn validate_error_code(code: &str) -> Result<(), FramingError> {
+    if code.is_empty()
+        || code.len() > MAX_RESPONSE_ERROR_CODE_BYTES
+        || !code
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+    {
+        return Err(FramingError::InvalidErrorCode);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn response_records_round_trip_without_encoding_body_bytes() {
+        let records = [
+            ResponseRecord::Start(
+                ResponseStart::new(
+                    200,
+                    vec![LogicalHeader::new(
+                        "content-type".to_string(),
+                        "text/event-stream".to_string(),
+                    )
+                    .unwrap()],
+                )
+                .unwrap(),
+            ),
+            ResponseRecord::Chunk(Bytes::from_static(b"data: hello\n\n")),
+            ResponseRecord::Chunk(Bytes::new()),
+            ResponseRecord::End,
+            ResponseRecord::Error {
+                code: "application_stream_failed".to_string(),
+            },
+        ];
+
+        for record in records {
+            let encoded = record.encode().unwrap();
+            let decoded = ResponseRecord::decode(&encoded).unwrap();
+            match (record, decoded) {
+                (ResponseRecord::Start(expected), ResponseRecord::Start(actual)) => {
+                    assert_eq!(actual, expected);
+                }
+                (ResponseRecord::Chunk(expected), ResponseRecord::Chunk(actual)) => {
+                    assert_eq!(actual, expected);
+                }
+                (ResponseRecord::End, ResponseRecord::End) => {}
+                (
+                    ResponseRecord::Error { code: expected },
+                    ResponseRecord::Error { code: actual },
+                ) => assert_eq!(actual, expected),
+                _ => panic!("response record kind changed during round trip"),
+            }
+        }
+    }
+
+    #[test]
+    fn record_and_outer_frame_limits_are_local_not_aggregate() {
+        let maximum = ResponseRecord::Chunk(Bytes::from(vec![0; MAX_RESPONSE_CHUNK_BYTES]))
+            .encode()
+            .unwrap();
+        assert_eq!(maximum.len(), MAX_RESPONSE_RECORD_PLAINTEXT_BYTES);
+        assert!(matches!(
+            ResponseRecord::Chunk(Bytes::from(vec![0; MAX_RESPONSE_CHUNK_BYTES + 1])).encode(),
+            Err(FramingError::RecordTooLarge)
+        ));
+
+        let ciphertext = vec![0; MAX_RESPONSE_RECORD_CIPHERTEXT_BYTES];
+        let framed = frame_ciphertext(&ciphertext).unwrap();
+        assert_eq!(
+            u32::from_be_bytes(framed[..4].try_into().unwrap()) as usize,
+            ciphertext.len()
+        );
+        assert_eq!(&framed[4..], ciphertext);
+    }
+
+    #[test]
+    fn metadata_and_terminal_shapes_are_strict() {
+        assert!(ResponseStart::new(199, vec![]).is_err());
+        assert!(ResponseRecord::Error {
+            code: "Not Portable".to_string()
+        }
+        .encode()
+        .is_err());
+        assert!(matches!(
+            ResponseRecord::decode(&[END_TAG, 0]),
+            Err(FramingError::TrailingBytes)
+        ));
+        assert!(
+            ResponseRecord::decode(b"\x01{\"status\":200,\"headers\":[],\"extra\":1}").is_err()
+        );
+    }
+
+    #[test]
+    fn repeated_response_headers_round_trip_in_order() {
+        let headers = vec![
+            LogicalHeader::new("x-repeat".into(), "first".into()).unwrap(),
+            LogicalHeader::new("x-repeat".into(), "second".into()).unwrap(),
+        ];
+        let encoded = ResponseRecord::Start(ResponseStart::new(200, headers.clone()).unwrap())
+            .encode()
+            .unwrap();
+        let decoded = ResponseRecord::decode(&encoded).unwrap();
+
+        let ResponseRecord::Start(start) = decoded else {
+            panic!("response start changed record kind");
+        };
+        assert_eq!(start.headers(), headers);
+    }
+}

--- a/src/transport_v2/gateway.rs
+++ b/src/transport_v2/gateway.rs
@@ -100,6 +100,8 @@ struct CreateSessionResponse {
 #[derive(Clone, Copy, Debug)]
 enum OuterError {
     BadRequest,
+    SessionNotFound,
+    RequestDecryptionFailed,
     PayloadTooLarge,
     UnsupportedMediaType,
     Unavailable,
@@ -108,12 +110,29 @@ enum OuterError {
 impl IntoResponse for OuterError {
     fn into_response(self) -> Response {
         let status = match self {
-            Self::BadRequest => StatusCode::BAD_REQUEST,
+            Self::BadRequest | Self::SessionNotFound | Self::RequestDecryptionFailed => {
+                StatusCode::BAD_REQUEST
+            }
             Self::PayloadTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
             Self::UnsupportedMediaType => StatusCode::UNSUPPORTED_MEDIA_TYPE,
             Self::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
         };
-        (status, "transport request rejected").into_response()
+        let mut response = (status, "transport request rejected").into_response();
+        let recovery_code = match self {
+            Self::SessionNotFound => Some(crate::SESSION_NOT_FOUND_ERROR_CODE),
+            Self::RequestDecryptionFailed => Some("request_decryption_failed"),
+            _ => None,
+        };
+        if let Some(code) = recovery_code {
+            response.headers_mut().insert(
+                crate::ERROR_CONTRACT_HEADER,
+                HeaderValue::from_static(crate::ERROR_CONTRACT_VERSION),
+            );
+            response
+                .headers_mut()
+                .insert(crate::ERROR_CODE_HEADER, HeaderValue::from_static(code));
+        }
+        response
     }
 }
 
@@ -565,7 +584,7 @@ fn map_session_insert_error(error: SessionStoreError) -> OuterError {
 
 fn map_session_lookup_error(error: SessionStoreError) -> OuterError {
     match error {
-        SessionStoreError::Missing | SessionStoreError::Expired => OuterError::BadRequest,
+        SessionStoreError::Missing | SessionStoreError::Expired => OuterError::SessionNotFound,
         SessionStoreError::Collision | SessionStoreError::Full | SessionStoreError::Unavailable => {
             OuterError::Unavailable
         }
@@ -574,11 +593,14 @@ fn map_session_lookup_error(error: SessionStoreError) -> OuterError {
 
 fn map_admission_error(error: SessionError) -> OuterError {
     match error {
+        SessionError::Expired => OuterError::SessionNotFound,
+        // open_and_admit authenticates the incoming record before claiming its
+        // replay ID. No application work has run when this rejection occurs.
+        SessionError::Crypto(CryptoError::Authentication) => OuterError::RequestDecryptionFailed,
         SessionError::Replay(ReplayError::GlobalCapacity | ReplayError::Unavailable) => {
             OuterError::Unavailable
         }
         SessionError::Replay(ReplayError::Duplicate | ReplayError::SessionCapacity)
-        | SessionError::Expired
         | SessionError::Crypto(_) => OuterError::BadRequest,
         SessionError::InvalidLifetime => OuterError::Unavailable,
     }
@@ -608,6 +630,15 @@ mod tests {
     }
 
     fn test_session(marker: u8) -> TestSession {
+        test_session_with_limits(marker, Duration::from_secs(60), 64, 128)
+    }
+
+    fn test_session_with_limits(
+        marker: u8,
+        lifetime: Duration,
+        replay_capacity: usize,
+        process_capacity: usize,
+    ) -> TestSession {
         let client_secret = EphemeralSecret::random_from_rng(OsRng);
         let client_public_key = PublicKey::from(&client_secret).to_bytes();
         let server_secret = EphemeralSecret::random_from_rng(OsRng);
@@ -616,14 +647,16 @@ mod tests {
             HandshakeTranscript::new([marker; 32], client_public_key, server_public_key);
         let client = derive_client_session(client_secret, &transcript).unwrap();
         let server_secrets = derive_server_session(server_secret, &transcript).unwrap();
-        let replay_budget = Arc::new(ReplayBudget::new(NonZeroUsize::new(128).unwrap()));
+        let replay_budget = Arc::new(ReplayBudget::new(
+            NonZeroUsize::new(process_capacity).unwrap(),
+        ));
         let routing_key = [marker; HANDSHAKE_CHALLENGE_BYTES];
         let server = Arc::new(
             Session::new(
                 server_secrets,
                 routing_key,
-                Duration::from_secs(60),
-                NonZeroUsize::new(64).unwrap(),
+                lifetime,
+                NonZeroUsize::new(replay_capacity).unwrap(),
                 replay_budget,
             )
             .unwrap(),
@@ -642,6 +675,100 @@ mod tests {
                 application,
                 sessions,
             }))
+    }
+
+    fn counting_application(dispatches: &Arc<AtomicUsize>) -> Router<()> {
+        Router::new().route(
+            "/count",
+            any({
+                let dispatches = Arc::clone(dispatches);
+                move || {
+                    let dispatches = Arc::clone(&dispatches);
+                    async move {
+                        dispatches.fetch_add(1, Ordering::SeqCst);
+                        StatusCode::NO_CONTENT
+                    }
+                }
+            }),
+        )
+    }
+
+    fn assert_outer_rejection(response: Response, status: StatusCode, recovery_code: Option<&str>) {
+        assert_eq!(response.status(), status);
+        assert_eq!(
+            response
+                .headers()
+                .get(crate::ERROR_CODE_HEADER)
+                .map(|value| value.to_str().unwrap()),
+            recovery_code,
+        );
+        if recovery_code.is_some() {
+            assert_eq!(
+                response
+                    .headers()
+                    .get(crate::ERROR_CONTRACT_HEADER)
+                    .unwrap(),
+                "1"
+            );
+        }
+    }
+
+    #[test]
+    fn recovery_codes_are_limited_to_missing_expired_and_incoming_authentication_errors() {
+        for error in [
+            map_session_lookup_error(SessionStoreError::Missing),
+            map_session_lookup_error(SessionStoreError::Expired),
+            map_admission_error(SessionError::Expired),
+        ] {
+            assert_outer_rejection(
+                error.into_response(),
+                StatusCode::BAD_REQUEST,
+                Some("session_not_found"),
+            );
+        }
+        assert_outer_rejection(
+            map_admission_error(SessionError::Crypto(CryptoError::Authentication)).into_response(),
+            StatusCode::BAD_REQUEST,
+            Some("request_decryption_failed"),
+        );
+
+        for error in [
+            OuterError::BadRequest,
+            map_admission_error(SessionError::Replay(ReplayError::Duplicate)),
+            map_admission_error(SessionError::Replay(ReplayError::SessionCapacity)),
+            map_admission_error(SessionError::Crypto(CryptoError::NonContributoryKey)),
+            map_admission_error(SessionError::Crypto(CryptoError::KeyDerivation)),
+            map_admission_error(SessionError::Crypto(CryptoError::TruncatedRecord)),
+            map_admission_error(SessionError::Crypto(CryptoError::Encryption)),
+            map_admission_error(SessionError::Crypto(CryptoError::SequenceExhausted)),
+        ] {
+            assert_outer_rejection(error.into_response(), StatusCode::BAD_REQUEST, None);
+        }
+        for error in [
+            map_session_insert_error(SessionStoreError::Collision),
+            map_session_insert_error(SessionStoreError::Full),
+            map_session_insert_error(SessionStoreError::Unavailable),
+            map_session_insert_error(SessionStoreError::Expired),
+            map_session_insert_error(SessionStoreError::Missing),
+            map_session_lookup_error(SessionStoreError::Collision),
+            map_session_lookup_error(SessionStoreError::Full),
+            map_session_lookup_error(SessionStoreError::Unavailable),
+            map_admission_error(SessionError::Replay(ReplayError::GlobalCapacity)),
+            map_admission_error(SessionError::Replay(ReplayError::Unavailable)),
+            map_admission_error(SessionError::InvalidLifetime),
+        ] {
+            assert_outer_rejection(error.into_response(), StatusCode::SERVICE_UNAVAILABLE, None);
+        }
+        assert_outer_rejection(
+            OuterError::PayloadTooLarge.into_response(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            None,
+        );
+        assert_outer_rejection(
+            OuterError::UnsupportedMediaType.into_response(),
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            None,
+        );
     }
 
     fn seal_request(
@@ -694,6 +821,7 @@ mod tests {
         response: Response,
     ) -> Vec<ResponseRecord> {
         assert_eq!(response.status(), StatusCode::OK);
+        assert!(!response.headers().contains_key(crate::ERROR_CODE_HEADER));
         assert_eq!(
             response.headers().get(header::CONTENT_TYPE),
             Some(&OUTER_CONTENT_TYPE)
@@ -821,19 +949,7 @@ mod tests {
         let sessions = Arc::new(SessionStore::new(NonZeroUsize::new(2).unwrap()));
         sessions.insert(Arc::clone(&test.server)).unwrap();
         let dispatches = Arc::new(AtomicUsize::new(0));
-        let application = Router::new().route(
-            "/count",
-            any({
-                let dispatches = Arc::clone(&dispatches);
-                move || {
-                    let dispatches = Arc::clone(&dispatches);
-                    async move {
-                        dispatches.fetch_add(1, Ordering::SeqCst);
-                        StatusCode::NO_CONTENT
-                    }
-                }
-            }),
-        );
+        let application = counting_application(&dispatches);
         let router = request_router(application, sessions);
         let request_id = RequestId::from_bytes([0x22; 16]);
         let record = seal_request(&test.client, request_id, "/count", None);
@@ -843,9 +959,10 @@ mod tests {
             header::AUTHORIZATION,
             HeaderValue::from_static("Bearer stolen"),
         );
-        assert_eq!(
-            router.clone().oneshot(forbidden).await.unwrap().status(),
-            StatusCode::BAD_REQUEST
+        assert_outer_rejection(
+            router.clone().oneshot(forbidden).await.unwrap(),
+            StatusCode::BAD_REQUEST,
+            None,
         );
 
         let mut missing_routing_key =
@@ -853,17 +970,13 @@ mod tests {
         missing_routing_key
             .headers_mut()
             .remove(&ROUTING_KEY_HEADER);
-        assert_eq!(
-            router
-                .clone()
-                .oneshot(missing_routing_key)
-                .await
-                .unwrap()
-                .status(),
-            StatusCode::BAD_REQUEST
+        assert_outer_rejection(
+            router.clone().oneshot(missing_routing_key).await.unwrap(),
+            StatusCode::BAD_REQUEST,
+            None,
         );
 
-        assert_eq!(
+        assert_outer_rejection(
             router
                 .clone()
                 .oneshot(outer_request(
@@ -872,22 +985,37 @@ mod tests {
                     record.clone(),
                 ))
                 .await
-                .unwrap()
-                .status(),
-            StatusCode::BAD_REQUEST
+                .unwrap(),
+            StatusCode::BAD_REQUEST,
+            None,
+        );
+
+        assert_outer_rejection(
+            router
+                .clone()
+                .oneshot(outer_request(
+                    test.server.id(),
+                    &test.routing_key,
+                    vec![0; MIN_REQUEST_RECORD_BYTES - 1],
+                ))
+                .await
+                .unwrap(),
+            StatusCode::BAD_REQUEST,
+            None,
         );
 
         let mut tampered = record.clone();
         *tampered.last_mut().unwrap() ^= 1;
-        assert_eq!(
+        assert_outer_rejection(
             router
                 .clone()
                 .oneshot(outer_request(test.server.id(), &test.routing_key, tampered))
                 .await
-                .unwrap()
-                .status(),
-            StatusCode::BAD_REQUEST
+                .unwrap(),
+            StatusCode::BAD_REQUEST,
+            Some("request_decryption_failed"),
         );
+        assert_eq!(dispatches.load(Ordering::SeqCst), 0);
 
         let response = router
             .clone()
@@ -902,13 +1030,13 @@ mod tests {
         assert!(matches!(&records[0], ResponseRecord::Start(start) if start.status() == 204));
         assert_eq!(dispatches.load(Ordering::SeqCst), 1);
 
-        assert_eq!(
+        assert_outer_rejection(
             router
                 .oneshot(outer_request(test.server.id(), &test.routing_key, record))
                 .await
-                .unwrap()
-                .status(),
-            StatusCode::BAD_REQUEST
+                .unwrap(),
+            StatusCode::BAD_REQUEST,
+            None,
         );
         assert_eq!(dispatches.load(Ordering::SeqCst), 1);
     }
@@ -916,7 +1044,8 @@ mod tests {
     #[tokio::test]
     async fn unknown_session_is_rejected_without_reading_the_body() {
         let sessions = Arc::new(SessionStore::new(NonZeroUsize::new(2).unwrap()));
-        let router = request_router(Router::new(), sessions);
+        let dispatches = Arc::new(AtomicUsize::new(0));
+        let router = request_router(counting_application(&dispatches), sessions);
         let body = Body::from_stream(stream::once(async {
             panic!("an unknown session body must not be polled");
             #[allow(unreachable_code)]
@@ -930,7 +1059,8 @@ mod tests {
             ))
             .await
             .unwrap();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_outer_rejection(response, StatusCode::BAD_REQUEST, Some("session_not_found"));
+        assert_eq!(dispatches.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
@@ -939,7 +1069,7 @@ mod tests {
         let sessions = Arc::new(SessionStore::new(NonZeroUsize::new(2).unwrap()));
         sessions.insert(Arc::clone(&test.server)).unwrap();
         let request_id = RequestId::from_bytes([0x92; 16]);
-        let record = seal_request(&test.client, request_id, "/unused", None);
+        let record = seal_request(&test.client, request_id, "/count", None);
         let session_id = test.server.id();
         let body = Body::from_stream(stream::once({
             let sessions = Arc::clone(&sessions);
@@ -948,13 +1078,125 @@ mod tests {
                 Ok::<_, io::Error>(Bytes::from(record))
             }
         }));
-        let router = request_router(Router::new(), sessions);
+        let dispatches = Arc::new(AtomicUsize::new(0));
+        let router = request_router(counting_application(&dispatches), sessions);
 
         let response = router
             .oneshot(outer_request_with_body(session_id, &test.routing_key, body))
             .await
             .unwrap();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_outer_rejection(response, StatusCode::BAD_REQUEST, Some("session_not_found"));
+        assert_eq!(dispatches.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn expired_session_is_rejected_before_reading_the_body() {
+        let test = test_session_with_limits(10, Duration::from_secs(1), 64, 128);
+        let sessions = Arc::new(SessionStore::new(NonZeroUsize::new(2).unwrap()));
+        sessions.insert(Arc::clone(&test.server)).unwrap();
+        let dispatches = Arc::new(AtomicUsize::new(0));
+        let router = request_router(counting_application(&dispatches), sessions);
+        tokio::time::sleep_until(test.server.expires_at().into()).await;
+        assert!(test.server.is_expired(Instant::now()));
+        let body = Body::from_stream(stream::once(async {
+            panic!("an expired session body must not be polled");
+            #[allow(unreachable_code)]
+            Ok::<_, io::Error>(Bytes::new())
+        }));
+        let response = router
+            .oneshot(outer_request_with_body(
+                test.server.id(),
+                &test.routing_key,
+                body,
+            ))
+            .await
+            .unwrap();
+        assert_outer_rejection(response, StatusCode::BAD_REQUEST, Some("session_not_found"));
+        assert_eq!(dispatches.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn expiry_during_upload_is_rejected_before_dispatch() {
+        let test = test_session_with_limits(11, Duration::from_secs(1), 64, 128);
+        let sessions = Arc::new(SessionStore::new(NonZeroUsize::new(2).unwrap()));
+        sessions.insert(Arc::clone(&test.server)).unwrap();
+        let record = seal_request(
+            &test.client,
+            RequestId::from_bytes([0x93; 16]),
+            "/count",
+            None,
+        );
+        let uploads = Arc::new(AtomicUsize::new(0));
+        let body = Body::from_stream(stream::once({
+            let session = Arc::clone(&test.server);
+            let uploads = Arc::clone(&uploads);
+            async move {
+                uploads.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep_until(session.expires_at().into()).await;
+                assert!(session.is_expired(Instant::now()));
+                Ok::<_, io::Error>(Bytes::from(record))
+            }
+        }));
+        let dispatches = Arc::new(AtomicUsize::new(0));
+        let router = request_router(counting_application(&dispatches), sessions);
+        let response = router
+            .oneshot(outer_request_with_body(
+                test.server.id(),
+                &test.routing_key,
+                body,
+            ))
+            .await
+            .unwrap();
+        assert_outer_rejection(response, StatusCode::BAD_REQUEST, Some("session_not_found"));
+        assert_eq!(uploads.load(Ordering::SeqCst), 1);
+        assert_eq!(dispatches.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn replay_capacity_rejections_are_unmarked_and_do_not_dispatch() {
+        for (session_capacity, process_capacity, rejection_status) in [
+            (1, 2, StatusCode::BAD_REQUEST),
+            (2, 1, StatusCode::SERVICE_UNAVAILABLE),
+        ] {
+            let test = test_session_with_limits(
+                12,
+                Duration::from_secs(60),
+                session_capacity,
+                process_capacity,
+            );
+            let sessions = Arc::new(SessionStore::new(NonZeroUsize::new(2).unwrap()));
+            sessions.insert(Arc::clone(&test.server)).unwrap();
+            let dispatches = Arc::new(AtomicUsize::new(0));
+            let router = request_router(counting_application(&dispatches), sessions);
+            let first_id = RequestId::from_bytes([0x94; 16]);
+            let response = router
+                .clone()
+                .oneshot(outer_request(
+                    test.server.id(),
+                    &test.routing_key,
+                    seal_request(&test.client, first_id, "/count", None),
+                ))
+                .await
+                .unwrap();
+            let records = decrypt_records(&test.client, first_id, response).await;
+            assert!(matches!(&records[0], ResponseRecord::Start(start) if start.status() == 204));
+            assert_eq!(dispatches.load(Ordering::SeqCst), 1);
+            let response = router
+                .oneshot(outer_request(
+                    test.server.id(),
+                    &test.routing_key,
+                    seal_request(
+                        &test.client,
+                        RequestId::from_bytes([0x95; 16]),
+                        "/count",
+                        None,
+                    ),
+                ))
+                .await
+                .unwrap();
+            assert_outer_rejection(response, rejection_status, None);
+            assert_eq!(dispatches.load(Ordering::SeqCst), 1);
+        }
     }
 
     #[tokio::test]
@@ -980,6 +1222,50 @@ mod tests {
         .await;
         assert!(matches!(&records[0], ResponseRecord::Start(start) if start.status() == 400));
         assert!(matches!(records.last(), Some(ResponseRecord::End)));
+    }
+
+    #[tokio::test]
+    async fn application_recovery_headers_stay_inside_the_encrypted_response() {
+        let test = test_session(13);
+        let sessions = Arc::new(SessionStore::new(NonZeroUsize::new(2).unwrap()));
+        sessions.insert(Arc::clone(&test.server)).unwrap();
+        let dispatches = Arc::new(AtomicUsize::new(0));
+        let application = Router::new().route(
+            "/count",
+            any({
+                let dispatches = Arc::clone(&dispatches);
+                move || {
+                    let dispatches = Arc::clone(&dispatches);
+                    async move {
+                        dispatches.fetch_add(1, Ordering::SeqCst);
+                        ApiError::SessionNotFound.into_response()
+                    }
+                }
+            }),
+        );
+        let router = request_router(application, sessions);
+        let request_id = RequestId::from_bytes([0x96; 16]);
+        let record = seal_request(&test.client, request_id, "/count", None);
+        let response = router
+            .clone()
+            .oneshot(outer_request(
+                test.server.id(),
+                &test.routing_key,
+                record.clone(),
+            ))
+            .await
+            .unwrap();
+        let records = decrypt_records(&test.client, request_id, response).await;
+        assert!(matches!(&records[0], ResponseRecord::Start(start)
+            if start.status() == 400 && start.headers().iter().any(|header|
+                header.name() == crate::ERROR_CODE_HEADER && header.value() == "session_not_found")));
+        assert_eq!(dispatches.load(Ordering::SeqCst), 1);
+        let response = router
+            .oneshot(outer_request(test.server.id(), &test.routing_key, record))
+            .await
+            .unwrap();
+        assert_outer_rejection(response, StatusCode::BAD_REQUEST, None);
+        assert_eq!(dispatches.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/src/transport_v2/gateway.rs
+++ b/src/transport_v2/gateway.rs
@@ -41,8 +41,8 @@ use super::{
         X25519_PUBLIC_KEY_BYTES,
     },
     envelope::{
-        EnvelopeError, LogicalHeader, RequestEnvelope, MAX_ENCODED_REQUEST_BYTES, REQUEST_ID_BYTES,
-        VERSION,
+        EnvelopeError, LogicalHeader, RequestEnvelope, RequestId, MAX_ENCODED_REQUEST_BYTES,
+        REQUEST_ID_BYTES, VERSION,
     },
     framing::{
         frame_ciphertext, FramingError, ResponseRecord, ResponseStart, MAX_RESPONSE_CHUNK_BYTES,
@@ -265,10 +265,11 @@ async fn dispatch_request(
         Ok(envelope) => envelope,
         Err(_) => return encrypted_response(admitted, ApiError::BadRequest.into_response()),
     };
-    let request = match build_application_request(envelope, admitted.session_id()) {
-        Ok(request) => request,
-        Err(_) => return encrypted_response(admitted, ApiError::BadRequest.into_response()),
-    };
+    let request =
+        match build_application_request(envelope, admitted.session_id(), admitted.request_id()) {
+            Ok(request) => request,
+            Err(_) => return encrypted_response(admitted, ApiError::BadRequest.into_response()),
+        };
 
     let response = state
         .application
@@ -282,6 +283,7 @@ async fn dispatch_request(
 fn build_application_request(
     envelope: RequestEnvelope,
     session_id: SessionId,
+    request_id: RequestId,
 ) -> Result<Request<Body>, EnvelopeError> {
     let parts = envelope.into_parts();
     let method =
@@ -302,6 +304,7 @@ fn build_application_request(
     request
         .extensions_mut()
         .insert(TransportSession::v2(session_id));
+    request.extensions_mut().insert(request_id);
     if let Some(credential) = parts.credential {
         request.extensions_mut().insert(credential);
     }
@@ -555,7 +558,7 @@ mod tests {
     use crate::provider_cache::CacheNamespaceRoot;
     use crate::transport_v2::{
         crypto::{derive_client_session, SessionSecrets},
-        envelope::{Credential, CredentialKind, RequestId},
+        envelope::{Credential, CredentialKind},
     };
 
     struct TestSession {
@@ -705,6 +708,10 @@ mod tests {
                     .extensions()
                     .get::<TransportSession>()
                     .is_some_and(TransportSession::is_v2));
+                assert_eq!(
+                    request.extensions().get::<RequestId>(),
+                    Some(&RequestId::from_bytes([0x11; 16]))
+                );
                 assert_eq!(
                     request.extensions().get::<Credential>().unwrap().value(),
                     "v2-token"

--- a/src/transport_v2/gateway.rs
+++ b/src/transport_v2/gateway.rs
@@ -50,7 +50,7 @@ use super::{
     session::{ReplayBudget, ReplayError, Session, SessionError, SessionStore, SessionStoreError},
 };
 
-const SESSION_LIFETIME: Duration = Duration::from_secs(65 * 60);
+const SESSION_LIFETIME: Duration = Duration::from_secs(60 * 60);
 const SESSION_MAINTENANCE_INTERVAL: Duration = Duration::from_secs(60);
 const MAX_SESSION_REQUEST_BYTES: usize = 4 * 1024;
 const MAX_SESSIONS: usize = 2_097_152;
@@ -60,6 +60,7 @@ const MAX_REQUEST_RECORD_BYTES: usize =
     REQUEST_ID_BYTES + MAX_ENCODED_REQUEST_BYTES + RECORD_TAG_BYTES;
 
 const SESSION_ID_HEADER: HeaderName = HeaderName::from_static("x-session-id");
+const ROUTING_KEY_HEADER: HeaderName = HeaderName::from_static("x-opensecret-routing-key");
 const OUTER_CONTENT_TYPE: HeaderValue = HeaderValue::from_static("application/octet-stream");
 
 #[derive(Clone)]
@@ -181,6 +182,7 @@ async fn create_session(
     if request.uri().query().is_some() {
         return Err(OuterError::BadRequest);
     }
+    let routing_key = parse_outer_routing_key(request.headers())?;
     reject_declared_oversize(request.headers(), MAX_SESSION_REQUEST_BYTES)?;
     let body = read_bounded_body(request.into_body(), MAX_SESSION_REQUEST_BYTES).await?;
     let payload: CreateSessionRequest =
@@ -190,6 +192,9 @@ async fn create_session(
     }
 
     let challenge = decode_canonical_fixed::<HANDSHAKE_CHALLENGE_BYTES>(&payload.challenge)?;
+    if challenge != routing_key {
+        return Err(OuterError::BadRequest);
+    }
     let client_public_key =
         decode_canonical_fixed::<X25519_PUBLIC_KEY_BYTES>(&payload.client_public_key)?;
 
@@ -214,6 +219,7 @@ async fn create_session(
     let session = Arc::new(
         Session::new(
             secrets,
+            challenge,
             SESSION_LIFETIME,
             NonZeroUsize::new(MAX_REPLAY_IDS_PER_SESSION)
                 .expect("transport-v2 per-session replay capacity must be non-zero"),
@@ -244,7 +250,19 @@ async fn dispatch_request(
         return Err(OuterError::BadRequest);
     }
     let session_id = parse_outer_session_id(request.headers())?;
+    let routing_key = parse_outer_routing_key(request.headers())?;
     reject_declared_oversize(request.headers(), MAX_REQUEST_RECORD_BYTES)?;
+
+    // Reject arbitrary session IDs before accepting a potentially large upload.
+    // Drop this short-lived reference immediately so a slow or abandoned body
+    // cannot pin the session. Admission still performs an authoritative lookup
+    // after the body is collected, since the session may expire or disappear in
+    // the meantime.
+    drop(get_routed_session(
+        &state.sessions,
+        session_id,
+        &routing_key,
+    )?);
     let record = read_bounded_body(request.into_body(), MAX_REQUEST_RECORD_BYTES).await?;
     if record.len() < MIN_REQUEST_RECORD_BYTES {
         return Err(OuterError::BadRequest);
@@ -252,10 +270,7 @@ async fn dispatch_request(
 
     // The body arrives before the session is retained. A slow or abandoned
     // upload therefore cannot pin session state.
-    let session = state
-        .sessions
-        .get(session_id)
-        .map_err(map_session_lookup_error)?;
+    let session = get_routed_session(&state.sessions, session_id, &routing_key)?;
     let (admitted, plaintext) = session
         .open_and_admit(&record)
         .map_err(map_admission_error)?;
@@ -502,6 +517,31 @@ fn parse_outer_session_id(headers: &HeaderMap) -> Result<SessionId, OuterError> 
         .ok_or(OuterError::BadRequest)
 }
 
+fn parse_outer_routing_key(
+    headers: &HeaderMap,
+) -> Result<[u8; HANDSHAKE_CHALLENGE_BYTES], OuterError> {
+    let values = headers.get_all(&ROUTING_KEY_HEADER);
+    let mut values = values.iter();
+    let value = values.next().ok_or(OuterError::BadRequest)?;
+    if values.next().is_some() {
+        return Err(OuterError::BadRequest);
+    }
+    let value = value.to_str().map_err(|_| OuterError::BadRequest)?;
+    decode_canonical_fixed(value)
+}
+
+fn get_routed_session(
+    sessions: &SessionStore,
+    session_id: SessionId,
+    routing_key: &[u8; HANDSHAKE_CHALLENGE_BYTES],
+) -> Result<Arc<Session>, OuterError> {
+    let session = sessions.get(session_id).map_err(map_session_lookup_error)?;
+    if !session.matches_routing_key(routing_key) {
+        return Err(OuterError::BadRequest);
+    }
+    Ok(session)
+}
+
 fn decode_canonical_fixed<const N: usize>(encoded: &str) -> Result<[u8; N], OuterError> {
     let decoded = STANDARD
         .decode(encoded.as_bytes())
@@ -564,6 +604,7 @@ mod tests {
     struct TestSession {
         client: SessionSecrets,
         server: Arc<Session>,
+        routing_key: [u8; HANDSHAKE_CHALLENGE_BYTES],
     }
 
     fn test_session(marker: u8) -> TestSession {
@@ -576,16 +617,22 @@ mod tests {
         let client = derive_client_session(client_secret, &transcript).unwrap();
         let server_secrets = derive_server_session(server_secret, &transcript).unwrap();
         let replay_budget = Arc::new(ReplayBudget::new(NonZeroUsize::new(128).unwrap()));
+        let routing_key = [marker; HANDSHAKE_CHALLENGE_BYTES];
         let server = Arc::new(
             Session::new(
                 server_secrets,
+                routing_key,
                 Duration::from_secs(60),
                 NonZeroUsize::new(64).unwrap(),
                 replay_budget,
             )
             .unwrap(),
         );
-        TestSession { client, server }
+        TestSession {
+            client,
+            server,
+            routing_key,
+        }
     }
 
     fn request_router(application: Router<()>, sessions: Arc<SessionStore>) -> Router<()> {
@@ -618,13 +665,26 @@ mod tests {
             .unwrap()
     }
 
-    fn outer_request(session_id: SessionId, record: Vec<u8>) -> Request<Body> {
+    fn outer_request(
+        session_id: SessionId,
+        routing_key: &[u8; HANDSHAKE_CHALLENGE_BYTES],
+        record: Vec<u8>,
+    ) -> Request<Body> {
+        outer_request_with_body(session_id, routing_key, Body::from(record))
+    }
+
+    fn outer_request_with_body(
+        session_id: SessionId,
+        routing_key: &[u8; HANDSHAKE_CHALLENGE_BYTES],
+        body: Body,
+    ) -> Request<Body> {
         Request::builder()
             .method(Method::POST)
             .uri("/v2/request")
             .header(header::CONTENT_TYPE, "application/octet-stream")
             .header(&SESSION_ID_HEADER, session_id.to_string())
-            .body(Body::from(record))
+            .header(&ROUTING_KEY_HEADER, STANDARD.encode(routing_key))
+            .body(body)
             .unwrap()
     }
 
@@ -729,6 +789,7 @@ mod tests {
         let request_id = RequestId::from_bytes([0x11; 16]);
         let request = outer_request(
             test.server.id(),
+            &test.routing_key,
             seal_request(
                 &test.client,
                 request_id,
@@ -777,7 +838,7 @@ mod tests {
         let request_id = RequestId::from_bytes([0x22; 16]);
         let record = seal_request(&test.client, request_id, "/count", None);
 
-        let mut forbidden = outer_request(test.server.id(), record.clone());
+        let mut forbidden = outer_request(test.server.id(), &test.routing_key, record.clone());
         forbidden.headers_mut().insert(
             header::AUTHORIZATION,
             HeaderValue::from_static("Bearer stolen"),
@@ -787,12 +848,41 @@ mod tests {
             StatusCode::BAD_REQUEST
         );
 
+        let mut missing_routing_key =
+            outer_request(test.server.id(), &test.routing_key, record.clone());
+        missing_routing_key
+            .headers_mut()
+            .remove(&ROUTING_KEY_HEADER);
+        assert_eq!(
+            router
+                .clone()
+                .oneshot(missing_routing_key)
+                .await
+                .unwrap()
+                .status(),
+            StatusCode::BAD_REQUEST
+        );
+
+        assert_eq!(
+            router
+                .clone()
+                .oneshot(outer_request(
+                    test.server.id(),
+                    &[0x93; HANDSHAKE_CHALLENGE_BYTES],
+                    record.clone(),
+                ))
+                .await
+                .unwrap()
+                .status(),
+            StatusCode::BAD_REQUEST
+        );
+
         let mut tampered = record.clone();
         *tampered.last_mut().unwrap() ^= 1;
         assert_eq!(
             router
                 .clone()
-                .oneshot(outer_request(test.server.id(), tampered))
+                .oneshot(outer_request(test.server.id(), &test.routing_key, tampered))
                 .await
                 .unwrap()
                 .status(),
@@ -801,7 +891,11 @@ mod tests {
 
         let response = router
             .clone()
-            .oneshot(outer_request(test.server.id(), record.clone()))
+            .oneshot(outer_request(
+                test.server.id(),
+                &test.routing_key,
+                record.clone(),
+            ))
             .await
             .unwrap();
         let records = decrypt_records(&test.client, request_id, response).await;
@@ -810,13 +904,57 @@ mod tests {
 
         assert_eq!(
             router
-                .oneshot(outer_request(test.server.id(), record))
+                .oneshot(outer_request(test.server.id(), &test.routing_key, record))
                 .await
                 .unwrap()
                 .status(),
             StatusCode::BAD_REQUEST
         );
         assert_eq!(dispatches.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn unknown_session_is_rejected_without_reading_the_body() {
+        let sessions = Arc::new(SessionStore::new(NonZeroUsize::new(2).unwrap()));
+        let router = request_router(Router::new(), sessions);
+        let body = Body::from_stream(stream::once(async {
+            panic!("an unknown session body must not be polled");
+            #[allow(unreachable_code)]
+            Ok::<_, io::Error>(Bytes::new())
+        }));
+        let response = router
+            .oneshot(outer_request_with_body(
+                SessionId::from_bytes([0x91; 16]),
+                &[0x91; HANDSHAKE_CHALLENGE_BYTES],
+                body,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn session_lookup_after_upload_remains_authoritative() {
+        let test = test_session(9);
+        let sessions = Arc::new(SessionStore::new(NonZeroUsize::new(2).unwrap()));
+        sessions.insert(Arc::clone(&test.server)).unwrap();
+        let request_id = RequestId::from_bytes([0x92; 16]);
+        let record = seal_request(&test.client, request_id, "/unused", None);
+        let session_id = test.server.id();
+        let body = Body::from_stream(stream::once({
+            let sessions = Arc::clone(&sessions);
+            async move {
+                sessions.remove(session_id).unwrap();
+                Ok::<_, io::Error>(Bytes::from(record))
+            }
+        }));
+        let router = request_router(Router::new(), sessions);
+
+        let response = router
+            .oneshot(outer_request_with_body(session_id, &test.routing_key, body))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]
@@ -835,7 +973,7 @@ mod tests {
             &test.client,
             request_id,
             router
-                .oneshot(outer_request(test.server.id(), record))
+                .oneshot(outer_request(test.server.id(), &test.routing_key, record))
                 .await
                 .unwrap(),
         )
@@ -859,6 +997,7 @@ mod tests {
         let response = router
             .oneshot(outer_request(
                 first.server.id(),
+                &first.routing_key,
                 seal_request(&first.client, request_id, "/ok", None),
             ))
             .await
@@ -915,6 +1054,7 @@ mod tests {
                 .clone()
                 .oneshot(outer_request(
                     test.server.id(),
+                    &test.routing_key,
                     seal_request(&test.client, success_id, "/stream", None),
                 ))
                 .await
@@ -933,6 +1073,7 @@ mod tests {
             router
                 .oneshot(outer_request(
                     test.server.id(),
+                    &test.routing_key,
                     seal_request(&test.client, error_id, "/stream-error", None),
                 ))
                 .await
@@ -986,6 +1127,7 @@ mod tests {
             router
                 .oneshot(outer_request(
                     test.server.id(),
+                    &test.routing_key,
                     seal_request(&test.client, request_id, "/too-many-headers", None),
                 ))
                 .await

--- a/src/transport_v2/gateway.rs
+++ b/src/transport_v2/gateway.rs
@@ -1,0 +1,992 @@
+use std::{
+    convert::Infallible,
+    future::poll_fn,
+    io,
+    num::NonZeroUsize,
+    pin::Pin,
+    str::FromStr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use async_stream::try_stream;
+use aws_nitro_enclaves_nsm_api::api::Request as NsmRequest;
+use axum::{
+    body::{to_bytes, Body, Bytes, HttpBody},
+    extract::State,
+    http::{header, HeaderMap, HeaderName, HeaderValue, Method, Request, StatusCode, Uri},
+    response::{IntoResponse, Response},
+    routing::post,
+    Json, Router,
+};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use futures::Stream;
+use rand_core::OsRng;
+use serde::{Deserialize, Serialize};
+use serde_bytes::ByteBuf;
+use tower::ServiceExt;
+use x25519_dalek::{EphemeralSecret, PublicKey};
+
+use crate::{
+    web::{
+        attestation_routes::generate_attestation_document, encryption_middleware::TransportSession,
+    },
+    ApiError, AppState,
+};
+
+use super::{
+    crypto::{
+        attestation_user_data, derive_server_session, CryptoError, HandshakeTranscript, SessionId,
+        HANDSHAKE_CHALLENGE_BYTES, MIN_REQUEST_RECORD_BYTES, RECORD_TAG_BYTES,
+        X25519_PUBLIC_KEY_BYTES,
+    },
+    envelope::{
+        EnvelopeError, LogicalHeader, RequestEnvelope, MAX_ENCODED_REQUEST_BYTES, REQUEST_ID_BYTES,
+        VERSION,
+    },
+    framing::{
+        frame_ciphertext, FramingError, ResponseRecord, ResponseStart, MAX_RESPONSE_CHUNK_BYTES,
+    },
+    session::{ReplayBudget, ReplayError, Session, SessionError, SessionStore, SessionStoreError},
+};
+
+const SESSION_LIFETIME: Duration = Duration::from_secs(65 * 60);
+const SESSION_MAINTENANCE_INTERVAL: Duration = Duration::from_secs(60);
+const MAX_SESSION_REQUEST_BYTES: usize = 4 * 1024;
+const MAX_SESSIONS: usize = 2_097_152;
+const MAX_REPLAY_IDS_PER_SESSION: usize = 1_048_576;
+const MAX_REPLAY_IDS_PROCESS_WIDE: usize = 16_777_216;
+const MAX_REQUEST_RECORD_BYTES: usize =
+    REQUEST_ID_BYTES + MAX_ENCODED_REQUEST_BYTES + RECORD_TAG_BYTES;
+
+const SESSION_ID_HEADER: HeaderName = HeaderName::from_static("x-session-id");
+const OUTER_CONTENT_TYPE: HeaderValue = HeaderValue::from_static("application/octet-stream");
+
+#[derive(Clone)]
+pub(crate) struct TransportV2Gateway {
+    sessions: Arc<SessionStore>,
+    session_state: Arc<SessionGatewayState>,
+    request_state: Arc<RequestGatewayState>,
+}
+
+struct SessionGatewayState {
+    app_state: Arc<AppState>,
+    sessions: Arc<SessionStore>,
+    replay_budget: Arc<ReplayBudget>,
+}
+
+struct RequestGatewayState {
+    application: Router<()>,
+    sessions: Arc<SessionStore>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CreateSessionRequest {
+    version: u8,
+    challenge: String,
+    client_public_key: String,
+}
+
+#[derive(Debug, Serialize)]
+struct CreateSessionResponse {
+    version: u8,
+    session_id: String,
+    attestation_document: String,
+    expires_in_seconds: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum OuterError {
+    BadRequest,
+    PayloadTooLarge,
+    UnsupportedMediaType,
+    Unavailable,
+}
+
+impl IntoResponse for OuterError {
+    fn into_response(self) -> Response {
+        let status = match self {
+            Self::BadRequest => StatusCode::BAD_REQUEST,
+            Self::PayloadTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
+            Self::UnsupportedMediaType => StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            Self::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
+        };
+        (status, "transport request rejected").into_response()
+    }
+}
+
+impl TransportV2Gateway {
+    pub(crate) fn new(app_state: Arc<AppState>, application: Router<()>) -> Self {
+        let replay_budget = Arc::new(ReplayBudget::new(
+            NonZeroUsize::new(MAX_REPLAY_IDS_PROCESS_WIDE)
+                .expect("transport-v2 replay capacity must be non-zero"),
+        ));
+        let sessions = Arc::new(SessionStore::new(
+            NonZeroUsize::new(MAX_SESSIONS)
+                .expect("transport-v2 session capacity must be non-zero"),
+        ));
+        Self {
+            sessions: Arc::clone(&sessions),
+            session_state: Arc::new(SessionGatewayState {
+                app_state,
+                sessions: Arc::clone(&sessions),
+                replay_budget,
+            }),
+            request_state: Arc::new(RequestGatewayState {
+                application,
+                sessions,
+            }),
+        }
+    }
+
+    pub(crate) fn router(&self) -> Router<()> {
+        Router::new()
+            .merge(
+                Router::new()
+                    .route("/v2/session", post(create_session))
+                    .with_state(Arc::clone(&self.session_state)),
+            )
+            .merge(
+                Router::new()
+                    .route("/v2/request", post(dispatch_request))
+                    .with_state(Arc::clone(&self.request_state)),
+            )
+    }
+
+    pub(crate) async fn run_maintenance(&self) -> Infallible {
+        let mut interval = tokio::time::interval(SESSION_MAINTENANCE_INTERVAL);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            match self.sessions.purge_expired(Instant::now()) {
+                Ok(removed) if removed > 0 => {
+                    tracing::debug!(removed, "purged expired transport-v2 sessions");
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    tracing::error!(?error, "failed to purge expired transport-v2 sessions");
+                }
+            }
+        }
+    }
+}
+
+async fn create_session(
+    State(state): State<Arc<SessionGatewayState>>,
+    request: Request<Body>,
+) -> Result<Json<CreateSessionResponse>, OuterError> {
+    require_content_type(request.headers(), "application/json")?;
+    reject_forbidden_outer_headers(request.headers())?;
+    if request.uri().query().is_some() {
+        return Err(OuterError::BadRequest);
+    }
+    reject_declared_oversize(request.headers(), MAX_SESSION_REQUEST_BYTES)?;
+    let body = read_bounded_body(request.into_body(), MAX_SESSION_REQUEST_BYTES).await?;
+    let payload: CreateSessionRequest =
+        serde_json::from_slice(&body).map_err(|_| OuterError::BadRequest)?;
+    if payload.version != VERSION {
+        return Err(OuterError::BadRequest);
+    }
+
+    let challenge = decode_canonical_fixed::<HANDSHAKE_CHALLENGE_BYTES>(&payload.challenge)?;
+    let client_public_key =
+        decode_canonical_fixed::<X25519_PUBLIC_KEY_BYTES>(&payload.client_public_key)?;
+
+    let server_secret = EphemeralSecret::random_from_rng(OsRng);
+    let server_public_key = PublicKey::from(&server_secret).to_bytes();
+    let transcript = HandshakeTranscript::new(challenge, client_public_key, server_public_key);
+    let secrets =
+        derive_server_session(server_secret, &transcript).map_err(|_| OuterError::BadRequest)?;
+    let session_id = secrets.session_id();
+
+    let attestation_document = generate_attestation_document(
+        Arc::clone(&state.app_state),
+        NsmRequest::Attestation {
+            user_data: Some(ByteBuf::from(attestation_user_data(&client_public_key))),
+            public_key: Some(ByteBuf::from(server_public_key.to_vec())),
+            nonce: Some(ByteBuf::from(challenge.to_vec())),
+        },
+    )
+    .await
+    .map_err(|_| OuterError::Unavailable)?;
+
+    let session = Arc::new(
+        Session::new(
+            secrets,
+            SESSION_LIFETIME,
+            NonZeroUsize::new(MAX_REPLAY_IDS_PER_SESSION)
+                .expect("transport-v2 per-session replay capacity must be non-zero"),
+            Arc::clone(&state.replay_budget),
+        )
+        .map_err(|_| OuterError::Unavailable)?,
+    );
+    state
+        .sessions
+        .insert(session)
+        .map_err(map_session_insert_error)?;
+
+    Ok(Json(CreateSessionResponse {
+        version: VERSION,
+        session_id: session_id.to_string(),
+        attestation_document: STANDARD.encode(attestation_document),
+        expires_in_seconds: SESSION_LIFETIME.as_secs(),
+    }))
+}
+
+async fn dispatch_request(
+    State(state): State<Arc<RequestGatewayState>>,
+    request: Request<Body>,
+) -> Result<Response, OuterError> {
+    require_content_type(request.headers(), "application/octet-stream")?;
+    reject_forbidden_outer_headers(request.headers())?;
+    if request.uri().query().is_some() {
+        return Err(OuterError::BadRequest);
+    }
+    let session_id = parse_outer_session_id(request.headers())?;
+    reject_declared_oversize(request.headers(), MAX_REQUEST_RECORD_BYTES)?;
+    let record = read_bounded_body(request.into_body(), MAX_REQUEST_RECORD_BYTES).await?;
+    if record.len() < MIN_REQUEST_RECORD_BYTES {
+        return Err(OuterError::BadRequest);
+    }
+
+    // The body arrives before the session is retained. A slow or abandoned
+    // upload therefore cannot pin session state.
+    let session = state
+        .sessions
+        .get(session_id)
+        .map_err(map_session_lookup_error)?;
+    let (admitted, plaintext) = session
+        .open_and_admit(&record)
+        .map_err(map_admission_error)?;
+    drop(record);
+
+    let envelope = match RequestEnvelope::decode_owned(admitted.request_id(), plaintext) {
+        Ok(envelope) => envelope,
+        Err(_) => return encrypted_response(admitted, ApiError::BadRequest.into_response()),
+    };
+    let request = match build_application_request(envelope, admitted.session_id()) {
+        Ok(request) => request,
+        Err(_) => return encrypted_response(admitted, ApiError::BadRequest.into_response()),
+    };
+
+    let response = state
+        .application
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("Axum Router has an infallible service error");
+    encrypted_response(admitted, response)
+}
+
+fn build_application_request(
+    envelope: RequestEnvelope,
+    session_id: SessionId,
+) -> Result<Request<Body>, EnvelopeError> {
+    let parts = envelope.into_parts();
+    let method =
+        Method::from_bytes(parts.method.as_bytes()).map_err(|_| EnvelopeError::InvalidMethod)?;
+    let uri = Uri::from_str(&parts.target).map_err(|_| EnvelopeError::InvalidTarget)?;
+    let mut request = Request::builder()
+        .method(method)
+        .uri(uri)
+        .body(parts.body.map_or_else(Body::empty, Body::from))
+        .map_err(|_| EnvelopeError::InvalidTarget)?;
+    for logical_header in parts.headers {
+        let name = HeaderName::from_bytes(logical_header.name().as_bytes())
+            .map_err(|_| EnvelopeError::InvalidHeaderName)?;
+        let value = HeaderValue::from_str(logical_header.value())
+            .map_err(|_| EnvelopeError::InvalidHeaderValue)?;
+        request.headers_mut().append(name, value);
+    }
+    request
+        .extensions_mut()
+        .insert(TransportSession::v2(session_id));
+    if let Some(credential) = parts.credential {
+        request.extensions_mut().insert(credential);
+    }
+    if let Some(cache_namespace_root) = parts.cache_namespace_root {
+        request.extensions_mut().insert(cache_namespace_root);
+    }
+    Ok(request)
+}
+
+fn encrypted_response(
+    admitted: super::session::AdmittedRequest,
+    mut response: Response,
+) -> Result<Response, OuterError> {
+    let response_start = ResponseStart::new(
+        response.status().as_u16(),
+        logical_response_headers(response.headers()),
+    );
+    let (start, mut body) = match response_start {
+        Ok(start) => (start, std::mem::replace(response.body_mut(), Body::empty())),
+        Err(_) => {
+            // Once a request has authenticated and claimed replay state, every
+            // representable application failure stays inside the encrypted
+            // channel. An oversized or invalid internal response head therefore
+            // becomes a minimal encrypted 500 rather than a plaintext outer 503.
+            (
+                ResponseStart::new(StatusCode::INTERNAL_SERVER_ERROR.as_u16(), Vec::new())
+                    .expect("a headerless 500 is a valid transport response start"),
+                Body::empty(),
+            )
+        }
+    };
+    let start = ResponseRecord::Start(start);
+    let mut writer = admitted
+        .begin_response()
+        .map_err(|_| OuterError::Unavailable)?;
+    let start = seal_framed(&mut writer, start).map_err(|_| OuterError::Unavailable)?;
+    let stream = try_stream! {
+        yield Bytes::from(start);
+        while let Some(frame) = poll_fn(|context| Pin::new(&mut body).poll_frame(context)).await {
+            let frame = match frame {
+                Ok(frame) => frame,
+                Err(_) => {
+                    let error = seal_framed(
+                        &mut writer,
+                        ResponseRecord::Error {
+                            code: "application_body_failed".to_string(),
+                        },
+                    ).map_err(io_error)?;
+                    yield Bytes::from(error);
+                    return;
+                }
+            };
+            match frame.into_data() {
+                Ok(bytes) => {
+                    for chunk in bytes.chunks(MAX_RESPONSE_CHUNK_BYTES) {
+                        let encrypted = seal_framed(
+                            &mut writer,
+                            ResponseRecord::Chunk(Bytes::copy_from_slice(chunk)),
+                        ).map_err(io_error)?;
+                        yield Bytes::from(encrypted);
+                    }
+                }
+                Err(frame) => {
+                    let code = if frame.is_trailers() {
+                        "application_trailers_unsupported"
+                    } else {
+                        "application_frame_unsupported"
+                    };
+                    let error = seal_framed(
+                        &mut writer,
+                        ResponseRecord::Error {
+                            code: code.to_string(),
+                        },
+                    ).map_err(io_error)?;
+                    yield Bytes::from(error);
+                    return;
+                }
+            }
+        }
+        let end = seal_framed(&mut writer, ResponseRecord::End).map_err(io_error)?;
+        yield Bytes::from(end);
+    };
+
+    let mut outer = Response::new(stream_body(stream));
+    *outer.status_mut() = StatusCode::OK;
+    outer
+        .headers_mut()
+        .insert(header::CONTENT_TYPE, OUTER_CONTENT_TYPE);
+    outer
+        .headers_mut()
+        .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    outer.headers_mut().insert(
+        HeaderName::from_static("x-accel-buffering"),
+        HeaderValue::from_static("no"),
+    );
+    Ok(outer)
+}
+
+fn seal_framed(
+    writer: &mut super::session::ResponseWriter,
+    record: ResponseRecord,
+) -> Result<Vec<u8>, SealFrameError> {
+    let plaintext = record.encode()?;
+    let ciphertext = writer.seal_next(&plaintext)?;
+    Ok(frame_ciphertext(&ciphertext)?)
+}
+
+#[derive(Debug, thiserror::Error)]
+enum SealFrameError {
+    #[error(transparent)]
+    Framing(#[from] FramingError),
+    #[error(transparent)]
+    Crypto(#[from] CryptoError),
+}
+
+fn io_error(error: SealFrameError) -> io::Error {
+    io::Error::other(error)
+}
+
+fn logical_response_headers(headers: &HeaderMap) -> Vec<LogicalHeader> {
+    headers
+        .iter()
+        .filter_map(|(name, value)| {
+            let value = value.to_str().ok()?;
+            LogicalHeader::new(name.as_str().to_string(), value.to_string()).ok()
+        })
+        .collect()
+}
+
+fn require_content_type(headers: &HeaderMap, expected: &str) -> Result<(), OuterError> {
+    let values = headers.get_all(header::CONTENT_TYPE);
+    let mut values = values.iter();
+    let Some(actual) = values.next() else {
+        return Err(OuterError::UnsupportedMediaType);
+    };
+    if values.next().is_some() || actual.as_bytes() != expected.as_bytes() {
+        return Err(OuterError::UnsupportedMediaType);
+    }
+    Ok(())
+}
+
+fn reject_forbidden_outer_headers(headers: &HeaderMap) -> Result<(), OuterError> {
+    for name in [
+        header::AUTHORIZATION,
+        HeaderName::from_static("proxy-authorization"),
+        header::COOKIE,
+        header::CONTENT_ENCODING,
+    ] {
+        if headers.contains_key(name) {
+            return Err(OuterError::BadRequest);
+        }
+    }
+    Ok(())
+}
+
+fn reject_declared_oversize(headers: &HeaderMap, maximum: usize) -> Result<(), OuterError> {
+    let values = headers.get_all(header::CONTENT_LENGTH);
+    let mut values = values.iter();
+    let Some(value) = values.next() else {
+        return Ok(());
+    };
+    if values.next().is_some() {
+        return Err(OuterError::BadRequest);
+    }
+    let declared = value
+        .to_str()
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .ok_or(OuterError::BadRequest)?;
+    if declared > maximum {
+        return Err(OuterError::PayloadTooLarge);
+    }
+    Ok(())
+}
+
+async fn read_bounded_body(body: Body, maximum: usize) -> Result<Bytes, OuterError> {
+    to_bytes(body, maximum)
+        .await
+        .map_err(|_| OuterError::PayloadTooLarge)
+}
+
+fn parse_outer_session_id(headers: &HeaderMap) -> Result<SessionId, OuterError> {
+    let values = headers.get_all(&SESSION_ID_HEADER);
+    let mut values = values.iter();
+    let Some(value) = values.next() else {
+        return Err(OuterError::BadRequest);
+    };
+    if values.next().is_some() {
+        return Err(OuterError::BadRequest);
+    }
+    value
+        .to_str()
+        .ok()
+        .and_then(|value| SessionId::from_str(value).ok())
+        .ok_or(OuterError::BadRequest)
+}
+
+fn decode_canonical_fixed<const N: usize>(encoded: &str) -> Result<[u8; N], OuterError> {
+    let decoded = STANDARD
+        .decode(encoded.as_bytes())
+        .map_err(|_| OuterError::BadRequest)?;
+    let bytes: [u8; N] = decoded.try_into().map_err(|_| OuterError::BadRequest)?;
+    if STANDARD.encode(bytes) != encoded {
+        return Err(OuterError::BadRequest);
+    }
+    Ok(bytes)
+}
+
+fn map_session_insert_error(error: SessionStoreError) -> OuterError {
+    match error {
+        SessionStoreError::Collision
+        | SessionStoreError::Full
+        | SessionStoreError::Unavailable
+        | SessionStoreError::Expired
+        | SessionStoreError::Missing => OuterError::Unavailable,
+    }
+}
+
+fn map_session_lookup_error(error: SessionStoreError) -> OuterError {
+    match error {
+        SessionStoreError::Missing | SessionStoreError::Expired => OuterError::BadRequest,
+        SessionStoreError::Collision | SessionStoreError::Full | SessionStoreError::Unavailable => {
+            OuterError::Unavailable
+        }
+    }
+}
+
+fn map_admission_error(error: SessionError) -> OuterError {
+    match error {
+        SessionError::Replay(ReplayError::GlobalCapacity | ReplayError::Unavailable) => {
+            OuterError::Unavailable
+        }
+        SessionError::Replay(ReplayError::Duplicate | ReplayError::SessionCapacity)
+        | SessionError::Expired
+        | SessionError::Crypto(_) => OuterError::BadRequest,
+        SessionError::InvalidLifetime => OuterError::Unavailable,
+    }
+}
+
+fn stream_body(stream: impl Stream<Item = Result<Bytes, io::Error>> + Send + 'static) -> Body {
+    Body::from_stream(stream)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::routing::any;
+    use futures::stream;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::provider_cache::CacheNamespaceRoot;
+    use crate::transport_v2::{
+        crypto::{derive_client_session, SessionSecrets},
+        envelope::{Credential, CredentialKind, RequestId},
+    };
+
+    struct TestSession {
+        client: SessionSecrets,
+        server: Arc<Session>,
+    }
+
+    fn test_session(marker: u8) -> TestSession {
+        let client_secret = EphemeralSecret::random_from_rng(OsRng);
+        let client_public_key = PublicKey::from(&client_secret).to_bytes();
+        let server_secret = EphemeralSecret::random_from_rng(OsRng);
+        let server_public_key = PublicKey::from(&server_secret).to_bytes();
+        let transcript =
+            HandshakeTranscript::new([marker; 32], client_public_key, server_public_key);
+        let client = derive_client_session(client_secret, &transcript).unwrap();
+        let server_secrets = derive_server_session(server_secret, &transcript).unwrap();
+        let replay_budget = Arc::new(ReplayBudget::new(NonZeroUsize::new(128).unwrap()));
+        let server = Arc::new(
+            Session::new(
+                server_secrets,
+                Duration::from_secs(60),
+                NonZeroUsize::new(64).unwrap(),
+                replay_budget,
+            )
+            .unwrap(),
+        );
+        TestSession { client, server }
+    }
+
+    fn request_router(application: Router<()>, sessions: Arc<SessionStore>) -> Router<()> {
+        Router::new()
+            .route("/v2/request", post(dispatch_request))
+            .with_state(Arc::new(RequestGatewayState {
+                application,
+                sessions,
+            }))
+    }
+
+    fn seal_request(
+        client: &SessionSecrets,
+        request_id: RequestId,
+        target: &str,
+        body: Option<Vec<u8>>,
+    ) -> Vec<u8> {
+        let envelope = RequestEnvelope::new(
+            request_id,
+            Some(Credential::new(CredentialKind::Bearer, "v2-token".into()).unwrap()),
+            Some(CacheNamespaceRoot::from_bytes([0x42; 32])),
+            "POST".into(),
+            target.into(),
+            vec![LogicalHeader::new("x-logical".into(), "present".into()).unwrap()],
+            body,
+        )
+        .unwrap();
+        client
+            .encrypt_request(request_id, &envelope.encode().unwrap())
+            .unwrap()
+    }
+
+    fn outer_request(session_id: SessionId, record: Vec<u8>) -> Request<Body> {
+        Request::builder()
+            .method(Method::POST)
+            .uri("/v2/request")
+            .header(header::CONTENT_TYPE, "application/octet-stream")
+            .header(&SESSION_ID_HEADER, session_id.to_string())
+            .body(Body::from(record))
+            .unwrap()
+    }
+
+    async fn decrypt_records(
+        client: &SessionSecrets,
+        request_id: RequestId,
+        response: Response,
+    ) -> Vec<ResponseRecord> {
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE),
+            Some(&OUTER_CONTENT_TYPE)
+        );
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let mut remaining = bytes.as_ref();
+        let mut sequence = 0_u64;
+        let mut records = Vec::new();
+        while !remaining.is_empty() {
+            let length = u32::from_be_bytes(remaining[..4].try_into().unwrap()) as usize;
+            let ciphertext = &remaining[4..4 + length];
+            let plaintext = client
+                .decrypt_response(request_id, sequence, ciphertext)
+                .unwrap();
+            records.push(ResponseRecord::decode(&plaintext).unwrap());
+            remaining = &remaining[4 + length..];
+            sequence += 1;
+        }
+        records
+    }
+
+    #[test]
+    fn application_header_projection_preserves_repeated_values_in_order() {
+        let test = test_session(8);
+        let request_id = RequestId::from_bytes([0x81; 16]);
+        let envelope = RequestEnvelope::new(
+            request_id,
+            None,
+            None,
+            "GET".into(),
+            "/health-check".into(),
+            vec![
+                LogicalHeader::new("x-repeat".into(), "request-first".into()).unwrap(),
+                LogicalHeader::new("x-repeat".into(), "request-second".into()).unwrap(),
+            ],
+            None,
+        )
+        .unwrap();
+        let request = build_application_request(envelope, test.server.id(), request_id).unwrap();
+        let request_values = request
+            .headers()
+            .get_all("x-repeat")
+            .iter()
+            .map(|value| value.to_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(request_values, ["request-first", "request-second"]);
+
+        let mut response_headers = HeaderMap::new();
+        response_headers.append("x-repeat", HeaderValue::from_static("response-first"));
+        response_headers.append("x-repeat", HeaderValue::from_static("response-second"));
+        let projected = logical_response_headers(&response_headers);
+        let response_values = projected
+            .iter()
+            .filter(|header| header.name() == "x-repeat")
+            .map(LogicalHeader::value)
+            .collect::<Vec<_>>();
+        assert_eq!(response_values, ["response-first", "response-second"]);
+    }
+
+    #[tokio::test]
+    async fn missing_content_length_is_accepted_and_whole_request_is_projected() {
+        let test = test_session(1);
+        let sessions = Arc::new(SessionStore::new(NonZeroUsize::new(2).unwrap()));
+        sessions.insert(Arc::clone(&test.server)).unwrap();
+        let application = Router::new().route(
+            "/echo",
+            any(|request: Request<Body>| async move {
+                assert_eq!(request.method(), Method::POST);
+                assert_eq!(request.uri().query(), Some("answer=42"));
+                assert_eq!(request.headers().get("x-logical").unwrap(), "present");
+                assert!(request
+                    .extensions()
+                    .get::<TransportSession>()
+                    .is_some_and(TransportSession::is_v2));
+                assert_eq!(
+                    request.extensions().get::<Credential>().unwrap().value(),
+                    "v2-token"
+                );
+                assert!(request.extensions().get::<CacheNamespaceRoot>().is_some());
+                let body = to_bytes(request.into_body(), 64).await.unwrap();
+                let mut response = (StatusCode::CREATED, body).into_response();
+                response
+                    .headers_mut()
+                    .insert("x-echo", HeaderValue::from_static("yes"));
+                response
+            }),
+        );
+        let router = request_router(application, sessions);
+        let request_id = RequestId::from_bytes([0x11; 16]);
+        let request = outer_request(
+            test.server.id(),
+            seal_request(
+                &test.client,
+                request_id,
+                "/echo?answer=42",
+                Some(b"hello".to_vec()),
+            ),
+        );
+        assert!(request.headers().get(header::CONTENT_LENGTH).is_none());
+
+        let records = decrypt_records(
+            &test.client,
+            request_id,
+            router.oneshot(request).await.unwrap(),
+        )
+        .await;
+        assert!(matches!(
+            &records[0],
+            ResponseRecord::Start(start)
+                if start.status() == 201
+                    && start.headers().iter().any(|header| header.name() == "x-echo")
+        ));
+        assert!(matches!(&records[1], ResponseRecord::Chunk(body) if body.as_ref() == b"hello"));
+        assert!(matches!(&records[2], ResponseRecord::End));
+    }
+
+    #[tokio::test]
+    async fn outer_rejection_and_failed_authentication_do_not_claim_replay_state() {
+        let test = test_session(2);
+        let sessions = Arc::new(SessionStore::new(NonZeroUsize::new(2).unwrap()));
+        sessions.insert(Arc::clone(&test.server)).unwrap();
+        let dispatches = Arc::new(AtomicUsize::new(0));
+        let application = Router::new().route(
+            "/count",
+            any({
+                let dispatches = Arc::clone(&dispatches);
+                move || {
+                    let dispatches = Arc::clone(&dispatches);
+                    async move {
+                        dispatches.fetch_add(1, Ordering::SeqCst);
+                        StatusCode::NO_CONTENT
+                    }
+                }
+            }),
+        );
+        let router = request_router(application, sessions);
+        let request_id = RequestId::from_bytes([0x22; 16]);
+        let record = seal_request(&test.client, request_id, "/count", None);
+
+        let mut forbidden = outer_request(test.server.id(), record.clone());
+        forbidden.headers_mut().insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer stolen"),
+        );
+        assert_eq!(
+            router.clone().oneshot(forbidden).await.unwrap().status(),
+            StatusCode::BAD_REQUEST
+        );
+
+        let mut tampered = record.clone();
+        *tampered.last_mut().unwrap() ^= 1;
+        assert_eq!(
+            router
+                .clone()
+                .oneshot(outer_request(test.server.id(), tampered))
+                .await
+                .unwrap()
+                .status(),
+            StatusCode::BAD_REQUEST
+        );
+
+        let response = router
+            .clone()
+            .oneshot(outer_request(test.server.id(), record.clone()))
+            .await
+            .unwrap();
+        let records = decrypt_records(&test.client, request_id, response).await;
+        assert!(matches!(&records[0], ResponseRecord::Start(start) if start.status() == 204));
+        assert_eq!(dispatches.load(Ordering::SeqCst), 1);
+
+        assert_eq!(
+            router
+                .oneshot(outer_request(test.server.id(), record))
+                .await
+                .unwrap()
+                .status(),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(dispatches.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn authenticated_malformed_envelope_gets_an_encrypted_error() {
+        let test = test_session(3);
+        let sessions = Arc::new(SessionStore::new(NonZeroUsize::new(2).unwrap()));
+        sessions.insert(Arc::clone(&test.server)).unwrap();
+        let router = request_router(Router::new(), sessions);
+        let request_id = RequestId::from_bytes([0x33; 16]);
+        let record = test
+            .client
+            .encrypt_request(request_id, b"not an envelope")
+            .unwrap();
+
+        let records = decrypt_records(
+            &test.client,
+            request_id,
+            router
+                .oneshot(outer_request(test.server.id(), record))
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert!(matches!(&records[0], ResponseRecord::Start(start) if start.status() == 400));
+        assert!(matches!(records.last(), Some(ResponseRecord::End)));
+    }
+
+    #[tokio::test]
+    async fn response_records_are_bound_to_the_admitted_session_and_request() {
+        let first = test_session(4);
+        let second = test_session(5);
+        let sessions = Arc::new(SessionStore::new(NonZeroUsize::new(3).unwrap()));
+        sessions.insert(Arc::clone(&first.server)).unwrap();
+        sessions.insert(Arc::clone(&second.server)).unwrap();
+        let router = request_router(
+            Router::new().route("/ok", any(|| async { StatusCode::NO_CONTENT })),
+            sessions,
+        );
+        let request_id = RequestId::from_bytes([0x44; 16]);
+        let response = router
+            .oneshot(outer_request(
+                first.server.id(),
+                seal_request(&first.client, request_id, "/ok", None),
+            ))
+            .await
+            .unwrap();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let length = u32::from_be_bytes(bytes[..4].try_into().unwrap()) as usize;
+        let ciphertext = &bytes[4..4 + length];
+
+        assert!(first
+            .client
+            .decrypt_response(request_id, 0, ciphertext)
+            .is_ok());
+        assert!(second
+            .client
+            .decrypt_response(request_id, 0, ciphertext)
+            .is_err());
+        assert!(first
+            .client
+            .decrypt_response(RequestId::from_bytes([0x45; 16]), 0, ciphertext)
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn streams_end_or_fail_with_an_authenticated_terminal_record() {
+        let test = test_session(6);
+        let sessions = Arc::new(SessionStore::new(NonZeroUsize::new(2).unwrap()));
+        sessions.insert(Arc::clone(&test.server)).unwrap();
+        let application = Router::new()
+            .route(
+                "/stream",
+                any(|| async {
+                    Response::new(Body::from_stream(stream::iter([
+                        Ok::<_, io::Error>(Bytes::from_static(b"one")),
+                        Ok(Bytes::from_static(b"two")),
+                    ])))
+                }),
+            )
+            .route(
+                "/stream-error",
+                any(|| async {
+                    Response::new(Body::from_stream(stream::iter([
+                        Ok::<_, io::Error>(Bytes::from_static(b"one")),
+                        Err(io::Error::other("boom")),
+                    ])))
+                }),
+            );
+        let router = request_router(application, sessions);
+
+        let success_id = RequestId::from_bytes([0x61; 16]);
+        let success = decrypt_records(
+            &test.client,
+            success_id,
+            router
+                .clone()
+                .oneshot(outer_request(
+                    test.server.id(),
+                    seal_request(&test.client, success_id, "/stream", None),
+                ))
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert!(matches!(success.last(), Some(ResponseRecord::End)));
+        assert!(success.iter().any(
+            |record| matches!(record, ResponseRecord::Chunk(body) if body.as_ref() == b"one")
+        ));
+
+        let error_id = RequestId::from_bytes([0x62; 16]);
+        let failure = decrypt_records(
+            &test.client,
+            error_id,
+            router
+                .oneshot(outer_request(
+                    test.server.id(),
+                    seal_request(&test.client, error_id, "/stream-error", None),
+                ))
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert!(matches!(
+            failure.last(),
+            Some(ResponseRecord::Error { code }) if code == "application_body_failed"
+        ));
+        assert!(!failure
+            .iter()
+            .any(|record| matches!(record, ResponseRecord::End)));
+    }
+
+    #[tokio::test]
+    async fn bounded_body_read_uses_actual_bytes_and_invalid_response_heads_stay_encrypted() {
+        assert_eq!(
+            read_bounded_body(Body::from(Bytes::from_static(b"four")), 4)
+                .await
+                .unwrap(),
+            Bytes::from_static(b"four")
+        );
+        assert!(matches!(
+            read_bounded_body(Body::from(Bytes::from_static(b"five!")), 4).await,
+            Err(OuterError::PayloadTooLarge)
+        ));
+
+        let test = test_session(7);
+        let sessions = Arc::new(SessionStore::new(NonZeroUsize::new(2).unwrap()));
+        sessions.insert(Arc::clone(&test.server)).unwrap();
+        let application = Router::new().route(
+            "/too-many-headers",
+            any(|| async {
+                let mut response =
+                    Response::new(Body::from(Bytes::from_static(b"must be discarded")));
+                for index in 0..=32 {
+                    response.headers_mut().insert(
+                        HeaderName::from_str(&format!("x-test-{index}")).unwrap(),
+                        HeaderValue::from_static("value"),
+                    );
+                }
+                response
+            }),
+        );
+        let router = request_router(application, sessions);
+        let request_id = RequestId::from_bytes([0x71; 16]);
+        let records = decrypt_records(
+            &test.client,
+            request_id,
+            router
+                .oneshot(outer_request(
+                    test.server.id(),
+                    seal_request(&test.client, request_id, "/too-many-headers", None),
+                ))
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert!(matches!(&records[0], ResponseRecord::Start(start) if start.status() == 500));
+        assert_eq!(records.len(), 2);
+        assert!(matches!(&records[1], ResponseRecord::End));
+    }
+}

--- a/src/transport_v2/mod.rs
+++ b/src/transport_v2/mod.rs
@@ -7,4 +7,5 @@
 pub(crate) mod crypto;
 pub(crate) mod envelope;
 pub(crate) mod framing;
+pub(crate) mod gateway;
 pub(crate) mod session;

--- a/src/transport_v2/mod.rs
+++ b/src/transport_v2/mod.rs
@@ -1,0 +1,10 @@
+//! Dormant primitives for the second version of the attested transport.
+//!
+//! This module deliberately contains no HTTP routing, application route table,
+//! authentication state machine, or memory scheduler. The active gateway is a
+//! separate stacked change.
+
+pub(crate) mod crypto;
+pub(crate) mod envelope;
+pub(crate) mod framing;
+pub(crate) mod session;

--- a/src/transport_v2/session.rs
+++ b/src/transport_v2/session.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use super::{
-    crypto::{CryptoError, ResponseSealer, SessionId, SessionSecrets},
+    crypto::{CryptoError, ResponseSealer, SessionId, SessionSecrets, HANDSHAKE_CHALLENGE_BYTES},
     envelope::RequestId,
 };
 
@@ -163,6 +163,7 @@ pub(crate) enum SessionError {
 /// here; credentials are authenticated independently on every request.
 pub(crate) struct Session {
     secrets: SessionSecrets,
+    routing_key: [u8; HANDSHAKE_CHALLENGE_BYTES],
     expires_at: Instant,
     replay: ReplayRegistry,
 }
@@ -241,12 +242,14 @@ impl fmt::Debug for Session {
 impl Session {
     pub(crate) fn new(
         secrets: SessionSecrets,
+        routing_key: [u8; HANDSHAKE_CHALLENGE_BYTES],
         lifetime: Duration,
         replay_capacity: NonZeroUsize,
         replay_budget: Arc<ReplayBudget>,
     ) -> Result<Self, SessionError> {
         Self::new_at(
             secrets,
+            routing_key,
             Instant::now(),
             lifetime,
             replay_capacity,
@@ -256,6 +259,7 @@ impl Session {
 
     fn new_at(
         secrets: SessionSecrets,
+        routing_key: [u8; HANDSHAKE_CHALLENGE_BYTES],
         now: Instant,
         lifetime: Duration,
         replay_capacity: NonZeroUsize,
@@ -269,6 +273,7 @@ impl Session {
             .ok_or(SessionError::InvalidLifetime)?;
         Ok(Self {
             secrets,
+            routing_key,
             expires_at,
             replay: ReplayRegistry::new(replay_capacity, replay_budget),
         })
@@ -280,6 +285,16 @@ impl Session {
 
     pub(crate) const fn expires_at(&self) -> Instant {
         self.expires_at
+    }
+
+    /// Confirms that the public load-balancer routing key belongs to this
+    /// attested session. The key is the client challenge already bound into
+    /// the handshake transcript; it conveys no identity or authorization.
+    pub(crate) fn matches_routing_key(
+        &self,
+        routing_key: &[u8; HANDSHAKE_CHALLENGE_BYTES],
+    ) -> bool {
+        &self.routing_key == routing_key
     }
 
     pub(crate) fn is_expired(&self, now: Instant) -> bool {
@@ -474,7 +489,15 @@ mod tests {
         let transcript = HandshakeTranscript::new([marker; 32], client_public, server_public);
         let secrets = derive_server_session(server_secret, &transcript).unwrap();
         Arc::new(
-            Session::new_at(secrets, now, lifetime, REPLAY_CAPACITY, replay_budget(128)).unwrap(),
+            Session::new_at(
+                secrets,
+                [marker; HANDSHAKE_CHALLENGE_BYTES],
+                now,
+                lifetime,
+                REPLAY_CAPACITY,
+                replay_budget(128),
+            )
+            .unwrap(),
         )
     }
 
@@ -584,6 +607,7 @@ mod tests {
         let session = Arc::new(
             Session::new_at(
                 derive_server_session(server_secret, &transcript).unwrap(),
+                [7; HANDSHAKE_CHALLENGE_BYTES],
                 start,
                 Duration::from_secs(60),
                 REPLAY_CAPACITY,
@@ -706,6 +730,7 @@ mod tests {
         assert_eq!(
             Session::new_at(
                 secrets,
+                [3; HANDSHAKE_CHALLENGE_BYTES],
                 now,
                 Duration::ZERO,
                 REPLAY_CAPACITY,

--- a/src/transport_v2/session.rs
+++ b/src/transport_v2/session.rs
@@ -1,0 +1,723 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+    num::NonZeroUsize,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
+    time::{Duration, Instant},
+};
+
+use super::{
+    crypto::{CryptoError, ResponseSealer, SessionId, SessionSecrets},
+    envelope::RequestId,
+};
+
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub(crate) enum ReplayError {
+    #[error("transport-v2 request ID was already used in this session")]
+    Duplicate,
+    #[error("transport-v2 session has reached its request-ID limit")]
+    SessionCapacity,
+    #[error("transport-v2 process has reached its aggregate request-ID limit")]
+    GlobalCapacity,
+    #[error("transport-v2 replay registry is unavailable")]
+    Unavailable,
+}
+
+/// A process-wide count of replay IDs that have actually been retained.
+/// Capacity is not preallocated and does not reserve memory.
+pub(crate) struct ReplayBudget {
+    claimed: AtomicUsize,
+    capacity: NonZeroUsize,
+}
+
+impl fmt::Debug for ReplayBudget {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ReplayBudget")
+            .field("claimed", &self.claimed.load(Ordering::Relaxed))
+            .field("capacity", &self.capacity)
+            .finish()
+    }
+}
+
+impl ReplayBudget {
+    pub(crate) const fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            claimed: AtomicUsize::new(0),
+            capacity,
+        }
+    }
+
+    fn claim_one(&self) -> Result<(), ReplayError> {
+        self.claimed
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |claimed| {
+                (claimed < self.capacity.get()).then_some(claimed + 1)
+            })
+            .map(|_| ())
+            .map_err(|_| ReplayError::GlobalCapacity)
+    }
+
+    fn release(&self, count: usize) {
+        if count == 0 {
+            return;
+        }
+        let previous = self.claimed.fetch_sub(count, Ordering::AcqRel);
+        debug_assert!(previous >= count, "replay budget underflow");
+    }
+
+    pub(crate) fn claimed(&self) -> usize {
+        self.claimed.load(Ordering::Acquire)
+    }
+
+    pub(crate) const fn capacity(&self) -> NonZeroUsize {
+        self.capacity
+    }
+}
+
+/// An exact, unordered, per-session replay set. It grows only for requests
+/// actually admitted; a shared counter bounds aggregate retained entries
+/// without reserving memory in advance.
+pub(crate) struct ReplayRegistry {
+    request_ids: Mutex<HashSet<RequestId>>,
+    capacity: NonZeroUsize,
+    budget: Arc<ReplayBudget>,
+}
+
+impl fmt::Debug for ReplayRegistry {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ReplayRegistry")
+            .field("capacity", &self.capacity)
+            .field("budget", &self.budget)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ReplayRegistry {
+    pub(crate) fn new(capacity: NonZeroUsize, budget: Arc<ReplayBudget>) -> Self {
+        Self {
+            request_ids: Mutex::new(HashSet::new()),
+            capacity,
+            budget,
+        }
+    }
+
+    /// Atomically claims an ID before application side effects. Arrival order
+    /// is irrelevant: only exact reuse is rejected.
+    pub(crate) fn claim(&self, request_id: RequestId) -> Result<(), ReplayError> {
+        let mut request_ids = self
+            .request_ids
+            .lock()
+            .map_err(|_| ReplayError::Unavailable)?;
+        if request_ids.contains(&request_id) {
+            return Err(ReplayError::Duplicate);
+        }
+        if request_ids.len() >= self.capacity.get() {
+            return Err(ReplayError::SessionCapacity);
+        }
+        self.budget.claim_one()?;
+        request_ids.insert(request_id);
+        Ok(())
+    }
+
+    pub(crate) fn len(&self) -> Result<usize, ReplayError> {
+        self.request_ids
+            .lock()
+            .map(|request_ids| request_ids.len())
+            .map_err(|_| ReplayError::Unavailable)
+    }
+
+    pub(crate) const fn capacity(&self) -> NonZeroUsize {
+        self.capacity
+    }
+}
+
+impl Drop for ReplayRegistry {
+    fn drop(&mut self) {
+        let retained = self
+            .request_ids
+            .get_mut()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .len();
+        self.budget.release(retained);
+    }
+}
+
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub(crate) enum SessionError {
+    #[error("transport-v2 session lifetime is invalid")]
+    InvalidLifetime,
+    #[error("transport-v2 session expired")]
+    Expired,
+    #[error(transparent)]
+    Crypto(#[from] CryptoError),
+    #[error(transparent)]
+    Replay(#[from] ReplayError),
+}
+
+/// One cryptographic session: directional keys, a fixed absolute expiry, and
+/// its exact replay set. Identity and authorization intentionally do not live
+/// here; credentials are authenticated independently on every request.
+pub(crate) struct Session {
+    secrets: SessionSecrets,
+    expires_at: Instant,
+    replay: ReplayRegistry,
+}
+
+/// Proof that one request ID was atomically claimed under one exact session.
+/// Only this type can begin an encrypted response for that request.
+pub(crate) struct AdmittedRequest {
+    session: Arc<Session>,
+    request_id: RequestId,
+}
+
+impl fmt::Debug for AdmittedRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("AdmittedRequest")
+            .field("session_id", &self.session.id())
+            .field("request_id", &self.request_id)
+            .finish()
+    }
+}
+
+/// The single response writer for an admitted request. It is derived from the
+/// exact session that decrypted and admitted the request, and retains only the
+/// response subkey and authenticated session/request identifiers needed to
+/// seal that response.
+pub(crate) struct ResponseWriter {
+    sealer: ResponseSealer,
+}
+
+impl fmt::Debug for ResponseWriter {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ResponseWriter")
+            .field("sealer", &self.sealer)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ResponseWriter {
+    pub(crate) fn seal_next(&mut self, plaintext: &[u8]) -> Result<Vec<u8>, CryptoError> {
+        self.sealer.seal_next(plaintext)
+    }
+}
+
+impl AdmittedRequest {
+    pub(crate) fn session_id(&self) -> SessionId {
+        self.session.id()
+    }
+
+    pub(crate) const fn request_id(&self) -> RequestId {
+        self.request_id
+    }
+
+    pub(crate) fn begin_response(self) -> Result<ResponseWriter, CryptoError> {
+        let Self {
+            session,
+            request_id,
+        } = self;
+        let sealer = session.secrets.response_sealer(request_id)?;
+        drop(session);
+        Ok(ResponseWriter { sealer })
+    }
+}
+
+impl fmt::Debug for Session {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Session")
+            .field("id", &self.id())
+            .field("expires_at", &self.expires_at)
+            .field("replay", &self.replay)
+            .finish()
+    }
+}
+
+impl Session {
+    pub(crate) fn new(
+        secrets: SessionSecrets,
+        lifetime: Duration,
+        replay_capacity: NonZeroUsize,
+        replay_budget: Arc<ReplayBudget>,
+    ) -> Result<Self, SessionError> {
+        Self::new_at(
+            secrets,
+            Instant::now(),
+            lifetime,
+            replay_capacity,
+            replay_budget,
+        )
+    }
+
+    fn new_at(
+        secrets: SessionSecrets,
+        now: Instant,
+        lifetime: Duration,
+        replay_capacity: NonZeroUsize,
+        replay_budget: Arc<ReplayBudget>,
+    ) -> Result<Self, SessionError> {
+        if lifetime.is_zero() {
+            return Err(SessionError::InvalidLifetime);
+        }
+        let expires_at = now
+            .checked_add(lifetime)
+            .ok_or(SessionError::InvalidLifetime)?;
+        Ok(Self {
+            secrets,
+            expires_at,
+            replay: ReplayRegistry::new(replay_capacity, replay_budget),
+        })
+    }
+
+    pub(crate) const fn id(&self) -> SessionId {
+        self.secrets.session_id()
+    }
+
+    pub(crate) const fn expires_at(&self) -> Instant {
+        self.expires_at
+    }
+
+    pub(crate) fn is_expired(&self, now: Instant) -> bool {
+        self.expires_at <= now
+    }
+
+    /// Authenticates the request record before claiming replay state. A caller
+    /// receives plaintext and a response capability only after both succeed.
+    pub(crate) fn open_and_admit(
+        self: &Arc<Self>,
+        record: &[u8],
+    ) -> Result<(AdmittedRequest, Vec<u8>), SessionError> {
+        let (request_id, plaintext) = self.secrets.decrypt_request(record)?;
+        self.claim_request_at(request_id, Instant::now())?;
+        Ok((
+            AdmittedRequest {
+                session: Arc::clone(self),
+                request_id,
+            },
+            plaintext,
+        ))
+    }
+
+    fn claim_request_at(&self, request_id: RequestId, now: Instant) -> Result<(), SessionError> {
+        if self.is_expired(now) {
+            return Err(SessionError::Expired);
+        }
+        self.replay.claim(request_id)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub(crate) enum SessionStoreError {
+    #[error("transport-v2 session store is unavailable")]
+    Unavailable,
+    #[error("transport-v2 session ID collision")]
+    Collision,
+    #[error("transport-v2 session store is full")]
+    Full,
+    #[error("transport-v2 session is missing")]
+    Missing,
+    #[error("transport-v2 session expired")]
+    Expired,
+}
+
+/// A fixed-count session map. Expired entries are reclaimed by lookup or the
+/// gateway's periodic purge, but a live session is never evicted to admit an
+/// unauthenticated new handshake.
+pub(crate) struct SessionStore {
+    sessions: Mutex<HashMap<SessionId, Arc<Session>>>,
+    capacity: NonZeroUsize,
+}
+
+impl fmt::Debug for SessionStore {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SessionStore")
+            .field("capacity", &self.capacity)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SessionStore {
+    pub(crate) fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            sessions: Mutex::new(HashMap::new()),
+            capacity,
+        }
+    }
+
+    pub(crate) fn insert(&self, session: Arc<Session>) -> Result<(), SessionStoreError> {
+        self.insert_at(session, Instant::now())
+    }
+
+    fn insert_at(&self, session: Arc<Session>, now: Instant) -> Result<(), SessionStoreError> {
+        if session.is_expired(now) {
+            return Err(SessionStoreError::Expired);
+        }
+        let mut sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| SessionStoreError::Unavailable)?;
+        let mut reclaimed = Vec::new();
+        if let Some(existing) = sessions.get(&session.id()) {
+            if existing.is_expired(now) {
+                if let Some(expired) = sessions.remove(&session.id()) {
+                    reclaimed.push(expired);
+                }
+            } else {
+                return Err(SessionStoreError::Collision);
+            }
+        }
+        if sessions.len() >= self.capacity.get() {
+            drop(sessions);
+            drop(reclaimed);
+            return Err(SessionStoreError::Full);
+        }
+        sessions.insert(session.id(), session);
+        drop(sessions);
+        drop(reclaimed);
+        Ok(())
+    }
+
+    pub(crate) fn get(&self, session_id: SessionId) -> Result<Arc<Session>, SessionStoreError> {
+        self.get_at(session_id, Instant::now())
+    }
+
+    fn get_at(
+        &self,
+        session_id: SessionId,
+        now: Instant,
+    ) -> Result<Arc<Session>, SessionStoreError> {
+        let mut sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| SessionStoreError::Unavailable)?;
+        let Some(session) = sessions.get(&session_id) else {
+            return Err(SessionStoreError::Missing);
+        };
+        if session.is_expired(now) {
+            let expired = sessions.remove(&session_id);
+            drop(sessions);
+            drop(expired);
+            return Err(SessionStoreError::Expired);
+        }
+        Ok(Arc::clone(session))
+    }
+
+    pub(crate) fn remove(
+        &self,
+        session_id: SessionId,
+    ) -> Result<Option<Arc<Session>>, SessionStoreError> {
+        self.sessions
+            .lock()
+            .map(|mut sessions| sessions.remove(&session_id))
+            .map_err(|_| SessionStoreError::Unavailable)
+    }
+
+    pub(crate) fn purge_expired(&self, now: Instant) -> Result<usize, SessionStoreError> {
+        let mut sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| SessionStoreError::Unavailable)?;
+        let expired_ids: Vec<_> = sessions
+            .iter()
+            .filter_map(|(id, session)| session.is_expired(now).then_some(*id))
+            .collect();
+        let expired: Vec<_> = expired_ids
+            .iter()
+            .filter_map(|id| sessions.remove(id))
+            .collect();
+        drop(sessions);
+        let removed = expired.len();
+        drop(expired);
+        Ok(removed)
+    }
+
+    pub(crate) fn len(&self) -> Result<usize, SessionStoreError> {
+        self.sessions
+            .lock()
+            .map(|sessions| sessions.len())
+            .map_err(|_| SessionStoreError::Unavailable)
+    }
+
+    pub(crate) const fn capacity(&self) -> NonZeroUsize {
+        self.capacity
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transport_v2::crypto::{
+        derive_client_session, derive_server_session, HandshakeTranscript, X25519_PUBLIC_KEY_BYTES,
+    };
+    use rand_core::OsRng;
+    use std::sync::Barrier;
+    use x25519_dalek::{EphemeralSecret, PublicKey};
+
+    const REPLAY_CAPACITY: NonZeroUsize = NonZeroUsize::new(8).unwrap();
+
+    fn replay_budget(capacity: usize) -> Arc<ReplayBudget> {
+        Arc::new(ReplayBudget::new(NonZeroUsize::new(capacity).unwrap()))
+    }
+
+    fn session_at(now: Instant, marker: u8, lifetime: Duration) -> Arc<Session> {
+        let client_secret = EphemeralSecret::random_from_rng(OsRng);
+        let client_public = PublicKey::from(&client_secret).to_bytes();
+        let server_secret = EphemeralSecret::random_from_rng(OsRng);
+        let server_public = PublicKey::from(&server_secret).to_bytes();
+        let transcript = HandshakeTranscript::new([marker; 32], client_public, server_public);
+        let secrets = derive_server_session(server_secret, &transcript).unwrap();
+        Arc::new(
+            Session::new_at(secrets, now, lifetime, REPLAY_CAPACITY, replay_budget(128)).unwrap(),
+        )
+    }
+
+    #[test]
+    fn replay_claims_are_exact_and_arrival_order_independent() {
+        let registry = ReplayRegistry::new(NonZeroUsize::new(3).unwrap(), replay_budget(16));
+        let first = RequestId::from_bytes([1; 16]);
+        let second = RequestId::from_bytes([2; 16]);
+        let third = RequestId::from_bytes([3; 16]);
+
+        registry.claim(third).unwrap();
+        registry.claim(first).unwrap();
+        registry.claim(second).unwrap();
+        assert_eq!(registry.claim(first), Err(ReplayError::Duplicate));
+        assert_eq!(registry.len().unwrap(), 3);
+        assert_eq!(registry.capacity().get(), 3);
+        assert_eq!(
+            registry.claim(RequestId::from_bytes([4; 16])),
+            Err(ReplayError::SessionCapacity)
+        );
+    }
+
+    #[test]
+    fn concurrent_replay_has_exactly_one_winner() {
+        let registry = Arc::new(ReplayRegistry::new(
+            NonZeroUsize::new(4).unwrap(),
+            replay_budget(16),
+        ));
+        let barrier = Arc::new(Barrier::new(9));
+        let request_id = RequestId::from_bytes([9; 16]);
+        let mut threads = Vec::new();
+        for _ in 0..8 {
+            let registry = Arc::clone(&registry);
+            let barrier = Arc::clone(&barrier);
+            threads.push(std::thread::spawn(move || {
+                barrier.wait();
+                registry.claim(request_id)
+            }));
+        }
+        barrier.wait();
+
+        let results: Vec<_> = threads
+            .into_iter()
+            .map(|thread| thread.join().unwrap())
+            .collect();
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| **result == Err(ReplayError::Duplicate))
+                .count(),
+            7
+        );
+    }
+
+    #[test]
+    fn aggregate_replay_pressure_is_shared_retryable_and_released_on_drop() {
+        let budget = replay_budget(1);
+        assert_eq!(budget.capacity().get(), 1);
+        let first = ReplayRegistry::new(NonZeroUsize::new(8).unwrap(), Arc::clone(&budget));
+        let second = ReplayRegistry::new(NonZeroUsize::new(8).unwrap(), Arc::clone(&budget));
+
+        first.claim(RequestId::from_bytes([1; 16])).unwrap();
+        assert_eq!(budget.claimed(), 1);
+        assert_eq!(
+            second.claim(RequestId::from_bytes([2; 16])),
+            Err(ReplayError::GlobalCapacity)
+        );
+        assert_eq!(second.len().unwrap(), 0);
+
+        drop(first);
+        assert_eq!(budget.claimed(), 0);
+        second.claim(RequestId::from_bytes([2; 16])).unwrap();
+        assert_eq!(budget.claimed(), 1);
+        drop(second);
+        assert_eq!(budget.claimed(), 0);
+    }
+
+    #[test]
+    fn session_expiry_is_absolute_and_checked_before_replay_claim() {
+        let start = Instant::now();
+        let session = session_at(start, 1, Duration::from_secs(10));
+        let request_id = RequestId::from_bytes([1; 16]);
+        session
+            .claim_request_at(request_id, start + Duration::from_secs(9))
+            .unwrap();
+        assert_eq!(
+            session.claim_request_at(
+                RequestId::from_bytes([2; 16]),
+                start + Duration::from_secs(10)
+            ),
+            Err(SessionError::Expired)
+        );
+        assert_eq!(session.replay.len().unwrap(), 1);
+    }
+
+    #[test]
+    fn response_writer_releases_session_memory_but_keeps_exact_binding() {
+        let start = Instant::now();
+        let client_secret = EphemeralSecret::random_from_rng(OsRng);
+        let client_public = PublicKey::from(&client_secret).to_bytes();
+        let server_secret = EphemeralSecret::random_from_rng(OsRng);
+        let server_public = PublicKey::from(&server_secret).to_bytes();
+        let transcript = HandshakeTranscript::new([7; 32], client_public, server_public);
+        let client = derive_client_session(client_secret, &transcript).unwrap();
+        let budget = replay_budget(128);
+        let session = Arc::new(
+            Session::new_at(
+                derive_server_session(server_secret, &transcript).unwrap(),
+                start,
+                Duration::from_secs(60),
+                REPLAY_CAPACITY,
+                Arc::clone(&budget),
+            )
+            .unwrap(),
+        );
+        let request_id = RequestId::from_bytes([7; 16]);
+        let request = client.encrypt_request(request_id, b"request").unwrap();
+        let (admitted, plaintext) = session.open_and_admit(&request).unwrap();
+        assert_eq!(plaintext, b"request");
+        assert_eq!(budget.claimed(), 1);
+        assert!(matches!(
+            session.open_and_admit(&request),
+            Err(SessionError::Replay(ReplayError::Duplicate))
+        ));
+
+        let weak_session = Arc::downgrade(&session);
+        let mut writer = admitted.begin_response().unwrap();
+        drop(session);
+        assert!(weak_session.upgrade().is_none());
+        assert_eq!(budget.claimed(), 0);
+
+        let first = writer.seal_next(b"start").unwrap();
+        let second = writer.seal_next(b"end").unwrap();
+        assert_eq!(
+            client.decrypt_response(request_id, 0, &first).unwrap(),
+            b"start"
+        );
+        assert_eq!(
+            client.decrypt_response(request_id, 1, &second).unwrap(),
+            b"end"
+        );
+    }
+
+    #[test]
+    fn store_rejects_collisions_and_never_evicts_live_sessions() {
+        let start = Instant::now();
+        let store = SessionStore::new(NonZeroUsize::new(1).unwrap());
+        let first = session_at(start, 1, Duration::from_secs(60));
+        store.insert_at(Arc::clone(&first), start).unwrap();
+        assert_eq!(
+            store.insert_at(Arc::clone(&first), start),
+            Err(SessionStoreError::Collision)
+        );
+
+        let second = session_at(start, 2, Duration::from_secs(60));
+        assert_eq!(
+            store.insert_at(Arc::clone(&second), start),
+            Err(SessionStoreError::Full)
+        );
+        assert!(Arc::ptr_eq(
+            &store.get_at(first.id(), start).unwrap(),
+            &first
+        ));
+        assert!(matches!(
+            store.get_at(second.id(), start),
+            Err(SessionStoreError::Missing)
+        ));
+        assert_eq!(store.len().unwrap(), 1);
+        assert_eq!(store.capacity().get(), 1);
+    }
+
+    #[test]
+    fn expired_sessions_are_reclaimed_without_invalidating_held_leases() {
+        let start = Instant::now();
+        let store = SessionStore::new(NonZeroUsize::new(1).unwrap());
+        let first = session_at(start, 1, Duration::from_secs(10));
+        store.insert_at(Arc::clone(&first), start).unwrap();
+        let held = store.get_at(first.id(), start).unwrap();
+
+        assert!(matches!(
+            store.get_at(first.id(), start + Duration::from_secs(10)),
+            Err(SessionStoreError::Expired)
+        ));
+        assert!(Arc::ptr_eq(&held, &first));
+
+        let second = session_at(start, 2, Duration::from_secs(60));
+        store
+            .insert_at(Arc::clone(&second), start + Duration::from_secs(10))
+            .unwrap();
+        assert!(Arc::ptr_eq(
+            &store
+                .get_at(second.id(), start + Duration::from_secs(10))
+                .unwrap(),
+            &second
+        ));
+    }
+
+    #[test]
+    fn purge_and_remove_release_only_the_targeted_store_entries() {
+        let start = Instant::now();
+        let store = SessionStore::new(NonZeroUsize::new(3).unwrap());
+        let expired = session_at(start, 1, Duration::from_secs(5));
+        let live = session_at(start, 2, Duration::from_secs(60));
+        store.insert_at(Arc::clone(&expired), start).unwrap();
+        store.insert_at(Arc::clone(&live), start).unwrap();
+
+        assert_eq!(
+            store.purge_expired(start + Duration::from_secs(5)).unwrap(),
+            1
+        );
+        assert_eq!(store.len().unwrap(), 1);
+        assert!(Arc::ptr_eq(
+            &store.remove(live.id()).unwrap().unwrap(),
+            &live
+        ));
+        assert_eq!(store.len().unwrap(), 0);
+    }
+
+    #[test]
+    fn invalid_session_lifetime_is_rejected() {
+        let now = Instant::now();
+        let client_secret = EphemeralSecret::random_from_rng(OsRng);
+        let client_public = PublicKey::from(&client_secret).to_bytes();
+        let server_secret = EphemeralSecret::random_from_rng(OsRng);
+        let server_public = PublicKey::from(&server_secret).to_bytes();
+        let transcript = HandshakeTranscript::new([3; 32], client_public, server_public);
+        let secrets = derive_server_session(server_secret, &transcript).unwrap();
+        assert_eq!(
+            Session::new_at(
+                secrets,
+                now,
+                Duration::ZERO,
+                REPLAY_CAPACITY,
+                replay_budget(16),
+            )
+            .unwrap_err(),
+            SessionError::InvalidLifetime
+        );
+    }
+
+    #[test]
+    fn x25519_public_keys_remain_full_width() {
+        assert_eq!(X25519_PUBLIC_KEY_BYTES, 32);
+    }
+}

--- a/src/web/attestation_routes.rs
+++ b/src/web/attestation_routes.rs
@@ -93,17 +93,34 @@ async fn get_attestation(
     };
 
     trace!("Generating attestation based on app mode");
-    let result = match data.app_mode {
-        AppMode::Local => generate_mock_attestation(data.clone(), request).await,
-        _ => generate_real_attestation(data, request).await,
-    };
-    result
+    let document = generate_attestation_document(data, request).await?;
+    Ok(attestation_response(document))
 }
 
-async fn generate_mock_attestation(
+pub(crate) async fn generate_attestation_document(
     data: Arc<AppState>,
     request: Request,
-) -> Result<(StatusCode, Json<AttestationResponse>), ApiError> {
+) -> Result<Vec<u8>, ApiError> {
+    match data.app_mode {
+        AppMode::Local => generate_mock_attestation_document(data, request).await,
+        _ => generate_real_attestation_document(request),
+    }
+}
+
+fn attestation_response(document: Vec<u8>) -> (StatusCode, Json<AttestationResponse>) {
+    let attestation_document = general_purpose::STANDARD.encode(document);
+    (
+        StatusCode::OK,
+        Json(AttestationResponse {
+            attestation_document,
+        }),
+    )
+}
+
+async fn generate_mock_attestation_document(
+    data: Arc<AppState>,
+    request: Request,
+) -> Result<Vec<u8>, ApiError> {
     let (user_data, nonce, public_key) = match request {
         Request::Attestation {
             user_data,
@@ -148,16 +165,7 @@ async fn generate_mock_attestation(
     })?;
     trace!("COSE_Sign1 structure encoded");
 
-    // Convert to base64
-    trace!("Converting to base64");
-    let attestation_doc_base64 = general_purpose::STANDARD.encode(&final_document);
-    trace!("Converted to base64");
-    Ok((
-        StatusCode::OK,
-        Json(AttestationResponse {
-            attestation_document: attestation_doc_base64,
-        }),
-    ))
+    Ok(final_document)
 }
 
 async fn create_mock_attestation_document(
@@ -340,10 +348,7 @@ fn create_cose_sign1(payload: Vec<u8>, signature: Vec<u8>) -> Value {
     ])
 }
 
-async fn generate_real_attestation(
-    _data: Arc<AppState>,
-    request: Request,
-) -> Result<(StatusCode, Json<AttestationResponse>), ApiError> {
+fn generate_real_attestation_document(request: Request) -> Result<Vec<u8>, ApiError> {
     // Initialize the Nitro Secure Module (NSM) driver
     let nsm_fd = nsm_init();
     if nsm_fd < 0 {
@@ -358,17 +363,7 @@ async fn generate_real_attestation(
 
     // Handle the response
     match response {
-        Response::Attestation { document } => {
-            // Convert the attestation document to a base64 encoded string
-            let attestation_doc_base64 = general_purpose::STANDARD.encode(&document);
-
-            Ok((
-                StatusCode::OK,
-                Json(AttestationResponse {
-                    attestation_document: attestation_doc_base64,
-                }),
-            ))
-        }
+        Response::Attestation { document } => Ok(document),
         Response::Error(_) => {
             error!("NSM returned an error response");
             Err(ApiError::InternalServerError)

--- a/src/web/encryption_middleware.rs
+++ b/src/web/encryption_middleware.rs
@@ -20,6 +20,42 @@ use crate::{ApiError, AppState};
 
 const MAX_ENCRYPTED_BODY_BYTES: usize = 50 * 1024 * 1024; // 50MB
 
+/// Identifies the transport context that must encrypt a handler response.
+///
+/// Keeping this distinct from the application's authenticated principal makes
+/// the response transport explicit at the handler boundary. V1 contains only
+/// the legacy session identifier; future protocol versions can carry their
+/// exact response-encryption context without changing every handler again.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TransportSession {
+    kind: TransportSessionKind,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum TransportSessionKind {
+    V1 { session_id: Uuid },
+}
+
+impl TransportSession {
+    fn v1(session_id: Uuid) -> Self {
+        Self {
+            kind: TransportSessionKind::V1 { session_id },
+        }
+    }
+
+    pub(crate) async fn encrypt_response_bytes(
+        &self,
+        state: &AppState,
+        plaintext: &[u8],
+    ) -> Result<Vec<u8>, ApiError> {
+        match &self.kind {
+            TransportSessionKind::V1 { session_id } => {
+                state.encrypt_session_data(session_id, plaintext).await
+            }
+        }
+    }
+}
+
 #[derive(Deserialize)]
 pub struct EncryptedRequest {
     pub encrypted: String,
@@ -73,7 +109,9 @@ where
     if std::any::TypeId::of::<T>() == std::any::TypeId::of::<()>() {
         request.extensions_mut().insert(());
     }
-    request.extensions_mut().insert(session_id);
+    request
+        .extensions_mut()
+        .insert(TransportSession::v1(session_id));
     let response = run_next(request).await;
     Ok(hold_resource_through_response_body(response, resource))
 }
@@ -128,7 +166,9 @@ where
     })?;
 
     request.extensions_mut().insert(decrypted);
-    request.extensions_mut().insert(session_id);
+    request
+        .extensions_mut()
+        .insert(TransportSession::v1(session_id));
     let response = next.run(request).await;
     Ok(hold_resource_through_response_body(response, session_lease))
 }
@@ -175,12 +215,12 @@ where
 
 pub async fn encrypt_response<T: Serialize>(
     state: &AppState,
-    session_id: &Uuid,
+    transport_session: &TransportSession,
     response: &T,
 ) -> Result<Json<EncryptedResponse<T>>, ApiError> {
     let response_json = serde_json::to_vec(response).map_err(|_| ApiError::InternalServerError)?;
-    let encrypted_response = state
-        .encrypt_session_data(session_id, &response_json)
+    let encrypted_response = transport_session
+        .encrypt_response_bytes(state, &response_json)
         .await?;
     Ok(Json(EncryptedResponse::new(
         base64::engine::general_purpose::STANDARD.encode(encrypted_response),
@@ -274,7 +314,10 @@ mod tests {
                 .body(Body::empty())
                 .unwrap(),
             move |request| {
-                assert_eq!(request.extensions().get::<Uuid>(), Some(&session_id));
+                assert_eq!(
+                    request.extensions().get::<TransportSession>(),
+                    Some(&TransportSession::v1(session_id))
+                );
                 assert!(request.extensions().get::<()>().is_some());
                 observed_calls.fetch_add(1, Ordering::SeqCst);
                 async { Response::new(Body::empty()) }

--- a/src/web/encryption_middleware.rs
+++ b/src/web/encryption_middleware.rs
@@ -1,15 +1,16 @@
 use axum::{
     body::{Body, Bytes, HttpBody},
-    extract::State,
-    http::{HeaderMap, Method, Request},
+    extract::{FromRequestParts, State},
+    http::{request::Parts, HeaderMap, Method, Request},
     middleware::Next,
     response::{IntoResponse, Response},
     Json,
 };
 use base64::Engine;
 use http_body::{Frame, SizeHint};
-use serde::de::DeserializeOwned;
+use serde::de::{DeserializeOwned, DeserializeSeed, IgnoredAny, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -19,6 +20,175 @@ use uuid::Uuid;
 use crate::{transport_v2::crypto::SessionId, ApiError, AppState};
 
 const MAX_ENCRYPTED_BODY_BYTES: usize = 50 * 1024 * 1024; // 50MB
+
+// Containers and scalar values each count as one node; object member names do
+// not count separately. String bytes are already covered by the body-size
+// limit and do not increase this count.
+const MAX_V2_JSON_NODES: usize = 1_048_576;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum JsonComplexityError {
+    Invalid,
+    TooManyNodes,
+}
+
+struct JsonNodeBudget {
+    remaining: usize,
+    exceeded: bool,
+}
+
+impl JsonNodeBudget {
+    fn claim<E: serde::de::Error>(&mut self) -> Result<(), E> {
+        match self.remaining.checked_sub(1) {
+            Some(remaining) => {
+                self.remaining = remaining;
+                Ok(())
+            }
+            None => {
+                self.exceeded = true;
+                Err(E::custom("JSON node limit exceeded"))
+            }
+        }
+    }
+}
+
+struct JsonNode<'a> {
+    budget: &'a mut JsonNodeBudget,
+}
+
+impl<'de> DeserializeSeed<'de> for JsonNode<'_> {
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        self.budget.claim::<D::Error>()?;
+        deserializer.deserialize_any(JsonNodeVisitor {
+            budget: self.budget,
+        })
+    }
+}
+
+struct JsonNodeVisitor<'a> {
+    budget: &'a mut JsonNodeBudget,
+}
+
+impl<'de> Visitor<'de> for JsonNodeVisitor<'_> {
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a JSON value")
+    }
+
+    fn visit_bool<E>(self, _value: bool) -> Result<Self::Value, E> {
+        Ok(())
+    }
+
+    fn visit_i64<E>(self, _value: i64) -> Result<Self::Value, E> {
+        Ok(())
+    }
+
+    fn visit_u64<E>(self, _value: u64) -> Result<Self::Value, E> {
+        Ok(())
+    }
+
+    fn visit_f64<E>(self, _value: f64) -> Result<Self::Value, E> {
+        Ok(())
+    }
+
+    fn visit_str<E>(self, _value: &str) -> Result<Self::Value, E> {
+        Ok(())
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E> {
+        Ok(())
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        while sequence
+            .next_element_seed(JsonNode {
+                budget: &mut *self.budget,
+            })?
+            .is_some()
+        {}
+        Ok(())
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        while map.next_key::<IgnoredAny>()?.is_some() {
+            map.next_value_seed(JsonNode {
+                budget: &mut *self.budget,
+            })?;
+        }
+        Ok(())
+    }
+}
+
+fn validate_json_complexity(input: &[u8], max_nodes: usize) -> Result<(), JsonComplexityError> {
+    let mut budget = JsonNodeBudget {
+        remaining: max_nodes,
+        exceeded: false,
+    };
+    let mut deserializer = serde_json::Deserializer::from_slice(input);
+    let parsed = JsonNode {
+        budget: &mut budget,
+    }
+    .deserialize(&mut deserializer);
+
+    if budget.exceeded {
+        return Err(JsonComplexityError::TooManyNodes);
+    }
+    parsed.map_err(|_| JsonComplexityError::Invalid)?;
+    deserializer.end().map_err(|_| JsonComplexityError::Invalid)
+}
+
+fn validate_v2_json_body(input: &[u8], max_nodes: usize) -> Result<(), ApiError> {
+    match validate_json_complexity(input, max_nodes) {
+        Ok(()) => Ok(()),
+        Err(JsonComplexityError::Invalid) => Err(ApiError::BadRequest),
+        Err(JsonComplexityError::TooManyNodes) => Err(ApiError::PayloadTooLarge),
+    }
+}
+
+/// A decrypted request body transferred exactly once from middleware to its
+/// handler.
+///
+/// Axum's [`axum::Extension`] extractor clones the stored value. That is fine
+/// for small request metadata, but can duplicate a large deserialized request
+/// body. This extractor removes the value from the request extensions instead,
+/// preserving ordinary handler ownership without a second allocation.
+pub struct Decrypted<T>(pub T);
+
+#[axum::async_trait]
+impl<S, T> FromRequestParts<S> for Decrypted<T>
+where
+    S: Send + Sync,
+    T: Clone + Send + Sync + 'static,
+{
+    type Rejection = ApiError;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .remove::<T>()
+            .map(Self)
+            .ok_or(ApiError::InternalServerError)
+    }
+}
+
+fn store_decrypted<T>(request: &mut Request<Body>, decrypted: T)
+where
+    T: Clone + Send + Sync + 'static,
+{
+    request.extensions_mut().insert(decrypted);
+}
 
 /// Identifies the transport context that must encrypt a handler response.
 ///
@@ -186,9 +356,10 @@ where
             let body_bytes = axum::body::to_bytes(body, MAX_ENCRYPTED_BODY_BYTES)
                 .await
                 .map_err(|_| ApiError::PayloadTooLarge)?;
+            validate_v2_json_body(&body_bytes, MAX_V2_JSON_NODES)?;
             let decoded =
                 serde_json::from_slice::<T>(&body_bytes).map_err(|_| ApiError::BadRequest)?;
-            request.extensions_mut().insert(decoded);
+            store_decrypted(&mut request, decoded);
         }
 
         return Ok(next.run(request).await);
@@ -234,7 +405,7 @@ where
         ApiError::BadRequest
     })?;
 
-    request.extensions_mut().insert(decrypted);
+    store_decrypted(&mut request, decrypted);
     request
         .extensions_mut()
         .insert(TransportSession::v1(session_id));
@@ -320,6 +491,82 @@ mod tests {
     use std::num::NonZeroUsize;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
+
+    #[derive(Debug)]
+    struct CloneSpy {
+        clone_count: Arc<AtomicUsize>,
+        value: String,
+    }
+
+    impl Clone for CloneSpy {
+        fn clone(&self) -> Self {
+            self.clone_count.fetch_add(1, Ordering::SeqCst);
+            Self {
+                clone_count: self.clone_count.clone(),
+                value: self.value.clone(),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn decrypted_body_is_moved_to_the_handler_without_cloning() {
+        let clone_count = Arc::new(AtomicUsize::new(0));
+        let mut request = Request::new(Body::empty());
+        store_decrypted(
+            &mut request,
+            CloneSpy {
+                clone_count: clone_count.clone(),
+                value: "request body".to_string(),
+            },
+        );
+        let (mut parts, _) = request.into_parts();
+
+        let Decrypted(body) = Decrypted::<CloneSpy>::from_request_parts(&mut parts, &())
+            .await
+            .unwrap();
+
+        assert_eq!(body.value, "request body");
+        assert_eq!(clone_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn decrypted_body_can_only_be_extracted_once() {
+        let mut request = Request::new(Body::empty());
+        store_decrypted(&mut request, "request body".to_string());
+        let (mut parts, _) = request.into_parts();
+
+        let first = Decrypted::<String>::from_request_parts(&mut parts, &()).await;
+        let second = Decrypted::<String>::from_request_parts(&mut parts, &()).await;
+
+        assert!(matches!(first, Ok(Decrypted(body)) if body == "request body"));
+        assert!(matches!(second, Err(ApiError::InternalServerError)));
+    }
+
+    #[test]
+    fn json_complexity_counts_structure_without_counting_string_bytes() {
+        let large_string = format!(r#""{}""#, "x".repeat(128 * 1024));
+        assert_eq!(validate_json_complexity(large_string.as_bytes(), 1), Ok(()));
+
+        let structured = br#"[true,{"payload":"aGVsbG8="},[-1,1.5,null]]"#;
+        assert_eq!(validate_json_complexity(structured, 8), Ok(()));
+        assert_eq!(
+            validate_json_complexity(structured, 7),
+            Err(JsonComplexityError::TooManyNodes)
+        );
+    }
+
+    #[test]
+    fn v2_json_preflight_distinguishes_invalid_json_from_excess_structure() {
+        assert!(matches!(
+            validate_v2_json_body(br#"[1,]"#, 16),
+            Err(ApiError::BadRequest)
+        ));
+        assert!(matches!(
+            validate_v2_json_body(br#"[1,2]"#, 2),
+            Err(ApiError::PayloadTooLarge)
+        ));
+        assert!(validate_v2_json_body(br#"[1,2]"#, 3).is_ok());
+    }
 
     #[test]
     fn classifies_every_bodyless_disjunct() {

--- a/src/web/encryption_middleware.rs
+++ b/src/web/encryption_middleware.rs
@@ -3,7 +3,7 @@ use axum::{
     extract::State,
     http::{HeaderMap, Method, Request},
     middleware::Next,
-    response::Response,
+    response::{IntoResponse, Response},
     Json,
 };
 use base64::Engine;
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use uuid::Uuid;
 
-use crate::{ApiError, AppState};
+use crate::{transport_v2::crypto::SessionId, ApiError, AppState};
 
 const MAX_ENCRYPTED_BODY_BYTES: usize = 50 * 1024 * 1024; // 50MB
 
@@ -33,13 +33,41 @@ pub struct TransportSession {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum TransportSessionKind {
-    V1 { session_id: Uuid },
+    V1 {
+        session_id: Uuid,
+    },
+    #[allow(dead_code)] // Constructed by the stacked V2 gateway.
+    V2 {
+        session_id: SessionId,
+    },
 }
 
 impl TransportSession {
     fn v1(session_id: Uuid) -> Self {
         Self {
             kind: TransportSessionKind::V1 { session_id },
+        }
+    }
+
+    /// Marks a request that has already been authenticated and decrypted by
+    /// the private Transport V2 gateway. This is an in-process capability: an
+    /// HTTP caller cannot create request extensions.
+    #[allow(dead_code)] // Constructed by the stacked V2 gateway.
+    pub(crate) fn v2(session_id: SessionId) -> Self {
+        Self {
+            kind: TransportSessionKind::V2 { session_id },
+        }
+    }
+
+    pub(crate) fn is_v2(&self) -> bool {
+        matches!(&self.kind, TransportSessionKind::V2 { .. })
+    }
+
+    #[allow(dead_code)] // Used by OAuth and native handoff in the gateway layer.
+    pub(crate) fn v2_session_id(&self) -> Option<SessionId> {
+        match &self.kind {
+            TransportSessionKind::V1 { .. } => None,
+            TransportSessionKind::V2 { session_id } => Some(*session_id),
         }
     }
 
@@ -52,6 +80,27 @@ impl TransportSession {
             TransportSessionKind::V1 { session_id } => {
                 state.encrypt_session_data(session_id, plaintext).await
             }
+            TransportSessionKind::V2 { .. } => Ok(plaintext.to_vec()),
+        }
+    }
+
+    /// Returns the exact `data:` payload expected by the logical SSE stream.
+    /// V1 keeps its per-event encryption and base64 wrapper; V2 leaves the
+    /// inner stream as ordinary UTF-8 because the gateway encrypts the entire
+    /// response carrier record-by-record.
+    pub(crate) async fn encode_sse_data(
+        &self,
+        state: &AppState,
+        plaintext: &str,
+    ) -> Result<String, ApiError> {
+        match &self.kind {
+            TransportSessionKind::V1 { .. } => {
+                let encrypted = self
+                    .encrypt_response_bytes(state, plaintext.as_bytes())
+                    .await?;
+                Ok(base64::engine::general_purpose::STANDARD.encode(encrypted))
+            }
+            TransportSessionKind::V2 { .. } => Ok(plaintext.to_string()),
         }
     }
 }
@@ -125,6 +174,26 @@ pub async fn decrypt_request<T>(
 where
     T: DeserializeOwned + Send + Sync + Clone + 'static,
 {
+    if request
+        .extensions()
+        .get::<TransportSession>()
+        .is_some_and(TransportSession::is_v2)
+    {
+        if std::any::TypeId::of::<T>() == std::any::TypeId::of::<()>() {
+            request.extensions_mut().insert(());
+        } else {
+            let body = std::mem::replace(request.body_mut(), Body::empty());
+            let body_bytes = axum::body::to_bytes(body, MAX_ENCRYPTED_BODY_BYTES)
+                .await
+                .map_err(|_| ApiError::PayloadTooLarge)?;
+            let decoded =
+                serde_json::from_slice::<T>(&body_bytes).map_err(|_| ApiError::BadRequest)?;
+            request.extensions_mut().insert(decoded);
+        }
+
+        return Ok(next.run(request).await);
+    }
+
     let session_id = parse_session_id(&headers)?;
 
     // Skip body processing for GET, DELETE, or when T is ().
@@ -217,14 +286,24 @@ pub async fn encrypt_response<T: Serialize>(
     state: &AppState,
     transport_session: &TransportSession,
     response: &T,
-) -> Result<Json<EncryptedResponse<T>>, ApiError> {
+) -> Result<Response, ApiError> {
     let response_json = serde_json::to_vec(response).map_err(|_| ApiError::InternalServerError)?;
+
+    if transport_session.is_v2() {
+        return Ok((
+            [(axum::http::header::CONTENT_TYPE, "application/json")],
+            response_json,
+        )
+            .into_response());
+    }
+
     let encrypted_response = transport_session
         .encrypt_response_bytes(state, &response_json)
         .await?;
-    Ok(Json(EncryptedResponse::new(
+    Ok(Json(EncryptedResponse::<T>::new(
         base64::engine::general_purpose::STANDARD.encode(encrypted_response),
-    )))
+    ))
+    .into_response())
 }
 
 #[cfg(test)]

--- a/src/web/login_routes.rs
+++ b/src/web/login_routes.rs
@@ -5,7 +5,10 @@ use crate::{
     jwt::{validate_token, AuthContext, NewToken, TokenType},
     models::email_verification::NewEmailVerification,
 };
-use crate::{jwt::USER_REFRESH, web::encryption_middleware::EncryptedResponse};
+use crate::{
+    jwt::USER_REFRESH,
+    web::encryption_middleware::{EncryptedResponse, TransportSession},
+};
 use crate::{
     web::encryption_middleware::{decrypt_request, encrypt_response},
     Error,
@@ -134,7 +137,7 @@ pub struct LogoutRequest {
 pub async fn login(
     State(data): State<Arc<AppState>>,
     Extension(creds): Extension<Credentials>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<AuthResponse>>, ApiError> {
     tracing::trace!("call login");
 
@@ -243,7 +246,7 @@ async fn login_internal(data: Arc<AppState>, creds: Credentials) -> Result<AuthR
 pub async fn logout(
     State(data): State<Arc<AppState>>,
     Extension(logout_request): Extension<LogoutRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     info!("Logout request received");
     // TODO actually delete the refresh token
@@ -256,7 +259,7 @@ pub async fn logout(
 pub async fn register(
     State(data): State<Arc<AppState>>,
     Extension(creds): Extension<RegisterCredentials>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<AuthResponse>>, ApiError> {
     tracing::trace!("call register");
 
@@ -342,7 +345,7 @@ pub async fn handle_new_user_registration(
 pub async fn refresh_token(
     State(data): State<Arc<AppState>>,
     Extension(refresh_request): Extension<RefreshRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<RefreshResponse>>, ApiError> {
     info!("Refresh token request received");
 
@@ -376,7 +379,7 @@ pub async fn refresh_token(
 pub async fn verify_email(
     State(data): State<Arc<AppState>>,
     Path(code): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     let verification = match data.db.get_email_verification_by_code(code) {
         Ok(v) => v,
@@ -410,7 +413,7 @@ pub async fn verify_email(
 pub async fn password_reset_request(
     State(data): State<Arc<AppState>>,
     Extension(payload): Extension<PasswordResetRequestPayload>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     // Get project by client_id
     let project = data
@@ -462,7 +465,7 @@ pub async fn password_reset_request(
 pub async fn password_reset_confirm(
     State(data): State<Arc<AppState>>,
     Extension(payload): Extension<PasswordResetConfirmPayload>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     // Get project by client_id
     let project = data

--- a/src/web/login_routes.rs
+++ b/src/web/login_routes.rs
@@ -5,10 +5,7 @@ use crate::{
     jwt::{validate_token, AuthContext, NewToken, TokenType},
     models::email_verification::NewEmailVerification,
 };
-use crate::{
-    jwt::USER_REFRESH,
-    web::encryption_middleware::{EncryptedResponse, TransportSession},
-};
+use crate::{jwt::USER_REFRESH, web::encryption_middleware::TransportSession};
 use crate::{
     web::encryption_middleware::{decrypt_request, encrypt_response},
     Error,
@@ -17,8 +14,9 @@ use crate::{ApiError, AppState};
 use axum::{
     extract::{Path, State},
     middleware::from_fn_with_state,
+    response::Response,
     routing::{get, post},
-    Extension, Json, Router,
+    Extension, Router,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -138,7 +136,7 @@ pub async fn login(
     State(data): State<Arc<AppState>>,
     Extension(creds): Extension<Credentials>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<AuthResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     tracing::trace!("call login");
 
     let auth_response = login_internal(data.clone(), creds).await?;
@@ -247,7 +245,7 @@ pub async fn logout(
     State(data): State<Arc<AppState>>,
     Extension(logout_request): Extension<LogoutRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     info!("Logout request received");
     // TODO actually delete the refresh token
     drop(logout_request.refresh_token);
@@ -260,7 +258,7 @@ pub async fn register(
     State(data): State<Arc<AppState>>,
     Extension(creds): Extension<RegisterCredentials>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<AuthResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     tracing::trace!("call register");
 
     let user = match data.register_user(creds.clone()).await {
@@ -346,7 +344,7 @@ pub async fn refresh_token(
     State(data): State<Arc<AppState>>,
     Extension(refresh_request): Extension<RefreshRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<RefreshResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     info!("Refresh token request received");
 
     let claims = validate_token(&refresh_request.refresh_token, &data, USER_REFRESH)?;
@@ -380,7 +378,7 @@ pub async fn verify_email(
     State(data): State<Arc<AppState>>,
     Path(code): Path<Uuid>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     let verification = match data.db.get_email_verification_by_code(code) {
         Ok(v) => v,
         Err(DBError::EmailVerificationNotFound) => return Err(ApiError::BadRequest),
@@ -414,7 +412,7 @@ pub async fn password_reset_request(
     State(data): State<Arc<AppState>>,
     Extension(payload): Extension<PasswordResetRequestPayload>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Get project by client_id
     let project = data
         .db
@@ -466,7 +464,7 @@ pub async fn password_reset_confirm(
     State(data): State<Arc<AppState>>,
     Extension(payload): Extension<PasswordResetConfirmPayload>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Get project by client_id
     let project = data
         .db

--- a/src/web/login_routes.rs
+++ b/src/web/login_routes.rs
@@ -1,3 +1,4 @@
+use crate::transport_v2::envelope::{Credential, CredentialKind};
 use crate::User;
 use crate::{
     db::DBError,
@@ -12,8 +13,10 @@ use crate::{
 };
 use crate::{ApiError, AppState};
 use axum::{
+    body::{Body, HttpBody},
     extract::{Path, State},
-    middleware::from_fn_with_state,
+    http::Request,
+    middleware::{from_fn_with_state, Next},
     response::Response,
     routing::{get, post},
     Extension, Router,
@@ -84,7 +87,7 @@ pub fn router(app_state: Arc<AppState>) -> Router<()> {
             "/refresh",
             post(refresh_token).layer(from_fn_with_state(
                 app_state.clone(),
-                decrypt_request::<RefreshRequest>,
+                prepare_refresh_request,
             )),
         )
         .route(
@@ -127,6 +130,35 @@ pub struct RefreshResponse {
     refresh_token: String,
 }
 
+async fn prepare_refresh_request(
+    State(state): State<Arc<AppState>>,
+    mut request: Request<Body>,
+    next: Next,
+) -> Result<Response, ApiError> {
+    let is_transport_v2 = request
+        .extensions()
+        .get::<TransportSession>()
+        .is_some_and(TransportSession::is_v2);
+    if is_transport_v2 {
+        if request.body().size_hint().exact() != Some(0) {
+            return Err(ApiError::BadRequest);
+        }
+        let refresh_token = request
+            .extensions()
+            .get::<Credential>()
+            .filter(|credential| credential.kind() == CredentialKind::Resumption)
+            .map(|credential| credential.value().to_string())
+            .ok_or(ApiError::InvalidJwt)?;
+        request
+            .extensions_mut()
+            .insert(RefreshRequest { refresh_token });
+        return Ok(next.run(request).await);
+    }
+
+    let headers = request.headers().clone();
+    decrypt_request::<RefreshRequest>(State(state), headers, request, next).await
+}
+
 #[derive(Deserialize, Clone)]
 pub struct LogoutRequest {
     refresh_token: String,
@@ -139,12 +171,16 @@ pub async fn login(
 ) -> Result<Response, ApiError> {
     tracing::trace!("call login");
 
-    let auth_response = login_internal(data.clone(), creds).await?;
+    let auth_response = login_internal(data.clone(), creds, session_id.is_v2()).await?;
     let result = encrypt_response(&data, &session_id, &auth_response).await;
     result
 }
 
-async fn login_internal(data: Arc<AppState>, creds: Credentials) -> Result<AuthResponse, ApiError> {
+async fn login_internal(
+    data: Arc<AppState>,
+    creds: Credentials,
+    is_transport_v2: bool,
+) -> Result<AuthResponse, ApiError> {
     // First get the project by client_id and verify it's active
     let project = data
         .db
@@ -212,13 +248,13 @@ async fn login_internal(data: Arc<AppState>, creds: Credentials) -> Result<AuthR
         Ok(Some(authenticated_user)) => {
             let access_token = NewToken::new_with_auth_context(
                 &authenticated_user.user,
-                TokenType::Access,
+                TokenType::access_for_transport(is_transport_v2),
                 &data,
                 &authenticated_user.auth_context,
             )?;
             let refresh_token = NewToken::new_with_auth_context(
                 &authenticated_user.user,
-                TokenType::Refresh,
+                TokenType::refresh_for_transport(is_transport_v2),
                 &data,
                 &authenticated_user.auth_context,
             )?;
@@ -285,6 +321,7 @@ pub async fn register(
             password: creds.password,
             client_id: creds.client_id,
         },
+        session_id.is_v2(),
     )
     .await?;
 
@@ -347,7 +384,12 @@ pub async fn refresh_token(
 ) -> Result<Response, ApiError> {
     info!("Refresh token request received");
 
-    let claims = validate_token(&refresh_request.refresh_token, &data, USER_REFRESH)?;
+    let refresh_audience = if session_id.is_v2() {
+        crate::jwt::TRANSPORT_V2_USER_REFRESH
+    } else {
+        USER_REFRESH
+    };
+    let claims = validate_token(&refresh_request.refresh_token, &data, refresh_audience)?;
 
     // Audience check is now handled by validate_token
     let user_id = Uuid::parse_str(&claims.sub).map_err(|_| ApiError::InvalidJwt)?;
@@ -361,10 +403,18 @@ pub async fn refresh_token(
     data.verify_seed_wrap_for_auth_context(&user, &auth_context)
         .map_err(|_| ApiError::InvalidJwt)?;
 
-    let new_access_token =
-        NewToken::new_with_auth_context(&user, TokenType::Access, &data, &auth_context)?;
-    let new_refresh_token =
-        NewToken::new_with_auth_context(&user, TokenType::Refresh, &data, &auth_context)?;
+    let new_access_token = NewToken::new_with_auth_context(
+        &user,
+        TokenType::access_for_transport(session_id.is_v2()),
+        &data,
+        &auth_context,
+    )?;
+    let new_refresh_token = NewToken::new_with_auth_context(
+        &user,
+        TokenType::refresh_for_transport(session_id.is_v2()),
+        &data,
+        &auth_context,
+    )?;
 
     let response = RefreshResponse {
         access_token: new_access_token.token,

--- a/src/web/login_routes.rs
+++ b/src/web/login_routes.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use crate::{jwt::USER_REFRESH, web::encryption_middleware::TransportSession};
 use crate::{
-    web::encryption_middleware::{decrypt_request, encrypt_response},
+    web::encryption_middleware::{decrypt_request, encrypt_response, Decrypted},
     Error,
 };
 use crate::{ApiError, AppState};
@@ -166,7 +166,7 @@ pub struct LogoutRequest {
 
 pub async fn login(
     State(data): State<Arc<AppState>>,
-    Extension(creds): Extension<Credentials>,
+    Decrypted(creds): Decrypted<Credentials>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     tracing::trace!("call login");
@@ -194,7 +194,7 @@ async fn login_internal(
             match data.db.get_user_by_email(email.clone(), project.id) {
                 Ok(user) => user,
                 Err(DBError::UserNotFound) => {
-                    error!("User not found by email: {email}");
+                    error!("User not found by provided login identifier");
                     return Err(ApiError::InvalidUsernameOrPassword);
                 }
                 Err(e) => {
@@ -279,7 +279,7 @@ async fn login_internal(
 
 pub async fn logout(
     State(data): State<Arc<AppState>>,
-    Extension(logout_request): Extension<LogoutRequest>,
+    Decrypted(logout_request): Decrypted<LogoutRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     info!("Logout request received");
@@ -292,7 +292,7 @@ pub async fn logout(
 
 pub async fn register(
     State(data): State<Arc<AppState>>,
-    Extension(creds): Extension<RegisterCredentials>,
+    Decrypted(creds): Decrypted<RegisterCredentials>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     tracing::trace!("call register");
@@ -379,7 +379,7 @@ pub async fn handle_new_user_registration(
 
 pub async fn refresh_token(
     State(data): State<Arc<AppState>>,
-    Extension(refresh_request): Extension<RefreshRequest>,
+    Decrypted(refresh_request): Decrypted<RefreshRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     info!("Refresh token request received");
@@ -460,7 +460,7 @@ pub async fn verify_email(
 
 pub async fn password_reset_request(
     State(data): State<Arc<AppState>>,
-    Extension(payload): Extension<PasswordResetRequestPayload>,
+    Decrypted(payload): Decrypted<PasswordResetRequestPayload>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     // Get project by client_id
@@ -512,7 +512,7 @@ pub async fn password_reset_request(
 
 pub async fn password_reset_confirm(
     State(data): State<Arc<AppState>>,
-    Extension(payload): Extension<PasswordResetConfirmPayload>,
+    Decrypted(payload): Decrypted<PasswordResetConfirmPayload>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     // Get project by client_id

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -3,6 +3,7 @@ pub mod audio_utils;
 pub mod encryption_middleware;
 mod health_routes;
 pub mod login_routes;
+mod native_handoff_routes;
 mod oauth_routes;
 mod openai;
 pub mod openai_auth;
@@ -14,6 +15,7 @@ pub(crate) mod web_safety;
 
 pub use health_routes::router_with_state as health_routes_with_state;
 pub use login_routes::router as login_routes;
+pub(crate) use native_handoff_routes::router as native_handoff_routes;
 pub use oauth_routes::router as oauth_routes;
 pub use openai::models_router as openai_models_routes;
 pub use openai::router as openai_routes;

--- a/src/web/native_handoff_routes.rs
+++ b/src/web/native_handoff_routes.rs
@@ -1,0 +1,155 @@
+use std::{str::FromStr, sync::Arc};
+
+use axum::{
+    extract::State, middleware::from_fn_with_state, response::Response, routing::post, Extension,
+    Router,
+};
+use serde::{Deserialize, Serialize};
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use crate::{
+    db::DBError,
+    jwt::{
+        issue_native_handoff_grant, validate_jwt, validate_native_handoff_grant, AuthContext,
+        NewToken, TokenType,
+    },
+    models::users::User,
+    provider_cache::CacheNamespaceRoot,
+    transport_v2::{
+        crypto::SessionId,
+        envelope::{Credential, RequestId},
+    },
+    web::{
+        encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
+        login_routes::AuthResponse,
+    },
+    ApiError, AppState,
+};
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct NativeHandoffGrantRequest {
+    native_session_id: String,
+    native_request_id: RequestId,
+}
+
+#[derive(Serialize)]
+struct NativeHandoffGrantResponse<'a> {
+    grant: &'a str,
+    expires_at: u64,
+}
+
+#[derive(Clone, Deserialize, Zeroize, ZeroizeOnDrop)]
+#[serde(deny_unknown_fields)]
+struct NativeHandoffRedeemRequest {
+    grant: String,
+}
+
+pub(crate) fn router(app_state: Arc<AppState>) -> Router<()> {
+    let grant = Router::new()
+        .route(
+            "/auth/native-handoff/grant",
+            post(create_native_handoff_grant).layer(from_fn_with_state(
+                app_state.clone(),
+                decrypt_request::<NativeHandoffGrantRequest>,
+            )),
+        )
+        .route_layer(from_fn_with_state(app_state.clone(), validate_jwt));
+    let redeem = Router::new().route(
+        "/auth/native-handoff/redeem",
+        post(redeem_native_handoff).layer(from_fn_with_state(
+            app_state.clone(),
+            decrypt_request::<NativeHandoffRedeemRequest>,
+        )),
+    );
+    grant.merge(redeem).with_state(app_state)
+}
+
+async fn create_native_handoff_grant(
+    State(app_state): State<Arc<AppState>>,
+    Extension(session): Extension<TransportSession>,
+    Extension(user): Extension<User>,
+    Extension(auth_context): Extension<AuthContext>,
+    Extension(request): Extension<NativeHandoffGrantRequest>,
+) -> Result<Response, ApiError> {
+    if !session.is_v2() {
+        return Err(ApiError::BadRequest);
+    }
+    let target_session_id =
+        SessionId::from_str(&request.native_session_id).map_err(|_| ApiError::BadRequest)?;
+    let mut issued = issue_native_handoff_grant(
+        &user,
+        &auth_context,
+        target_session_id,
+        request.native_request_id,
+        &app_state,
+    )?;
+    let expires_at =
+        u64::try_from(issued.expires_at.timestamp()).map_err(|_| ApiError::InternalServerError)?;
+    let response = encrypt_response(
+        &app_state,
+        &session,
+        &NativeHandoffGrantResponse {
+            grant: &issued.grant,
+            expires_at,
+        },
+    )
+    .await;
+    issued.grant.zeroize();
+    response
+}
+
+async fn redeem_native_handoff(
+    State(app_state): State<Arc<AppState>>,
+    Extension(session): Extension<TransportSession>,
+    Extension(request_id): Extension<RequestId>,
+    credential: Option<Extension<Credential>>,
+    cache_root: Option<Extension<CacheNamespaceRoot>>,
+    Extension(request): Extension<NativeHandoffRedeemRequest>,
+) -> Result<Response, ApiError> {
+    let session_id = session.v2_session_id().ok_or(ApiError::BadRequest)?;
+    if credential.is_some() || cache_root.is_some() {
+        return Err(ApiError::BadRequest);
+    }
+
+    let (user_id, auth_context) =
+        validate_native_handoff_grant(&request.grant, session_id, request_id, &app_state)?;
+    let user = app_state
+        .db
+        .get_user_by_uuid(user_id)
+        .map_err(|error| match error {
+            DBError::UserNotFound => ApiError::InvalidJwt,
+            _ => ApiError::InternalServerError,
+        })?;
+    if user.project_id != auth_context.project_id
+        || app_state
+            .verify_seed_wrap_for_auth_context(&user, &auth_context)
+            .is_err()
+    {
+        return Err(ApiError::InvalidJwt);
+    }
+
+    let access_token = NewToken::new_with_auth_context(
+        &user,
+        TokenType::TransportV2Access,
+        &app_state,
+        &auth_context,
+    )?;
+    let refresh_token = NewToken::new_with_auth_context(
+        &user,
+        TokenType::TransportV2Refresh,
+        &app_state,
+        &auth_context,
+    )?;
+    encrypt_response(
+        &app_state,
+        &session,
+        &AuthResponse {
+            id: user.uuid,
+            email: user.email,
+            access_token: access_token.token,
+            refresh_token: refresh_token.token,
+        },
+    )
+    .await
+}

--- a/src/web/native_handoff_routes.rs
+++ b/src/web/native_handoff_routes.rs
@@ -20,7 +20,7 @@ use crate::{
         envelope::{Credential, RequestId},
     },
     web::{
-        encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
+        encryption_middleware::{decrypt_request, encrypt_response, Decrypted, TransportSession},
         login_routes::AuthResponse,
     },
     ApiError, AppState,
@@ -70,7 +70,7 @@ async fn create_native_handoff_grant(
     Extension(session): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(request): Extension<NativeHandoffGrantRequest>,
+    Decrypted(request): Decrypted<NativeHandoffGrantRequest>,
 ) -> Result<Response, ApiError> {
     if !session.is_v2() {
         return Err(ApiError::BadRequest);
@@ -105,7 +105,7 @@ async fn redeem_native_handoff(
     Extension(request_id): Extension<RequestId>,
     credential: Option<Extension<Credential>>,
     cache_root: Option<Extension<CacheNamespaceRoot>>,
-    Extension(request): Extension<NativeHandoffRedeemRequest>,
+    Decrypted(request): Decrypted<NativeHandoffRedeemRequest>,
 ) -> Result<Response, ApiError> {
     let session_id = session.v2_session_id().ok_or(ApiError::BadRequest)?;
     if credential.is_some() || cache_root.is_some() {

--- a/src/web/oauth_routes.rs
+++ b/src/web/oauth_routes.rs
@@ -3,9 +3,7 @@ use crate::apple_signin::{generate_apple_client_secret, validate_apple_native_to
 use crate::models::oauth::NewUserOAuthConnection;
 use crate::models::oauth::UserOAuthConnection;
 use crate::oauth::{BasicClient, OAuthState};
-use crate::web::encryption_middleware::{
-    decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
-};
+use crate::web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession};
 use crate::web::login_routes::handle_new_user_registration;
 use crate::web::platform::common::{
     PROJECT_APPLE_OAUTH_SECRET, PROJECT_GITHUB_OAUTH_SECRET, PROJECT_GOOGLE_OAUTH_SECRET,
@@ -24,8 +22,9 @@ use crate::{
 };
 use axum::{
     extract::{Extension, State},
+    response::Response,
     routing::post,
-    Json, Router,
+    Router,
 };
 use base64::Engine as _;
 use oauth2::TokenResponse;
@@ -425,7 +424,7 @@ pub async fn initiate_oauth(
     Extension(auth_request): Extension<OAuthAuthRequest>,
     Extension(session_id): Extension<TransportSession>,
     provider_name: &str,
-) -> Result<Json<EncryptedResponse<OAuthOAuthCallbackResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Get project
     let project = app_state
         .db
@@ -477,7 +476,7 @@ pub async fn oauth_callback(
     Extension(callback_request): Extension<OAuthCallbackRequest>,
     Extension(session_id): Extension<TransportSession>,
     provider_name: &str,
-) -> Result<Json<EncryptedResponse<OAuthCallbackResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!(
         "Received code (redacted, len={})",
         callback_request.code.len()
@@ -1282,7 +1281,7 @@ pub async fn handle_apple_native_signin(
     State(app_state): State<Arc<AppState>>,
     Extension(request): Extension<AppleNativeSignInRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<OAuthCallbackResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Handling Apple native sign-in");
 
     // Get project

--- a/src/web/oauth_routes.rs
+++ b/src/web/oauth_routes.rs
@@ -2,7 +2,7 @@ use crate::apple_signin::{generate_apple_client_secret, validate_apple_native_to
 #[cfg(test)]
 use crate::models::oauth::NewUserOAuthConnection;
 use crate::models::oauth::UserOAuthConnection;
-use crate::oauth::{BasicClient, OAuthState};
+use crate::oauth::{BasicClient, OAuthCodeBinding, OAuthState};
 use crate::web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession};
 use crate::web::login_routes::handle_new_user_registration;
 use crate::web::platform::common::{
@@ -443,8 +443,43 @@ pub async fn initiate_oauth(
             ApiError::InternalServerError
         })?;
 
-    // Generate initial authorization URL to get the CSRF token
-    let (initial_url, csrf_token) = oauth_provider.generate_authorize_url(&oauth_client).await;
+    // V2 adds a provider-verified authorization-code binding. V1 deliberately
+    // retains its existing authorization URL and state behavior.
+    let v2_session_id = session_id.v2_session_id();
+    let (initial_url, csrf_token, code_binding) = if v2_session_id.is_some() {
+        let authorization = match provider_name {
+            "github" => {
+                oauth_provider
+                    .as_github()
+                    .ok_or(ApiError::InternalServerError)?
+                    .generate_bound_authorize_url(&oauth_client)
+                    .await
+            }
+            "google" => {
+                oauth_provider
+                    .as_google()
+                    .ok_or(ApiError::InternalServerError)?
+                    .generate_bound_authorize_url(&oauth_client)
+                    .await
+            }
+            "apple" => {
+                oauth_provider
+                    .as_apple()
+                    .ok_or(ApiError::InternalServerError)?
+                    .generate_bound_authorize_url(&oauth_client)
+                    .await
+            }
+            _ => return Err(ApiError::InternalServerError),
+        };
+        (
+            authorization.auth_url,
+            authorization.csrf_token,
+            Some(authorization.code_binding),
+        )
+    } else {
+        let (auth_url, csrf_token) = oauth_provider.generate_authorize_url(&oauth_client).await;
+        (auth_url, csrf_token, None)
+    };
 
     // Create our state that includes both CSRF token and client_id
     let state = OAuthState {
@@ -453,10 +488,25 @@ pub async fn initiate_oauth(
     };
 
     // Store the complete state in the provider
-    oauth_provider
-        .store_state(csrf_token.secret(), state.clone())
-        .await
-        .map_err(|_| ApiError::TooManyRequests)?;
+    match (v2_session_id, code_binding) {
+        (Some(session_id), Some(code_binding)) => {
+            oauth_provider
+                .store_state_for_session(
+                    csrf_token.secret(),
+                    state.clone(),
+                    session_id,
+                    code_binding,
+                )
+                .await
+        }
+        (None, None) => {
+            oauth_provider
+                .store_state(csrf_token.secret(), state.clone())
+                .await
+        }
+        _ => return Err(ApiError::InternalServerError),
+    }
+    .map_err(|_| ApiError::TooManyRequests)?;
 
     let state_json = serde_json::to_string(&state).map_err(|_| ApiError::InternalServerError)?;
     let state_base64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(state_json);
@@ -508,12 +558,28 @@ pub async fn oauth_callback(
 
     // Validate and atomically consume the complete state so a successful match is one-time.
     // A mismatched state is left in the store for the legitimate callback.
-    let is_valid = oauth_provider.consume_state(&state).await;
+    let is_transport_v2 = session_id.is_v2();
+    let code_binding = match session_id.v2_session_id() {
+        Some(session_id) => oauth_provider
+            .consume_state_for_session(&state, session_id)
+            .await
+            .map(Some),
+        None => oauth_provider.consume_state(&state).await.then_some(None),
+    };
 
-    if !is_valid {
+    let Some(code_binding) = code_binding else {
         error!("Invalid state in {} callback", provider_name);
         return Err(ApiError::BadRequest);
-    }
+    };
+
+    let (pkce_verifier, apple_nonce) = match (is_transport_v2, provider_name, code_binding) {
+        (false, _, None) => (None, None),
+        (true, "github" | "google", Some(OAuthCodeBinding::Pkce(verifier))) => {
+            (Some(verifier), None)
+        }
+        (true, "apple", Some(OAuthCodeBinding::AppleNonce(nonce))) => (None, Some(nonce)),
+        _ => return Err(ApiError::InternalServerError),
+    };
 
     // Get project (we can trust the client_id now since we validated it against our stored state)
     debug!("Getting project from client_id: {:?}", state.client_id);
@@ -746,14 +812,17 @@ pub async fn oauth_callback(
                 error!("Failed to build OAuth HTTP client: {:?}", e);
                 ApiError::InternalServerError
             })?;
-        let token = oauth_client
-            .exchange_code(AuthorizationCode::new(callback_request.code.clone()))
-            .request_async(&http_client)
-            .await
-            .map_err(|e| {
-                error!("Failed to exchange code for access token: {:?}", e);
-                ApiError::InternalServerError
-            })?;
+        let exchange =
+            oauth_client.exchange_code(AuthorizationCode::new(callback_request.code.clone()));
+        let exchange = if let Some(verifier) = pkce_verifier {
+            exchange.set_pkce_verifier(verifier)
+        } else {
+            exchange
+        };
+        let token = exchange.request_async(&http_client).await.map_err(|e| {
+            error!("Failed to exchange code for access token: {:?}", e);
+            ApiError::InternalServerError
+        })?;
 
         // No ID token for non-Apple providers
         (token, None)
@@ -868,7 +937,14 @@ pub async fn oauth_callback(
             })?;
 
             // Verify the token just like we do for native sign-in
-            let apple_user = match fetch_apple_user(&app_state, &id_token, &client_id).await {
+            let apple_user = match fetch_apple_user(
+                &app_state,
+                &id_token,
+                &client_id,
+                apple_nonce.as_ref().map(|nonce| nonce.as_str()),
+            )
+            .await
+            {
                 Ok(user) => {
                     debug!("Successfully verified Apple ID token");
                     user
@@ -903,7 +979,8 @@ pub async fn oauth_callback(
         }
     };
 
-    let auth_response = oauth_callback_response(&app_state, &authenticated_user)?;
+    let auth_response =
+        oauth_callback_response(&app_state, &authenticated_user, session_id.is_v2())?;
     encrypt_response(&app_state, &session_id, &auth_response).await
 }
 
@@ -1070,13 +1147,19 @@ async fn fetch_apple_user(
     app_state: &AppState,
     id_token: &str,
     client_id: &str,
+    expected_nonce: Option<&str>,
 ) -> Result<AppleUser, ApiError> {
     debug!("Parsing and validating Apple ID token");
 
-    // Validate the token using the shared verifier (no nonce validation for now in web flow)
-    let claims =
-        validate_apple_native_token(&app_state.apple_jwt_verifier, id_token, client_id, None)
-            .await?;
+    // V2 requires the provider-signed ID token to carry the nonce generated
+    // for this exact state and session. V1 continues without nonce validation.
+    let claims = validate_apple_native_token(
+        &app_state.apple_jwt_verifier,
+        id_token,
+        client_id,
+        expected_nonce,
+    )
+    .await?;
 
     // Create an AppleUser from the claims
     let apple_user = AppleUser {
@@ -1124,10 +1207,11 @@ fn authenticated_oauth_user(
 fn oauth_callback_response(
     app_state: &AppState,
     authenticated_user: &AuthenticatedOAuthUser,
+    is_transport_v2: bool,
 ) -> Result<OAuthCallbackResponse, ApiError> {
     let access_token = NewToken::new_with_auth_context(
         &authenticated_user.user,
-        TokenType::Access,
+        TokenType::access_for_transport(is_transport_v2),
         app_state,
         &authenticated_user.auth_context,
     )
@@ -1137,7 +1221,7 @@ fn oauth_callback_response(
     })?;
     let refresh_token = NewToken::new_with_auth_context(
         &authenticated_user.user,
-        TokenType::Refresh,
+        TokenType::refresh_for_transport(is_transport_v2),
         app_state,
         &authenticated_user.auth_context,
     )
@@ -1382,7 +1466,8 @@ pub async fn handle_apple_native_signin(
 
         let authenticated_user =
             authenticated_oauth_user(&app_state, user, "apple", &verified_user_id)?;
-        let auth_response = oauth_callback_response(&app_state, &authenticated_user)?;
+        let auth_response =
+            oauth_callback_response(&app_state, &authenticated_user, session_id.is_v2())?;
 
         debug!("Apple sign-in successful for existing user");
         return encrypt_response(&app_state, &session_id, &auth_response).await;
@@ -1450,7 +1535,8 @@ pub async fn handle_apple_native_signin(
     )
     .await?;
 
-    let auth_response = oauth_callback_response(&app_state, &authenticated_user)?;
+    let auth_response =
+        oauth_callback_response(&app_state, &authenticated_user, session_id.is_v2())?;
 
     debug!("Apple native sign-in successful for new user");
     encrypt_response(&app_state, &session_id, &auth_response).await

--- a/src/web/oauth_routes.rs
+++ b/src/web/oauth_routes.rs
@@ -3,7 +3,9 @@ use crate::apple_signin::{generate_apple_client_secret, validate_apple_native_to
 use crate::models::oauth::NewUserOAuthConnection;
 use crate::models::oauth::UserOAuthConnection;
 use crate::oauth::{BasicClient, OAuthCodeBinding, OAuthState};
-use crate::web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession};
+use crate::web::encryption_middleware::{
+    decrypt_request, encrypt_response, Decrypted, TransportSession,
+};
 use crate::web::login_routes::handle_new_user_registration;
 use crate::web::platform::common::{
     PROJECT_APPLE_OAUTH_SECRET, PROJECT_GITHUB_OAUTH_SECRET, PROJECT_GOOGLE_OAUTH_SECRET,
@@ -421,7 +423,7 @@ async fn get_project_oauth_client(
 
 pub async fn initiate_oauth(
     State(app_state): State<Arc<AppState>>,
-    Extension(auth_request): Extension<OAuthAuthRequest>,
+    Decrypted(auth_request): Decrypted<OAuthAuthRequest>,
     Extension(session_id): Extension<TransportSession>,
     provider_name: &str,
 ) -> Result<Response, ApiError> {
@@ -523,7 +525,7 @@ pub async fn initiate_oauth(
 
 pub async fn oauth_callback(
     State(app_state): State<Arc<AppState>>,
-    Extension(callback_request): Extension<OAuthCallbackRequest>,
+    Decrypted(callback_request): Decrypted<OAuthCallbackRequest>,
     Extension(session_id): Extension<TransportSession>,
     provider_name: &str,
 ) -> Result<Response, ApiError> {
@@ -531,7 +533,10 @@ pub async fn oauth_callback(
         "Received code (redacted, len={})",
         callback_request.code.len()
     );
-    debug!("Received state: {}", callback_request.state);
+    debug!(
+        "Received OAuth state (redacted, len={})",
+        callback_request.state.len()
+    );
 
     // Decode and parse the state
     let state_json = base64::engine::general_purpose::URL_SAFE_NO_PAD
@@ -753,28 +758,10 @@ pub async fn oauth_callback(
 
         // Check if successful
         if !status.is_success() {
-            let error_text = response.text().await.unwrap_or_default();
-            error!("Error response from Apple: {}", error_text);
-
-            // Try to parse the error as JSON for more details
-            if let Ok(error_json) = serde_json::from_str::<serde_json::Value>(&error_text) {
-                if let Some(error_obj) = error_json.get("error") {
-                    error!("Error type: {}", error_obj);
-
-                    // If it's an invalid_client error, log diagnostic info
-                    if error_obj.as_str() == Some("invalid_client") {
-                        error!("invalid_client error detected - this typically means the client_secret JWT is invalid");
-                        error!("JWT verification failed - check Team ID, Key ID, and private key configuration");
-                    }
-                }
-            }
-
-            error!("Apple OAuth token exchange failed. Possible issues:");
-            error!("1. Client ID might be wrong (check if it needs .services suffix)");
-            error!("2. Team ID or Key ID might not match the private key");
-            error!("3. Private key might be invalid or in wrong format");
-            error!("4. The authorization code might be invalid or expired");
-            error!("5. Redirect URI might not match the one used in the authorization request");
+            error!(
+                "Apple OAuth token exchange returned non-success status: {}",
+                status
+            );
 
             return Err(ApiError::InternalServerError);
         }
@@ -1010,16 +997,11 @@ async fn fetch_github_user(
     trace!("GitHub API response headers: {:?}", headers);
 
     if !status.is_success() {
-        let error_body = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "Unable to read error body".to_string());
         error!(
             "GitHub API returned non-success status: {} {}",
             status,
             status.canonical_reason().unwrap_or("")
         );
-        error!("Error response body: {}", error_body);
         return Err(ApiError::InternalServerError);
     }
 
@@ -1031,8 +1013,11 @@ async fn fetch_github_user(
     trace!("GitHub user response body: {}", user_body);
 
     let mut github_user: GithubUser = serde_json::from_str(&user_body).map_err(|e| {
-        error!("Failed to parse GitHub user JSON: {:?}", e);
-        error!("GitHub user response body: {}", user_body);
+        error!(
+            "Failed to parse GitHub user JSON: {} (response_bytes={})",
+            e,
+            user_body.len()
+        );
         ApiError::InternalServerError
     })?;
 
@@ -1057,16 +1042,11 @@ async fn fetch_github_user(
         trace!("GitHub emails API response headers: {:?}", emails_headers);
 
         if !emails_status.is_success() {
-            let error_body = emails_response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unable to read error body".to_string());
             error!(
                 "GitHub API returned non-success status for emails: {} {}",
                 emails_status,
                 emails_status.canonical_reason().unwrap_or("")
             );
-            error!("Error response body for emails: {}", error_body);
             return Err(ApiError::InternalServerError);
         }
 
@@ -1078,8 +1058,11 @@ async fn fetch_github_user(
         trace!("GitHub emails response body: {}", emails_body);
 
         let emails: Vec<GithubEmail> = serde_json::from_str(&emails_body).map_err(|e| {
-            error!("Failed to parse GitHub emails JSON: {:?}", e);
-            error!("GitHub emails response body: {}", emails_body);
+            error!(
+                "Failed to parse GitHub emails JSON: {} (response_bytes={})",
+                e,
+                emails_body.len()
+            );
             ApiError::InternalServerError
         })?;
 
@@ -1118,14 +1101,7 @@ async fn fetch_google_user(
 
     let status = response.status();
     if !status.is_success() {
-        let error_body = response
-            .text()
-            .await
-            .unwrap_or_else(|_| "Unable to read error body".to_string());
-        error!(
-            "Google API returned non-success status: {} {}",
-            status, error_body
-        );
+        error!("Google API returned non-success status: {}", status);
         return Err(ApiError::InternalServerError);
     }
 
@@ -1363,7 +1339,7 @@ async fn find_or_create_user_from_oauth(
 /// Handler for Apple native sign-in (iOS Sign in with Apple)
 pub async fn handle_apple_native_signin(
     State(app_state): State<Arc<AppState>>,
-    Extension(request): Extension<AppleNativeSignInRequest>,
+    Decrypted(request): Decrypted<AppleNativeSignInRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     debug!("Handling Apple native sign-in");
@@ -1451,10 +1427,7 @@ pub async fn handle_apple_native_signin(
             ApiError::InternalServerError
         })?
     {
-        debug!(
-            "Found existing connection for Apple ID: {}",
-            verified_user_id
-        );
+        debug!("Found existing Apple OAuth connection");
 
         let user = app_state.db.get_user_by_uuid(connection.user_id)?;
         if user.project_id != project.id {
@@ -1474,10 +1447,7 @@ pub async fn handle_apple_native_signin(
     }
 
     // If we get here, user doesn't exist - need to create new user
-    debug!(
-        "No existing user found with Apple ID: {}, creating new user",
-        verified_user_id
-    );
+    debug!("No existing Apple OAuth connection; creating new user");
 
     // For new users, we absolutely need an email
     // Determine the email to use - prioritize the one from the token if available

--- a/src/web/oauth_routes.rs
+++ b/src/web/oauth_routes.rs
@@ -3,7 +3,9 @@ use crate::apple_signin::{generate_apple_client_secret, validate_apple_native_to
 use crate::models::oauth::NewUserOAuthConnection;
 use crate::models::oauth::UserOAuthConnection;
 use crate::oauth::{BasicClient, OAuthState};
-use crate::web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse};
+use crate::web::encryption_middleware::{
+    decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+};
 use crate::web::login_routes::handle_new_user_registration;
 use crate::web::platform::common::{
     PROJECT_APPLE_OAUTH_SECRET, PROJECT_GITHUB_OAUTH_SECRET, PROJECT_GOOGLE_OAUTH_SECRET,
@@ -421,7 +423,7 @@ async fn get_project_oauth_client(
 pub async fn initiate_oauth(
     State(app_state): State<Arc<AppState>>,
     Extension(auth_request): Extension<OAuthAuthRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     provider_name: &str,
 ) -> Result<Json<EncryptedResponse<OAuthOAuthCallbackResponse>>, ApiError> {
     // Get project
@@ -473,7 +475,7 @@ pub async fn initiate_oauth(
 pub async fn oauth_callback(
     State(app_state): State<Arc<AppState>>,
     Extension(callback_request): Extension<OAuthCallbackRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     provider_name: &str,
 ) -> Result<Json<EncryptedResponse<OAuthCallbackResponse>>, ApiError> {
     debug!(
@@ -1279,7 +1281,7 @@ async fn find_or_create_user_from_oauth(
 pub async fn handle_apple_native_signin(
     State(app_state): State<Arc<AppState>>,
     Extension(request): Extension<AppleNativeSignInRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<OAuthCallbackResponse>>, ApiError> {
     debug!("Handling Apple native sign-in");
 

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -11,9 +11,7 @@ use crate::provider_routing::{ProviderName, ProviderRoutingError};
 use crate::proxy_config::ProxyConfig;
 use crate::sqs::UsageEvent;
 use crate::web::audio_utils::{merge_transcriptions, AudioSplitter, TINFOIL_MAX_SIZE};
-use crate::web::encryption_middleware::{
-    decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
-};
+use crate::web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession};
 use crate::web::openai_auth::AuthMethod;
 use crate::web::responses::{ResponseExecution, ResponseExecutionTaskGuard};
 use crate::{ApiError, AppState};
@@ -23,7 +21,7 @@ use axum::{
     response::sse::{Event, Sse},
     response::{IntoResponse, Response},
     routing::{get, post},
-    Json, Router,
+    Router,
 };
 use base64::{engine::general_purpose, Engine as _};
 use bigdecimal::BigDecimal;
@@ -813,9 +811,16 @@ async fn proxy_openai(
     let billing_context = BillingContext::new(auth_method, requested_model_name);
 
     // Get the completion stream - billing happens automatically inside!
-    let completion =
-        get_chat_completion_response(&state, &user, body, &headers, billing_context, model_plan)
-            .await?;
+    let completion = get_chat_completion_response(
+        &state,
+        &user,
+        body,
+        &headers,
+        billing_context,
+        model_plan,
+        session_id.is_v2(),
+    )
+    .await?;
 
     debug!(
         "Received completion from provider: {} (streaming: {})",
@@ -844,7 +849,9 @@ async fn proxy_openai(
     debug!("Handling streaming response");
     let mut rx = completion.stream;
 
+    let require_explicit_terminal = session_id.is_v2();
     let stream = async_stream::stream! {
+        let mut saw_terminal = false;
         while let Some(chunk) = rx.recv().await {
             match chunk {
                 CompletionChunk::StreamChunk(json) => {
@@ -867,10 +874,12 @@ async fn proxy_openai(
                     trace!("Received usage chunk (billing already processed)");
                 }
                 CompletionChunk::Done => {
+                    saw_terminal = true;
                     yield Ok(Event::default().data("[DONE]"));
                     break;
                 }
                 CompletionChunk::Error(error_msg) => {
+                    saw_terminal = true;
                     error!("Stream error from completion API: {}", error_msg);
                     match encrypt_sse_event(&state, &session_id, &stream_error_payload(&error_msg)).await {
                         Ok(event) => yield Ok(event),
@@ -883,6 +892,7 @@ async fn proxy_openai(
                     break;
                 }
                 CompletionChunk::FullResponse(_) => {
+                    saw_terminal = true;
                     // Shouldn't happen in streaming mode
                     error!("Received FullResponse in streaming mode");
                     match encrypt_sse_event(&state, &session_id, &stream_error_payload("Invalid event format")).await {
@@ -894,6 +904,22 @@ async fn proxy_openai(
                         }
                     }
                     break;
+                }
+            }
+        }
+
+        if require_explicit_terminal && !saw_terminal {
+            error!("Completion stream closed without a terminal event");
+            match encrypt_sse_event(
+                &state,
+                &session_id,
+                &stream_error_payload("Completion stream ended unexpectedly"),
+            )
+            .await
+            {
+                Ok(event) => yield Ok(event),
+                Err(error) => {
+                    error!("Failed to encode terminal stream error: {:?}", error);
                 }
             }
         }
@@ -927,6 +953,7 @@ pub async fn get_chat_completion_response(
     headers: &HeaderMap,
     billing_context: BillingContext,
     model_plan: ModelPlan,
+    require_provider_done: bool,
 ) -> Result<CompletionStream, ApiError> {
     get_chat_completion_response_with_expected_route(
         state,
@@ -938,6 +965,7 @@ pub async fn get_chat_completion_response(
         None,
         None,
         None,
+        require_provider_done,
     )
     .await
 }
@@ -952,6 +980,7 @@ pub(crate) async fn get_chat_completion_response_for_execution(
     billing_context: BillingContext,
     model_plan: ModelPlan,
     response_execution: ResponseExecution,
+    require_provider_done: bool,
 ) -> Result<CompletionStream, ApiError> {
     let response_execution_guard = response_execution.begin_task().map_err(|_| {
         debug!("Response execution was cancelled before a provider turn could start");
@@ -967,6 +996,7 @@ pub(crate) async fn get_chat_completion_response_for_execution(
         None,
         Some(response_execution),
         Some(response_execution_guard),
+        require_provider_done,
     )
     .await
 }
@@ -1000,6 +1030,7 @@ pub(crate) async fn get_chat_completion_response_for_expected_route(
         }),
         None,
         None,
+        false,
     )
     .await
 }
@@ -1027,6 +1058,7 @@ async fn get_chat_completion_response_with_expected_route(
     expected_route: Option<ExpectedCompletionRoute<'_>>,
     response_execution: Option<ResponseExecution>,
     response_execution_guard: Option<ResponseExecutionTaskGuard>,
+    require_provider_done: bool,
 ) -> Result<CompletionStream, ApiError> {
     if body.is_null() || body.as_object().is_none_or(|obj| obj.is_empty()) {
         error!("Request body is empty or invalid");
@@ -1424,7 +1456,14 @@ async fn get_chat_completion_response_with_expected_route(
                         &tx_consumer,
                     )
                     .await;
-                    let _ = tx_consumer.send(CompletionChunk::Done).await;
+                    let terminal = if require_provider_done {
+                        CompletionChunk::Error(
+                            "Provider stream ended before its completion marker".to_string(),
+                        )
+                    } else {
+                        CompletionChunk::Done
+                    };
+                    let _ = tx_consumer.send(terminal).await;
                     return;
                 }
                 Err(_) => {
@@ -1791,23 +1830,21 @@ async fn encrypt_sse_event(
     json: &Value,
 ) -> Result<Event, ApiError> {
     let json_str = json.to_string();
-    let encrypted_data = transport_session
-        .encrypt_response_bytes(state, json_str.as_bytes())
+    let event_data = transport_session
+        .encode_sse_data(state, &json_str)
         .await
         .map_err(|e| {
-            error!("Failed to encrypt SSE event data: {:?}", e);
+            error!("Failed to encode SSE event data: {:?}", e);
             ApiError::InternalServerError
         })?;
-
-    let base64_encrypted = general_purpose::STANDARD.encode(&encrypted_data);
-    Ok(Event::default().data(base64_encrypted))
+    Ok(Event::default().data(event_data))
 }
 
 async fn proxy_models(
     State(state): State<Arc<AppState>>,
     axum::Extension(session_id): axum::Extension<TransportSession>,
     user: Option<axum::Extension<User>>,
-) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     let _ = user;
     let proxy_config = state.proxy_router.get_completion_proxy();
     let models_response = if proxy_config.provider_name == "tinfoil" {
@@ -1871,7 +1908,7 @@ async fn proxy_model_catalog(
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(_body): axum::Extension<()>,
-) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     let billing_access = state.chat_billing_access(user.uuid, false).await;
     let model_plan = ModelPlan::from_is_paid(
         billing_access.is_some_and(crate::billing::ChatBillingAccess::is_paid),
@@ -1986,7 +2023,7 @@ async fn proxy_transcription(
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(transcription_request): axum::Extension<TranscriptionRequest>,
-) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Check if guest user is allowed (paid guests are allowed, free guests are not)
     if user.is_guest() {
         if let Some(billing_client) = &state.billing_client {
@@ -2391,7 +2428,7 @@ async fn proxy_tts(
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(tts_request): axum::Extension<TTSRequest>,
-) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     let prepared = prepare_tts_request(tts_request).map_err(|validation_error| {
         warn!(
             error = %validation_error,
@@ -2484,7 +2521,7 @@ async fn proxy_embeddings(
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(embedding_request): axum::Extension<EmbeddingRequest>,
-) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Check if guest user is allowed (paid guests are allowed, free guests are not)
     if user.is_guest() {
         if let Some(billing_client) = &state.billing_client {

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -11,7 +11,9 @@ use crate::provider_routing::{ProviderName, ProviderRoutingError};
 use crate::proxy_config::ProxyConfig;
 use crate::sqs::UsageEvent;
 use crate::web::audio_utils::{merge_transcriptions, AudioSplitter, TINFOIL_MAX_SIZE};
-use crate::web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse};
+use crate::web::encryption_middleware::{
+    decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+};
 use crate::web::openai_auth::AuthMethod;
 use crate::web::responses::{ResponseExecution, ResponseExecutionTaskGuard};
 use crate::{ApiError, AppState};
@@ -755,7 +757,7 @@ pub fn models_router(app_state: Arc<AppState>) -> Router<()> {
 async fn proxy_openai(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
-    axum::Extension(session_id): axum::Extension<Uuid>,
+    axum::Extension(session_id): axum::Extension<TransportSession>,
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(auth_method): axum::Extension<AuthMethod>,
     axum::Extension(mut body): axum::Extension<Value>,
@@ -1785,12 +1787,12 @@ fn build_usage_event(
 /// Helper to encrypt an SSE event
 async fn encrypt_sse_event(
     state: &AppState,
-    session_id: &Uuid,
+    transport_session: &TransportSession,
     json: &Value,
 ) -> Result<Event, ApiError> {
     let json_str = json.to_string();
-    let encrypted_data = state
-        .encrypt_session_data(session_id, json_str.as_bytes())
+    let encrypted_data = transport_session
+        .encrypt_response_bytes(state, json_str.as_bytes())
         .await
         .map_err(|e| {
             error!("Failed to encrypt SSE event data: {:?}", e);
@@ -1803,7 +1805,7 @@ async fn encrypt_sse_event(
 
 async fn proxy_models(
     State(state): State<Arc<AppState>>,
-    axum::Extension(session_id): axum::Extension<Uuid>,
+    axum::Extension(session_id): axum::Extension<TransportSession>,
     user: Option<axum::Extension<User>>,
 ) -> Result<Json<EncryptedResponse<Value>>, ApiError> {
     let _ = user;
@@ -1865,7 +1867,7 @@ async fn fetch_provider_models(
 async fn proxy_model_catalog(
     State(state): State<Arc<AppState>>,
     _headers: HeaderMap,
-    axum::Extension(session_id): axum::Extension<Uuid>,
+    axum::Extension(session_id): axum::Extension<TransportSession>,
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(_body): axum::Extension<()>,
@@ -1980,7 +1982,7 @@ async fn send_transcription_with_retries(
 async fn proxy_transcription(
     State(state): State<Arc<AppState>>,
     _headers: HeaderMap,
-    axum::Extension(session_id): axum::Extension<Uuid>,
+    axum::Extension(session_id): axum::Extension<TransportSession>,
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(transcription_request): axum::Extension<TranscriptionRequest>,
@@ -2385,7 +2387,7 @@ async fn ensure_paid_tts_access(state: &AppState, user: &User) -> Result<(), Api
 
 async fn proxy_tts(
     State(state): State<Arc<AppState>>,
-    axum::Extension(session_id): axum::Extension<Uuid>,
+    axum::Extension(session_id): axum::Extension<TransportSession>,
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(tts_request): axum::Extension<TTSRequest>,
@@ -2478,7 +2480,7 @@ async fn proxy_tts(
 async fn proxy_embeddings(
     State(state): State<Arc<AppState>>,
     _headers: HeaderMap,
-    axum::Extension(session_id): axum::Extension<Uuid>,
+    axum::Extension(session_id): axum::Extension<TransportSession>,
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
     axum::Extension(embedding_request): axum::Extension<EmbeddingRequest>,

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -14,7 +14,9 @@ use crate::provider_routing::{ProviderName, ProviderRoutingError};
 use crate::proxy_config::ProxyConfig;
 use crate::sqs::UsageEvent;
 use crate::web::audio_utils::{merge_transcriptions, AudioSplitter, TINFOIL_MAX_SIZE};
-use crate::web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession};
+use crate::web::encryption_middleware::{
+    decrypt_request, encrypt_response, Decrypted, TransportSession,
+};
 use crate::web::openai_auth::AuthMethod;
 use crate::web::responses::{ResponseExecution, ResponseExecutionTaskGuard};
 use crate::{ApiError, AppState};
@@ -836,7 +838,7 @@ async fn proxy_openai(
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(auth_method): axum::Extension<AuthMethod>,
     cache_namespace_root: Option<axum::Extension<CacheNamespaceRoot>>,
-    axum::Extension(mut body): axum::Extension<Value>,
+    Decrypted(mut body): Decrypted<Value>,
 ) -> Result<Response, ApiError> {
     let cache_policy = CompletionCachePolicy::for_request(
         &session_id,
@@ -1931,13 +1933,9 @@ async fn fetch_provider_models(
 
     if !res.is_success() {
         let status = res.status_code();
-        let body_bytes = res.bytes().await.ok();
-        let error_msg = body_bytes
-            .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
-            .unwrap_or_else(|| status.to_string());
         error!(
-            "Provider {} returned non-success status for models: {} - {}",
-            proxy_config.provider_name, status, error_msg
+            "Provider {} returned non-success status for models: {}",
+            proxy_config.provider_name, status
         );
         return Err(ApiError::InternalServerError);
     }
@@ -2074,7 +2072,7 @@ async fn proxy_transcription(
     axum::Extension(session_id): axum::Extension<TransportSession>,
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
-    axum::Extension(transcription_request): axum::Extension<TranscriptionRequest>,
+    Decrypted(transcription_request): Decrypted<TranscriptionRequest>,
 ) -> Result<Response, ApiError> {
     // Check if guest user is allowed (paid guests are allowed, free guests are not)
     if user.is_guest() {
@@ -2392,14 +2390,9 @@ async fn send_transcription_request(
                 Ok(response_json)
             } else {
                 let status = res.status_code();
-                let body_bytes = res.bytes().await.ok();
-                let error_msg = body_bytes
-                    .map(|b| String::from_utf8_lossy(&b).to_string())
-                    .unwrap_or_else(|| status.to_string());
-
                 error!(
-                    "Provider {} returned transcription error: {} - {}",
-                    provider.provider_name, status, error_msg
+                    "Provider {} returned non-success status for transcription: {}",
+                    provider.provider_name, status
                 );
                 Err(ApiError::InternalServerError)
             }
@@ -2479,7 +2472,7 @@ async fn proxy_tts(
     axum::Extension(session_id): axum::Extension<TransportSession>,
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
-    axum::Extension(tts_request): axum::Extension<TTSRequest>,
+    Decrypted(tts_request): Decrypted<TTSRequest>,
 ) -> Result<Response, ApiError> {
     let prepared = prepare_tts_request(tts_request).map_err(|validation_error| {
         warn!(
@@ -2581,7 +2574,7 @@ async fn proxy_embeddings(
     axum::Extension(session_id): axum::Extension<TransportSession>,
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(_auth_method): axum::Extension<AuthMethod>,
-    axum::Extension(embedding_request): axum::Extension<EmbeddingRequest>,
+    Decrypted(embedding_request): Decrypted<EmbeddingRequest>,
 ) -> Result<Response, ApiError> {
     // Check if guest user is allowed (paid guests are allowed, free guests are not)
     if user.is_guest() {
@@ -2650,13 +2643,9 @@ async fn proxy_embeddings(
 
     if !res.is_success() {
         let status = res.status_code();
-        let body_bytes = res.bytes().await.ok();
-        let error_msg = body_bytes
-            .map(|b| String::from_utf8_lossy(&b).to_string())
-            .unwrap_or_else(|| status.to_string());
         error!(
-            "Embeddings proxy returned non-success status: {} - {}",
-            status, error_msg
+            "Provider {} returned non-success status for embeddings: {}",
+            proxy_config.provider_name, status
         );
         return Err(ApiError::InternalServerError);
     }

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -4,6 +4,9 @@ use crate::model_config::{
 };
 use crate::models::token_usage::NewTokenUsage;
 use crate::models::users::User;
+use crate::provider_cache::{
+    derive_tinfoil_cache_namespace, CacheNamespaceRoot, DerivedCacheNamespace,
+};
 use crate::provider_client::{
     ProviderClient, ProviderRequest, ProviderRequestError, ProviderResponse,
 };
@@ -15,8 +18,9 @@ use crate::web::encryption_middleware::{decrypt_request, encrypt_response, Trans
 use crate::web::openai_auth::AuthMethod;
 use crate::web::responses::{ResponseExecution, ResponseExecutionTaskGuard};
 use crate::{ApiError, AppState};
-use axum::http::HeaderMap;
+use axum::http::{header, HeaderMap};
 use axum::{
+    body::Body,
     extract::State,
     response::sse::{Event, Sse},
     response::{IntoResponse, Response},
@@ -52,6 +56,37 @@ const MAX_BOUNDED_PROVIDER_RESPONSE_BYTES: usize = 256 * 1024;
 
 const PROVIDER_MANAGED_CACHE_SALT_FIELD: &str = "cache_salt";
 const PROVIDER_MANAGED_USER_CACHE_SECRET_FIELD: &str = "user_cache_secret";
+
+/// The provider cache namespace is an explicit input to every completion.
+/// This prevents a V2 request from silently falling back to the legacy,
+/// operator-computable SHA256(user UUID) namespace.
+#[derive(Clone)]
+pub(crate) enum CompletionCachePolicy {
+    LegacyV1,
+    BoundV2(DerivedCacheNamespace),
+}
+
+impl CompletionCachePolicy {
+    pub(crate) fn for_request(
+        transport: &TransportSession,
+        cache_namespace_root: Option<CacheNamespaceRoot>,
+        verified_user_id: Uuid,
+    ) -> Result<Self, ApiError> {
+        if transport.is_v2() {
+            let root = cache_namespace_root.ok_or(ApiError::BadRequest)?;
+            Ok(Self::BoundV2(derive_tinfoil_cache_namespace(
+                &root,
+                verified_user_id,
+            )))
+        } else {
+            Ok(Self::LegacyV1)
+        }
+    }
+
+    pub(crate) const fn requires_provider_done(&self) -> bool {
+        matches!(self, Self::BoundV2(_))
+    }
+}
 
 #[derive(Clone, Default)]
 struct CompletionRequestLogMetadata {
@@ -519,6 +554,48 @@ pub struct BillingContext {
     pub model_name: String,
 }
 
+/// Application policy carried with an internal completion request.
+///
+/// Keeping these values together makes it difficult for nested inference paths
+/// to forget the transport-specific cache boundary while retaining the shared
+/// completion implementation used by Chat and Responses.
+pub(crate) struct CompletionExecutionContext<'a> {
+    billing: BillingContext,
+    model_plan: ModelPlan,
+    cache: &'a CompletionCachePolicy,
+    response_execution: Option<ResponseExecution>,
+    response_execution_guard: Option<ResponseExecutionTaskGuard>,
+}
+
+impl<'a> CompletionExecutionContext<'a> {
+    pub(crate) const fn new(
+        billing: BillingContext,
+        model_plan: ModelPlan,
+        cache: &'a CompletionCachePolicy,
+    ) -> Self {
+        Self {
+            billing,
+            model_plan,
+            cache,
+            response_execution: None,
+            response_execution_guard: None,
+        }
+    }
+
+    fn with_response_execution(
+        mut self,
+        response_execution: ResponseExecution,
+    ) -> Result<Self, ApiError> {
+        let response_execution_guard = response_execution.begin_task().map_err(|_| {
+            debug!("Response execution was cancelled before a provider turn could start");
+            ApiError::ServiceUnavailable
+        })?;
+        self.response_execution = Some(response_execution);
+        self.response_execution_guard = Some(response_execution_guard);
+        Ok(self)
+    }
+}
+
 impl BillingContext {
     pub fn new(auth_method: AuthMethod, model_name: String) -> Self {
         Self {
@@ -758,8 +835,14 @@ async fn proxy_openai(
     axum::Extension(session_id): axum::Extension<TransportSession>,
     axum::Extension(user): axum::Extension<User>,
     axum::Extension(auth_method): axum::Extension<AuthMethod>,
+    cache_namespace_root: Option<axum::Extension<CacheNamespaceRoot>>,
     axum::Extension(mut body): axum::Extension<Value>,
 ) -> Result<Response, ApiError> {
+    let cache_policy = CompletionCachePolicy::for_request(
+        &session_id,
+        cache_namespace_root.map(|axum::Extension(root)| root),
+        user.uuid,
+    )?;
     let billing_access = state
         .chat_billing_access(user.uuid, auth_method == AuthMethod::ApiKey)
         .await;
@@ -816,9 +899,7 @@ async fn proxy_openai(
         &user,
         body,
         &headers,
-        billing_context,
-        model_plan,
-        session_id.is_v2(),
+        CompletionExecutionContext::new(billing_context, model_plan, &cache_policy),
     )
     .await?;
 
@@ -951,23 +1032,10 @@ pub async fn get_chat_completion_response(
     user: &User,
     body: Value,
     headers: &HeaderMap,
-    billing_context: BillingContext,
-    model_plan: ModelPlan,
-    require_provider_done: bool,
+    execution: CompletionExecutionContext<'_>,
 ) -> Result<CompletionStream, ApiError> {
-    get_chat_completion_response_with_expected_route(
-        state,
-        user,
-        body,
-        headers,
-        billing_context,
-        model_plan,
-        None,
-        None,
-        None,
-        require_provider_done,
-    )
-    .await
+    get_chat_completion_response_with_expected_route(state, user, body, headers, execution, None)
+        .await
 }
 
 /// Responses-only completion entry point with process-local task ownership.
@@ -977,28 +1045,12 @@ pub(crate) async fn get_chat_completion_response_for_execution(
     user: &User,
     body: Value,
     headers: &HeaderMap,
-    billing_context: BillingContext,
-    model_plan: ModelPlan,
+    execution: CompletionExecutionContext<'_>,
     response_execution: ResponseExecution,
-    require_provider_done: bool,
 ) -> Result<CompletionStream, ApiError> {
-    let response_execution_guard = response_execution.begin_task().map_err(|_| {
-        debug!("Response execution was cancelled before a provider turn could start");
-        ApiError::ServiceUnavailable
-    })?;
-    get_chat_completion_response_with_expected_route(
-        state,
-        user,
-        body,
-        headers,
-        billing_context,
-        model_plan,
-        None,
-        Some(response_execution),
-        Some(response_execution_guard),
-        require_provider_done,
-    )
-    .await
+    let execution = execution.with_response_execution(response_execution)?;
+    get_chat_completion_response_with_expected_route(state, user, body, headers, execution, None)
+        .await
 }
 
 /// Run an entitled completion only if routing resolves to the server-selected
@@ -1010,8 +1062,7 @@ pub(crate) async fn get_chat_completion_response_for_expected_route(
     user: &User,
     body: Value,
     headers: &HeaderMap,
-    billing_context: BillingContext,
-    model_plan: ModelPlan,
+    execution: CompletionExecutionContext<'_>,
     route: ServerSelectedCompletionRoute<'_>,
 ) -> Result<CompletionStream, ApiError> {
     let continuum_cache_salt = (route.provider_name == ProviderName::Continuum.as_str())
@@ -1021,16 +1072,12 @@ pub(crate) async fn get_chat_completion_response_for_expected_route(
         user,
         body,
         headers,
-        billing_context,
-        model_plan,
+        execution,
         Some(ExpectedCompletionRoute {
             provider_name: route.provider_name,
             provider_model_id: route.provider_model_id,
             continuum_cache_salt,
         }),
-        None,
-        None,
-        false,
     )
     .await
 }
@@ -1047,19 +1094,24 @@ struct ExpectedCompletionRoute<'a> {
     continuum_cache_salt: Option<String>,
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn get_chat_completion_response_with_expected_route(
     state: &Arc<AppState>,
     user: &User,
     body: Value,
     headers: &HeaderMap,
-    mut billing_context: BillingContext,
-    model_plan: ModelPlan,
+    execution: CompletionExecutionContext<'_>,
     expected_route: Option<ExpectedCompletionRoute<'_>>,
-    response_execution: Option<ResponseExecution>,
-    response_execution_guard: Option<ResponseExecutionTaskGuard>,
-    require_provider_done: bool,
 ) -> Result<CompletionStream, ApiError> {
+    let CompletionExecutionContext {
+        mut billing,
+        model_plan,
+        cache,
+        response_execution,
+        response_execution_guard,
+    } = execution;
+    let billing_context = &mut billing;
+    let cache_policy = cache;
+    let require_provider_done = cache_policy.requires_provider_done();
     if body.is_null() || body.as_object().is_none_or(|obj| obj.is_empty()) {
         error!("Request body is empty or invalid");
         return Err(ApiError::BadRequest);
@@ -1167,6 +1219,7 @@ async fn get_chat_completion_response_with_expected_route(
         &mut modified_body,
         &selected_route.proxy.provider_name,
         user.uuid,
+        cache_policy,
     );
     if let Some(expected_route) = &expected_route {
         apply_server_selected_cache_isolation(
@@ -1281,14 +1334,8 @@ async fn get_chat_completion_response_with_expected_route(
 
         // ✅ Handle billing HERE, inside completions API
         if let Some(usage) = extract_usage(&response_json) {
-            publish_usage_event_internal(
-                state,
-                user,
-                &billing_context,
-                usage,
-                &successful_provider,
-            )
-            .await;
+            publish_usage_event_internal(state, user, billing_context, usage, &successful_provider)
+                .await;
         }
 
         // Return the full response as a single chunk
@@ -1587,6 +1634,7 @@ fn apply_provider_managed_request_fields(
     body: &mut serde_json::Map<String, Value>,
     provider_name: &str,
     user_uuid: Uuid,
+    cache_policy: &CompletionCachePolicy,
 ) {
     if body.remove(PROVIDER_MANAGED_CACHE_SALT_FIELD).is_some() {
         debug!("Stripped provider-managed completion request field: cache_salt");
@@ -1597,9 +1645,13 @@ fn apply_provider_managed_request_fields(
         .is_some();
 
     if provider_name == ProviderName::Tinfoil.as_str() {
+        let user_cache_secret = match cache_policy {
+            CompletionCachePolicy::LegacyV1 => tinfoil_user_cache_secret(user_uuid),
+            CompletionCachePolicy::BoundV2(namespace) => namespace.tinfoil_user_cache_secret(),
+        };
         body.insert(
             PROVIDER_MANAGED_USER_CACHE_SECRET_FIELD.to_string(),
-            json!(tinfoil_user_cache_secret(user_uuid)),
+            json!(user_cache_secret),
         );
         if replaced_user_cache_secret {
             debug!("Replaced provider-managed completion request field: user_cache_secret");
@@ -2491,8 +2543,7 @@ async fn proxy_tts(
         ApiError::InternalServerError
     })??;
 
-    let (response_payload, is_json_response) =
-        build_tts_response_payload(&body_bytes, &response_content_type);
+    let is_json_response = serde_json::from_slice::<Value>(&body_bytes).is_ok();
     if is_json_response {
         warn!(
             model = %prepared.model,
@@ -2510,7 +2561,17 @@ async fn proxy_tts(
         );
     }
 
-    // Encrypt and return the response
+    // Transport V2 encrypts the complete logical HTTP response in the gateway,
+    // so it can preserve the provider's native audio or JSON bytes. V1 keeps
+    // its established JSON/base64 response contract unchanged.
+    if session_id.is_v2() {
+        return Response::builder()
+            .header(header::CONTENT_TYPE, response_content_type)
+            .body(Body::from(body_bytes))
+            .map_err(|_| ApiError::InternalServerError);
+    }
+
+    let (response_payload, _) = build_tts_response_payload(&body_bytes, &response_content_type);
     encrypt_response(&state, &session_id, &response_payload).await
 }
 
@@ -3140,12 +3201,46 @@ mod tests {
             ("messages".to_string(), json!([])),
         ]);
 
-        apply_provider_managed_request_fields(&mut body, ProviderName::Tinfoil.as_str(), user_uuid);
+        apply_provider_managed_request_fields(
+            &mut body,
+            ProviderName::Tinfoil.as_str(),
+            user_uuid,
+            &CompletionCachePolicy::LegacyV1,
+        );
 
         assert_eq!(body.get("model"), Some(&json!("kimi-k2-6")));
         assert_eq!(body.get("messages"), Some(&json!([])));
         assert!(!body.contains_key(PROVIDER_MANAGED_CACHE_SALT_FIELD));
         assert_eq!(
+            body.get(PROVIDER_MANAGED_USER_CACHE_SECRET_FIELD),
+            Some(&json!(tinfoil_user_cache_secret(user_uuid)))
+        );
+    }
+
+    #[test]
+    fn bound_v2_cache_namespace_replaces_legacy_and_client_values() {
+        let user_uuid = Uuid::from_u128(42);
+        let root = CacheNamespaceRoot::from_bytes([0x55; 32]);
+        let namespace = derive_tinfoil_cache_namespace(&root, user_uuid);
+        let expected = namespace.tinfoil_user_cache_secret();
+        let mut body = serde_json::Map::from_iter([
+            ("cache_salt".to_string(), json!("user-supplied")),
+            ("user_cache_secret".to_string(), json!("client-controlled")),
+        ]);
+
+        apply_provider_managed_request_fields(
+            &mut body,
+            ProviderName::Tinfoil.as_str(),
+            user_uuid,
+            &CompletionCachePolicy::BoundV2(namespace),
+        );
+
+        assert!(!body.contains_key(PROVIDER_MANAGED_CACHE_SALT_FIELD));
+        assert_eq!(
+            body.get(PROVIDER_MANAGED_USER_CACHE_SECRET_FIELD),
+            Some(&json!(expected))
+        );
+        assert_ne!(
             body.get(PROVIDER_MANAGED_USER_CACHE_SECRET_FIELD),
             Some(&json!(tinfoil_user_cache_secret(user_uuid)))
         );
@@ -3162,6 +3257,7 @@ mod tests {
             &mut body,
             ProviderName::Continuum.as_str(),
             Uuid::from_u128(42),
+            &CompletionCachePolicy::LegacyV1,
         );
 
         assert!(!body.contains_key(PROVIDER_MANAGED_CACHE_SALT_FIELD));
@@ -3180,6 +3276,7 @@ mod tests {
             &mut body,
             ProviderName::Continuum.as_str(),
             user_uuid,
+            &CompletionCachePolicy::LegacyV1,
         );
         assert!(!body.contains_key(PROVIDER_MANAGED_CACHE_SALT_FIELD));
 

--- a/src/web/openai_auth.rs
+++ b/src/web/openai_auth.rs
@@ -1,4 +1,8 @@
-use crate::jwt::{validate_access_token_for_auth, AuthContext, USER_ACCESS};
+use crate::jwt::{
+    validate_access_token_for_auth, AuthContext, TRANSPORT_V2_USER_ACCESS, USER_ACCESS,
+};
+use crate::transport_v2::envelope::{Credential, CredentialKind};
+use crate::web::encryption_middleware::TransportSession;
 use crate::ApiError;
 use axum::{
     body::Body,
@@ -17,31 +21,54 @@ pub enum AuthMethod {
     ApiKey,
 }
 
+#[derive(Clone, Copy)]
+enum PresentedCredential<'a> {
+    ApiKey(&'a str),
+    Bearer(&'a str),
+}
+
 pub async fn validate_openai_auth(
     State(data): State<Arc<crate::AppState>>,
     mut req: Request<Body>,
     next: Next,
 ) -> Response {
-    // Extract Authorization header
-    if let Some(auth_header) = req
-        .headers()
-        .get(header::AUTHORIZATION)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.strip_prefix("Bearer "))
-    {
-        // Check if it's a UUID (API key) or JWT (contains dots)
-        if !auth_header.contains('.') {
-            // Try to parse as UUID (API key)
-            if let Ok(api_key_uuid) = Uuid::parse_str(auth_header) {
-                // Hash the API key (UUID string with dashes)
+    let is_transport_v2 = req
+        .extensions()
+        .get::<TransportSession>()
+        .is_some_and(TransportSession::is_v2);
+    let presented = if is_transport_v2 {
+        match req.extensions().get::<Credential>() {
+            Some(credential) if credential.kind() == CredentialKind::ApiKey => {
+                PresentedCredential::ApiKey(credential.value())
+            }
+            Some(credential) if credential.kind() == CredentialKind::Bearer => {
+                PresentedCredential::Bearer(credential.value())
+            }
+            _ => return ApiError::InvalidJwt.into_response(),
+        }
+    } else {
+        let Some(value) = req
+            .headers()
+            .get(header::AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.strip_prefix("Bearer "))
+        else {
+            return ApiError::InvalidJwt.into_response();
+        };
+        if value.contains('.') {
+            PresentedCredential::Bearer(value)
+        } else {
+            PresentedCredential::ApiKey(value)
+        }
+    };
+
+    let token = match presented {
+        PresentedCredential::ApiKey(api_key) => match Uuid::parse_str(api_key) {
+            Ok(api_key_uuid) => {
                 let mut hasher = Sha256::new();
-                hasher.update(api_key_uuid.to_string().as_bytes()); // to_string() includes dashes
+                hasher.update(api_key_uuid.to_string().as_bytes());
                 let key_hash = format!("{:x}", hasher.finalize());
-
-                // Look up the API key in database
-                let db_result = data.db.get_user_by_api_key_hash(&key_hash);
-
-                match db_result {
+                match data.db.get_user_by_api_key_hash(&key_hash) {
                     Ok(Some(user)) => {
                         req.extensions_mut().insert(user);
                         req.extensions_mut().insert(AuthMethod::ApiKey);
@@ -57,26 +84,26 @@ pub async fn validate_openai_auth(
                     }
                 }
             }
-        }
-    }
-
-    // Fall back to JWT validation
-    // Try to validate as JWT
-    let token = match req
-        .headers()
-        .get(header::AUTHORIZATION)
-        .and_then(|auth_header| auth_header.to_str().ok())
-        .and_then(|auth_value| auth_value.strip_prefix("Bearer ").map(ToString::to_string))
-    {
-        Some(token) => token,
-        None => return ApiError::InvalidJwt.into_response(),
+            Err(_) if is_transport_v2 => return ApiError::Unauthorized.into_response(),
+            // Preserve V1's legacy behavior: a non-UUID bearer without dots
+            // falls through to JWT validation and returns InvalidJwt.
+            Err(_) => api_key,
+        },
+        PresentedCredential::Bearer(token) => token,
     };
 
-    let (claims, access_token_expired) =
-        match validate_access_token_for_auth(&token, &data, USER_ACCESS) {
-            Ok(validation) => validation,
-            Err(_) => return ApiError::InvalidJwt.into_response(),
-        };
+    let (claims, access_token_expired) = match validate_access_token_for_auth(
+        token,
+        &data,
+        if is_transport_v2 {
+            TRANSPORT_V2_USER_ACCESS
+        } else {
+            USER_ACCESS
+        },
+    ) {
+        Ok(validation) => validation,
+        Err(_) => return ApiError::InvalidJwt.into_response(),
+    };
 
     let auth_context = match AuthContext::from_claims(&claims) {
         Ok(auth_context) => auth_context,
@@ -130,7 +157,16 @@ pub async fn validate_optional_openai_auth(
     req: Request<Body>,
     next: Next,
 ) -> Response {
-    if !req.headers().contains_key(header::AUTHORIZATION) {
+    let is_transport_v2 = req
+        .extensions()
+        .get::<TransportSession>()
+        .is_some_and(TransportSession::is_v2);
+    let has_credential = if is_transport_v2 {
+        req.extensions().get::<Credential>().is_some()
+    } else {
+        req.headers().contains_key(header::AUTHORIZATION)
+    };
+    if !has_credential {
         return next.run(req).await;
     }
 

--- a/src/web/platform/invite_routes.rs
+++ b/src/web/platform/invite_routes.rs
@@ -5,7 +5,9 @@ use crate::{
         org_memberships::{NewOrgMembership, OrgRole},
         platform_users::PlatformUser,
     },
-    web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+    web::encryption_middleware::{
+        decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+    },
     ApiError, AppState, DBError,
 };
 use axum::{
@@ -55,7 +57,7 @@ async fn create_invite(
     Extension(platform_user): Extension<PlatformUser>,
     Path(org_id): Path<Uuid>,
     Extension(create_request): Extension<CreateInviteRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<InviteResponse>>, ApiError> {
     debug!("Creating invite");
 
@@ -133,7 +135,7 @@ async fn list_invites(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path(org_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<Vec<InviteResponse>>>, ApiError> {
     debug!("Listing organization invites");
 
@@ -187,7 +189,7 @@ async fn get_invite(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, invite_code)): Path<(Uuid, Uuid)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<DetailedInviteResponse>>, ApiError> {
     debug!("Getting invite by code");
 
@@ -247,7 +249,7 @@ async fn delete_invite(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, invite_code)): Path<(Uuid, Uuid)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     debug!("Deleting invite");
 
@@ -299,7 +301,7 @@ async fn accept_invite(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path(code): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     debug!("Accepting invite");
 

--- a/src/web/platform/invite_routes.rs
+++ b/src/web/platform/invite_routes.rs
@@ -5,16 +5,15 @@ use crate::{
         org_memberships::{NewOrgMembership, OrgRole},
         platform_users::PlatformUser,
     },
-    web::encryption_middleware::{
-        decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
-    },
+    web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
     ApiError, AppState, DBError,
 };
 use axum::{
     extract::{Path, State},
     middleware::from_fn_with_state,
+    response::Response,
     routing::{delete, get, post},
-    Extension, Json, Router,
+    Extension, Router,
 };
 use std::sync::Arc;
 use tokio::spawn;
@@ -58,7 +57,7 @@ async fn create_invite(
     Path(org_id): Path<Uuid>,
     Extension(create_request): Extension<CreateInviteRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<InviteResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Creating invite");
 
     // Get the org by UUID
@@ -136,7 +135,7 @@ async fn list_invites(
     Extension(platform_user): Extension<PlatformUser>,
     Path(org_id): Path<Uuid>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<Vec<InviteResponse>>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Listing organization invites");
 
     // Get the org by UUID
@@ -169,7 +168,7 @@ async fn list_invites(
         .filter(|invite| !invite.used && invite.expires_at > now)
         .collect::<Vec<_>>();
 
-    let response = active_invites
+    let response: Vec<InviteResponse> = active_invites
         .into_iter()
         .map(|invite| InviteResponse {
             code: invite.code,
@@ -190,7 +189,7 @@ async fn get_invite(
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, invite_code)): Path<(Uuid, Uuid)>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<DetailedInviteResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Getting invite by code");
 
     // Get the org by UUID
@@ -250,7 +249,7 @@ async fn delete_invite(
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, invite_code)): Path<(Uuid, Uuid)>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Deleting invite");
 
     // Get the org by UUID
@@ -302,7 +301,7 @@ async fn accept_invite(
     Extension(platform_user): Extension<PlatformUser>,
     Path(code): Path<Uuid>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Accepting invite");
 
     // Get and validate the invite code

--- a/src/web/platform/invite_routes.rs
+++ b/src/web/platform/invite_routes.rs
@@ -5,7 +5,7 @@ use crate::{
         org_memberships::{NewOrgMembership, OrgRole},
         platform_users::PlatformUser,
     },
-    web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
+    web::encryption_middleware::{decrypt_request, encrypt_response, Decrypted, TransportSession},
     ApiError, AppState, DBError,
 };
 use axum::{
@@ -55,7 +55,7 @@ async fn create_invite(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path(org_id): Path<Uuid>,
-    Extension(create_request): Extension<CreateInviteRequest>,
+    Decrypted(create_request): Decrypted<CreateInviteRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     debug!("Creating invite");

--- a/src/web/platform/login_routes.rs
+++ b/src/web/platform/login_routes.rs
@@ -6,7 +6,7 @@ use crate::{
         platform_users::NewPlatformUser,
     },
     transport_v2::envelope::{Credential, CredentialKind},
-    web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
+    web::encryption_middleware::{decrypt_request, encrypt_response, Decrypted, TransportSession},
     ApiError, AppState, Error,
 };
 use axum::{
@@ -225,12 +225,12 @@ async fn prepare_platform_refresh_request(
 
 pub async fn login_platform_user(
     State(data): State<Arc<AppState>>,
-    Extension(login_request): Extension<PlatformLoginRequest>,
+    Decrypted(login_request): Decrypted<PlatformLoginRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     // Validate request
-    if let Err(errors) = login_request.validate() {
-        error!("Validation error: {:?}", errors);
+    if login_request.validate().is_err() {
+        error!("Platform login request validation failed");
         return Err(ApiError::BadRequest);
     }
 
@@ -285,12 +285,12 @@ async fn login_internal_platform(
 
 pub async fn register_platform_user(
     State(data): State<Arc<AppState>>,
-    Extension(register_request): Extension<PlatformRegisterRequest>,
+    Decrypted(register_request): Decrypted<PlatformRegisterRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     // Validate request
-    if let Err(errors) = register_request.validate() {
-        error!("Validation error: {:?}", errors);
+    if register_request.validate().is_err() {
+        error!("Platform registration request validation failed");
         return Err(ApiError::BadRequest);
     }
 
@@ -398,12 +398,12 @@ pub async fn register_platform_user(
 
 pub async fn refresh_platform_token(
     State(data): State<Arc<AppState>>,
-    Extension(refresh_request): Extension<PlatformRefreshRequest>,
+    Decrypted(refresh_request): Decrypted<PlatformRefreshRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     // Validate request
-    if let Err(errors) = refresh_request.validate() {
-        error!("Validation error: {:?}", errors);
+    if refresh_request.validate().is_err() {
+        error!("Platform token refresh request validation failed");
         return Err(ApiError::BadRequest);
     }
 
@@ -492,7 +492,7 @@ pub async fn verify_platform_email(
 
 pub async fn logout_platform_user(
     State(data): State<Arc<AppState>>,
-    Extension(logout_request): Extension<PlatformLogoutRequest>,
+    Decrypted(logout_request): Decrypted<PlatformLogoutRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     info!("Platform logout request received");
@@ -506,12 +506,12 @@ pub async fn logout_platform_user(
 
 pub async fn platform_password_reset_request(
     State(data): State<Arc<AppState>>,
-    Extension(payload): Extension<PlatformPasswordResetRequestPayload>,
+    Decrypted(payload): Decrypted<PlatformPasswordResetRequestPayload>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     // Validate request
-    if let Err(errors) = payload.validate() {
-        error!("Validation error: {:?}", errors);
+    if payload.validate().is_err() {
+        error!("Platform password reset request validation failed");
         return Err(ApiError::BadRequest);
     }
 
@@ -558,12 +558,12 @@ pub async fn platform_password_reset_request(
 
 pub async fn platform_password_reset_confirm(
     State(data): State<Arc<AppState>>,
-    Extension(payload): Extension<PlatformPasswordResetConfirmPayload>,
+    Decrypted(payload): Decrypted<PlatformPasswordResetConfirmPayload>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     // Validate request
-    if let Err(errors) = payload.validate() {
-        error!("Validation error: {:?}", errors);
+    if payload.validate().is_err() {
+        error!("Platform password reset confirmation validation failed");
         return Err(ApiError::BadRequest);
     }
 

--- a/src/web/platform/login_routes.rs
+++ b/src/web/platform/login_routes.rs
@@ -5,16 +5,15 @@ use crate::{
         org_memberships::OrgRole, platform_email_verification::NewPlatformEmailVerification,
         platform_users::NewPlatformUser,
     },
-    web::encryption_middleware::{
-        decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
-    },
+    web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
     ApiError, AppState, Error,
 };
 use axum::{
     extract::{Path, State},
     middleware::from_fn_with_state,
+    response::Response,
     routing::{get, post},
-    Extension, Json, Router,
+    Extension, Router,
 };
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -196,7 +195,7 @@ pub async fn login_platform_user(
     State(data): State<Arc<AppState>>,
     Extension(login_request): Extension<PlatformLoginRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<PlatformAuthResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Validate request
     if let Err(errors) = login_request.validate() {
         error!("Validation error: {:?}", errors);
@@ -248,7 +247,7 @@ pub async fn register_platform_user(
     State(data): State<Arc<AppState>>,
     Extension(register_request): Extension<PlatformRegisterRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<PlatformAuthResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Validate request
     if let Err(errors) = register_request.validate() {
         error!("Validation error: {:?}", errors);
@@ -353,7 +352,7 @@ pub async fn refresh_platform_token(
     State(data): State<Arc<AppState>>,
     Extension(refresh_request): Extension<PlatformRefreshRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<PlatformRefreshResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Validate request
     if let Err(errors) = refresh_request.validate() {
         error!("Validation error: {:?}", errors);
@@ -386,7 +385,7 @@ pub async fn verify_platform_email(
     State(data): State<Arc<AppState>>,
     Path(code): Path<Uuid>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Retrieve the verification record using the code
     let verification = match data.db.get_platform_email_verification_by_code(code) {
         Ok(verification) => verification,
@@ -436,7 +435,7 @@ pub async fn logout_platform_user(
     State(data): State<Arc<AppState>>,
     Extension(logout_request): Extension<PlatformLogoutRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     info!("Platform logout request received");
 
     // TODO: Implement token invalidation logic here when needed
@@ -450,7 +449,7 @@ pub async fn platform_password_reset_request(
     State(data): State<Arc<AppState>>,
     Extension(payload): Extension<PlatformPasswordResetRequestPayload>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Validate request
     if let Err(errors) = payload.validate() {
         error!("Validation error: {:?}", errors);
@@ -502,7 +501,7 @@ pub async fn platform_password_reset_confirm(
     State(data): State<Arc<AppState>>,
     Extension(payload): Extension<PlatformPasswordResetConfirmPayload>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Validate request
     if let Err(errors) = payload.validate() {
         error!("Validation error: {:?}", errors);

--- a/src/web/platform/login_routes.rs
+++ b/src/web/platform/login_routes.rs
@@ -5,12 +5,15 @@ use crate::{
         org_memberships::OrgRole, platform_email_verification::NewPlatformEmailVerification,
         platform_users::NewPlatformUser,
     },
+    transport_v2::envelope::{Credential, CredentialKind},
     web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
     ApiError, AppState, Error,
 };
 use axum::{
+    body::{Body, HttpBody},
     extract::{Path, State},
-    middleware::from_fn_with_state,
+    http::Request,
+    middleware::{from_fn_with_state, Next},
     response::Response,
     routing::{get, post},
     Extension, Router,
@@ -159,7 +162,7 @@ pub fn router(app_state: Arc<AppState>) -> Router<()> {
             "/platform/refresh",
             post(refresh_platform_token).layer(from_fn_with_state(
                 app_state.clone(),
-                decrypt_request::<PlatformRefreshRequest>,
+                prepare_platform_refresh_request,
             )),
         )
         .route(
@@ -191,6 +194,35 @@ pub fn router(app_state: Arc<AppState>) -> Router<()> {
         .with_state(app_state)
 }
 
+async fn prepare_platform_refresh_request(
+    State(state): State<Arc<AppState>>,
+    mut request: Request<Body>,
+    next: Next,
+) -> Result<Response, ApiError> {
+    let is_transport_v2 = request
+        .extensions()
+        .get::<TransportSession>()
+        .is_some_and(TransportSession::is_v2);
+    if is_transport_v2 {
+        if request.body().size_hint().exact() != Some(0) {
+            return Err(ApiError::BadRequest);
+        }
+        let refresh_token = request
+            .extensions()
+            .get::<Credential>()
+            .filter(|credential| credential.kind() == CredentialKind::Resumption)
+            .map(|credential| credential.value().to_string())
+            .ok_or(ApiError::InvalidJwt)?;
+        request
+            .extensions_mut()
+            .insert(PlatformRefreshRequest { refresh_token });
+        return Ok(next.run(request).await);
+    }
+
+    let headers = request.headers().clone();
+    decrypt_request::<PlatformRefreshRequest>(State(state), headers, request, next).await
+}
+
 pub async fn login_platform_user(
     State(data): State<Arc<AppState>>,
     Extension(login_request): Extension<PlatformLoginRequest>,
@@ -202,7 +234,8 @@ pub async fn login_platform_user(
         return Err(ApiError::BadRequest);
     }
 
-    let auth_response = login_internal_platform(data.clone(), login_request).await?;
+    let auth_response =
+        login_internal_platform(data.clone(), login_request, session_id.is_v2()).await?;
     let result = encrypt_response(&data, &session_id, &auth_response).await;
     result
 }
@@ -210,6 +243,7 @@ pub async fn login_platform_user(
 async fn login_internal_platform(
     data: Arc<AppState>,
     login_request: PlatformLoginRequest,
+    is_transport_v2: bool,
 ) -> Result<PlatformAuthResponse, ApiError> {
     // Authenticate the platform user
     match data
@@ -218,10 +252,16 @@ async fn login_internal_platform(
     {
         Ok(Some(platform_user)) => {
             // Generate tokens
-            let access_token =
-                NewToken::new_for_platform_user(&platform_user, TokenType::Access, &data)?;
-            let refresh_token =
-                NewToken::new_for_platform_user(&platform_user, TokenType::Refresh, &data)?;
+            let access_token = NewToken::new_for_platform_user(
+                &platform_user,
+                TokenType::access_for_transport(is_transport_v2),
+                &data,
+            )?;
+            let refresh_token = NewToken::new_for_platform_user(
+                &platform_user,
+                TokenType::refresh_for_transport(is_transport_v2),
+                &data,
+            )?;
 
             let auth_response = PlatformAuthResponse {
                 id: platform_user.uuid,
@@ -333,8 +373,16 @@ pub async fn register_platform_user(
     });
 
     // Generate tokens
-    let access_token = NewToken::new_for_platform_user(&platform_user, TokenType::Access, &data)?;
-    let refresh_token = NewToken::new_for_platform_user(&platform_user, TokenType::Refresh, &data)?;
+    let access_token = NewToken::new_for_platform_user(
+        &platform_user,
+        TokenType::access_for_transport(session_id.is_v2()),
+        &data,
+    )?;
+    let refresh_token = NewToken::new_for_platform_user(
+        &platform_user,
+        TokenType::refresh_for_transport(session_id.is_v2()),
+        &data,
+    )?;
 
     let response = PlatformAuthResponse {
         id: platform_user.uuid,
@@ -359,18 +407,29 @@ pub async fn refresh_platform_token(
         return Err(ApiError::BadRequest);
     }
 
+    let refresh_audience = if session_id.is_v2() {
+        crate::jwt::TRANSPORT_V2_PLATFORM_REFRESH
+    } else {
+        PLATFORM_REFRESH
+    };
     let claims =
-        crate::jwt::validate_token(&refresh_request.refresh_token, &data, PLATFORM_REFRESH)?;
+        crate::jwt::validate_token(&refresh_request.refresh_token, &data, refresh_audience)?;
     let platform_user_id = Uuid::parse_str(&claims.sub).map_err(|_| ApiError::InvalidJwt)?;
 
     // Verify platform user still exists
     let platform_user = data.db.get_platform_user_by_uuid(platform_user_id)?;
 
     // Generate new tokens
-    let new_access_token =
-        NewToken::new_for_platform_user(&platform_user, TokenType::Access, &data)?;
-    let new_refresh_token =
-        NewToken::new_for_platform_user(&platform_user, TokenType::Refresh, &data)?;
+    let new_access_token = NewToken::new_for_platform_user(
+        &platform_user,
+        TokenType::access_for_transport(session_id.is_v2()),
+        &data,
+    )?;
+    let new_refresh_token = NewToken::new_for_platform_user(
+        &platform_user,
+        TokenType::refresh_for_transport(session_id.is_v2()),
+        &data,
+    )?;
 
     let response = PlatformRefreshResponse {
         access_token: new_access_token.token,

--- a/src/web/platform/login_routes.rs
+++ b/src/web/platform/login_routes.rs
@@ -5,7 +5,9 @@ use crate::{
         org_memberships::OrgRole, platform_email_verification::NewPlatformEmailVerification,
         platform_users::NewPlatformUser,
     },
-    web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+    web::encryption_middleware::{
+        decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+    },
     ApiError, AppState, Error,
 };
 use axum::{
@@ -193,7 +195,7 @@ pub fn router(app_state: Arc<AppState>) -> Router<()> {
 pub async fn login_platform_user(
     State(data): State<Arc<AppState>>,
     Extension(login_request): Extension<PlatformLoginRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<PlatformAuthResponse>>, ApiError> {
     // Validate request
     if let Err(errors) = login_request.validate() {
@@ -245,7 +247,7 @@ async fn login_internal_platform(
 pub async fn register_platform_user(
     State(data): State<Arc<AppState>>,
     Extension(register_request): Extension<PlatformRegisterRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<PlatformAuthResponse>>, ApiError> {
     // Validate request
     if let Err(errors) = register_request.validate() {
@@ -350,7 +352,7 @@ pub async fn register_platform_user(
 pub async fn refresh_platform_token(
     State(data): State<Arc<AppState>>,
     Extension(refresh_request): Extension<PlatformRefreshRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<PlatformRefreshResponse>>, ApiError> {
     // Validate request
     if let Err(errors) = refresh_request.validate() {
@@ -383,7 +385,7 @@ pub async fn refresh_platform_token(
 pub async fn verify_platform_email(
     State(data): State<Arc<AppState>>,
     Path(code): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     // Retrieve the verification record using the code
     let verification = match data.db.get_platform_email_verification_by_code(code) {
@@ -433,7 +435,7 @@ pub async fn verify_platform_email(
 pub async fn logout_platform_user(
     State(data): State<Arc<AppState>>,
     Extension(logout_request): Extension<PlatformLogoutRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     info!("Platform logout request received");
 
@@ -447,7 +449,7 @@ pub async fn logout_platform_user(
 pub async fn platform_password_reset_request(
     State(data): State<Arc<AppState>>,
     Extension(payload): Extension<PlatformPasswordResetRequestPayload>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     // Validate request
     if let Err(errors) = payload.validate() {
@@ -499,7 +501,7 @@ pub async fn platform_password_reset_request(
 pub async fn platform_password_reset_confirm(
     State(data): State<Arc<AppState>>,
     Extension(payload): Extension<PlatformPasswordResetConfirmPayload>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     // Validate request
     if let Err(errors) = payload.validate() {

--- a/src/web/platform/me_routes.rs
+++ b/src/web/platform/me_routes.rs
@@ -2,7 +2,7 @@ use crate::{
     email::send_platform_verification_email,
     models::platform_email_verification::NewPlatformEmailVerification,
     models::platform_users::PlatformUser,
-    web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
+    web::encryption_middleware::{decrypt_request, encrypt_response, Decrypted, TransportSession},
     ApiError, AppState,
 };
 use axum::{
@@ -199,12 +199,12 @@ async fn request_platform_verification(
 pub async fn platform_change_password(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
-    Extension(change_request): Extension<PlatformChangePasswordRequest>,
+    Decrypted(change_request): Decrypted<PlatformChangePasswordRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     // Validate request
-    if let Err(errors) = change_request.validate() {
-        error!("Validation error: {:?}", errors);
+    if change_request.validate().is_err() {
+        error!("Platform password change request validation failed");
         return Err(ApiError::BadRequest);
     }
 

--- a/src/web/platform/me_routes.rs
+++ b/src/web/platform/me_routes.rs
@@ -2,16 +2,15 @@ use crate::{
     email::send_platform_verification_email,
     models::platform_email_verification::NewPlatformEmailVerification,
     models::platform_users::PlatformUser,
-    web::encryption_middleware::{
-        decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
-    },
+    web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
     ApiError, AppState,
 };
 use axum::{
     extract::State,
     middleware::from_fn_with_state,
+    response::Response,
     routing::{get, post},
-    Extension, Json, Router,
+    Extension, Router,
 };
 use serde::Deserialize;
 use serde_json::json;
@@ -65,7 +64,7 @@ async fn get_platform_user(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<MeResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Check if email is verified
     let email_verified = match data
         .db
@@ -132,7 +131,7 @@ async fn request_platform_verification(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Check if the user is already verified
     match data
         .db
@@ -202,7 +201,7 @@ pub async fn platform_change_password(
     Extension(platform_user): Extension<PlatformUser>,
     Extension(change_request): Extension<PlatformChangePasswordRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Validate request
     if let Err(errors) = change_request.validate() {
         error!("Validation error: {:?}", errors);

--- a/src/web/platform/me_routes.rs
+++ b/src/web/platform/me_routes.rs
@@ -2,7 +2,9 @@ use crate::{
     email::send_platform_verification_email,
     models::platform_email_verification::NewPlatformEmailVerification,
     models::platform_users::PlatformUser,
-    web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+    web::encryption_middleware::{
+        decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+    },
     ApiError, AppState,
 };
 use axum::{
@@ -16,7 +18,6 @@ use serde_json::json;
 use std::sync::Arc;
 use tokio::spawn;
 use tracing::error;
-use uuid::Uuid;
 use validator::Validate;
 
 use super::common::{MeResponse, OrgResponse, PlatformUserResponse};
@@ -63,7 +64,7 @@ pub fn router(app_state: Arc<AppState>) -> Router {
 async fn get_platform_user(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<MeResponse>>, ApiError> {
     // Check if email is verified
     let email_verified = match data
@@ -130,7 +131,7 @@ async fn get_platform_user(
 async fn request_platform_verification(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     // Check if the user is already verified
     match data
@@ -200,7 +201,7 @@ pub async fn platform_change_password(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Extension(change_request): Extension<PlatformChangePasswordRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     // Validate request
     if let Err(errors) = change_request.validate() {

--- a/src/web/platform/membership_routes.rs
+++ b/src/web/platform/membership_routes.rs
@@ -3,7 +3,9 @@ use crate::{
         org_memberships::{OrgMembershipError, OrgRole},
         platform_users::PlatformUser,
     },
-    web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+    web::encryption_middleware::{
+        decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+    },
     ApiError, AppState, DBError,
 };
 use axum::{
@@ -44,7 +46,7 @@ async fn list_memberships(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path(org_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<Vec<MembershipResponse>>>, ApiError> {
     debug!("Listing memberships");
 
@@ -87,7 +89,7 @@ async fn update_membership(
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, user_id)): Path<(Uuid, Uuid)>,
     Extension(update_request): Extension<UpdateMembershipRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<MembershipResponse>>, ApiError> {
     debug!(
         "Updating membership for user {} in org {} to role {:?}",
@@ -193,7 +195,7 @@ async fn delete_membership(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, user_id)): Path<(Uuid, Uuid)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     debug!("Deleting membership");
 

--- a/src/web/platform/membership_routes.rs
+++ b/src/web/platform/membership_routes.rs
@@ -3,7 +3,7 @@ use crate::{
         org_memberships::{OrgMembershipError, OrgRole},
         platform_users::PlatformUser,
     },
-    web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
+    web::encryption_middleware::{decrypt_request, encrypt_response, Decrypted, TransportSession},
     ApiError, AppState, DBError,
 };
 use axum::{
@@ -87,7 +87,7 @@ async fn update_membership(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, user_id)): Path<(Uuid, Uuid)>,
-    Extension(update_request): Extension<UpdateMembershipRequest>,
+    Decrypted(update_request): Decrypted<UpdateMembershipRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     debug!(

--- a/src/web/platform/membership_routes.rs
+++ b/src/web/platform/membership_routes.rs
@@ -3,16 +3,15 @@ use crate::{
         org_memberships::{OrgMembershipError, OrgRole},
         platform_users::PlatformUser,
     },
-    web::encryption_middleware::{
-        decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
-    },
+    web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
     ApiError, AppState, DBError,
 };
 use axum::{
     extract::{Path, State},
     middleware::from_fn_with_state,
+    response::Response,
     routing::{delete, get, patch},
-    Extension, Json, Router,
+    Extension, Router,
 };
 use std::sync::Arc;
 use tracing::{debug, error};
@@ -47,7 +46,7 @@ async fn list_memberships(
     Extension(platform_user): Extension<PlatformUser>,
     Path(org_id): Path<Uuid>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<Vec<MembershipResponse>>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Listing memberships");
 
     // Get the org by UUID
@@ -72,7 +71,7 @@ async fn list_memberships(
         })?;
 
     // Create response directly from the joined results
-    let response = memberships_with_users
+    let response: Vec<MembershipResponse> = memberships_with_users
         .into_iter()
         .map(|m| MembershipResponse {
             user_id: m.platform_user_id,
@@ -90,7 +89,7 @@ async fn update_membership(
     Path((org_id, user_id)): Path<(Uuid, Uuid)>,
     Extension(update_request): Extension<UpdateMembershipRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<MembershipResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!(
         "Updating membership for user {} in org {} to role {:?}",
         user_id, org_id, update_request.role
@@ -196,7 +195,7 @@ async fn delete_membership(
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, user_id)): Path<(Uuid, Uuid)>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Deleting membership");
 
     // Get the org by UUID

--- a/src/web/platform/org_routes.rs
+++ b/src/web/platform/org_routes.rs
@@ -1,6 +1,6 @@
 use crate::{
     models::{org_memberships::OrgRole, orgs::NewOrg, platform_users::PlatformUser},
-    web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
+    web::encryption_middleware::{decrypt_request, encrypt_response, Decrypted, TransportSession},
     ApiError, AppState,
 };
 use axum::{
@@ -41,14 +41,14 @@ pub fn router(app_state: Arc<AppState>) -> Router {
 async fn create_org(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
-    Extension(create_request): Extension<CreateOrgRequest>,
+    Decrypted(create_request): Decrypted<CreateOrgRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     debug!("Creating new organization");
 
     // Validate request
-    if let Err(errors) = create_request.validate() {
-        error!("Validation error: {:?}", errors);
+    if create_request.validate().is_err() {
+        error!("Organization creation request validation failed");
         return Err(ApiError::BadRequest);
     }
 

--- a/src/web/platform/org_routes.rs
+++ b/src/web/platform/org_routes.rs
@@ -1,6 +1,8 @@
 use crate::{
     models::{org_memberships::OrgRole, orgs::NewOrg, platform_users::PlatformUser},
-    web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+    web::encryption_middleware::{
+        decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+    },
     ApiError, AppState,
 };
 use axum::{
@@ -41,7 +43,7 @@ async fn create_org(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Extension(create_request): Extension<CreateOrgRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<OrgResponse>>, ApiError> {
     debug!("Creating new organization");
 
@@ -72,7 +74,7 @@ async fn create_org(
 async fn list_orgs(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<Vec<OrgResponse>>>, ApiError> {
     debug!("Listing organizations");
 
@@ -112,7 +114,7 @@ async fn delete_org(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path(org_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     debug!("Deleting organization");
 

--- a/src/web/platform/org_routes.rs
+++ b/src/web/platform/org_routes.rs
@@ -1,15 +1,14 @@
 use crate::{
     models::{org_memberships::OrgRole, orgs::NewOrg, platform_users::PlatformUser},
-    web::encryption_middleware::{
-        decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
-    },
+    web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
     ApiError, AppState,
 };
 use axum::{
     extract::{Path, State},
     middleware::from_fn_with_state,
+    response::Response,
     routing::{delete, get, post},
-    Extension, Json, Router,
+    Extension, Router,
 };
 use std::sync::Arc;
 use tracing::{debug, error};
@@ -44,7 +43,7 @@ async fn create_org(
     Extension(platform_user): Extension<PlatformUser>,
     Extension(create_request): Extension<CreateOrgRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<OrgResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Creating new organization");
 
     // Validate request
@@ -75,7 +74,7 @@ async fn list_orgs(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<Vec<OrgResponse>>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Listing organizations");
 
     // Get all memberships for the user
@@ -115,7 +114,7 @@ async fn delete_org(
     Extension(platform_user): Extension<PlatformUser>,
     Path(org_id): Path<Uuid>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Deleting organization");
 
     // Get org by UUID instead of ID

--- a/src/web/platform/project_routes.rs
+++ b/src/web/platform/project_routes.rs
@@ -6,17 +6,16 @@ use crate::{
         platform_users::PlatformUser,
         project_settings::{EmailSettings, OAuthSettings},
     },
-    web::encryption_middleware::{
-        decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
-    },
+    web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
     ApiError, AppState,
 };
 use axum::routing::put;
 use axum::{
     extract::{Path, State},
     middleware::from_fn_with_state,
+    response::Response,
     routing::{delete, get, patch, post},
-    Extension, Json, Router,
+    Extension, Router,
 };
 use base64::engine::general_purpose;
 use base64::Engine as _;
@@ -111,7 +110,7 @@ async fn create_project(
     Path(org_id): Path<Uuid>,
     Extension(create_request): Extension<CreateProjectRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<ProjectResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Creating new project");
 
     // Validate request
@@ -184,7 +183,7 @@ async fn list_projects(
     Extension(platform_user): Extension<PlatformUser>,
     Path(org_id): Path<Uuid>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<Vec<ProjectResponse>>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Listing projects");
 
     // Get org by UUID
@@ -205,7 +204,7 @@ async fn list_projects(
         ApiError::InternalServerError
     })?;
 
-    let response = projects
+    let response: Vec<ProjectResponse> = projects
         .into_iter()
         .map(|p| ProjectResponse {
             id: p.uuid,
@@ -226,7 +225,7 @@ async fn update_project(
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
     Extension(update_request): Extension<UpdateProjectRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<ProjectResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Updating project");
 
     // Get org and project by UUID
@@ -308,7 +307,7 @@ async fn get_project(
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<ProjectResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Getting project");
 
     // Get org and project by UUID
@@ -352,7 +351,7 @@ async fn delete_project(
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Deleting project");
 
     // Get org and project by UUID
@@ -401,7 +400,7 @@ async fn create_secret(
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
     Extension(create_request): Extension<CreateSecretRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<SecretResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Creating project secret");
 
     // Validate request
@@ -479,7 +478,7 @@ async fn list_secrets(
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<Vec<SecretResponse>>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Listing project secrets");
 
     // Get org and project by UUID
@@ -531,7 +530,7 @@ async fn delete_secret(
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id, key_name)): Path<(Uuid, Uuid, String)>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Deleting project secret");
 
     // Get org and project by UUID
@@ -593,7 +592,7 @@ async fn get_email_settings(
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<EmailSettings>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Getting project email settings");
 
     // Get org and project by UUID
@@ -637,7 +636,7 @@ async fn update_email_settings(
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
     Extension(update_request): Extension<UpdateEmailSettingsRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<EmailSettings>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Updating project email settings");
 
     // Validate request
@@ -700,7 +699,7 @@ async fn get_oauth_settings(
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<OAuthSettings>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Getting project OAuth settings");
 
     // Get org and project by UUID
@@ -741,7 +740,7 @@ async fn update_oauth_settings(
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
     Extension(update_request): Extension<UpdateOAuthSettingsRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<OAuthSettings>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Updating project OAuth settings");
 
     // Validate request using validator

--- a/src/web/platform/project_routes.rs
+++ b/src/web/platform/project_routes.rs
@@ -6,7 +6,9 @@ use crate::{
         platform_users::PlatformUser,
         project_settings::{EmailSettings, OAuthSettings},
     },
-    web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+    web::encryption_middleware::{
+        decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+    },
     ApiError, AppState,
 };
 use axum::routing::put;
@@ -108,7 +110,7 @@ async fn create_project(
     Extension(platform_user): Extension<PlatformUser>,
     Path(org_id): Path<Uuid>,
     Extension(create_request): Extension<CreateProjectRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<ProjectResponse>>, ApiError> {
     debug!("Creating new project");
 
@@ -181,7 +183,7 @@ async fn list_projects(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path(org_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<Vec<ProjectResponse>>>, ApiError> {
     debug!("Listing projects");
 
@@ -223,7 +225,7 @@ async fn update_project(
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
     Extension(update_request): Extension<UpdateProjectRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<ProjectResponse>>, ApiError> {
     debug!("Updating project");
 
@@ -305,7 +307,7 @@ async fn get_project(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<ProjectResponse>>, ApiError> {
     debug!("Getting project");
 
@@ -349,7 +351,7 @@ async fn delete_project(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     debug!("Deleting project");
 
@@ -398,7 +400,7 @@ async fn create_secret(
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
     Extension(create_request): Extension<CreateSecretRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<SecretResponse>>, ApiError> {
     debug!("Creating project secret");
 
@@ -476,7 +478,7 @@ async fn list_secrets(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<Vec<SecretResponse>>>, ApiError> {
     debug!("Listing project secrets");
 
@@ -528,7 +530,7 @@ async fn delete_secret(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id, key_name)): Path<(Uuid, Uuid, String)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     debug!("Deleting project secret");
 
@@ -590,7 +592,7 @@ async fn get_email_settings(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<EmailSettings>>, ApiError> {
     debug!("Getting project email settings");
 
@@ -634,7 +636,7 @@ async fn update_email_settings(
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
     Extension(update_request): Extension<UpdateEmailSettingsRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<EmailSettings>>, ApiError> {
     debug!("Updating project email settings");
 
@@ -697,7 +699,7 @@ async fn get_oauth_settings(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<OAuthSettings>>, ApiError> {
     debug!("Getting project OAuth settings");
 
@@ -738,7 +740,7 @@ async fn update_oauth_settings(
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
     Extension(update_request): Extension<UpdateOAuthSettingsRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<OAuthSettings>>, ApiError> {
     debug!("Updating project OAuth settings");
 

--- a/src/web/platform/project_routes.rs
+++ b/src/web/platform/project_routes.rs
@@ -6,7 +6,7 @@ use crate::{
         platform_users::PlatformUser,
         project_settings::{EmailSettings, OAuthSettings},
     },
-    web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
+    web::encryption_middleware::{decrypt_request, encrypt_response, Decrypted, TransportSession},
     ApiError, AppState,
 };
 use axum::routing::put;
@@ -108,14 +108,14 @@ async fn create_project(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path(org_id): Path<Uuid>,
-    Extension(create_request): Extension<CreateProjectRequest>,
+    Decrypted(create_request): Decrypted<CreateProjectRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     debug!("Creating new project");
 
     // Validate request
-    if let Err(errors) = create_request.validate() {
-        error!("Validation error: {:?}", errors);
+    if create_request.validate().is_err() {
+        error!("Project creation request validation failed");
         return Err(ApiError::BadRequest);
     }
 
@@ -223,7 +223,7 @@ async fn update_project(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
-    Extension(update_request): Extension<UpdateProjectRequest>,
+    Decrypted(update_request): Decrypted<UpdateProjectRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     debug!("Updating project");
@@ -398,14 +398,14 @@ async fn create_secret(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
-    Extension(create_request): Extension<CreateSecretRequest>,
+    Decrypted(create_request): Decrypted<CreateSecretRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     debug!("Creating project secret");
 
     // Validate request
-    if let Err(errors) = create_request.validate() {
-        error!("Validation error: {:?}", errors);
+    if create_request.validate().is_err() {
+        error!("Project secret creation request validation failed");
         return Err(ApiError::BadRequest);
     }
 
@@ -634,14 +634,14 @@ async fn update_email_settings(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
-    Extension(update_request): Extension<UpdateEmailSettingsRequest>,
+    Decrypted(update_request): Decrypted<UpdateEmailSettingsRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     debug!("Updating project email settings");
 
     // Validate request
-    if let Err(errors) = update_request.validate() {
-        error!("Validation error: {:?}", errors);
+    if update_request.validate().is_err() {
+        error!("Project email settings request validation failed");
         return Err(ApiError::BadRequest);
     }
 
@@ -738,14 +738,14 @@ async fn update_oauth_settings(
     State(data): State<Arc<AppState>>,
     Extension(platform_user): Extension<PlatformUser>,
     Path((org_id, project_id)): Path<(Uuid, Uuid)>,
-    Extension(update_request): Extension<UpdateOAuthSettingsRequest>,
+    Decrypted(update_request): Decrypted<UpdateOAuthSettingsRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     debug!("Updating project OAuth settings");
 
     // Validate request using validator
-    if let Err(errors) = update_request.validate() {
-        error!("Validation error: {:?}", errors);
+    if update_request.validate().is_err() {
+        error!("Project OAuth settings request validation failed");
         return Err(ApiError::BadRequest);
     }
 

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -4,7 +4,9 @@ use crate::message_signing::SigningAlgorithm;
 use crate::private_key::{
     derive_bip85_mnemonic_from_root, plaintext_user_seed_to_mnemonic, VALID_BIP39_WORD_COUNTS,
 };
-use crate::web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession};
+use crate::web::encryption_middleware::{
+    decrypt_request, encrypt_response, Decrypted, TransportSession,
+};
 use crate::Error;
 use crate::{
     db::DBError, email::send_verification_email, models::email_verification::NewEmailVerification,
@@ -641,7 +643,7 @@ pub async fn put_kv(
     Extension(auth_context): Extension<AuthContext>,
     Extension(session_id): Extension<TransportSession>,
     Path(key): Path<String>,
-    Extension(value): Extension<String>,
+    Decrypted(value): Decrypted<String>,
 ) -> Result<Response, ApiError> {
     match data.put(&user, &auth_context, key, value.clone()).await {
         Ok(kv) => kv,
@@ -774,7 +776,7 @@ pub async fn change_password(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(change_request): Extension<ChangePasswordRequest>,
+    Decrypted(change_request): Decrypted<ChangePasswordRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     // Check if user is an OAuth-only user
@@ -932,7 +934,7 @@ pub async fn sign_message(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(sign_request): Extension<SignMessageRequest>,
+    Decrypted(sign_request): Decrypted<SignMessageRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     // Validate key_options
@@ -1036,7 +1038,7 @@ pub async fn get_public_key(
 pub async fn generate_third_party_token(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
-    Extension(request): Extension<ThirdPartyTokenRequest>,
+    Decrypted(request): Decrypted<ThirdPartyTokenRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     // Validate the audience
@@ -1072,7 +1074,7 @@ pub async fn encrypt_data(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(request): Extension<EncryptDataRequest>,
+    Decrypted(request): Decrypted<EncryptDataRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     // Validate key_options
@@ -1126,7 +1128,7 @@ pub async fn decrypt_data(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(request): Extension<DecryptDataRequest>,
+    Decrypted(request): Decrypted<DecryptDataRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     // Validate key_options
@@ -1195,7 +1197,7 @@ pub async fn decrypt_data(
 pub async fn initiate_account_deletion(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
-    Extension(delete_request): Extension<InitiateAccountDeletionRequest>,
+    Decrypted(delete_request): Decrypted<InitiateAccountDeletionRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     info!("User {} is initiating account deletion request", user.uuid);
@@ -1229,7 +1231,7 @@ pub async fn initiate_account_deletion(
 pub async fn confirm_account_deletion(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
-    Extension(confirm_request): Extension<ConfirmAccountDeletionRequest>,
+    Decrypted(confirm_request): Decrypted<ConfirmAccountDeletionRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     info!("User {} is confirming account deletion", user.uuid);
@@ -1277,14 +1279,14 @@ pub async fn confirm_account_deletion(
 pub async fn create_api_key(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
-    Extension(request): Extension<CreateApiKeyRequest>,
+    Decrypted(request): Decrypted<CreateApiKeyRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
     debug!("Creating new API key for user: {}", user.uuid);
 
     // Validate the request
-    if let Err(e) = request.validate() {
-        error!("API key request validation failed: {:?}", e);
+    if request.validate().is_err() {
+        error!("API key request validation failed");
         return Err(ApiError::BadRequest);
     }
 

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -808,13 +808,13 @@ pub async fn change_password(
                 Ok(new_auth_context) => {
                     let access_token = NewToken::new_with_auth_context(
                         &user,
-                        TokenType::Access,
+                        TokenType::access_for_transport(session_id.is_v2()),
                         &data,
                         &new_auth_context,
                     )?;
                     let refresh_token = NewToken::new_with_auth_context(
                         &user,
-                        TokenType::Refresh,
+                        TokenType::refresh_for_transport(session_id.is_v2()),
                         &data,
                         &new_auth_context,
                     )?;

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -4,7 +4,9 @@ use crate::message_signing::SigningAlgorithm;
 use crate::private_key::{
     derive_bip85_mnemonic_from_root, plaintext_user_seed_to_mnemonic, VALID_BIP39_WORD_COUNTS,
 };
-use crate::web::encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse};
+use crate::web::encryption_middleware::{
+    decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+};
 use crate::Error;
 use crate::KVPair;
 use crate::{
@@ -554,7 +556,7 @@ pub fn router(app_state: Arc<AppState>) -> Router<()> {
 pub async fn user_protected(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<ProtectedUserData>>, ApiError> {
     let mut app_user: AppUser = AppUser::from(&user);
 
@@ -622,7 +624,7 @@ pub async fn get_kv(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Path(key): Path<String>,
 ) -> Result<Json<EncryptedResponse<Option<String>>>, ApiError> {
     let value = match data.get(&user, &auth_context, key).await {
@@ -639,7 +641,7 @@ pub async fn put_kv(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Path(key): Path<String>,
     Extension(value): Extension<String>,
 ) -> Result<Json<EncryptedResponse<String>>, ApiError> {
@@ -657,7 +659,7 @@ pub async fn delete_kv(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Path(key): Path<String>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     match data.delete(&user, &auth_context, key).await {
@@ -675,7 +677,7 @@ pub async fn delete_kv(
 pub async fn delete_all_kv(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     match data.delete_all(user.uuid).await {
         Ok(_) => {
@@ -695,7 +697,7 @@ pub async fn list_kv(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<Vec<KVPair>>>, ApiError> {
     let kvs = match data.list(&user, &auth_context).await {
         Ok(kvs) => kvs,
@@ -710,7 +712,7 @@ pub async fn list_kv(
 pub async fn request_new_verification_code(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     // First check if user has an email
     let email = match user.get_email() {
@@ -775,7 +777,7 @@ pub async fn change_password(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(change_request): Extension<ChangePasswordRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     // Check if user is an OAuth-only user
     if user.password_enc.is_none() {
@@ -845,7 +847,7 @@ pub async fn get_private_key(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Query(query): Query<DerivationPathQuery>,
 ) -> Result<Json<EncryptedResponse<PrivateKeyResponse>>, ApiError> {
     // Validate paths if present
@@ -890,7 +892,7 @@ pub async fn get_private_key_bytes(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Query(query): Query<DerivationPathQuery>,
 ) -> Result<Json<EncryptedResponse<PrivateKeyBytesResponse>>, ApiError> {
     // Validate derivation path if present
@@ -933,7 +935,7 @@ pub async fn sign_message(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(sign_request): Extension<SignMessageRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<SignMessageResponseJson>>, ApiError> {
     // Validate key_options
     let validation_query = DerivationPathQuery {
@@ -985,7 +987,7 @@ pub async fn get_public_key(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Query(query): Query<PublicKeyQuery>,
 ) -> Result<Json<EncryptedResponse<PublicKeyResponseJson>>, ApiError> {
     // Validate the key_options
@@ -1037,7 +1039,7 @@ pub async fn generate_third_party_token(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(request): Extension<ThirdPartyTokenRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<ThirdPartyTokenResponse>>, ApiError> {
     // Validate the audience
     if let Some(audience) = request.audience.as_ref() {
@@ -1073,7 +1075,7 @@ pub async fn encrypt_data(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(request): Extension<EncryptDataRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<EncryptDataResponse>>, ApiError> {
     // Validate key_options
     let validation_query = DerivationPathQuery {
@@ -1127,7 +1129,7 @@ pub async fn decrypt_data(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(request): Extension<DecryptDataRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<String>>, ApiError> {
     // Validate key_options
     let validation_query = DerivationPathQuery {
@@ -1196,7 +1198,7 @@ pub async fn initiate_account_deletion(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(delete_request): Extension<InitiateAccountDeletionRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     info!("User {} is initiating account deletion request", user.uuid);
 
@@ -1230,7 +1232,7 @@ pub async fn confirm_account_deletion(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(confirm_request): Extension<ConfirmAccountDeletionRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     info!("User {} is confirming account deletion", user.uuid);
 
@@ -1278,7 +1280,7 @@ pub async fn create_api_key(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(request): Extension<CreateApiKeyRequest>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<CreateApiKeyResponse>>, ApiError> {
     debug!("Creating new API key for user: {}", user.uuid);
 
@@ -1334,7 +1336,7 @@ pub async fn create_api_key(
 pub async fn list_api_keys(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<ListApiKeysResponse>>, ApiError> {
     debug!("Listing API keys for user: {}", user.uuid);
 
@@ -1363,7 +1365,7 @@ pub async fn delete_api_key(
     State(data): State<Arc<AppState>>,
     Path(name): Path<String>,
     Extension(user): Extension<User>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     debug!("Deleting API key '{}' for user: {}", name, user.uuid);
 

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -4,11 +4,8 @@ use crate::message_signing::SigningAlgorithm;
 use crate::private_key::{
     derive_bip85_mnemonic_from_root, plaintext_user_seed_to_mnemonic, VALID_BIP39_WORD_COUNTS,
 };
-use crate::web::encryption_middleware::{
-    decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
-};
+use crate::web::encryption_middleware::{decrypt_request, encrypt_response, TransportSession};
 use crate::Error;
-use crate::KVPair;
 use crate::{
     db::DBError, email::send_verification_email, models::email_verification::NewEmailVerification,
     models::users::User, ApiError, AppState,
@@ -18,12 +15,13 @@ use crate::{
 const BIP85_PURPOSE: u32 = 83696968; // BIP-85 purpose value
 const BIP85_APPLICATION_BIP39: u32 = 39; // Application number for BIP-39 mnemonics
 use axum::middleware::from_fn_with_state;
+use axum::Extension;
 use axum::{
     extract::{Path, Query, State},
+    response::Response,
     routing::{delete, get, post, put},
     Router,
 };
-use axum::{Extension, Json};
 use base64::{engine::general_purpose, Engine as _};
 use bitcoin::bip32::DerivationPath;
 use chrono::{DateTime, Utc};
@@ -557,7 +555,7 @@ pub async fn user_protected(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<ProtectedUserData>>, ApiError> {
+) -> Result<Response, ApiError> {
     let mut app_user: AppUser = AppUser::from(&user);
 
     // Set email verification status - only if not a guest user
@@ -626,7 +624,7 @@ pub async fn get_kv(
     Extension(auth_context): Extension<AuthContext>,
     Extension(session_id): Extension<TransportSession>,
     Path(key): Path<String>,
-) -> Result<Json<EncryptedResponse<Option<String>>>, ApiError> {
+) -> Result<Response, ApiError> {
     let value = match data.get(&user, &auth_context, key).await {
         Ok(kv) => kv,
         Err(e) => {
@@ -644,7 +642,7 @@ pub async fn put_kv(
     Extension(session_id): Extension<TransportSession>,
     Path(key): Path<String>,
     Extension(value): Extension<String>,
-) -> Result<Json<EncryptedResponse<String>>, ApiError> {
+) -> Result<Response, ApiError> {
     match data.put(&user, &auth_context, key, value.clone()).await {
         Ok(kv) => kv,
         Err(e) => {
@@ -661,7 +659,7 @@ pub async fn delete_kv(
     Extension(auth_context): Extension<AuthContext>,
     Extension(session_id): Extension<TransportSession>,
     Path(key): Path<String>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     match data.delete(&user, &auth_context, key).await {
         Ok(_) => {
             let response = json!({ "message": "Resource deleted successfully" });
@@ -678,7 +676,7 @@ pub async fn delete_all_kv(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     match data.delete_all(user.uuid).await {
         Ok(_) => {
             let response = json!({
@@ -698,7 +696,7 @@ pub async fn list_kv(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<Vec<KVPair>>>, ApiError> {
+) -> Result<Response, ApiError> {
     let kvs = match data.list(&user, &auth_context).await {
         Ok(kvs) => kvs,
         Err(e) => {
@@ -713,7 +711,7 @@ pub async fn request_new_verification_code(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     // First check if user has an email
     let email = match user.get_email() {
         Some(email) => email.to_string(),
@@ -778,7 +776,7 @@ pub async fn change_password(
     Extension(auth_context): Extension<AuthContext>,
     Extension(change_request): Extension<ChangePasswordRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Check if user is an OAuth-only user
     if user.password_enc.is_none() {
         error!("OAuth-only user attempted to change password");
@@ -849,7 +847,7 @@ pub async fn get_private_key(
     Extension(auth_context): Extension<AuthContext>,
     Extension(session_id): Extension<TransportSession>,
     Query(query): Query<DerivationPathQuery>,
-) -> Result<Json<EncryptedResponse<PrivateKeyResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Validate paths if present
     query.validate()?;
 
@@ -894,7 +892,7 @@ pub async fn get_private_key_bytes(
     Extension(auth_context): Extension<AuthContext>,
     Extension(session_id): Extension<TransportSession>,
     Query(query): Query<DerivationPathQuery>,
-) -> Result<Json<EncryptedResponse<PrivateKeyBytesResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Validate derivation path if present
     query.validate()?;
 
@@ -936,7 +934,7 @@ pub async fn sign_message(
     Extension(auth_context): Extension<AuthContext>,
     Extension(sign_request): Extension<SignMessageRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<SignMessageResponseJson>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Validate key_options
     let validation_query = DerivationPathQuery {
         key_options: sign_request.key_options.clone(),
@@ -989,7 +987,7 @@ pub async fn get_public_key(
     Extension(auth_context): Extension<AuthContext>,
     Extension(session_id): Extension<TransportSession>,
     Query(query): Query<PublicKeyQuery>,
-) -> Result<Json<EncryptedResponse<PublicKeyResponseJson>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Validate the key_options
     let validation_query = DerivationPathQuery {
         key_options: query.key_options.clone(),
@@ -1040,7 +1038,7 @@ pub async fn generate_third_party_token(
     Extension(user): Extension<User>,
     Extension(request): Extension<ThirdPartyTokenRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<ThirdPartyTokenResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Validate the audience
     if let Some(audience) = request.audience.as_ref() {
         if audience.is_empty() || (audience.contains(':') && url::Url::parse(audience).is_err()) {
@@ -1076,7 +1074,7 @@ pub async fn encrypt_data(
     Extension(auth_context): Extension<AuthContext>,
     Extension(request): Extension<EncryptDataRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<EncryptDataResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Validate key_options
     let validation_query = DerivationPathQuery {
         key_options: request.key_options.clone(),
@@ -1130,7 +1128,7 @@ pub async fn decrypt_data(
     Extension(auth_context): Extension<AuthContext>,
     Extension(request): Extension<DecryptDataRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<String>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Validate key_options
     let validation_query = DerivationPathQuery {
         key_options: request.key_options.clone(),
@@ -1199,7 +1197,7 @@ pub async fn initiate_account_deletion(
     Extension(user): Extension<User>,
     Extension(delete_request): Extension<InitiateAccountDeletionRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     info!("User {} is initiating account deletion request", user.uuid);
 
     // Create the account deletion request
@@ -1233,7 +1231,7 @@ pub async fn confirm_account_deletion(
     Extension(user): Extension<User>,
     Extension(confirm_request): Extension<ConfirmAccountDeletionRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     info!("User {} is confirming account deletion", user.uuid);
 
     // Confirm the account deletion
@@ -1281,7 +1279,7 @@ pub async fn create_api_key(
     Extension(user): Extension<User>,
     Extension(request): Extension<CreateApiKeyRequest>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<CreateApiKeyResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Creating new API key for user: {}", user.uuid);
 
     // Validate the request
@@ -1337,7 +1335,7 @@ pub async fn list_api_keys(
     State(data): State<Arc<AppState>>,
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<ListApiKeysResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Listing API keys for user: {}", user.uuid);
 
     let api_keys = data
@@ -1366,7 +1364,7 @@ pub async fn delete_api_key(
     Path(name): Path<String>,
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Deleting API key '{}' for user: {}", name, user.uuid);
 
     data.db

--- a/src/web/responses/conversation_projects.rs
+++ b/src/web/responses/conversation_projects.rs
@@ -7,9 +7,7 @@ use crate::{
     models::users::User,
     tokens::count_tokens,
     web::{
-        encryption_middleware::{
-            decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
-        },
+        encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
         responses::{
             constants::{
                 DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_ORDER, MAX_PAGINATION_LIMIT,
@@ -23,8 +21,9 @@ use crate::{
 use axum::{
     extract::{Path, Query, State},
     middleware::from_fn_with_state,
+    response::Response,
     routing::{delete, get, post},
-    Extension, Json, Router,
+    Extension, Router,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -163,7 +162,7 @@ async fn create_conversation_project(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<CreateConversationProjectRequest>,
-) -> Result<Json<EncryptedResponse<ConversationProjectResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     let name = validate_project_name(&body.name)?;
     let user_key = state
         .get_user_key(&user, &auth_context, None, None)
@@ -189,7 +188,7 @@ async fn list_conversation_projects(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-) -> Result<Json<EncryptedResponse<ConversationProjectListResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     let limit = if params.limit <= 0 {
         DEFAULT_PAGINATION_LIMIT
     } else {
@@ -246,7 +245,7 @@ async fn get_conversation_project(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-) -> Result<Json<EncryptedResponse<ConversationProjectResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     let ctx = ConversationProjectContext::load(&state, project_id, &user, &auth_context).await?;
     let instructions = state
         .db
@@ -269,7 +268,7 @@ async fn update_conversation_project(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<UpdateConversationProjectRequest>,
-) -> Result<Json<EncryptedResponse<ConversationProjectResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     if body.name.is_none() && body.instructions.is_missing() {
         return Err(ApiError::BadRequest);
     }
@@ -325,7 +324,7 @@ async fn delete_conversation_project(
     Path(project_id): Path<Uuid>,
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
-) -> Result<Json<EncryptedResponse<DeletedObjectResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!(
         "Deleting conversation project {} for user {}",
         project_id, user.uuid

--- a/src/web/responses/conversation_projects.rs
+++ b/src/web/responses/conversation_projects.rs
@@ -7,7 +7,9 @@ use crate::{
     models::users::User,
     tokens::count_tokens,
     web::{
-        encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+        encryption_middleware::{
+            decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+        },
         responses::{
             constants::{
                 DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_ORDER, MAX_PAGINATION_LIMIT,
@@ -157,7 +159,7 @@ fn build_project_response(
 
 async fn create_conversation_project(
     State(state): State<Arc<AppState>>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<CreateConversationProjectRequest>,
@@ -184,7 +186,7 @@ async fn create_conversation_project(
 async fn list_conversation_projects(
     State(state): State<Arc<AppState>>,
     Query(params): Query<ListConversationProjectsParams>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<ConversationProjectListResponse>>, ApiError> {
@@ -241,7 +243,7 @@ async fn list_conversation_projects(
 async fn get_conversation_project(
     State(state): State<Arc<AppState>>,
     Path(project_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<ConversationProjectResponse>>, ApiError> {
@@ -263,7 +265,7 @@ async fn get_conversation_project(
 async fn update_conversation_project(
     State(state): State<Arc<AppState>>,
     Path(project_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<UpdateConversationProjectRequest>,
@@ -321,7 +323,7 @@ async fn update_conversation_project(
 async fn delete_conversation_project(
     State(state): State<Arc<AppState>>,
     Path(project_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
 ) -> Result<Json<EncryptedResponse<DeletedObjectResponse>>, ApiError> {
     debug!(

--- a/src/web/responses/conversation_projects.rs
+++ b/src/web/responses/conversation_projects.rs
@@ -7,7 +7,7 @@ use crate::{
     models::users::User,
     tokens::count_tokens,
     web::{
-        encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
+        encryption_middleware::{decrypt_request, encrypt_response, Decrypted, TransportSession},
         responses::{
             constants::{
                 DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_ORDER, MAX_PAGINATION_LIMIT,
@@ -161,7 +161,7 @@ async fn create_conversation_project(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(body): Extension<CreateConversationProjectRequest>,
+    Decrypted(body): Decrypted<CreateConversationProjectRequest>,
 ) -> Result<Response, ApiError> {
     let name = validate_project_name(&body.name)?;
     let user_key = state
@@ -267,7 +267,7 @@ async fn update_conversation_project(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(body): Extension<UpdateConversationProjectRequest>,
+    Decrypted(body): Decrypted<UpdateConversationProjectRequest>,
 ) -> Result<Response, ApiError> {
     if body.name.is_none() && body.instructions.is_missing() {
         return Err(ApiError::BadRequest);

--- a/src/web/responses/conversations.rs
+++ b/src/web/responses/conversations.rs
@@ -7,9 +7,7 @@ use crate::{
     models::responses::{ConversationProjectFilter, NewConversation},
     models::users::User,
     web::{
-        encryption_middleware::{
-            decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
-        },
+        encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
         responses::{
             constants::{
                 self, DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_ORDER, MAX_PAGINATION_LIMIT,
@@ -24,8 +22,9 @@ use crate::{
 use axum::{
     extract::{Path, Query, State},
     middleware::from_fn_with_state,
+    response::Response,
     routing::{delete, get, post},
-    Extension, Json, Router,
+    Extension, Router,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -388,7 +387,7 @@ async fn create_conversation(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<CreateConversationRequest>,
-) -> Result<Json<EncryptedResponse<ConversationResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Reject initial items - not supported in our simplified flow
     // Users must use POST /v1/responses to add messages to conversations
     if let Some(items) = &body.items {
@@ -472,7 +471,7 @@ async fn get_conversation(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-) -> Result<Json<EncryptedResponse<ConversationResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     let ctx = ConversationContext::load(&state, conversation_id, &user, &auth_context).await?;
     let mut project_cache = HashMap::new();
     let response = build_conversation_response(
@@ -495,7 +494,7 @@ async fn update_conversation(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<UpdateConversationRequest>,
-) -> Result<Json<EncryptedResponse<ConversationResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     if body.metadata.is_none() && body.project_id.is_missing() && body.pinned.is_none() {
         return Err(ApiError::BadRequest);
     }
@@ -557,7 +556,7 @@ async fn delete_conversation(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-) -> Result<Json<EncryptedResponse<DeletedObjectResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     let ctx = ConversationContext::load(&state, conversation_id, &user, &auth_context).await?;
 
     // Delete the conversation (cascades will delete all associated responses)
@@ -579,7 +578,7 @@ async fn list_conversation_items(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-) -> Result<Json<EncryptedResponse<ConversationItemListResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     let ctx = ConversationContext::load(&state, conversation_id, &user, &auth_context).await?;
 
     // Validate limit
@@ -645,7 +644,7 @@ async fn get_conversation_item(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-) -> Result<Json<EncryptedResponse<ConversationItem>>, ApiError> {
+) -> Result<Response, ApiError> {
     let ctx = ConversationContext::load(&state, conversation_id, &user, &auth_context).await?;
 
     // Get all messages from the conversation
@@ -680,7 +679,7 @@ async fn list_conversations(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-) -> Result<Json<EncryptedResponse<ConversationListResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Validate limit
     let limit = if params.limit <= 0 {
         DEFAULT_PAGINATION_LIMIT
@@ -754,7 +753,7 @@ async fn delete_all_conversations(
     State(state): State<Arc<AppState>>,
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
-) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
+) -> Result<Response, ApiError> {
     state
         .db
         .delete_all_conversations(user.uuid)
@@ -777,7 +776,7 @@ async fn batch_delete_conversations(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(body): Extension<BatchDeleteConversationsRequest>,
-) -> Result<Json<EncryptedResponse<BatchDeleteConversationsResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     // Validate batch size
     if body.ids.is_empty() || body.ids.len() > MAX_CONVERSATION_BATCH_SIZE {
         return Err(ApiError::BadRequest);
@@ -838,7 +837,7 @@ async fn batch_update_conversation_project(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(body): Extension<BatchUpdateConversationProjectRequest>,
-) -> Result<Json<EncryptedResponse<BatchUpdateConversationProjectResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     if body.ids.is_empty() || body.ids.len() > MAX_CONVERSATION_BATCH_SIZE {
         return Err(ApiError::BadRequest);
     }

--- a/src/web/responses/conversations.rs
+++ b/src/web/responses/conversations.rs
@@ -7,7 +7,9 @@ use crate::{
     models::responses::{ConversationProjectFilter, NewConversation},
     models::users::User,
     web::{
-        encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+        encryption_middleware::{
+            decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+        },
         responses::{
             constants::{
                 self, DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_ORDER, MAX_PAGINATION_LIMIT,
@@ -382,7 +384,7 @@ fn build_conversation_response(
 /// POST /v1/conversations - Create a new conversation
 async fn create_conversation(
     State(state): State<Arc<AppState>>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<CreateConversationRequest>,
@@ -467,7 +469,7 @@ async fn create_conversation(
 async fn get_conversation(
     State(state): State<Arc<AppState>>,
     Path(conversation_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<ConversationResponse>>, ApiError> {
@@ -489,7 +491,7 @@ async fn get_conversation(
 async fn update_conversation(
     State(state): State<Arc<AppState>>,
     Path(conversation_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<UpdateConversationRequest>,
@@ -552,7 +554,7 @@ async fn update_conversation(
 async fn delete_conversation(
     State(state): State<Arc<AppState>>,
     Path(conversation_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<DeletedObjectResponse>>, ApiError> {
@@ -574,7 +576,7 @@ async fn list_conversation_items(
     State(state): State<Arc<AppState>>,
     Path(conversation_id): Path<Uuid>,
     Query(params): Query<ListItemsParams>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<ConversationItemListResponse>>, ApiError> {
@@ -640,7 +642,7 @@ async fn list_conversation_items(
 async fn get_conversation_item(
     State(state): State<Arc<AppState>>,
     Path((conversation_id, item_id)): Path<(Uuid, Uuid)>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<ConversationItem>>, ApiError> {
@@ -675,7 +677,7 @@ async fn get_conversation_item(
 async fn list_conversations(
     State(state): State<Arc<AppState>>,
     Query(params): Query<ListConversationsParams>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<ConversationListResponse>>, ApiError> {
@@ -750,7 +752,7 @@ async fn list_conversations(
 /// DELETE /v1/conversations - Delete all conversations
 async fn delete_all_conversations(
     State(state): State<Arc<AppState>>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
 ) -> Result<Json<EncryptedResponse<serde_json::Value>>, ApiError> {
     state
@@ -772,7 +774,7 @@ const MAX_CONVERSATION_BATCH_SIZE: usize = 20;
 /// POST /v1/conversations/batch-delete - Delete multiple specific conversations
 async fn batch_delete_conversations(
     State(state): State<Arc<AppState>>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(body): Extension<BatchDeleteConversationsRequest>,
 ) -> Result<Json<EncryptedResponse<BatchDeleteConversationsResponse>>, ApiError> {
@@ -833,7 +835,7 @@ async fn batch_delete_conversations(
 /// POST /v1/conversations/batch-update-project - Update project assignment for multiple conversations
 async fn batch_update_conversation_project(
     State(state): State<Arc<AppState>>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(body): Extension<BatchUpdateConversationProjectRequest>,
 ) -> Result<Json<EncryptedResponse<BatchUpdateConversationProjectResponse>>, ApiError> {

--- a/src/web/responses/conversations.rs
+++ b/src/web/responses/conversations.rs
@@ -7,7 +7,7 @@ use crate::{
     models::responses::{ConversationProjectFilter, NewConversation},
     models::users::User,
     web::{
-        encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
+        encryption_middleware::{decrypt_request, encrypt_response, Decrypted, TransportSession},
         responses::{
             constants::{
                 self, DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_ORDER, MAX_PAGINATION_LIMIT,
@@ -386,7 +386,7 @@ async fn create_conversation(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(body): Extension<CreateConversationRequest>,
+    Decrypted(body): Decrypted<CreateConversationRequest>,
 ) -> Result<Response, ApiError> {
     // Reject initial items - not supported in our simplified flow
     // Users must use POST /v1/responses to add messages to conversations
@@ -493,7 +493,7 @@ async fn update_conversation(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(body): Extension<UpdateConversationRequest>,
+    Decrypted(body): Decrypted<UpdateConversationRequest>,
 ) -> Result<Response, ApiError> {
     if body.metadata.is_none() && body.project_id.is_missing() && body.pinned.is_none() {
         return Err(ApiError::BadRequest);
@@ -775,7 +775,7 @@ async fn batch_delete_conversations(
     State(state): State<Arc<AppState>>,
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
-    Extension(body): Extension<BatchDeleteConversationsRequest>,
+    Decrypted(body): Decrypted<BatchDeleteConversationsRequest>,
 ) -> Result<Response, ApiError> {
     // Validate batch size
     if body.ids.is_empty() || body.ids.len() > MAX_CONVERSATION_BATCH_SIZE {
@@ -836,7 +836,7 @@ async fn batch_update_conversation_project(
     State(state): State<Arc<AppState>>,
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
-    Extension(body): Extension<BatchUpdateConversationProjectRequest>,
+    Decrypted(body): Decrypted<BatchUpdateConversationProjectRequest>,
 ) -> Result<Response, ApiError> {
     if body.ids.is_empty() || body.ids.len() > MAX_CONVERSATION_BATCH_SIZE {
         return Err(ApiError::BadRequest);

--- a/src/web/responses/events.rs
+++ b/src/web/responses/events.rs
@@ -1,10 +1,9 @@
 //! SSE event handling utilities
 
-use crate::AppState;
+use crate::{web::encryption_middleware::TransportSession, AppState};
 use axum::response::sse::Event;
 use serde::Serialize;
 use tracing::{error, trace};
-use uuid::Uuid;
 
 use super::constants::{
     ERROR_DATA_ENCRYPTION_FAILED, ERROR_DATA_SERIALIZATION_FAILED, EVENT_RESPONSE_CANCELLED,
@@ -32,16 +31,20 @@ use super::handlers::{
 /// - Sequence number management
 pub struct SseEventEmitter<'a> {
     state: &'a AppState,
-    session_id: Uuid,
+    transport_session: TransportSession,
     sequence_number: i32,
 }
 
 impl<'a> SseEventEmitter<'a> {
     /// Create a new SSE event emitter
-    pub fn new(state: &'a AppState, session_id: Uuid, initial_sequence: i32) -> Self {
+    pub fn new(
+        state: &'a AppState,
+        transport_session: TransportSession,
+        initial_sequence: i32,
+    ) -> Self {
         Self {
             state,
-            session_id,
+            transport_session,
             sequence_number: initial_sequence,
         }
     }
@@ -63,7 +66,7 @@ impl<'a> SseEventEmitter<'a> {
     pub async fn emit<T: Serialize>(&mut self, event_type: &str, data: &T) -> Event {
         match serde_json::to_value(data) {
             Ok(json) => {
-                match encrypt_event(self.state, &self.session_id, event_type, &json).await {
+                match encrypt_event(self.state, &self.transport_session, event_type, &json).await {
                     Ok(event) => {
                         self.sequence_number += 1;
                         trace!(
@@ -97,7 +100,7 @@ impl<'a> SseEventEmitter<'a> {
     pub async fn emit_without_sequence<T: Serialize>(&self, event_type: &str, data: &T) -> Event {
         match serde_json::to_value(data) {
             Ok(json) => {
-                match encrypt_event(self.state, &self.session_id, event_type, &json).await {
+                match encrypt_event(self.state, &self.transport_session, event_type, &json).await {
                     Ok(event) => event,
                     Err(e) => {
                         error!("Failed to encrypt {} event: {:?}", event_type, e);

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -17,9 +17,7 @@ use crate::{
     models::users::User,
     tokens::count_tokens,
     web::{
-        encryption_middleware::{
-            decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
-        },
+        encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
         openai::{
             ensure_completion_model_access, get_chat_completion_response,
             get_chat_completion_response_for_execution,
@@ -55,9 +53,8 @@ use axum::{
         IntoResponse, Response,
     },
     routing::{delete, get, post},
-    Extension, Json, Router,
+    Extension, Router,
 };
-use base64::Engine;
 use chrono::Utc;
 use futures::Stream;
 use secp256k1::SecretKey;
@@ -3080,6 +3077,7 @@ fn spawn_title_generation_task(
             &headers,
             billing_context,
             ModelPlan::Free,
+            false,
         )
         .await
         {
@@ -3938,6 +3936,7 @@ async fn stream_one_assistant_turn(
     tool_turn_count: usize,
     prompt_token_estimate: usize,
     response_execution: ResponseExecution,
+    require_provider_done: bool,
 ) -> Result<AssistantTurnOutcome, ApiError> {
     let mut chat_request = build_model_turn_request(body, prompt_messages, tools_enabled);
 
@@ -3971,6 +3970,7 @@ async fn stream_one_assistant_turn(
         billing_context,
         model_plan,
         response_execution,
+        require_provider_done,
     )
     .await?;
 
@@ -4233,6 +4233,7 @@ async fn setup_completion_processor(
     tx_storage: mpsc::Sender<StorageMessage>,
     mut rx_tool_ack: mpsc::Receiver<Result<(), String>>,
     response_execution: ResponseExecution,
+    require_provider_done: bool,
 ) -> Result<crate::models::responses::Response, ApiError> {
     let tools_enabled = context.web_search_enabled;
     let mut prompt_messages = Arc::as_ref(&context.prompt_messages).clone();
@@ -4259,6 +4260,7 @@ async fn setup_completion_processor(
                 tool_turn_count,
                 prompt_token_estimate,
                 response_execution.clone(),
+                require_provider_done,
             )
             .await?
             {
@@ -4321,6 +4323,7 @@ async fn create_response_stream(
     Extension(mut body): Extension<ResponsesCreateRequest>,
 ) -> Result<Response, ApiError> {
     trace!("=== ENTERING create_response_stream ===");
+    let require_explicit_terminal = session_id.is_v2();
     trace!("User: {}", user.uuid);
     let requested_model = body.model.clone();
     let billing_access = state.chat_billing_access(user.uuid, false).await;
@@ -4640,6 +4643,7 @@ async fn create_response_stream(
                     orchestrator_tx_storage.clone(),
                     rx_tool_ack,
                     orchestrator_execution.clone(),
+                    require_explicit_terminal,
                 )
                 .await
                 {
@@ -4708,6 +4712,7 @@ async fn create_response_stream(
         let mut total_prompt_tokens_used = 0i32;
         let mut total_completion_tokens = 0i32;
         let mut durable_completion_pending = false;
+        let mut saw_terminal = false;
         loop {
             let msg = if durable_completion_pending {
                 next_client_message_after_durable_completion(&mut rx_client)
@@ -4910,6 +4915,7 @@ async fn create_response_stream(
                             // by the main response has exited.
                             drop(client_execution_guard.take());
                             response_execution.wait_for_quiescence().await;
+                            saw_terminal = true;
                             yield Ok(ResponseEvent::Cancelled(cancelled_event).to_sse_event(&mut emitter).await);
                             break;
                         }
@@ -4931,6 +4937,7 @@ async fn create_response_stream(
                                 },
                             };
                             drop(client_execution_guard.take());
+                            saw_terminal = true;
                             yield Ok(ResponseEvent::Error(error_event).to_sse_event(&mut emitter).await);
                             break;
                         }
@@ -4960,6 +4967,7 @@ async fn create_response_stream(
 
                     drop(client_execution_guard.take());
                     response_execution.wait_for_quiescence().await;
+                    saw_terminal = true;
                     yield Ok(ResponseEvent::Completed(completed_event).to_sse_event(&mut emitter).await);
                     break;
                 }
@@ -5000,6 +5008,7 @@ async fn create_response_stream(
                                 },
                             };
                             drop(client_execution_guard.take());
+                            saw_terminal = true;
                             yield Ok(ResponseEvent::Error(error_event).to_sse_event(&mut emitter).await);
                             break;
                         }
@@ -5017,6 +5026,7 @@ async fn create_response_stream(
 
                     drop(client_execution_guard.take());
                     response_execution.wait_for_quiescence().await;
+                    saw_terminal = true;
                     yield Ok(ResponseEvent::Cancelled(cancelled_event).to_sse_event(&mut emitter).await);
                     break;
                 }
@@ -5034,6 +5044,7 @@ async fn create_response_stream(
                         };
                         drop(client_execution_guard.take());
                         response_execution.wait_for_quiescence().await;
+                        saw_terminal = true;
                         yield Ok(ResponseEvent::Cancelled(cancelled_event).to_sse_event(&mut emitter).await);
                         break;
                     }
@@ -5055,6 +5066,7 @@ async fn create_response_stream(
                     };
 
                     drop(client_execution_guard.take());
+                    saw_terminal = true;
                     yield Ok(ResponseEvent::Error(error_event).to_sse_event(&mut emitter).await);
                     break;
                 }
@@ -5182,6 +5194,18 @@ async fn create_response_stream(
             }
         }
 
+        if require_explicit_terminal && !saw_terminal {
+            error!("Responses client stream closed without a terminal event");
+            let error_event = ResponseErrorEvent {
+                event_type: EVENT_RESPONSE_ERROR,
+                error: ResponseError {
+                    error_type: "stream_error".to_string(),
+                    message: "Response stream ended unexpectedly".to_string(),
+                },
+            };
+            yield Ok(ResponseEvent::Error(error_event).to_sse_event(&mut emitter).await);
+        }
+
         // Client stream is done, but storage and upstream tasks continue independently
         trace!("Client SSE stream ending");
     };
@@ -5222,16 +5246,14 @@ pub async fn encrypt_event(
 ) -> Result<Event, ApiError> {
     trace!("encrypt_event called for event type: {}", event_type);
     let payload_str = payload.to_string();
-    let encrypted = transport_session
-        .encrypt_response_bytes(state, payload_str.as_bytes())
+    let event_data = transport_session
+        .encode_sse_data(state, &payload_str)
         .await
         .map_err(|e| {
-            error!("Failed to encrypt event data: {:?}", e);
+            error!("Failed to encode event data: {:?}", e);
             ApiError::InternalServerError
         })?;
-
-    let base64_encrypted = base64::engine::general_purpose::STANDARD.encode(&encrypted);
-    Ok(Event::default().event(event_type).data(base64_encrypted))
+    Ok(Event::default().event(event_type).data(event_data))
 }
 
 /// GET /v1/responses/{id} - Retrieve a single response
@@ -5241,7 +5263,7 @@ async fn get_response(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<ResponsesRetrieveResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Getting response {} for user {}", id, user.uuid);
 
     // Get the response
@@ -5403,7 +5425,7 @@ async fn cancel_response(
     Path(id): Path<Uuid>,
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<ResponsesRetrieveResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Cancelling response {} for user {}", id, user.uuid);
 
     // Verify the response exists and belongs to the user, and is in_progress
@@ -5526,7 +5548,7 @@ async fn delete_response(
     Path(id): Path<Uuid>,
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
-) -> Result<Json<EncryptedResponse<DeletedObjectResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Deleting response {} for user {}", id, user.uuid);
 
     let existing = state

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -18,7 +18,7 @@ use crate::{
     provider_cache::CacheNamespaceRoot,
     tokens::count_tokens,
     web::{
-        encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
+        encryption_middleware::{decrypt_request, encrypt_response, Decrypted, TransportSession},
         openai::{
             ensure_completion_model_access, get_chat_completion_response,
             get_chat_completion_response_for_execution,
@@ -4321,7 +4321,7 @@ async fn create_response_stream(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     cache_namespace_root: Option<Extension<CacheNamespaceRoot>>,
-    Extension(mut body): Extension<ResponsesCreateRequest>,
+    Decrypted(mut body): Decrypted<ResponsesCreateRequest>,
 ) -> Result<Response, ApiError> {
     trace!("=== ENTERING create_response_stream ===");
     let require_explicit_terminal = session_id.is_v2();

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -15,14 +15,15 @@ use crate::{
         NewToolCall, NewToolOutput, NewUserMessage, ResponseStatus, ResponsesError,
     },
     models::users::User,
+    provider_cache::CacheNamespaceRoot,
     tokens::count_tokens,
     web::{
         encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
         openai::{
             ensure_completion_model_access, get_chat_completion_response,
             get_chat_completion_response_for_execution,
-            get_chat_completion_response_for_expected_route, BillingContext, CompletionChunk,
-            ServerSelectedCompletionRoute,
+            get_chat_completion_response_for_expected_route, BillingContext, CompletionCachePolicy,
+            CompletionChunk, CompletionExecutionContext, ServerSelectedCompletionRoute,
         },
         openai_auth::AuthMethod,
         responses::{
@@ -2828,6 +2829,7 @@ fn clamp_image_description_tokens(text: &str) -> i32 {
 struct ResponsesImageDescriptionExecutor<'a> {
     state: &'a Arc<AppState>,
     user: &'a User,
+    cache_policy: &'a CompletionCachePolicy,
     _access: PaidImageDescriptionAccess,
 }
 
@@ -2865,8 +2867,7 @@ impl ImageDescriptionAttemptExecutor for ResponsesImageDescriptionExecutor<'_> {
             self.user,
             request,
             &headers,
-            billing_context,
-            ModelPlan::Paid,
+            CompletionExecutionContext::new(billing_context, ModelPlan::Paid, self.cache_policy),
             ServerSelectedCompletionRoute {
                 provider_name: candidate.provider.as_str(),
                 provider_model_id: candidate.provider_model_id,
@@ -2912,12 +2913,14 @@ impl ImageDescriptionAttemptExecutor for ResponsesImageDescriptionExecutor<'_> {
 async fn describe_images(
     state: &Arc<AppState>,
     user: &User,
+    cache_policy: &CompletionCachePolicy,
     access: PaidImageDescriptionAccess,
     images: &[ImageAttachment],
 ) -> Result<Vec<ImageDescriptionToolPair>, ApiError> {
     let executor = ResponsesImageDescriptionExecutor {
         state,
         user,
+        cache_policy,
         _access: access,
     };
     let fallback_policy = RetryNonTerminalImageDescriptionFallbackPolicy;
@@ -3034,6 +3037,7 @@ fn spawn_title_generation_task(
     user: User,
     user_key: SecretKey,
     user_content: String,
+    cache_policy: CompletionCachePolicy,
 ) {
     tokio::spawn(async move {
         debug!(
@@ -3075,9 +3079,7 @@ fn spawn_title_generation_task(
             &user,
             title_request,
             &headers,
-            billing_context,
-            ModelPlan::Free,
-            false,
+            CompletionExecutionContext::new(billing_context, ModelPlan::Free, &cache_policy),
         )
         .await
         {
@@ -3936,7 +3938,7 @@ async fn stream_one_assistant_turn(
     tool_turn_count: usize,
     prompt_token_estimate: usize,
     response_execution: ResponseExecution,
-    require_provider_done: bool,
+    cache_policy: &CompletionCachePolicy,
 ) -> Result<AssistantTurnOutcome, ApiError> {
     let mut chat_request = build_model_turn_request(body, prompt_messages, tools_enabled);
 
@@ -3967,10 +3969,8 @@ async fn stream_one_assistant_turn(
         user,
         chat_request.take(),
         headers,
-        billing_context,
-        model_plan,
+        CompletionExecutionContext::new(billing_context, model_plan, cache_policy),
         response_execution,
-        require_provider_done,
     )
     .await?;
 
@@ -4233,7 +4233,7 @@ async fn setup_completion_processor(
     tx_storage: mpsc::Sender<StorageMessage>,
     mut rx_tool_ack: mpsc::Receiver<Result<(), String>>,
     response_execution: ResponseExecution,
-    require_provider_done: bool,
+    cache_policy: &CompletionCachePolicy,
 ) -> Result<crate::models::responses::Response, ApiError> {
     let tools_enabled = context.web_search_enabled;
     let mut prompt_messages = Arc::as_ref(&context.prompt_messages).clone();
@@ -4260,7 +4260,7 @@ async fn setup_completion_processor(
                 tool_turn_count,
                 prompt_token_estimate,
                 response_execution.clone(),
-                require_provider_done,
+                cache_policy,
             )
             .await?
             {
@@ -4320,10 +4320,16 @@ async fn create_response_stream(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
+    cache_namespace_root: Option<Extension<CacheNamespaceRoot>>,
     Extension(mut body): Extension<ResponsesCreateRequest>,
 ) -> Result<Response, ApiError> {
     trace!("=== ENTERING create_response_stream ===");
     let require_explicit_terminal = session_id.is_v2();
+    let cache_policy = CompletionCachePolicy::for_request(
+        &session_id,
+        cache_namespace_root.map(|Extension(root)| root),
+        user.uuid,
+    )?;
     trace!("User: {}", user.uuid);
     let requested_model = body.model.clone();
     let billing_access = state.chat_billing_access(user.uuid, false).await;
@@ -4404,7 +4410,16 @@ async fn create_response_stream(
     // Phase 2b: Describe all current-turn images before any database write or
     // SSE response. A complete cascade failure therefore leaves no partial chat.
     let image_descriptions = match image_access {
-        Some(access) => describe_images(&state, &user, access, &prepared.image_attachments).await?,
+        Some(access) => {
+            describe_images(
+                &state,
+                &user,
+                &cache_policy,
+                access,
+                &prepared.image_attachments,
+            )
+            .await?
+        }
         None => Vec::new(),
     };
 
@@ -4535,6 +4550,7 @@ async fn create_response_stream(
             user.clone(),
             prepared.user_key,
             user_content,
+            cache_policy.clone(),
         );
     }
 
@@ -4605,6 +4621,7 @@ async fn create_response_stream(
     let orchestrator_conversation = conversation_for_stream.clone();
     let orchestrator_prompt_messages = prompt_messages.clone();
     let orchestrator_execution = response_execution.clone();
+    let orchestrator_cache_policy = cache_policy.clone();
 
     tokio::spawn(async move {
         let _orchestrator_execution_guard = orchestrator_execution_guard;
@@ -4643,7 +4660,7 @@ async fn create_response_stream(
                     orchestrator_tx_storage.clone(),
                     rx_tool_ack,
                     orchestrator_execution.clone(),
-                    require_explicit_terminal,
+                    &orchestrator_cache_policy,
                 )
                 .await
                 {

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -17,7 +17,9 @@ use crate::{
     models::users::User,
     tokens::count_tokens,
     web::{
-        encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+        encryption_middleware::{
+            decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+        },
         openai::{
             ensure_completion_model_access, get_chat_completion_response,
             get_chat_completion_response_for_execution,
@@ -4313,7 +4315,7 @@ async fn setup_completion_processor(
 async fn create_response_stream(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(mut body): Extension<ResponsesCreateRequest>,
@@ -5214,14 +5216,14 @@ where
 /// Helper to create encrypted SSE event
 pub async fn encrypt_event(
     state: &AppState,
-    session_id: &Uuid,
+    transport_session: &TransportSession,
     event_type: &str,
     payload: &Value,
 ) -> Result<Event, ApiError> {
     trace!("encrypt_event called for event type: {}", event_type);
     let payload_str = payload.to_string();
-    let encrypted = state
-        .encrypt_session_data(session_id, payload_str.as_bytes())
+    let encrypted = transport_session
+        .encrypt_response_bytes(state, payload_str.as_bytes())
         .await
         .map_err(|e| {
             error!("Failed to encrypt event data: {:?}", e);
@@ -5238,7 +5240,7 @@ async fn get_response(
     Path(id): Path<Uuid>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<ResponsesRetrieveResponse>>, ApiError> {
     debug!("Getting response {} for user {}", id, user.uuid);
 
@@ -5400,7 +5402,7 @@ async fn cancel_response(
     State(state): State<Arc<AppState>>,
     Path(id): Path<Uuid>,
     Extension(user): Extension<User>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<ResponsesRetrieveResponse>>, ApiError> {
     debug!("Cancelling response {} for user {}", id, user.uuid);
 
@@ -5523,7 +5525,7 @@ async fn delete_response(
     State(state): State<Arc<AppState>>,
     Path(id): Path<Uuid>,
     Extension(user): Extension<User>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
 ) -> Result<Json<EncryptedResponse<DeletedObjectResponse>>, ApiError> {
     debug!("Deleting response {} for user {}", id, user.uuid);
 

--- a/src/web/responses/instructions.rs
+++ b/src/web/responses/instructions.rs
@@ -8,7 +8,7 @@ use crate::{
     models::users::User,
     tokens::count_tokens,
     web::{
-        encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
+        encryption_middleware::{decrypt_request, encrypt_response, Decrypted, TransportSession},
         responses::{
             constants::{
                 DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_ORDER, MAX_PAGINATION_LIMIT,
@@ -251,7 +251,7 @@ async fn create_instruction(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(body): Extension<CreateInstructionRequest>,
+    Decrypted(body): Decrypted<CreateInstructionRequest>,
 ) -> Result<Response, ApiError> {
     debug!("Creating new instruction for user: {}", user.uuid);
 
@@ -346,7 +346,7 @@ async fn update_instruction(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-    Extension(body): Extension<UpdateInstructionRequest>,
+    Decrypted(body): Decrypted<UpdateInstructionRequest>,
 ) -> Result<Response, ApiError> {
     debug!(
         "Updating instruction {} for user {}",

--- a/src/web/responses/instructions.rs
+++ b/src/web/responses/instructions.rs
@@ -8,7 +8,9 @@ use crate::{
     models::users::User,
     tokens::count_tokens,
     web::{
-        encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+        encryption_middleware::{
+            decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+        },
         responses::{
             constants::{
                 DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_ORDER, MAX_PAGINATION_LIMIT,
@@ -247,7 +249,7 @@ impl InstructionResponseBuilder {
 /// POST /v1/instructions - Create a new user instruction
 async fn create_instruction(
     State(state): State<Arc<AppState>>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<CreateInstructionRequest>,
@@ -318,7 +320,7 @@ async fn create_instruction(
 async fn get_instruction(
     State(state): State<Arc<AppState>>,
     Path(instruction_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<InstructionResponse>>, ApiError> {
@@ -342,7 +344,7 @@ async fn get_instruction(
 async fn update_instruction(
     State(state): State<Arc<AppState>>,
     Path(instruction_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<UpdateInstructionRequest>,
@@ -418,7 +420,7 @@ async fn update_instruction(
 async fn delete_instruction(
     State(state): State<Arc<AppState>>,
     Path(instruction_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<DeletedObjectResponse>>, ApiError> {
@@ -448,7 +450,7 @@ async fn delete_instruction(
 async fn list_instructions(
     State(state): State<Arc<AppState>>,
     Query(params): Query<ListInstructionsParams>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<InstructionListResponse>>, ApiError> {
@@ -522,7 +524,7 @@ async fn list_instructions(
 async fn set_default_instruction(
     State(state): State<Arc<AppState>>,
     Path(instruction_id): Path<Uuid>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
 ) -> Result<Json<EncryptedResponse<InstructionResponse>>, ApiError> {

--- a/src/web/responses/instructions.rs
+++ b/src/web/responses/instructions.rs
@@ -8,9 +8,7 @@ use crate::{
     models::users::User,
     tokens::count_tokens,
     web::{
-        encryption_middleware::{
-            decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
-        },
+        encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
         responses::{
             constants::{
                 DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_ORDER, MAX_PAGINATION_LIMIT,
@@ -24,8 +22,9 @@ use crate::{
 use axum::{
     extract::{Path, Query, State},
     middleware::from_fn_with_state,
+    response::Response,
     routing::{delete, get, post},
-    Extension, Json, Router,
+    Extension, Router,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -253,7 +252,7 @@ async fn create_instruction(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<CreateInstructionRequest>,
-) -> Result<Json<EncryptedResponse<InstructionResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Creating new instruction for user: {}", user.uuid);
 
     // Validate input
@@ -323,7 +322,7 @@ async fn get_instruction(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-) -> Result<Json<EncryptedResponse<InstructionResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!(
         "Getting instruction {} for user {}",
         instruction_id, user.uuid
@@ -348,7 +347,7 @@ async fn update_instruction(
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
     Extension(body): Extension<UpdateInstructionRequest>,
-) -> Result<Json<EncryptedResponse<InstructionResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!(
         "Updating instruction {} for user {}",
         instruction_id, user.uuid
@@ -423,7 +422,7 @@ async fn delete_instruction(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-) -> Result<Json<EncryptedResponse<DeletedObjectResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!(
         "Deleting instruction {} for user {}",
         instruction_id, user.uuid
@@ -453,7 +452,7 @@ async fn list_instructions(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-) -> Result<Json<EncryptedResponse<InstructionListResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!("Listing instructions for user: {}", user.uuid);
 
     let limit = if params.limit <= 0 {
@@ -527,7 +526,7 @@ async fn set_default_instruction(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(auth_context): Extension<AuthContext>,
-) -> Result<Json<EncryptedResponse<InstructionResponse>>, ApiError> {
+) -> Result<Response, ApiError> {
     debug!(
         "Setting instruction {} as default for user {}",
         instruction_id, user.uuid

--- a/src/web/web_routes.rs
+++ b/src/web/web_routes.rs
@@ -30,7 +30,7 @@ use crate::{
     },
     models::users::User,
     web::{
-        encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
+        encryption_middleware::{decrypt_request, encrypt_response, Decrypted, TransportSession},
         web_safety::{compact_untrusted_markdown, normalize_public_https_url, strip_image_embeds},
     },
     ApiError, AppMode, AppState,
@@ -273,7 +273,7 @@ async fn search_web(
     axum::extract::State(state): axum::extract::State<Arc<AppState>>,
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
-    Extension(body): Extension<Value>,
+    Decrypted(body): Decrypted<Value>,
 ) -> Result<Response, WebRouteError> {
     let request = serde_json::from_value::<WebSearchRequest>(body)
         .map_err(|_| WebRouteError::InvalidRequest)?;
@@ -293,7 +293,7 @@ async fn extract_web(
     axum::extract::State(state): axum::extract::State<Arc<AppState>>,
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
-    Extension(body): Extension<Value>,
+    Decrypted(body): Decrypted<Value>,
 ) -> Result<Response, WebRouteError> {
     let request = serde_json::from_value::<WebExtractRequest>(body)
         .map_err(|_| WebRouteError::InvalidRequest)?;

--- a/src/web/web_routes.rs
+++ b/src/web/web_routes.rs
@@ -22,7 +22,6 @@ use std::{
     time::Duration,
 };
 use tracing::{debug, info, warn};
-use uuid::Uuid;
 
 use crate::{
     kagi::{
@@ -31,7 +30,9 @@ use crate::{
     },
     models::users::User,
     web::{
-        encryption_middleware::{decrypt_request, encrypt_response, EncryptedResponse},
+        encryption_middleware::{
+            decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
+        },
         web_safety::{compact_untrusted_markdown, normalize_public_https_url, strip_image_embeds},
     },
     ApiError, AppMode, AppState,
@@ -272,7 +273,7 @@ pub fn router(app_state: Arc<AppState>) -> Router<()> {
 
 async fn search_web(
     axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(body): Extension<Value>,
 ) -> Result<Json<EncryptedResponse<WebSearchResponse>>, WebRouteError> {
@@ -292,7 +293,7 @@ async fn search_web(
 
 async fn extract_web(
     axum::extract::State(state): axum::extract::State<Arc<AppState>>,
-    Extension(session_id): Extension<Uuid>,
+    Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(body): Extension<Value>,
 ) -> Result<Json<EncryptedResponse<WebExtractResponse>>, WebRouteError> {

--- a/src/web/web_routes.rs
+++ b/src/web/web_routes.rs
@@ -30,9 +30,7 @@ use crate::{
     },
     models::users::User,
     web::{
-        encryption_middleware::{
-            decrypt_request, encrypt_response, EncryptedResponse, TransportSession,
-        },
+        encryption_middleware::{decrypt_request, encrypt_response, TransportSession},
         web_safety::{compact_untrusted_markdown, normalize_public_https_url, strip_image_embeds},
     },
     ApiError, AppMode, AppState,
@@ -276,7 +274,7 @@ async fn search_web(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(body): Extension<Value>,
-) -> Result<Json<EncryptedResponse<WebSearchResponse>>, WebRouteError> {
+) -> Result<Response, WebRouteError> {
     let request = serde_json::from_value::<WebSearchRequest>(body)
         .map_err(|_| WebRouteError::InvalidRequest)?;
     let options = validate_search_request(request)?;
@@ -296,7 +294,7 @@ async fn extract_web(
     Extension(session_id): Extension<TransportSession>,
     Extension(user): Extension<User>,
     Extension(body): Extension<Value>,
-) -> Result<Json<EncryptedResponse<WebExtractResponse>>, WebRouteError> {
+) -> Result<Response, WebRouteError> {
     let request = serde_json::from_value::<WebExtractRequest>(body)
         .map_err(|_| WebRouteError::InvalidRequest)?;
     let (urls, timeout) = validate_extract_request(request)?;


### PR DESCRIPTION
Adds Transport V2 alongside the existing V1 protocol. New clients send the credential, cache namespace root and complete logical request inside one authenticated encrypted envelope; existing clients continue using the V1 routes and wire behavior.

This is the complete current backend implementation, consolidated for final review and controlled dev validation.

## Changes

- Add attested session establishment and the isolated `/v2/session` and `/v2/request` gateway, with per-request AEAD keys, atomic replay admission before application dispatch, bounded session/replay/body storage, and authenticated response records with explicit finality.
- Share application handling across transports while preserving route-specific authorization, status/error behavior and streaming. Authentication remains per request rather than authority stored in the transport session.
- Bind V2 OAuth and one-use native handoff to the initiating transport context. Derive provider-cache namespaces from the private client root and verified account identity.
- Emit exact outer HTTP 400 recovery markers only for an actually missing/expired session or incoming request AEAD authentication failure. The matching SDKs permit one resend of the captured operation after a verified replacement handshake. Replay/capacity/routing errors, ordinary application failures, ambiguous network outcomes and client response-verification failures do not authorize that resend.

The recovery markers are unauthenticated. This deliberately preserves V1-style best-effort recovery, including mutations: a forwarding attacker can forge a marker after execution and induce a duplicate in a new session. Per-session replay protection does not guarantee cross-session at-most-once execution.

[Wire contract and deployment notes](https://github.com/OpenSecretCloud/opensecret/blob/e488430f9c147ab64f78c2ff8322b52356472a7f/docs/transport-v2-protocol.md) · [Matching Maple/TypeScript/Rust recovery commit](https://github.com/OpenSecretCloud/Maple/commit/c1f8c5ae52f82f214656ee09d58f3bb64991d6bb)

## Validation

Local checks used the pinned Nix environment with development service hooks disabled:

- `cargo fmt --all -- --check`
- `RUSTFLAGS="-D warnings" cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --locked --all-features`: **518 passed, 23 ignored**.
- `RUSTFLAGS="-D warnings" cargo build --locked`: passed.
- A real local backend restart with the actual TypeScript SDK and disposable PostgreSQL produced `request 400 → session 200 → request 200`. Independent SQL auditing showed **zero writes before the SDK received the rejection, then exactly one write after recovery**, with credentials/account retained. This used local mock attestation and is not a deployed Nitro or browser/OS test.
- Both SDK recovery suites and consuming proxy/Maple checks passed locally. Independent source review found no actionable issue in the bounded recovery change. GitHub checks for this consolidated PR are separate evidence.

GitHub checks at `e488430f` pass, including Rust tests/lints, RustSec, CodeQL, and the [development enclave reproducible build](https://github.com/OpenSecretCloud/opensecret/actions/runs/33981981028/job/101348708469). The production build is skipped for PRs; the development PR build does not compare PCR references. CodeQL nonce alerts #66, #67 and #68 were individually reviewed and dismissed as false positives with documented reasoning: requests use per-request derived keys, and response nonces include an advancing sequence.

## Rollout and remaining limits

- No database migration, schema backfill, new required runtime variable, deployed secret or additional service is introduced. No EIF/PCR reference is changed by this PR.
- Deploying the backend makes the V2 endpoints reachable immediately; the built-in caps are active. Assess existing ingress controls and use bounded dev traffic. Stable DNS persistence can provide normal creator-enclave routing; V2 HTTP-header affinity is conditional on a proxied HTTP topology, not a universal DNS-only requirement.
- Controlled dev validation still needs the exact Linux/ARM64 EIF and dev PCR/trust preparation, released V1-client smoke, real Nitro handshakes, provider streaming, failover and capacity observations. Full native OAuth testing requires hosted/native assets targeting the same backend. Nothing in the local results claims those deployed checks have already passed.
- A retained low-priority edge case can turn oversized internal response metadata into outer 503 instead of the intended encrypted 500. It is not marked retryable. Maple's configured-project confirmation check remains deferred from the coordinated rollout scope.

## Superseded review stack

Replaces the earlier Transport V2 PRs: #308, #309, #310, #313, #318, #327, #330, #331, #332, #333, #334, #336 and #337. Their discussions remain historical review context; the implementation and current validation are collected here.
