### PR TITLE
Correlate request logs and sanitize sensitive diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,10 @@ transport; protected routes are not ordinary plaintext `fetch`, `curl`, or
 - Treat billing and feature flags only as configurable external HTTP APIs.
   Their server credentials remain backend-only, and each changed call site
   must define its own unavailable, timeout, denial, and success behavior.
+- Follow `docs/logging.md` for request correlation and safe diagnostics. Retain
+  spans across spawned work and streaming bodies; skip arguments by default in
+  instrumentation and explicitly allowlist fields. Error Display/Debug can
+  contain user data: use bounded typed categories, including at debug/trace.
 - Separate source-confirmed, test-confirmed, build-confirmed, live-confirmed,
   inferred, and unverified claims. Source and local tests do not prove deployed
   PCRs, KMS/IAM policy, artifact identity, network placement, or log retention.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,11 @@ transport; protected routes are not ordinary plaintext `fetch`, `curl`, or
   prompts, reasoning, decrypted bodies, response deltas, provider bodies, or
   other sensitive user content. Safe metadata must be bounded and allowlisted;
   `trace` is not a private channel.
+- PII is not categorically excluded: relevant IDs, email addresses, API-key
+  display names, model/provider names, and non-content request parameters are
+  valid diagnostics. The protected boundary is keys/credentials and plaintext
+  that belongs encrypted at rest, including messages, titles, instructions,
+  KV keys/values, and tool/media content. Select metadata fields explicitly.
 - Preserve capacity, expiry, one-use/lease, cleanup, cancellation, and failure
   behavior at unauthenticated, cryptographic, streaming, and external-service
   boundaries.

--- a/docs/dev-shell.md
+++ b/docs/dev-shell.md
@@ -33,6 +33,7 @@ belongs to the current checkout.
 
 `APP_MODE=local` writes line-buffered tracing to stdout so redirected `cargo run`
 logs appear immediately. When `RUST_LOG` is unset the default is
-`opensecret=debug` plus `axum_login`, `tower_sessions`, `sqlx=warn`, and
-`tower_http`. Override `RUST_LOG` to quiet or expand that set. Do not log
-secrets, tokens, decrypted bodies, or raw provider payloads.
+`warn,opensecret=info`. Add a focused module override such as
+`opensecret::web::responses=debug` when investigating. Keep the application
+root at info to retain request spans. See [logging and request correlation](logging.md)
+for trace IDs, body outcomes, privacy rules, and the parent logger's framing limits.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,103 @@
+# Application logs and request correlation
+
+The binary and enclave entrypoint default to `RUST_LOG=warn,opensecret=info`.
+Dependencies stay at warning level; application events remain visible. For a
+focused investigation, keep the application root enabled and add a module:
+
+```sh
+RUST_LOG=warn,opensecret=info,opensecret::web::responses=debug
+```
+
+An inherited `RUST_LOG` overrides the default too. If trace IDs are missing,
+check the launching shell's filter: `RUST_LOG=warn` disables the info-level
+request spans. Set `RUST_LOG=warn,opensecret=info` on the managed backend start
+command to retain them without changing generated environment files.
+
+Logs remain line-oriented tracing text with ANSI disabled. Local stdout is
+line-buffered. This change does not add a metrics endpoint, exporter, collector,
+or JSON log format. `trace` and `debug` are still host-visible logs, not private
+channels for decrypted content.
+
+## Follow one request
+
+Every incoming HTTP request receives a fresh server-generated, 32-character
+hexadecimal `trace_id` on its `http_request` span. Search for that field across
+the selected time window and all relevant origin streams. Never use an account,
+session, token, client-supplied request ID, or provider ID as a trace ID.
+Incoming tracing headers are not trusted or copied into these fields, and the
+ID is not added to client or provider HTTP headers.
+
+The span records a standard method and the router's matched route template.
+Unknown methods become `OTHER`, unmatched routes become `unmatched`, and raw
+paths, query strings, headers, and bodies are excluded. Transport V2's internal
+dispatch adds a `logical_request` child span under the same outer trace. Its
+logical route template is backend diagnostic metadata, not decrypted content.
+
+The request span surrounds middleware and handlers, then follows response-body
+polling and destruction. Request-owned background inference, storage, title,
+usage, recovery, and email tasks capture the current span when spawned, so
+their events remain correlated after the client body ends. Existing inference
+request/execution/attempt IDs and response IDs keep their separate meanings.
+Periodic service maintenance and startup jobs do not invent request IDs.
+
+`HTTP response body finished` records `status`, `elapsed_ms`, and one outcome:
+
+| Outcome | Meaning |
+| --- | --- |
+| `body_complete` | The application produced the full HTTP body. |
+| `body_error` | Body production returned an error. Its payload is not logged. |
+| `body_dropped` | The body was dropped before completion. |
+
+These events do not prove client receipt, inference success, cancellation of
+background execution, or storage commit. Use the corresponding execution and
+storage terminal events for those conclusions. Successful health probes and
+early drops are debug-level summaries; body errors and server-error statuses
+remain warnings. A normal response otherwise has one info-level body summary.
+Transport V2 has a summary for its logical response and its outer encrypted
+response, distinguishable by span context.
+
+## Add or change logging
+
+- Prefer fixed operation/reason fields and allowlisted provider/model/status
+  metadata. Treat unknown client/provider strings as content even when they
+  appear in an error. Do not log whole errors, records, claims, headers, OAuth
+  responses, prompts, deltas, KMS output, or credential-bearing URLs.
+- Use `observability::error_kind` for supported Rust error chains, or a narrow
+  typed classifier for a particular boundary. It deliberately returns a fixed
+  fallback for unknown types. Add a typed category when more detail is needed;
+  do not fall back to `Display`/`Debug` or parse arbitrary error messages.
+- Use `#[tracing::instrument(skip_all)]` with explicit safe fields for operation
+  spans. Normal awaited calls inherit context. Detached futures need
+  `.in_current_span()`; blocking closures need a captured span and `in_scope`.
+  Never hold an entered-span guard across an `await`.
+- Expected malformed input, expired credentials, missing records, and client
+  disconnects are not automatically infrastructure errors. Preserve warnings
+  for actual provider unavailability, storage failure, and incomplete execution.
+- Keep one useful failure at the owning boundary when possible. Default info
+  should not emit per-token/per-delta progress. Temporary debug overrides must
+  retain the same privacy rules.
+
+The database startup span records configured maximum/minimum pool sizes,
+elapsed initialization time, and actual connected/idle counts on success. On
+failure it records a bounded class and time before the existing startup panic.
+The pool's worker error handler also emits typed categories instead of raw
+PostgreSQL connection or validation diagnostics.
+Pool limits, retries, timeouts, and proxy behavior are unchanged. A pool timeout
+alone does not establish PostgreSQL saturation or a connection leak.
+
+## Validation boundaries
+
+The correlation tests exercise concurrent routing, untrusted metadata,
+background work, logical dispatch, frame/trailer preservation, early drop, and
+body errors. Privacy tests use synthetic payload-bearing OAuth, JWT, Resend,
+database, JSON, UTF-8, KMS, and derivation-path failures. Run the backend's
+normal validation skill before submitting changes; use a pinned SDK against
+the managed local backend for encrypted protocol checks.
+
+The parent logger in the pinned Nitro toolkit still emits socket chunks as
+CloudWatch events. A CloudWatch event is therefore not necessarily one complete
+application line, and this backend change does not repair event framing or
+delivery loss. Reassemble per stream before counting lines or extracting trace
+fields. Deployment/PCR validation and live log verification remain separate.
+
+The async span rules follow the upstream [tracing Instrument documentation](https://docs.rs/tracing/latest/tracing/trait.Instrument.html).

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -58,14 +58,26 @@ response, distinguishable by span context.
 
 ## Add or change logging
 
-- Prefer fixed operation/reason fields and allowlisted provider/model/status
-  metadata. Treat unknown client/provider strings as content even when they
-  appear in an error. Do not log whole errors, records, claims, headers, OAuth
-  responses, prompts, deltas, KMS output, or credential-bearing URLs.
+- The confidentiality boundary is content and secret material, not PII in
+  general. User/project/client/response IDs, email addresses, API-key display
+  names (never the actual key), model/provider names, status, counts, timings,
+  and other non-content request parameters are useful diagnostic metadata.
+  Retain them when relevant, with bounded/escaped string fields.
+- Never log user/enclave/session keys, mnemonics, passwords, tokens, credentials,
+  or plaintext that belongs encrypted at rest: prompts, completions, assistant
+  messages/reasoning, conversation titles, instructions, KV keys/values,
+  tool arguments/results, or media content. Being encrypted during transport
+  does not make the decrypted value safe to log.
+- Select metadata fields explicitly. Whole records, claims, headers, OAuth
+  documents, provider bodies, KMS output, and arbitrary error text may mix
+  allowed metadata with prohibited content. Avoid dumping those containers;
+  keep the useful fields without retaining their payloads.
 - Use `observability::error_kind` for supported Rust error chains, or a narrow
   typed classifier for a particular boundary. It deliberately returns a fixed
   fallback for unknown types. Add a typed category when more detail is needed;
   do not fall back to `Display`/`Debug` or parse arbitrary error messages.
+  `Result::expect`/`unwrap` and a failed `main -> Result` also print error
+  `Debug`; erase retained secret buffers and parse text before those paths.
 - Use `#[tracing::instrument(skip_all)]` with explicit safe fields for operation
   spans. Normal awaited calls inherit context. Detached futures need
   `.in_current_span()`; blocking closures need a captured span and `in_scope`.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,20 @@ log() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
 }
 
+# jq errors can include the input being parsed, including credentials and
+# decrypted values. Keep stdout and exit status for the caller, but report only
+# the fixed stage name and status when parsing fails.
+secret_jq() {
+    local stage="$1"
+    shift
+    local status=0
+    jq "$@" 2>/dev/null || status=$?
+    if [ "$status" -ne 0 ]; then
+        log "Error: startup_stage=$stage exit_code=$status" >&2
+    fi
+    return "$status"
+}
+
 # BEGIN ENCLAVE_ENTROPY_PREFLIGHT
 # Fail closed before any application or KMS work if the enclave entropy path is
 # not the one we expect. Positional overrides exist only so this function can
@@ -187,12 +201,16 @@ vsock_request() {
     local port=$2
     local request=$3
 
-    response=$(python3 /app/vsock_helper.py "$cid" "$port" "$request")
+    # The helper can dump raw response bytes on decoding failures.
+    response=$(python3 /app/vsock_helper.py "$cid" "$port" "$request" 2>/dev/null)
+    local status=$?
+    if [ "$status" -ne 0 ]; then
+        log "Error: startup_stage=fetch_parent_response exit_code=$status" >&2
+    fi
     
     # Check if the response contains an error
-    if echo "$response" | jq -e 'has("error")' > /dev/null; then
-        error_message=$(echo "$response" | jq -r '.error')
-        log "VSOCK request failed: $error_message"
+    if echo "$response" | jq -e 'has("error")' > /dev/null 2>&1; then
+        log "Error: startup_stage=fetch_parent_response status=parent_error" >&2
         return 1
     fi
 
@@ -295,20 +313,19 @@ if [ -z "$aws_creds" ]; then
 fi
 
 # Add error checking for jq parsing
-if ! access_key_id=$(echo "$aws_creds" | jq -r '.response_value.AccessKeyId'); then
+if ! access_key_id=$(echo "$aws_creds" | secret_jq parse_aws_access_key_id -r '.response_value.AccessKeyId'); then
     log "Error: Failed to parse AccessKeyId from AWS credentials"
-    log "AWS credentials response: $aws_creds"
     exit 1
 fi
-if ! secret_access_key=$(echo "$aws_creds" | jq -r '.response_value.SecretAccessKey'); then
+if ! secret_access_key=$(echo "$aws_creds" | secret_jq parse_aws_secret_access_key -r '.response_value.SecretAccessKey'); then
     log "Error: Failed to parse SecretAccessKey from AWS credentials"
     exit 1
 fi
-if ! session_token=$(echo "$aws_creds" | jq -r '.response_value.Token'); then
+if ! session_token=$(echo "$aws_creds" | secret_jq parse_aws_session_token -r '.response_value.Token'); then
     log "Error: Failed to parse Token from AWS credentials"
     exit 1
 fi
-if ! region=$(echo "$aws_creds" | jq -r '.response_value.Region'); then
+if ! region=$(echo "$aws_creds" | secret_jq parse_aws_region -r '.response_value.Region'); then
     log "Error: Failed to parse Region from AWS credentials"
     exit 1
 fi
@@ -318,13 +335,12 @@ log "AWS credentials retrieved and parsed successfully"
 # Get encrypted database URL from Secrets Manager
 log "Fetching encrypted database URL"
 secret_response=$(get_database_url_secret)
-log "Retrieved raw secret response"
+log "Received database secret response"
 
 # Extract the database_url value from the JSON structure
-encrypted_db_url=$(echo "$secret_response" | jq -r '.response_value | fromjson | .database_url')
+encrypted_db_url=$(echo "$secret_response" | secret_jq parse_database_secret -r '.response_value | fromjson | .database_url')
 if [ -z "$encrypted_db_url" ]; then
     log "Error: Failed to get encrypted database URL"
-    log "Secret response: $secret_response"
     exit 1
 fi
 
@@ -338,7 +354,11 @@ decryption_output=$(kmstool_enclave_cli decrypt \
     --aws-access-key-id "$access_key_id" \
     --aws-secret-access-key "$secret_access_key" \
     --aws-session-token "$session_token" \
-    --ciphertext "$encrypted_db_url" 2>&1)
+    --ciphertext "$encrypted_db_url" 2>&1) || {
+        status=$?
+        log "Error: startup_stage=decrypt_database_url exit_code=$status"
+        exit "$status"
+    }
 
 log "Got decryption output, parsing URL"
 
@@ -346,7 +366,6 @@ decrypted_db_url=$(echo "$decryption_output" | sed -n 's/PLAINTEXT: //p')
 
 if [ -z "$decrypted_db_url" ]; then
     log "Error: Failed to decrypt database URL"
-    log "Decryption output: $decryption_output"
     exit 1
 fi
 
@@ -368,7 +387,7 @@ if [ -z "$DB_HOSTNAME" ]; then
 fi
 
 echo "127.0.0.1 $DB_HOSTNAME" >> /etc/hosts
-log "Added $DB_HOSTNAME to /etc/hosts"
+log "Added database host mapping to /etc/hosts"
 
 # Add OpenAI API hostname to /etc/hosts
 echo "127.0.0.1 api.openai.com" >> /etc/hosts
@@ -459,7 +478,7 @@ log "Created /app/libnsm.so"
 log "Network configuration:"
 ip addr show
 ip route
-cat /etc/hosts
+# Do not dump /etc/hosts: the database hostname comes from a decrypted secret.
 
 # Start the traffic forwarder for the database in the background
 log "Starting database traffic forwarder"
@@ -868,20 +887,18 @@ if [ "$APP_MODE" != "local" ]; then
     # Get Continuum Proxy API key from Secrets Manager
     log "Fetching Continuum Proxy API key"
     continuum_proxy_api_key_response=$(get_continuum_proxy_api_key_secret)
-    log "Retrieved raw Continuum Proxy API key response"
+    log "Received Continuum Proxy API key response"
 
     # Check if the response is an error
-    if echo "$continuum_proxy_api_key_response" | jq -e '.response_type == "error"' > /dev/null; then
-        error_message=$(echo "$continuum_proxy_api_key_response" | jq -r '.response_value')
-        log "Error: Failed to get Continuum Proxy API key. Error message: $error_message"
+    if echo "$continuum_proxy_api_key_response" | jq -e '.response_type == "error"' > /dev/null 2>&1; then
+        log "Error: startup_stage=fetch_continuum_proxy_key status=parent_error"
         exit 1
     fi
 
     # Extract the encrypted API key value from the JSON structure
-    continuum_proxy_api_key_encrypted=$(echo "$continuum_proxy_api_key_response" | jq -r '.response_value | fromjson | .api_key')
+    continuum_proxy_api_key_encrypted=$(echo "$continuum_proxy_api_key_response" | secret_jq parse_continuum_proxy_key -r '.response_value | fromjson | .api_key')
     if [ -z "$continuum_proxy_api_key_encrypted" ]; then
         log "Error: Failed to extract Continuum Proxy API key from the response"
-        log "Secret response: $continuum_proxy_api_key_response"
         exit 1
     fi
 
@@ -893,13 +910,16 @@ if [ "$APP_MODE" != "local" ]; then
         --aws-access-key-id "$access_key_id" \
         --aws-secret-access-key "$secret_access_key" \
         --aws-session-token "$session_token" \
-        --ciphertext "$continuum_proxy_api_key_encrypted" 2>&1)
+        --ciphertext "$continuum_proxy_api_key_encrypted" 2>&1) || {
+            status=$?
+            log "Error: startup_stage=decrypt_continuum_proxy_key exit_code=$status"
+            exit "$status"
+        }
 
     decrypted_api_key=$(echo "$decryption_output" | sed -n 's/PLAINTEXT: //p')
 
     if [ -z "$decrypted_api_key" ]; then
         log "Error: Failed to decrypt Continuum Proxy API key"
-        log "Decryption output: $decryption_output"
         exit 1
     fi
 
@@ -925,20 +945,18 @@ if [ "$APP_MODE" != "local" ]; then
     # Get Tinfoil Proxy API key from Secrets Manager
     log "Fetching Tinfoil Proxy API key"
     tinfoil_proxy_api_key_response=$(get_tinfoil_proxy_api_key_secret)
-    log "Retrieved raw Tinfoil Proxy API key response"
+    log "Received Tinfoil Proxy API key response"
 
     # Check if the response is an error
-    if echo "$tinfoil_proxy_api_key_response" | jq -e '.response_type == "error"' > /dev/null; then
-        error_message=$(echo "$tinfoil_proxy_api_key_response" | jq -r '.response_value')
-        log "Error: Failed to get Tinfoil Proxy API key. Error message: $error_message"
+    if echo "$tinfoil_proxy_api_key_response" | jq -e '.response_type == "error"' > /dev/null 2>&1; then
+        log "Error: startup_stage=fetch_tinfoil_proxy_key status=parent_error"
         exit 1
     fi
 
     # Extract the encrypted API key value from the JSON structure
-    tinfoil_proxy_api_key_encrypted=$(echo "$tinfoil_proxy_api_key_response" | jq -r '.response_value | fromjson | .api_key')
+    tinfoil_proxy_api_key_encrypted=$(echo "$tinfoil_proxy_api_key_response" | secret_jq parse_tinfoil_proxy_key -r '.response_value | fromjson | .api_key')
     if [ -z "$tinfoil_proxy_api_key_encrypted" ]; then
         log "Error: Failed to extract Tinfoil Proxy API key from the response"
-        log "Secret response: $tinfoil_proxy_api_key_response"
         exit 1
     fi
 
@@ -950,13 +968,16 @@ if [ "$APP_MODE" != "local" ]; then
         --aws-access-key-id "$access_key_id" \
         --aws-secret-access-key "$secret_access_key" \
         --aws-session-token "$session_token" \
-        --ciphertext "$tinfoil_proxy_api_key_encrypted" 2>&1)
+        --ciphertext "$tinfoil_proxy_api_key_encrypted" 2>&1) || {
+            status=$?
+            log "Error: startup_stage=decrypt_tinfoil_proxy_key exit_code=$status"
+            exit "$status"
+        }
 
     decrypted_api_key=$(echo "$decryption_output" | sed -n 's/PLAINTEXT: //p')
 
     if [ -z "$decrypted_api_key" ]; then
         log "Error: Failed to decrypt Tinfoil Proxy API key"
-        log "Decryption output: $decryption_output"
         exit 1
     fi
 
@@ -978,7 +999,9 @@ fi
 
 # Start the opensecret
 log "Starting opensecret..."
-RUST_LOG_STYLE=never RUST_LOG="${RUST_LOG:-debug,hyper=info,aws_smithy_runtime=info,aws_smithy_runtime_api=info,aws_sdk_sqs=info,aws_config=info}" APP_MODE="$APP_MODE" OPENAI_API_BASE="$OPENAI_API_BASE" TINFOIL_API_KEY="$tinfoil_proxy_api_key" /app/opensecret &
+# Application milestones remain visible; dependencies do not inherit debug.
+# An explicit RUST_LOG still selects a more detailed operator-requested filter.
+RUST_LOG_STYLE=never RUST_LOG="${RUST_LOG:-warn,opensecret=info}" APP_MODE="$APP_MODE" OPENAI_API_BASE="$OPENAI_API_BASE" TINFOIL_API_KEY="$tinfoil_proxy_api_key" /app/opensecret &
 
 # Wait for the opensecret to start
 log "Waiting for opensecret to start"

--- a/src/apple_signin.rs
+++ b/src/apple_signin.rs
@@ -68,6 +68,36 @@ where
 const APPLE_JWKS_URL: &str = "https://appleid.apple.com/auth/keys";
 const APPLE_ISSUER: &str = "https://appleid.apple.com";
 
+// Error payloads may include decoded claims or key material. Only emit an
+// allowlisted category, including an explicit fallback for unfamiliar errors.
+fn jwt_error_kind(error: &jsonwebtoken::errors::Error) -> &'static str {
+    use jsonwebtoken::errors::ErrorKind;
+    match error.kind() {
+        ErrorKind::InvalidToken => "invalid_token",
+        ErrorKind::InvalidSignature => "invalid_signature",
+        ErrorKind::ExpiredSignature => "expired",
+        ErrorKind::ImmatureSignature => "not_yet_valid",
+        ErrorKind::InvalidIssuer => "invalid_issuer",
+        ErrorKind::InvalidAudience => "invalid_audience",
+        ErrorKind::InvalidSubject => "invalid_subject",
+        ErrorKind::MissingRequiredClaim(_) => "missing_claim",
+        ErrorKind::InvalidClaimFormat(_) => "invalid_claim_format",
+        ErrorKind::InvalidAlgorithm
+        | ErrorKind::InvalidAlgorithmName
+        | ErrorKind::MissingAlgorithm => "invalid_algorithm",
+        ErrorKind::InvalidKeyFormat
+        | ErrorKind::InvalidRsaKey(_)
+        | ErrorKind::InvalidEcdsaKey
+        | ErrorKind::InvalidEddsaKey => "invalid_key",
+        ErrorKind::Json(_) => "json",
+        ErrorKind::Base64(_) => "base64",
+        ErrorKind::Utf8(_) => "utf8",
+        ErrorKind::Signing(_) | ErrorKind::RsaFailedSigning => "signing",
+        ErrorKind::Provider(_) => "crypto_provider",
+        _ => "other",
+    }
+}
+
 // Cache of Apple's public keys, with timestamp for refresh logic
 pub struct AppleJwksCache {
     keys: HashMap<String, AppleKey>,
@@ -87,7 +117,10 @@ pub struct AppleKey {
 impl AppleKey {
     pub fn to_decoding_key(&self) -> Result<DecodingKey, ApiError> {
         DecodingKey::from_rsa_components(&self.n, &self.e).map_err(|e| {
-            error!("Failed to create decoding key from RSA components: {:?}", e);
+            error!(
+                error_kind = jwt_error_kind(&e),
+                "Failed to create decoding key from RSA components"
+            );
             ApiError::InternalServerError
         })
     }
@@ -142,7 +175,10 @@ impl AppleJwtVerifier {
     ) -> Result<AppleIdTokenClaims, ApiError> {
         // Get the kid from the token header
         let header = decode_header(token).map_err(|e| {
-            error!("Failed to decode JWT header: {:?}", e);
+            error!(
+                error_kind = jwt_error_kind(&e),
+                "Failed to decode JWT header"
+            );
             ApiError::InvalidJwt
         })?;
 
@@ -151,7 +187,7 @@ impl AppleJwtVerifier {
             ApiError::InvalidJwt
         })?;
 
-        debug!("Validating Apple JWT with kid: {}", kid);
+        debug!("Validating Apple JWT");
 
         // Get the matching public key
         let decoding_key = self.get_key_for_kid(&kid).await?;
@@ -172,7 +208,10 @@ impl AppleJwtVerifier {
         let token_data =
             jsonwebtoken::decode::<AppleIdTokenClaims>(token, &decoding_key, &validation).map_err(
                 |e| {
-                    error!("JWT verification failed: {:?}", e);
+                    error!(
+                        error_kind = jwt_error_kind(&e),
+                        "Apple JWT verification failed"
+                    );
                     ApiError::InvalidJwt
                 },
             )?;
@@ -227,7 +266,7 @@ impl AppleJwtVerifier {
         // Now try to get the key with a fresh cache
         let cache = self.jwks_cache.read().await;
         let key = cache.keys.get(kid).ok_or_else(|| {
-            error!("Key ID {} not found in Apple JWKS even after refresh", kid);
+            error!("Token key ID not found in Apple JWKS even after refresh");
             ApiError::InvalidJwt
         })?;
 
@@ -259,7 +298,11 @@ impl AppleJwtVerifier {
             .send()
             .await
             .map_err(|e| {
-                error!("Failed to fetch Apple JWKS: {:?}", e);
+                error!(
+                    timeout = e.is_timeout(),
+                    connect = e.is_connect(),
+                    "Failed to fetch Apple JWKS"
+                );
                 ApiError::InternalServerError
             })?;
 
@@ -269,7 +312,11 @@ impl AppleJwtVerifier {
         }
 
         let jwks: JwksResponse = response.json().await.map_err(|e| {
-            error!("Failed to parse Apple JWKS response: {:?}", e);
+            error!(
+                timeout = e.is_timeout(),
+                decode = e.is_decode(),
+                "Failed to parse Apple JWKS response"
+            );
             ApiError::InternalServerError
         })?;
 
@@ -386,6 +433,33 @@ pub fn generate_apple_client_secret(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn apple_jwt_error_category_omits_custom_provider_and_claim_descriptions() {
+        use jsonwebtoken::errors::{Error, ErrorKind};
+        const PRIVATE: &str = "PRIVATE_APPLE_CLAIM_AND_KEY_SENTINEL";
+        let errors = [
+            (
+                Error::from(ErrorKind::Provider(PRIVATE.to_string())),
+                "crypto_provider",
+            ),
+            (
+                Error::from(ErrorKind::InvalidClaimFormat(PRIVATE.to_string())),
+                "invalid_claim_format",
+            ),
+            (
+                Error::from(ErrorKind::InvalidRsaKey(PRIVATE.to_string())),
+                "invalid_key",
+            ),
+        ];
+        for (error, expected) in errors {
+            assert!(error.to_string().contains(PRIVATE));
+            let category = jwt_error_kind(&error);
+            assert_eq!(category, expected);
+            assert!(!category.contains(PRIVATE));
+        }
+    }
+
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
     use openssl::{
         ec::{EcGroup, EcKey},

--- a/src/aws_credentials.rs
+++ b/src/aws_credentials.rs
@@ -146,7 +146,10 @@ impl AwsCredentialManager {
                         );
                         panic!("Could not obtain AWS credentials after maximum retries");
                     }
-                    tracing::error!("Failed to refresh AWS credentials: {:?}", e);
+                    tracing::error!(
+                        error_kind = crate::observability::error_kind(&e),
+                        "Failed to refresh AWS credentials"
+                    );
                     tracing::info!(
                         "Retrying in 5 seconds... (attempt {}/{})",
                         attempts,

--- a/src/billing.rs
+++ b/src/billing.rs
@@ -111,16 +111,13 @@ impl BillingClient {
         let response = request.send().await?;
 
         if response.status().is_success() {
-            response
-                .json::<UsageResponse>()
-                .await
-                .map_err(|e| BillingError::ParseError(e.to_string()))
+            response.json::<UsageResponse>().await.map_err(|e| {
+                BillingError::ParseError(crate::observability::error_kind(&e).to_owned())
+            })
         } else {
-            let error = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "Unknown error".to_string());
-            Err(BillingError::ServiceError(error))
+            let status = response.status().as_u16();
+            // Never retain an external body in an error later formatted by callers.
+            Err(BillingError::ServiceError(format!("HTTP {status}")))
         }
     }
 
@@ -169,8 +166,8 @@ impl BillingClient {
         }
         let plan_usage = plan_usage.unwrap_or_else(|error| {
             warn!(
-                "Billing plan lookup failed for API request (user_id={}): {}; using free model access",
-                user_id, error
+                error_kind = crate::observability::error_kind(&error),
+                "Billing plan lookup failed for API request; using free model access"
             );
             UsageResponse {
                 can_use: false,

--- a/src/db.rs
+++ b/src/db.rs
@@ -752,12 +752,21 @@ pub(crate) struct PostgresConnection {
     db: Pool<ConnectionManager<PgConnection>>,
 }
 
+fn log_db_failure(error: &DBError, operation: &'static str) {
+    let error_kind = crate::observability::error_kind(error);
+    if error_kind == "db_not_found" {
+        debug!(error_kind, operation, "Database lookup did not find a row");
+    } else {
+        error!(error_kind, operation, "Database operation failed");
+    }
+}
+
 impl DBConnection for PostgresConnection {
     fn create_user(&self, new_user: NewUser) -> Result<User, DBError> {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_user.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to create user: {:?}", e);
+            log_db_failure(e, "Failed to create user");
         }
         result
     }
@@ -766,7 +775,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = User::get_by_uuid(conn, uuid)?.ok_or(DBError::UserNotFound);
         if let Err(ref e) = result {
-            error!("Failed to get user by UUID: {:?}", e);
+            log_db_failure(e, "Failed to get user by UUID");
         }
         result
     }
@@ -775,7 +784,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = User::get_by_email(conn, email, project_id)?.ok_or(DBError::UserNotFound);
         if let Err(ref e) = result {
-            error!("Failed to get user by email: {:?}", e);
+            log_db_failure(e, "Failed to get user by email");
         }
         result
     }
@@ -937,7 +946,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = verification.verify(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to verify email: {:?}", e);
+            log_db_failure(e, "Failed to verify email");
         }
         result
     }
@@ -949,7 +958,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_request.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to create password reset request: {:?}", e);
+            log_db_failure(e, "Failed to create password reset request");
         }
         result
     }
@@ -963,7 +972,7 @@ impl DBConnection for PostgresConnection {
         let result = PasswordResetRequest::get_by_user_id_and_code(conn, user_id, &encrypted_code)
             .map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to get password reset request: {:?}", e);
+            log_db_failure(e, "Failed to get password reset request");
         }
         result
     }
@@ -1008,7 +1017,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = request.mark_as_reset(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to mark password reset request as complete: {:?}", e);
+            log_db_failure(e, "Failed to mark password reset request as complete");
         }
         result
     }
@@ -1230,7 +1239,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_org.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to create org: {:?}", e);
+            log_db_failure(e, "Failed to create org");
         }
         result
     }
@@ -1239,7 +1248,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = Org::get_by_id(conn, id)?.ok_or(DBError::OrgNotFound);
         if let Err(ref e) = result {
-            error!("Failed to get org by ID: {:?}", e);
+            log_db_failure(e, "Failed to get org by ID");
         }
         result
     }
@@ -1248,7 +1257,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = Org::get_by_uuid(conn, uuid)?.ok_or(DBError::OrgNotFound);
         if let Err(ref e) = result {
-            error!("Failed to get org by UUID: {:?}", e);
+            log_db_failure(e, "Failed to get org by UUID");
         }
         result
     }
@@ -1257,7 +1266,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = Org::get_by_name(conn, name).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to get org by name: {:?}", e);
+            log_db_failure(e, "Failed to get org by name");
         }
         result
     }
@@ -1266,7 +1275,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = Org::get_all(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to get all orgs: {:?}", e);
+            log_db_failure(e, "Failed to get all orgs");
         }
         result
     }
@@ -1275,7 +1284,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = org.update(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to update org: {:?}", e);
+            log_db_failure(e, "Failed to update org");
         }
         result
     }
@@ -1284,7 +1293,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = org.delete(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to delete org: {:?}", e);
+            log_db_failure(e, "Failed to delete org");
         }
         result
     }
@@ -1294,7 +1303,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_project.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to create org project: {:?}", e);
+            log_db_failure(e, "Failed to create org project");
         }
         result
     }
@@ -1303,7 +1312,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = OrgProject::get_by_id(conn, id)?.ok_or(DBError::OrgProjectNotFound);
         if let Err(ref e) = result {
-            error!("Failed to get org project by ID: {:?}", e);
+            log_db_failure(e, "Failed to get org project by ID");
         }
         result
     }
@@ -1312,7 +1321,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = OrgProject::get_by_uuid(conn, uuid)?.ok_or(DBError::OrgProjectNotFound);
         if let Err(ref e) = result {
-            error!("Failed to get org project by UUID: {:?}", e);
+            log_db_failure(e, "Failed to get org project by UUID");
         }
         result
     }
@@ -1322,7 +1331,7 @@ impl DBConnection for PostgresConnection {
         let result =
             OrgProject::get_by_client_id(conn, client_id)?.ok_or(DBError::OrgProjectNotFound);
         if let Err(ref e) = result {
-            error!("Failed to get org project by client ID: {:?}", e);
+            log_db_failure(e, "Failed to get org project by client ID");
         }
         result
     }
@@ -1335,7 +1344,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = OrgProject::get_by_name_and_org(conn, name, org_id).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to get org project by name and org: {:?}", e);
+            log_db_failure(e, "Failed to get org project by name and org");
         }
         result
     }
@@ -1344,7 +1353,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = OrgProject::get_all_for_org(conn, org_id).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to get all org projects for org: {:?}", e);
+            log_db_failure(e, "Failed to get all org projects for org");
         }
         result
     }
@@ -1353,7 +1362,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = OrgProject::get_active_for_org(conn, org_id).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to get active org projects for org: {:?}", e);
+            log_db_failure(e, "Failed to get active org projects for org");
         }
         result
     }
@@ -1362,7 +1371,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = project.update(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to update org project: {:?}", e);
+            log_db_failure(e, "Failed to update org project");
         }
         result
     }
@@ -1371,7 +1380,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = project.delete(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to delete org project: {:?}", e);
+            log_db_failure(e, "Failed to delete org project");
         }
         result
     }
@@ -1384,7 +1393,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_secret.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to create org project secret: {:?}", e);
+            log_db_failure(e, "Failed to create org project secret");
         }
         result
     }
@@ -1394,7 +1403,7 @@ impl DBConnection for PostgresConnection {
         let result =
             OrgProjectSecret::get_by_id(conn, id)?.ok_or(DBError::OrgProjectSecretNotFound);
         if let Err(ref e) = result {
-            error!("Failed to get org project secret by ID: {:?}", e);
+            log_db_failure(e, "Failed to get org project secret by ID");
         }
         result
     }
@@ -1408,9 +1417,9 @@ impl DBConnection for PostgresConnection {
         let result = OrgProjectSecret::get_by_key_name_and_project(conn, key_name, project_id)
             .map_err(DBError::from);
         if let Err(ref e) = result {
-            error!(
-                "Failed to get org project secret by key name and project: {:?}",
-                e
+            log_db_failure(
+                e,
+                "Failed to get org project secret by key name and project",
             );
         }
         result
@@ -1423,7 +1432,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = OrgProjectSecret::get_all_for_project(conn, project_id).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to get all org project secrets for project: {:?}", e);
+            log_db_failure(e, "Failed to get all org project secrets for project");
         }
         result
     }
@@ -1432,7 +1441,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = secret.update(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to update org project secret: {:?}", e);
+            log_db_failure(e, "Failed to update org project secret");
         }
         result
     }
@@ -1441,7 +1450,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = secret.delete(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to delete org project secret: {:?}", e);
+            log_db_failure(e, "Failed to delete org project secret");
         }
         result
     }
@@ -1451,7 +1460,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_invite.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to create invite code: {:?}", e);
+            log_db_failure(e, "Failed to create invite code");
         }
         result
     }
@@ -1460,7 +1469,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = InviteCode::get_by_id(conn, id)?.ok_or(DBError::InviteCodeNotFound);
         if let Err(ref e) = result {
-            error!("Failed to get invite code by ID: {:?}", e);
+            log_db_failure(e, "Failed to get invite code by ID");
         }
         result
     }
@@ -1469,7 +1478,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = InviteCode::get_by_code(conn, code)?.ok_or(DBError::InviteCodeNotFound);
         if let Err(ref e) = result {
-            error!("Failed to get invite code by code: {:?}", e);
+            log_db_failure(e, "Failed to get invite code by code");
         }
         result
     }
@@ -1482,7 +1491,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = InviteCode::get_by_email_and_org(conn, email, org_id).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to get invite code by email and org: {:?}", e);
+            log_db_failure(e, "Failed to get invite code by email and org");
         }
         result
     }
@@ -1491,7 +1500,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = InviteCode::get_all_for_org(conn, org_id).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to get all invite codes for org: {:?}", e);
+            log_db_failure(e, "Failed to get all invite codes for org");
         }
         result
     }
@@ -1500,7 +1509,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = invite.mark_as_used(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to mark invite code as used: {:?}", e);
+            log_db_failure(e, "Failed to mark invite code as used");
         }
         result
     }
@@ -1509,7 +1518,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = invite.update(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to update invite code: {:?}", e);
+            log_db_failure(e, "Failed to update invite code");
         }
         result
     }
@@ -1518,7 +1527,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = invite.delete(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to delete invite code: {:?}", e);
+            log_db_failure(e, "Failed to delete invite code");
         }
         result
     }
@@ -1528,7 +1537,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_user.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to create platform user: {:?}", e);
+            log_db_failure(e, "Failed to create platform user");
         }
         result
     }
@@ -1537,7 +1546,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = PlatformUser::get_by_id(conn, id)?.ok_or(DBError::PlatformUserNotFound);
         if let Err(ref e) = result {
-            error!("Failed to get platform user by ID: {:?}", e);
+            log_db_failure(e, "Failed to get platform user by ID");
         }
         result
     }
@@ -1546,7 +1555,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = PlatformUser::get_by_uuid(conn, uuid)?.ok_or(DBError::PlatformUserNotFound);
         if let Err(ref e) = result {
-            error!("Failed to get platform user by UUID: {:?}", e);
+            log_db_failure(e, "Failed to get platform user by UUID");
         }
         result
     }
@@ -1555,7 +1564,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = PlatformUser::get_by_email(conn, email).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to get platform user by email: {:?}", e);
+            log_db_failure(e, "Failed to get platform user by email");
         }
         result
     }
@@ -1564,7 +1573,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = user.update(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to update platform user: {:?}", e);
+            log_db_failure(e, "Failed to update platform user");
         }
         result
     }
@@ -1579,7 +1588,7 @@ impl DBConnection for PostgresConnection {
             .update_password(conn, new_password_enc)
             .map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to update platform user password: {:?}", e);
+            log_db_failure(e, "Failed to update platform user password");
         }
         result
     }
@@ -1594,7 +1603,7 @@ impl DBConnection for PostgresConnection {
             .insert(conn)
             .map_err(DBError::OrgMembershipError);
         if let Err(ref e) = result {
-            error!("Failed to create org membership: {:?}", e);
+            log_db_failure(e, "Failed to create org membership");
         }
         result
     }
@@ -1608,10 +1617,7 @@ impl DBConnection for PostgresConnection {
         let result = OrgMembership::get_by_platform_user_and_org(conn, platform_user_id, org_id)
             .map_err(DBError::from);
         if let Err(ref e) = result {
-            error!(
-                "Failed to get org membership by platform user and org: {:?}",
-                e
-            );
+            log_db_failure(e, "Failed to get org membership by platform user and org");
         }
         result
     }
@@ -1626,9 +1632,9 @@ impl DBConnection for PostgresConnection {
             OrgMembership::get_by_platform_user_and_org_with_user(conn, platform_user_id, org_id)
                 .map_err(DBError::from);
         if let Err(ref e) = result {
-            error!(
-                "Failed to get org membership with user info by platform user and org: {:?}",
-                e
+            log_db_failure(
+                e,
+                "Failed to get org membership with user info by platform user and org",
             );
         }
         result
@@ -1642,10 +1648,7 @@ impl DBConnection for PostgresConnection {
         let result =
             OrgMembership::get_all_for_platform_user(conn, platform_user_id).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!(
-                "Failed to get all org memberships for platform user: {:?}",
-                e
-            );
+            log_db_failure(e, "Failed to get all org memberships for platform user");
         }
         result
     }
@@ -1654,7 +1657,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = OrgMembership::get_all_for_org(conn, org_id).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to get all org memberships for org: {:?}", e);
+            log_db_failure(e, "Failed to get all org memberships for org");
         }
         result
     }
@@ -1666,10 +1669,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = OrgMembership::get_all_with_users_for_org(conn, org_id).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!(
-                "Failed to get all org memberships with users for org: {:?}",
-                e
-            );
+            log_db_failure(e, "Failed to get all org memberships with users for org");
         }
         result
     }
@@ -1678,7 +1678,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = membership.update(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to update org membership: {:?}", e);
+            log_db_failure(e, "Failed to update org membership");
         }
         result
     }
@@ -1687,7 +1687,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = membership.delete(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to delete org membership: {:?}", e);
+            log_db_failure(e, "Failed to delete org membership");
         }
         result
     }
@@ -1708,7 +1708,7 @@ impl DBConnection for PostgresConnection {
                 _ => DBError::from(e),
             });
         if let Err(ref e) = result {
-            error!("Failed to update org membership role: {:?}", e);
+            log_db_failure(e, "Failed to update org membership role");
         }
         result
     }
@@ -1728,7 +1728,7 @@ impl DBConnection for PostgresConnection {
                 _ => DBError::from(e),
             });
         if let Err(ref e) = result {
-            error!("Failed to delete org membership: {:?}", e);
+            log_db_failure(e, "Failed to delete org membership");
         }
         result
     }
@@ -1898,7 +1898,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_verification.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to create platform email verification: {:?}", e);
+            log_db_failure(e, "Failed to create platform email verification");
         }
         result
     }
@@ -1911,7 +1911,7 @@ impl DBConnection for PostgresConnection {
         let result = PlatformEmailVerification::get_by_id(conn, id)?
             .ok_or(DBError::PlatformEmailVerificationNotFound);
         if let Err(ref e) = result {
-            error!("Failed to get platform email verification by ID: {:?}", e);
+            log_db_failure(e, "Failed to get platform email verification by ID");
         }
         result
     }
@@ -1924,9 +1924,9 @@ impl DBConnection for PostgresConnection {
         let result = PlatformEmailVerification::get_by_platform_user_id(conn, platform_user_id)?
             .ok_or(DBError::PlatformEmailVerificationNotFound);
         if let Err(ref e) = result {
-            error!(
-                "Failed to get platform email verification by platform user ID: {:?}",
-                e
+            log_db_failure(
+                e,
+                "Failed to get platform email verification by platform user ID",
             );
         }
         result
@@ -1940,7 +1940,7 @@ impl DBConnection for PostgresConnection {
         let result = PlatformEmailVerification::get_by_verification_code(conn, code)?
             .ok_or(DBError::PlatformEmailVerificationNotFound);
         if let Err(ref e) = result {
-            error!("Failed to get platform email verification by code: {:?}", e);
+            log_db_failure(e, "Failed to get platform email verification by code");
         }
         result
     }
@@ -1952,7 +1952,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = verification.update(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to update platform email verification: {:?}", e);
+            log_db_failure(e, "Failed to update platform email verification");
         }
         result
     }
@@ -1964,7 +1964,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = verification.delete(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to delete platform email verification: {:?}", e);
+            log_db_failure(e, "Failed to delete platform email verification");
         }
         result
     }
@@ -1976,7 +1976,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = verification.verify(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to verify platform email: {:?}", e);
+            log_db_failure(e, "Failed to verify platform email");
         }
         result
     }
@@ -1989,7 +1989,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_request.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to create platform password reset request: {:?}", e);
+            log_db_failure(e, "Failed to create platform password reset request");
         }
         result
     }
@@ -2004,7 +2004,7 @@ impl DBConnection for PostgresConnection {
             PlatformPasswordResetRequest::get_by_user_id_and_code(conn, user_id, &encrypted_code)
                 .map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to get platform password reset request: {:?}", e);
+            log_db_failure(e, "Failed to get platform password reset request");
         }
         result
     }
@@ -2016,9 +2016,9 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = request.mark_as_reset(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!(
-                "Failed to mark platform password reset request as complete: {:?}",
-                e
+            log_db_failure(
+                e,
+                "Failed to mark platform password reset request as complete",
             );
         }
         result
@@ -2033,7 +2033,7 @@ impl DBConnection for PostgresConnection {
             _ => DBError::from(e),
         });
         if let Err(ref e) = result {
-            error!("Failed to validate platform invite code: {:?}", e);
+            log_db_failure(e, "Failed to validate platform invite code");
         }
         result
     }
@@ -2105,7 +2105,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = new_request.insert(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to create account deletion request: {:?}", e);
+            log_db_failure(e, "Failed to create account deletion request");
         }
         result
     }
@@ -2120,7 +2120,7 @@ impl DBConnection for PostgresConnection {
             AccountDeletionRequest::get_by_user_id_and_code(conn, user_id, &encrypted_code)
                 .map_err(DBError::from);
         if let Err(ref e) = result {
-            error!("Failed to get account deletion request: {:?}", e);
+            log_db_failure(e, "Failed to get account deletion request");
         }
         result
     }
@@ -2132,10 +2132,7 @@ impl DBConnection for PostgresConnection {
         let conn = &mut self.db.get().map_err(|_| DBError::ConnectionError)?;
         let result = request.mark_as_deleted(conn).map_err(DBError::from);
         if let Err(ref e) = result {
-            error!(
-                "Failed to mark account deletion request as complete: {:?}",
-                e
-            );
+            log_db_failure(e, "Failed to mark account deletion request as complete");
         }
         result
     }
@@ -2986,8 +2983,41 @@ impl DBConnection for PostgresConnection {
     // Maintenance
 }
 
+/// Replace r2d2's default Display-based logging, including worker connection
+/// failures that happen before build() returns a sanitized pool timeout.
+#[derive(Debug)]
+struct PoolErrorHandler;
+
+impl diesel::r2d2::HandleError<diesel::r2d2::Error> for PoolErrorHandler {
+    fn handle_error(&self, error: diesel::r2d2::Error) {
+        use diesel::result::ConnectionError;
+
+        let (stage, error_kind) = match &error {
+            diesel::r2d2::Error::ConnectionError(error) => match error {
+                ConnectionError::InvalidCString(_) | ConnectionError::InvalidConnectionUrl(_) => {
+                    ("connect", "db_connection_url")
+                }
+                ConnectionError::BadConnection(_) => ("connect", "db_connection_failed"),
+                ConnectionError::CouldntSetupConfiguration(error) => {
+                    ("connection_setup", crate::observability::error_kind(error))
+                }
+                _ => ("connect", "db_connection_failed"),
+            },
+            diesel::r2d2::Error::QueryError(error) => {
+                ("connection_check", crate::observability::error_kind(error))
+            }
+        };
+        error!(
+            stage,
+            error_kind, "Database pool connection operation failed"
+        );
+    }
+}
+
+#[tracing::instrument(skip_all, fields(max_connections = 20, min_idle = 5))]
 pub(crate) fn setup_db(url: String) -> Arc<dyn DBConnection + Send + Sync> {
-    info!("Connecting to database...");
+    let started = std::time::Instant::now();
+    info!("Connecting to database");
     let manager = ConnectionManager::<PgConnection>::new(url);
 
     let pool = Pool::builder()
@@ -2997,9 +3027,110 @@ pub(crate) fn setup_db(url: String) -> Arc<dyn DBConnection + Send + Sync> {
         .idle_timeout(Some(std::time::Duration::from_secs(600))) // 10 minutes
         .max_lifetime(Some(std::time::Duration::from_secs(1800))) // 30 minutes
         .test_on_check_out(true)
+        .error_handler(Box::new(PoolErrorHandler))
         .build(manager)
-        .expect("Unable to build DB connection pool");
+        .unwrap_or_else(|error| {
+            error!(
+                error_kind = crate::observability::error_kind(&error),
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "Unable to build DB connection pool"
+            );
+            // Preserve the startup failure without formatting a potentially
+            // sensitive PostgreSQL diagnostic into the panic message.
+            panic!("Unable to build DB connection pool");
+        });
 
-    info!("Connected to database with pool size: 20, min idle: 5");
+    let state = pool.state();
+    info!(
+        elapsed_ms = started.elapsed().as_millis() as u64,
+        connections = state.connections,
+        idle_connections = state.idle_connections,
+        "Database pool ready"
+    );
     Arc::new(PostgresConnection { db: pool })
+}
+
+#[cfg(test)]
+mod pool_error_log_tests {
+    use super::*;
+    use diesel::r2d2::HandleError;
+    use diesel::result::{ConnectionError, DatabaseErrorKind, Error as QueryError};
+    use std::io::Write;
+    use std::sync::Mutex;
+
+    #[derive(Clone, Default)]
+    struct Capture(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for Capture {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn pool_error_handler_omits_database_diagnostics_at_default_log_level() {
+        const PRIVATE: &str = "PRIVATE_DATABASE_HOST_USER_AND_QUERY_SENTINEL";
+        let errors = [
+            diesel::r2d2::Error::ConnectionError(ConnectionError::BadConnection(
+                PRIVATE.to_owned(),
+            )),
+            diesel::r2d2::Error::ConnectionError(ConnectionError::InvalidConnectionUrl(
+                PRIVATE.to_owned(),
+            )),
+            diesel::r2d2::Error::ConnectionError(ConnectionError::CouldntSetupConfiguration(
+                QueryError::DatabaseError(
+                    DatabaseErrorKind::ReadOnlyTransaction,
+                    Box::new(PRIVATE.to_owned()),
+                ),
+            )),
+            diesel::r2d2::Error::QueryError(QueryError::DatabaseError(
+                DatabaseErrorKind::ClosedConnection,
+                Box::new(PRIVATE.to_owned()),
+            )),
+        ];
+        for error in &errors {
+            assert!(error.to_string().contains(PRIVATE));
+        }
+
+        let capture = Capture::default();
+        let writer = capture.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_env_filter(crate::DEFAULT_RUST_LOG_FILTER)
+            .with_ansi(false)
+            .without_time()
+            .with_writer(move || writer.clone())
+            .finish();
+        tracing::subscriber::with_default(subscriber, || {
+            for error in errors {
+                PoolErrorHandler.handle_error(error);
+            }
+        });
+
+        let output = String::from_utf8(capture.0.lock().unwrap().clone()).unwrap();
+        assert_eq!(
+            output
+                .matches("Database pool connection operation failed")
+                .count(),
+            4
+        );
+        for expected in [
+            "db_connection_failed",
+            "db_connection_url",
+            "connection_setup",
+            "db_read_only_transaction",
+            "connection_check",
+            "db_closed_connection",
+        ] {
+            assert!(
+                output.contains(expected),
+                "missing diagnostic category {expected}"
+            );
+        }
+        assert!(!output.contains(PRIVATE));
+    }
 }

--- a/src/email.rs
+++ b/src/email.rs
@@ -21,6 +21,36 @@ pub enum EmailError {
     DatabaseError(#[from] DBError),
 }
 
+fn log_send_error(email_kind: &'static str, error: &resend_rs::Error) {
+    // Resend's Display/Debug includes provider messages and sometimes the full
+    // response. Those can contain addresses or email content.
+    match error {
+        resend_rs::Error::Http(error) => error!(
+            email_kind,
+            error_kind = "http",
+            timeout = error.is_timeout(),
+            connect = error.is_connect(),
+            "Failed to send email"
+        ),
+        resend_rs::Error::Resend(error) => error!(
+            email_kind,
+            error_kind = ?error.kind(),
+            status = error.status_code,
+            "Failed to send email"
+        ),
+        resend_rs::Error::Parse(_) => error!(
+            email_kind,
+            error_kind = "response_parse",
+            "Failed to send email"
+        ),
+        resend_rs::Error::RateLimit { .. } => error!(
+            email_kind,
+            error_kind = "rate_limit",
+            "Failed to send email"
+        ),
+    }
+}
+
 const WELCOME_EMAIL_HTML: &str = r#"
 <!DOCTYPE html>
 <html lang="en">
@@ -309,7 +339,7 @@ async fn get_project_email_settings(
 
     // Verify provider is resend
     if email_settings.provider != "resend" {
-        error!("Unsupported email provider: {}", email_settings.provider);
+        error!("Unsupported email provider");
         return Err(EmailError::IncompleteSettings);
     }
 
@@ -347,8 +377,8 @@ pub async fn send_hello_email(
     let project = app_state
         .db
         .get_org_project_by_id(project_id)
-        .map_err(|e| {
-            error!("Failed to get project: {}", e);
+        .map_err(|_| {
+            error!("Failed to get email project");
             EmailError::UnknownError
         })?;
 
@@ -375,7 +405,7 @@ pub async fn send_hello_email(
         .with_scheduled_at(&scheduled_at);
 
     let _email = resend.emails.send(email).await.map_err(|e| {
-        tracing::error!("Failed to send email: {}", e);
+        log_send_error("hello", &e);
         EmailError::UnknownError
     });
     Ok(())
@@ -394,14 +424,14 @@ pub async fn send_verification_email(
     let project = app_state
         .db
         .get_org_project_by_id(project_id)
-        .map_err(|e| {
-            error!("Failed to get project: {}", e);
+        .map_err(|_| {
+            error!("Failed to get email project");
             EmailError::UnknownError
         })?;
 
     // Get organization name for the team signature
-    let org = app_state.db.get_org_by_id(project.org_id).map_err(|e| {
-        error!("Failed to get organization: {}", e);
+    let org = app_state.db.get_org_by_id(project.org_id).map_err(|_| {
+        error!("Failed to get email organization");
         EmailError::UnknownError
     })?;
 
@@ -463,7 +493,7 @@ pub async fn send_verification_email(
     let email = CreateEmailBaseOptions::new(from_email, to, subject).with_html(&html_content);
 
     let _email = resend.emails.send(email).await.map_err(|e| {
-        tracing::error!("Failed to send email: {}", e);
+        log_send_error("verification", &e);
         EmailError::UnknownError
     });
     Ok(())
@@ -482,14 +512,14 @@ pub async fn send_password_reset_email(
     let project = app_state
         .db
         .get_org_project_by_id(project_id)
-        .map_err(|e| {
-            error!("Failed to get project: {}", e);
+        .map_err(|_| {
+            error!("Failed to get email project");
             EmailError::UnknownError
         })?;
 
     // Get organization name for the team signature
-    let org = app_state.db.get_org_by_id(project.org_id).map_err(|e| {
-        error!("Failed to get organization: {}", e);
+    let org = app_state.db.get_org_by_id(project.org_id).map_err(|_| {
+        error!("Failed to get email organization");
         EmailError::UnknownError
     })?;
 
@@ -530,7 +560,7 @@ pub async fn send_password_reset_email(
     let email = CreateEmailBaseOptions::new(from_email, to, subject).with_html(&html_content);
 
     let _email = resend.emails.send(email).await.map_err(|e| {
-        tracing::error!("Failed to send email: {}", e);
+        log_send_error("password_reset", &e);
         EmailError::UnknownError
     });
     Ok(())
@@ -548,14 +578,14 @@ pub async fn send_password_reset_confirmation_email(
     let project = app_state
         .db
         .get_org_project_by_id(project_id)
-        .map_err(|e| {
-            error!("Failed to get project: {}", e);
+        .map_err(|_| {
+            error!("Failed to get email project");
             EmailError::UnknownError
         })?;
 
     // Get organization name for the team signature
-    let org = app_state.db.get_org_by_id(project.org_id).map_err(|e| {
-        error!("Failed to get organization: {}", e);
+    let org = app_state.db.get_org_by_id(project.org_id).map_err(|_| {
+        error!("Failed to get email organization");
         EmailError::UnknownError
     })?;
 
@@ -598,7 +628,7 @@ pub async fn send_password_reset_confirmation_email(
     let email = CreateEmailBaseOptions::new(from_email, to, subject).with_html(&html_content);
 
     let _email = resend.emails.send(email).await.map_err(|e| {
-        tracing::error!("Failed to send email: {}", e);
+        log_send_error("password_reset_confirmation", &e);
         EmailError::UnknownError
     });
     Ok(())
@@ -671,7 +701,7 @@ pub async fn send_platform_verification_email(
     let email = CreateEmailBaseOptions::new(from_email, to, subject).with_html(&html_content);
 
     let _email = resend.emails.send(email).await.map_err(|e| {
-        tracing::error!("Failed to send email: {}", e);
+        log_send_error("platform_verification", &e);
         EmailError::UnknownError
     });
     Ok(())
@@ -746,7 +776,7 @@ pub async fn send_platform_invite_email(
     let email = CreateEmailBaseOptions::new(from, to, subject).with_html(&html_content);
 
     let _email = resend.emails.send(email).await.map_err(|e| {
-        tracing::error!("Failed to send email: {}", e);
+        log_send_error("platform_invite", &e);
         EmailError::UnknownError
     });
     Ok(())
@@ -830,7 +860,7 @@ pub async fn send_platform_password_reset_email(
     let email = CreateEmailBaseOptions::new(from_email, to, subject).with_html(&html_content);
 
     let _email = resend.emails.send(email).await.map_err(|e| {
-        tracing::error!("Failed to send email: {}", e);
+        log_send_error("platform_password_reset", &e);
         EmailError::UnknownError
     });
     Ok(())
@@ -885,7 +915,7 @@ pub async fn send_platform_password_reset_confirmation_email(
     let email = CreateEmailBaseOptions::new(from_email, to, subject).with_html(&html_content);
 
     let _email = resend.emails.send(email).await.map_err(|e| {
-        tracing::error!("Failed to send email: {}", e);
+        log_send_error("platform_password_reset_confirmation", &e);
         EmailError::UnknownError
     });
     Ok(())
@@ -904,14 +934,14 @@ pub async fn send_account_deletion_email(
     let project = app_state
         .db
         .get_org_project_by_id(project_id)
-        .map_err(|e| {
-            error!("Failed to get project: {}", e);
+        .map_err(|_| {
+            error!("Failed to get email project");
             EmailError::UnknownError
         })?;
 
     // Get organization name for the team signature
-    let org = app_state.db.get_org_by_id(project.org_id).map_err(|e| {
-        error!("Failed to get organization: {}", e);
+    let org = app_state.db.get_org_by_id(project.org_id).map_err(|_| {
+        error!("Failed to get email organization");
         EmailError::UnknownError
     })?;
 
@@ -953,7 +983,7 @@ pub async fn send_account_deletion_email(
     let email = CreateEmailBaseOptions::new(from_email, to, subject).with_html(&html_content);
 
     let _email = resend.emails.send(email).await.map_err(|e| {
-        tracing::error!("Failed to send email: {}", e);
+        log_send_error("account_deletion", &e);
         EmailError::UnknownError
     });
     Ok(())
@@ -971,14 +1001,14 @@ pub async fn send_account_deletion_confirmation_email(
     let project = app_state
         .db
         .get_org_project_by_id(project_id)
-        .map_err(|e| {
-            error!("Failed to get project: {}", e);
+        .map_err(|_| {
+            error!("Failed to get email project");
             EmailError::UnknownError
         })?;
 
     // Get organization name for the team signature
-    let org = app_state.db.get_org_by_id(project.org_id).map_err(|e| {
-        error!("Failed to get organization: {}", e);
+    let org = app_state.db.get_org_by_id(project.org_id).map_err(|_| {
+        error!("Failed to get email organization");
         EmailError::UnknownError
     })?;
 
@@ -1016,8 +1046,61 @@ pub async fn send_account_deletion_confirmation_email(
     let email = CreateEmailBaseOptions::new(from_email, to, subject).with_html(&html_content);
 
     let _email = resend.emails.send(email).await.map_err(|e| {
-        tracing::error!("Failed to send email: {}", e);
+        log_send_error("account_deletion_confirmation", &e);
         EmailError::UnknownError
     });
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone, Default)]
+    struct Capture(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for Capture {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn resend_error_logs_omit_provider_descriptions_and_response_payloads() {
+        const PRIVATE: &str = "PRIVATE_EMAIL_ADDRESS_AND_BODY_SENTINEL";
+        let provider_error = resend_rs::Error::Resend(resend_rs::types::ErrorResponse {
+            status_code: 422,
+            name: PRIVATE.to_string(),
+            message: PRIVATE.to_string(),
+        });
+        let parse_error = resend_rs::Error::Parse(PRIVATE.to_string());
+        assert!(provider_error.to_string().contains(PRIVATE));
+        assert!(parse_error.to_string().contains(PRIVATE));
+
+        let capture = Capture::default();
+        let writer = capture.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .without_time()
+            .with_writer(move || writer.clone())
+            .finish();
+        tracing::subscriber::with_default(subscriber, || {
+            log_send_error("verification", &provider_error);
+            log_send_error("password_reset", &parse_error);
+        });
+
+        let output = String::from_utf8(capture.0.lock().unwrap().clone()).unwrap();
+        assert_eq!(output.matches("Failed to send email").count(), 2);
+        assert!(output.contains("Unrecognized"));
+        assert!(output.contains("422"));
+        assert!(output.contains("response_parse"));
+        assert!(!output.contains(PRIVATE));
+    }
 }

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -12,7 +12,11 @@ use secp256k1::rand::rngs::OsRng;
 use secp256k1::SecretKey;
 use serde::de::DeserializeOwned;
 use sha2::{Digest, Sha256, Sha512};
-use std::{process::Command, sync::Arc};
+use std::{
+    io,
+    process::{Command, Output},
+    sync::Arc,
+};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
@@ -245,7 +249,7 @@ impl CanonicalBytes {
 /// ```ignore
 /// let content: Option<MessageContent> = decrypt_content(&user_key, msg.content_enc.as_ref())
 ///     .map_err(|e| {
-///         error!("Failed to decrypt message: {:?}", e);
+///         error!(error_kind = crate::observability::error_kind(&e), "Failed to decrypt message");
 ///         ApiError::InternalServerError
 ///     })?;
 /// ```
@@ -262,8 +266,15 @@ where
 
     let decrypted_bytes = decrypt_with_key(key, encrypted)?;
 
-    let value = serde_json::from_slice(&decrypted_bytes)
-        .map_err(|e| EncryptError::DeserializationFailed(e.to_string()))?;
+    let value = serde_json::from_slice(&decrypted_bytes).map_err(|error| {
+        // Serde's message can quote a decrypted string when its type is wrong.
+        EncryptError::DeserializationFailed(format!(
+            "JSON {:?} at line {} column {}",
+            error.classify(),
+            error.line(),
+            error.column()
+        ))
+    })?;
 
     Ok(Some(value))
 }
@@ -288,7 +299,7 @@ where
 /// ```ignore
 /// let text: Option<String> = decrypt_string(&user_key, msg.content_enc.as_ref())
 ///     .map_err(|e| {
-///         error!("Failed to decrypt message: {:?}", e);
+///         error!(error_kind = crate::observability::error_kind(&e), "Failed to decrypt message");
 ///         ApiError::InternalServerError
 ///     })?;
 /// ```
@@ -353,25 +364,47 @@ pub fn decrypt_with_kms(
         .arg(aws_session_token)
         .arg("--ciphertext")
         .arg(ciphertext)
-        .output()
-        .map_err(|e| {
-            tracing::error!(
-                "Failed to execute kmstool_enclave_cli for decryption: {}",
-                e
-            );
-            EncryptError::KmsError(e.to_string())
-        })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        tracing::error!("kmstool_enclave_cli decryption failed: {}", stderr);
-        return Err(EncryptError::KmsError(stderr.to_string()));
-    }
-
-    let output_str =
-        String::from_utf8(output.stdout).map_err(|e| EncryptError::KmsError(e.to_string()))?;
+        .output();
+    let output_str = check_kmstool_output("decrypt", output)?;
 
     parse_kmstool_plaintext(&output_str, "decrypt", None)
+}
+
+/// Subprocess diagnostics may contain credentials or key material. Discard them
+/// at this boundary so neither logs nor callers formatting an error retain them.
+fn check_kmstool_output(
+    operation: &'static str,
+    output: io::Result<Output>,
+) -> Result<String, EncryptError> {
+    let output = output.map_err(|error| {
+        let kind = error.kind();
+        tracing::error!(operation, error_kind = ?kind, "Failed to execute kmstool_enclave_cli");
+        EncryptError::KmsError(format!("kmstool {operation} execution failed: {kind:?}"))
+    })?;
+
+    if !output.status.success() {
+        let exit_code = output.status.code();
+        tracing::error!(
+            operation,
+            error_kind = "process_failed",
+            ?exit_code,
+            "kmstool_enclave_cli failed"
+        );
+        let detail = match exit_code {
+            Some(code) => format!("kmstool {operation} failed (exit code {code})"),
+            None => format!("kmstool {operation} terminated without an exit code"),
+        };
+        return Err(EncryptError::KmsError(detail));
+    }
+
+    String::from_utf8(output.stdout).map_err(|_| {
+        tracing::error!(
+            operation,
+            error_kind = "invalid_utf8",
+            "Invalid kmstool_enclave_cli output"
+        );
+        EncryptError::KmsError(format!("Invalid UTF-8 in kmstool {operation} output"))
+    })
 }
 
 #[derive(Debug)]
@@ -505,20 +538,8 @@ pub fn create_new_encryption_key(
         .arg(aws_kms_key_id)
         .arg("--key-spec")
         .arg("AES-256")
-        .output()
-        .map_err(|e| {
-            tracing::error!("Failed to execute kmstool_enclave_cli: {}", e);
-            EncryptError::KmsError(e.to_string())
-        })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        tracing::error!("kmstool_enclave_cli failed: {}", stderr);
-        return Err(EncryptError::KmsError(stderr.to_string()));
-    }
-
-    let output_str =
-        String::from_utf8(output.stdout).map_err(|e| EncryptError::KmsError(e.to_string()))?;
+        .output();
+    let output_str = check_kmstool_output("genkey", output)?;
     parse_kmstool_genkey(&output_str)
 }
 
@@ -577,26 +598,8 @@ pub async fn generate_random_bytes_from_enclave(
         .arg(aws_session_token)
         .arg("--length")
         .arg(length.to_string())
-        .output()
-        .map_err(|e| {
-            tracing::error!(
-                "Failed to execute kmstool_enclave_cli for random byte generation: {}",
-                e
-            );
-            EncryptError::KmsError(e.to_string())
-        })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        tracing::error!(
-            "kmstool_enclave_cli random byte generation failed: {}",
-            stderr
-        );
-        return Err(EncryptError::KmsError(stderr.to_string()));
-    }
-
-    let output_str =
-        String::from_utf8(output.stdout).map_err(|e| EncryptError::KmsError(e.to_string()))?;
+        .output();
+    let output_str = check_kmstool_output("genrandom", output)?;
 
     parse_kmstool_plaintext(&output_str, "genrandom", Some(length))
 }
@@ -647,6 +650,126 @@ impl CustomRng {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    fn synthetic_kmstool_output(status: i32, stdout: Vec<u8>, stderr: Vec<u8>) -> Output {
+        use std::os::unix::process::ExitStatusExt;
+
+        Output {
+            status: std::process::ExitStatus::from_raw(status),
+            stdout,
+            stderr,
+        }
+    }
+
+    #[test]
+    fn kmstool_execution_error_retains_only_operation_and_kind() {
+        let error = check_kmstool_output(
+            "decrypt",
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "private subprocess diagnostic",
+            )),
+        )
+        .unwrap_err();
+
+        assert!(matches!(&error, EncryptError::KmsError(_)));
+        assert!(error.to_string().contains("decrypt"));
+        assert!(error.to_string().contains("PermissionDenied"));
+        assert!(!format!("{error:?} {error}").contains("private subprocess diagnostic"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn kmstool_process_failure_does_not_retain_output() {
+        for operation in ["decrypt", "genkey", "genrandom"] {
+            for status in [23 << 8, 9] {
+                let error = check_kmstool_output(
+                    operation,
+                    Ok(synthetic_kmstool_output(
+                        status,
+                        b"private stdout payload".to_vec(),
+                        b"private stderr payload".to_vec(),
+                    )),
+                )
+                .unwrap_err();
+
+                assert!(matches!(&error, EncryptError::KmsError(_)));
+                let diagnostic = format!("{error:?} {error}");
+                assert!(!diagnostic.contains("private stdout payload"));
+                assert!(!diagnostic.contains("private stderr payload"));
+                assert!(diagnostic.contains(operation));
+                if status == 23 << 8 {
+                    assert!(diagnostic.contains("exit code 23"));
+                } else {
+                    assert!(diagnostic.contains("without an exit code"));
+                }
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn kmstool_invalid_utf8_does_not_retain_output() {
+        let mut stdout = b"private stdout payload".to_vec();
+        stdout.push(0xff);
+        let error = check_kmstool_output(
+            "genkey",
+            Ok(synthetic_kmstool_output(
+                0,
+                stdout,
+                b"private stderr payload".to_vec(),
+            )),
+        )
+        .unwrap_err();
+
+        let diagnostic = format!("{error:?} {error}");
+        assert!(matches!(error, EncryptError::KmsError(_)));
+        assert!(diagnostic.contains("Invalid UTF-8"));
+        assert!(!diagnostic.contains("private stdout payload"));
+        assert!(!diagnostic.contains("private stderr payload"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn kmstool_success_preserves_stdout_for_exact_parsing() {
+        let stdout = "PLAINTEXT: dGVzdA==\n";
+        let actual = check_kmstool_output(
+            "decrypt",
+            Ok(synthetic_kmstool_output(
+                0,
+                stdout.as_bytes().to_vec(),
+                b"private stderr payload".to_vec(),
+            )),
+        )
+        .unwrap();
+
+        assert_eq!(actual, stdout);
+    }
+
+    #[tokio::test]
+    async fn content_deserialization_error_does_not_retain_decrypted_value() {
+        let key = SecretKey::from_slice(&[1u8; 32]).unwrap();
+        let plaintext = br#""private decrypted value""#;
+        let original_error = serde_json::from_slice::<u32>(plaintext).unwrap_err();
+        assert!(original_error
+            .to_string()
+            .contains("private decrypted value"));
+
+        let encrypted = encrypt_with_key(&key, plaintext).await;
+        let error = decrypt_content::<u32>(&key, Some(&encrypted)).unwrap_err();
+        assert!(matches!(&error, EncryptError::DeserializationFailed(_)));
+        let diagnostic = format!("{error:?} {error}");
+        assert!(diagnostic.contains("JSON Data at line 1 column"));
+        assert!(!diagnostic.contains("private decrypted value"));
+
+        assert_eq!(decrypt_content::<u32>(&key, None).unwrap(), None);
+        let valid = encrypt_with_key(&key, b"123").await;
+        assert_eq!(
+            decrypt_content::<u32>(&key, Some(&valid)).unwrap(),
+            Some(123)
+        );
+    }
 
     fn kmstool_plaintext_output(bytes: &[u8]) -> String {
         format!("{KMSTOOL_PLAINTEXT_PREFIX}{}\n", STANDARD.encode(bytes))

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -378,7 +378,11 @@ impl NewToken {
             .db
             .get_org_project_by_client_id(project_client_id)
             .map_err(|e| {
-                tracing::error!("Error looking up JWT project");
+                tracing::error!(
+                    %project_client_id,
+                    error_kind = crate::observability::error_kind(&e),
+                    "Error looking up JWT project"
+                );
                 match e {
                     DBError::OrgProjectNotFound => ApiError::BadRequest,
                     _ => ApiError::InternalServerError,
@@ -394,21 +398,22 @@ impl NewToken {
                 // Decrypt the custom JWT secret using the enclave key
                 let secret_key =
                     secp256k1::SecretKey::from_slice(&app_state.enclave_key).map_err(|_| {
-                        tracing::error!("Failed to create secret key from enclave key");
+                        tracing::error!(%project_client_id, "Failed to create secret key from enclave key");
                         ApiError::InternalServerError
                     })?;
 
-                let decrypted_key =
-                    crate::encrypt::decrypt_with_key(&secret_key, &secret.secret_enc).map_err(
-                        |_| {
-                            tracing::error!("Failed to decrypt custom JWT secret");
-                            ApiError::InternalServerError
-                        },
-                    )?;
+                let decrypted_key = crate::encrypt::decrypt_with_key(
+                    &secret_key,
+                    &secret.secret_enc,
+                )
+                .map_err(|_| {
+                    tracing::error!(%project_client_id, "Failed to decrypt custom JWT secret");
+                    ApiError::InternalServerError
+                })?;
 
                 // For custom secrets, use HS256 algorithm (HMAC with shared secret)
                 // This is what third-party services like Supabase expect
-                tracing::debug!("Using custom JWT secret with HS256");
+                tracing::debug!(%project_client_id, "Using custom JWT secret with HS256");
 
                 // Create HS256 header
                 let jwt_header = JwtHeader::new(JwtAlgorithm::HS256);
@@ -423,28 +428,33 @@ impl NewToken {
                         jsonwebtoken::errors::ErrorKind::Signing(_) => "signing",
                         _ => "other",
                     };
-                    tracing::error!(error_kind, "Error creating HS256 token with custom secret");
+                    tracing::error!(%project_client_id, error_kind, "Error creating HS256 token with custom secret");
                     ApiError::InternalServerError
                 })
             }
             Ok(None) => {
                 // No custom secret found, use the default key
-                tracing::debug!("No custom JWT secret found, using default");
+                tracing::debug!(%project_client_id, "No custom JWT secret found, using default");
                 let es256k = Es256k::<Sha256>::new(app_state.config.jwt_keys.secp.clone());
 
                 es256k
                     .token(header, claims, &app_state.config.jwt_keys.signing_key)
                     .map_err(|e| {
                         tracing::error!(
+                            %project_client_id,
                             error_kind = token_creation_error_kind(&e),
                             "Error creating token"
                         );
                         ApiError::InternalServerError
                     })
             }
-            Err(_) => {
+            Err(error) => {
                 // Database error looking up the secret
-                tracing::error!("Database error looking up custom JWT secret");
+                tracing::error!(
+                    %project_client_id,
+                    error_kind = crate::observability::error_kind(&error),
+                    "Database error looking up custom JWT secret"
+                );
                 Err(ApiError::InternalServerError)
             }
         }
@@ -469,7 +479,7 @@ impl NewToken {
             | TokenType::Refresh
             | TokenType::TransportV2Access
             | TokenType::TransportV2Refresh => {
-                tracing::error!("User access/refresh tokens require AuthContext");
+                tracing::error!(user_id = %user.uuid, project_id = user.project_id, "User access/refresh tokens require AuthContext");
                 return Err(ApiError::BadRequest);
             }
         };
@@ -485,7 +495,7 @@ impl NewToken {
             auth_binding: None,
         };
 
-        tracing::debug!("Creating new third-party token");
+        tracing::debug!(user_id = %user.uuid, project_id = user.project_id, "Creating new third-party token");
 
         // Account for clock drift by setting issued_at 1 minute in the past
         let now = Utc::now();
@@ -512,6 +522,8 @@ impl NewToken {
                 .token(&header, &claims, &app_state.config.jwt_keys.signing_key)
                 .map_err(|e| {
                     tracing::error!(
+                        user_id = %user.uuid,
+                        project_id = user.project_id,
                         error_kind = token_creation_error_kind(&e),
                         "Error creating token"
                     );
@@ -519,7 +531,7 @@ impl NewToken {
                 })?
         };
 
-        tracing::debug!("Successfully created token");
+        tracing::debug!(user_id = %user.uuid, project_id = user.project_id, "Successfully created token");
 
         Ok(Self {
             token: token_string,
@@ -533,7 +545,12 @@ impl NewToken {
         auth_context: &AuthContext,
     ) -> Result<Self, ApiError> {
         if user.project_id != auth_context.project_id {
-            tracing::error!("User token auth context project does not match user project");
+            tracing::error!(
+                user_id = %user.uuid,
+                project_id = user.project_id,
+                auth_project_id = auth_context.project_id,
+                "User token auth context project does not match user project"
+            );
             return Err(ApiError::BadRequest);
         }
 
@@ -571,7 +588,7 @@ impl NewToken {
         };
         auth_context.apply_to_claims(&mut custom_claims);
 
-        tracing::debug!("Creating new user token with auth context");
+        tracing::debug!(user_id = %user.uuid, project_id = user.project_id, "Creating new user token with auth context");
 
         let now = Utc::now();
         let iat = now - Duration::minutes(1);
@@ -589,6 +606,8 @@ impl NewToken {
             .token(&header, &claims, &app_state.config.jwt_keys.signing_key)
             .map_err(|e| {
                 tracing::error!(
+                    user_id = %user.uuid,
+                    project_id = user.project_id,
                     error_kind = token_creation_error_kind(&e),
                     "Error creating v2 user token"
                 );
@@ -643,7 +662,7 @@ impl NewToken {
             auth_binding: None,
         };
 
-        tracing::debug!("Creating new platform token");
+        tracing::debug!(platform_user_id = %user.uuid, "Creating new platform token");
 
         // Account for clock drift by setting issued_at 1 minute in the past
         let now = Utc::now();
@@ -662,13 +681,14 @@ impl NewToken {
             .token(&header, &claims, &app_state.config.jwt_keys.signing_key)
             .map_err(|e| {
                 tracing::error!(
+                    platform_user_id = %user.uuid,
                     error_kind = token_creation_error_kind(&e),
                     "Error creating token"
                 );
                 ApiError::InternalServerError
             })?;
 
-        tracing::debug!("Successfully created platform token");
+        tracing::debug!(platform_user_id = %user.uuid, "Successfully created platform token");
 
         Ok(Self {
             token: token_string,
@@ -731,13 +751,15 @@ fn issue_native_handoff_grant_with_keys(
         )
         .map_err(|error| {
             tracing::error!(
+                %user_id,
+                project_id = auth_context.project_id,
                 error_kind = token_creation_error_kind(&error),
                 "failed to create transport-v2 native handoff grant"
             );
             ApiError::InternalServerError
         })?;
     if !is_canonical_compact_jwt(&grant) {
-        tracing::error!("issued transport-v2 native handoff grant exceeded its wire contract");
+        tracing::error!(%user_id, project_id = auth_context.project_id, "issued transport-v2 native handoff grant exceeded its wire contract");
         return Err(ApiError::InternalServerError);
     }
 
@@ -935,14 +957,24 @@ pub async fn validate_jwt(
 
     let user = match data.get_user(user_uuid).await {
         Ok(user) => user,
-        Err(_) => {
-            tracing::error!("Error getting JWT user");
+        Err(error) => {
+            tracing::error!(
+                user_id = %user_uuid,
+                project_id = auth_context.project_id,
+                error_kind = crate::observability::error_kind(&error),
+                "Error getting JWT user"
+            );
             return ApiError::InternalServerError.into_response();
         }
     };
 
     if user.project_id != auth_context.project_id {
-        tracing::error!("JWT auth context project does not match user project");
+        tracing::error!(
+            user_id = %user_uuid,
+            project_id = user.project_id,
+            auth_project_id = auth_context.project_id,
+            "JWT auth context project does not match user project"
+        );
         return ApiError::InvalidJwt.into_response();
     }
 
@@ -950,7 +982,7 @@ pub async fn validate_jwt(
         .verify_seed_wrap_for_auth_context(&user, &auth_context)
         .is_err()
     {
-        tracing::error!("JWT auth context no longer unwraps an active seed wrap");
+        tracing::error!(user_id = %user_uuid, project_id = user.project_id, "JWT auth context no longer unwraps an active seed wrap");
         return ApiError::InvalidJwt.into_response();
     }
 
@@ -1012,8 +1044,12 @@ pub async fn validate_platform_jwt(
 
     let platform_user = match data.db.get_platform_user_by_uuid(platform_user_id) {
         Ok(user) => user,
-        Err(_) => {
-            tracing::error!("Error getting platform JWT user");
+        Err(error) => {
+            tracing::error!(
+                %platform_user_id,
+                error_kind = crate::observability::error_kind(&error),
+                "Error getting platform JWT user"
+            );
             return ApiError::Unauthorized.into_response();
         }
     };

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -60,6 +60,42 @@ pub(crate) const TRANSPORT_V2_NATIVE_HANDOFF_MAX_BYTES: usize = 4 * 1024;
 
 pub const USER_TOKEN_FORMAT_V2: u8 = 2;
 
+// JWT errors can carry untrusted headers, claims, or serializer messages. Keep
+// diagnostics useful without formatting any of those payloads into logs.
+fn token_creation_error_kind(error: &jwt_compact::CreationError) -> &'static str {
+    match error {
+        jwt_compact::CreationError::Header(_) => "header_serialization",
+        jwt_compact::CreationError::Claims(_) => "claims_serialization",
+        jwt_compact::CreationError::CborClaims(_) => "cbor_claims_serialization",
+        _ => "other",
+    }
+}
+
+fn token_parse_error_kind(error: &jwt_compact::ParseError) -> &'static str {
+    match error {
+        jwt_compact::ParseError::InvalidTokenStructure => "invalid_structure",
+        jwt_compact::ParseError::InvalidBase64Encoding => "invalid_base64",
+        jwt_compact::ParseError::MalformedHeader(_) => "malformed_header",
+        jwt_compact::ParseError::UnsupportedContentType(_) => "unsupported_content_type",
+        _ => "other",
+    }
+}
+
+fn token_validation_error_kind(error: &jwt_compact::ValidationError) -> &'static str {
+    match error {
+        jwt_compact::ValidationError::AlgorithmMismatch { .. } => "algorithm_mismatch",
+        jwt_compact::ValidationError::InvalidSignatureLen { .. } => "invalid_signature_length",
+        jwt_compact::ValidationError::MalformedSignature(_) => "malformed_signature",
+        jwt_compact::ValidationError::InvalidSignature => "invalid_signature",
+        jwt_compact::ValidationError::MalformedClaims(_) => "malformed_claims",
+        jwt_compact::ValidationError::MalformedCborClaims(_) => "malformed_cbor_claims",
+        jwt_compact::ValidationError::NoClaim(_) => "missing_claim",
+        jwt_compact::ValidationError::Expired => "expired",
+        jwt_compact::ValidationError::NotMature => "not_yet_valid",
+        _ => "other",
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum TokenType {
     Access,
@@ -260,10 +296,7 @@ impl TokenType {
 
         // 1. Check for reserved audiences
         if RESERVED_AUDIENCES.contains(&aud) {
-            tracing::error!(
-                "Third-party tokens cannot use internal audience types: {}",
-                aud
-            );
+            tracing::error!("Third-party tokens cannot use internal audience types");
             return Err(ApiError::BadRequest);
         }
 
@@ -271,10 +304,9 @@ impl TokenType {
         const MAX_AUDIENCE_LENGTH: usize = 50;
         if aud.len() > MAX_AUDIENCE_LENGTH {
             tracing::error!(
-                "Audience value exceeds maximum length of {}: {} (length: {})",
-                MAX_AUDIENCE_LENGTH,
-                aud,
-                aud.len()
+                max_length = MAX_AUDIENCE_LENGTH,
+                audience_bytes = aud.len(),
+                "Audience value exceeds maximum length"
             );
             return Err(ApiError::BadRequest);
         }
@@ -302,7 +334,7 @@ impl TokenType {
                 || c == '%'
                 || c == '#'
         }) {
-            tracing::error!("Audience contains disallowed characters: {}", aud);
+            tracing::error!("Audience contains disallowed characters");
             return Err(ApiError::BadRequest);
         }
 
@@ -314,8 +346,8 @@ impl TokenType {
 
         // 6. Parse as URI to ensure it's valid if it contains ':'
         if aud.contains(':') {
-            Url::parse(aud).map_err(|e| {
-                tracing::error!("Invalid audience URI format: {}, error: {:?}", aud, e);
+            Url::parse(aud).map_err(|_| {
+                tracing::error!("Invalid audience URI format");
                 ApiError::BadRequest
             })?;
         }
@@ -336,12 +368,8 @@ impl NewToken {
         use crate::web::platform::common::THIRD_PARTY_JWT_SECRET;
 
         // Parse the "azp" value which should be the project client_id
-        let project_client_id = Uuid::parse_str(azp).map_err(|e| {
-            tracing::error!(
-                "Invalid project client_id format in azp: {}, error: {:?}",
-                azp,
-                e
-            );
+        let project_client_id = Uuid::parse_str(azp).map_err(|_| {
+            tracing::error!("Invalid project client_id format in azp");
             ApiError::BadRequest
         })?;
 
@@ -350,11 +378,7 @@ impl NewToken {
             .db
             .get_org_project_by_client_id(project_client_id)
             .map_err(|e| {
-                tracing::error!(
-                    "Error looking up project with client_id {}: {:?}",
-                    project_client_id,
-                    e
-                );
+                tracing::error!("Error looking up JWT project");
                 match e {
                     DBError::OrgProjectNotFound => ApiError::BadRequest,
                     _ => ApiError::InternalServerError,
@@ -369,29 +393,22 @@ impl NewToken {
             Ok(Some(secret)) => {
                 // Decrypt the custom JWT secret using the enclave key
                 let secret_key =
-                    secp256k1::SecretKey::from_slice(&app_state.enclave_key).map_err(|e| {
-                        tracing::error!("Failed to create secret key from enclave key: {:?}", e);
+                    secp256k1::SecretKey::from_slice(&app_state.enclave_key).map_err(|_| {
+                        tracing::error!("Failed to create secret key from enclave key");
                         ApiError::InternalServerError
                     })?;
 
                 let decrypted_key =
                     crate::encrypt::decrypt_with_key(&secret_key, &secret.secret_enc).map_err(
-                        |e| {
-                            tracing::error!(
-                                "Failed to decrypt custom JWT secret for project {}: {:?}",
-                                project_client_id,
-                                e
-                            );
+                        |_| {
+                            tracing::error!("Failed to decrypt custom JWT secret");
                             ApiError::InternalServerError
                         },
                     )?;
 
                 // For custom secrets, use HS256 algorithm (HMAC with shared secret)
                 // This is what third-party services like Supabase expect
-                tracing::debug!(
-                    "Using custom JWT secret with HS256 for project {}",
-                    project_client_id
-                );
+                tracing::debug!("Using custom JWT secret with HS256");
 
                 // Create HS256 header
                 let jwt_header = JwtHeader::new(JwtAlgorithm::HS256);
@@ -400,33 +417,34 @@ impl NewToken {
                 let encoding_key = EncodingKey::from_secret(&decrypted_key);
 
                 // Encode the token using HS256
-                jwt_encode(&jwt_header, claims, &encoding_key).map_err(|e| {
-                    tracing::error!("Error creating HS256 token with custom secret: {:?}", e);
+                jwt_encode(&jwt_header, claims, &encoding_key).map_err(|error| {
+                    let error_kind = match error.kind() {
+                        jsonwebtoken::errors::ErrorKind::Json(_) => "serialization",
+                        jsonwebtoken::errors::ErrorKind::Signing(_) => "signing",
+                        _ => "other",
+                    };
+                    tracing::error!(error_kind, "Error creating HS256 token with custom secret");
                     ApiError::InternalServerError
                 })
             }
             Ok(None) => {
                 // No custom secret found, use the default key
-                tracing::debug!(
-                    "No custom JWT secret found for project {}, using default",
-                    project_client_id
-                );
+                tracing::debug!("No custom JWT secret found, using default");
                 let es256k = Es256k::<Sha256>::new(app_state.config.jwt_keys.secp.clone());
 
                 es256k
                     .token(header, claims, &app_state.config.jwt_keys.signing_key)
                     .map_err(|e| {
-                        tracing::error!("Error creating token: {:?}", e);
+                        tracing::error!(
+                            error_kind = token_creation_error_kind(&e),
+                            "Error creating token"
+                        );
                         ApiError::InternalServerError
                     })
             }
-            Err(e) => {
+            Err(_) => {
                 // Database error looking up the secret
-                tracing::error!(
-                    "Database error looking up custom JWT secret for project {}: {:?}",
-                    project_client_id,
-                    e
-                );
+                tracing::error!("Database error looking up custom JWT secret");
                 Err(ApiError::InternalServerError)
             }
         }
@@ -467,7 +485,7 @@ impl NewToken {
             auth_binding: None,
         };
 
-        tracing::debug!("Creating new token with claims: {:?}", custom_claims);
+        tracing::debug!("Creating new third-party token");
 
         // Account for clock drift by setting issued_at 1 minute in the past
         let now = Utc::now();
@@ -493,7 +511,10 @@ impl NewToken {
             es256k
                 .token(&header, &claims, &app_state.config.jwt_keys.signing_key)
                 .map_err(|e| {
-                    tracing::error!("Error creating token: {:?}", e);
+                    tracing::error!(
+                        error_kind = token_creation_error_kind(&e),
+                        "Error creating token"
+                    );
                     ApiError::InternalServerError
                 })?
         };
@@ -550,11 +571,7 @@ impl NewToken {
         };
         auth_context.apply_to_claims(&mut custom_claims);
 
-        tracing::debug!(
-            "Creating new v2 user token for user {} with audience {:?}",
-            user.get_id(),
-            custom_claims.aud
-        );
+        tracing::debug!("Creating new user token with auth context");
 
         let now = Utc::now();
         let iat = now - Duration::minutes(1);
@@ -571,7 +588,10 @@ impl NewToken {
         let token_string = es256k
             .token(&header, &claims, &app_state.config.jwt_keys.signing_key)
             .map_err(|e| {
-                tracing::error!("Error creating v2 user token: {:?}", e);
+                tracing::error!(
+                    error_kind = token_creation_error_kind(&e),
+                    "Error creating v2 user token"
+                );
                 ApiError::InternalServerError
             })?;
 
@@ -623,10 +643,7 @@ impl NewToken {
             auth_binding: None,
         };
 
-        tracing::debug!(
-            "Creating new platform token with claims: {:?}",
-            custom_claims
-        );
+        tracing::debug!("Creating new platform token");
 
         // Account for clock drift by setting issued_at 1 minute in the past
         let now = Utc::now();
@@ -644,7 +661,10 @@ impl NewToken {
         let token_string = es256k
             .token(&header, &claims, &app_state.config.jwt_keys.signing_key)
             .map_err(|e| {
-                tracing::error!("Error creating token: {:?}", e);
+                tracing::error!(
+                    error_kind = token_creation_error_kind(&e),
+                    "Error creating token"
+                );
                 ApiError::InternalServerError
             })?;
 
@@ -710,7 +730,10 @@ fn issue_native_handoff_grant_with_keys(
             &jwt_keys.signing_key,
         )
         .map_err(|error| {
-            tracing::error!(?error, "failed to create transport-v2 native handoff grant");
+            tracing::error!(
+                error_kind = token_creation_error_kind(&error),
+                "failed to create transport-v2 native handoff grant"
+            );
             ApiError::InternalServerError
         })?;
     if !is_canonical_compact_jwt(&grant) {
@@ -904,16 +927,16 @@ pub async fn validate_jwt(
 
     let user_uuid: Uuid = match Uuid::parse_str(&claims.sub) {
         Ok(uuid) => uuid,
-        Err(e) => {
-            tracing::error!("Error parsing user uuid: {:?}", e);
+        Err(_) => {
+            tracing::error!("Error parsing user uuid in JWT");
             return ApiError::InvalidJwt.into_response();
         }
     };
 
     let user = match data.get_user(user_uuid).await {
         Ok(user) => user,
-        Err(e) => {
-            tracing::error!("Error getting user: {:?}", e);
+        Err(_) => {
+            tracing::error!("Error getting JWT user");
             return ApiError::InternalServerError.into_response();
         }
     };
@@ -923,11 +946,11 @@ pub async fn validate_jwt(
         return ApiError::InvalidJwt.into_response();
     }
 
-    if let Err(e) = data.verify_seed_wrap_for_auth_context(&user, &auth_context) {
-        tracing::error!(
-            "JWT auth context no longer unwraps an active seed wrap: {:?}",
-            e
-        );
+    if data
+        .verify_seed_wrap_for_auth_context(&user, &auth_context)
+        .is_err()
+    {
+        tracing::error!("JWT auth context no longer unwraps an active seed wrap");
         return ApiError::InvalidJwt.into_response();
     }
 
@@ -981,16 +1004,16 @@ pub async fn validate_platform_jwt(
 
     let platform_user_id: Uuid = match Uuid::parse_str(&claims.sub) {
         Ok(uuid) => uuid,
-        Err(e) => {
-            tracing::error!("Error parsing platform user uuid: {:?}", e);
+        Err(_) => {
+            tracing::error!("Error parsing platform user uuid in JWT");
             return ApiError::InvalidJwt.into_response();
         }
     };
 
     let platform_user = match data.db.get_platform_user_by_uuid(platform_user_id) {
         Ok(user) => user,
-        Err(e) => {
-            tracing::error!("Error getting platform user: {:?}", e);
+        Err(_) => {
+            tracing::error!("Error getting platform JWT user");
             return ApiError::Unauthorized.into_response();
         }
     };
@@ -1058,7 +1081,10 @@ fn validate_token_with_keys_for_auth(
     let parsed_token = match UntrustedToken::new(original_token) {
         Ok(token) => token,
         Err(e) => {
-            tracing::error!("Failed to parse token: {:?}", e);
+            tracing::error!(
+                error_kind = token_parse_error_kind(&e),
+                "Failed to parse token"
+            );
             return Err(ApiError::InvalidJwt);
         }
     };
@@ -1074,15 +1100,11 @@ fn validate_token_with_keys_for_auth(
                 let claims: &Claims<CustomClaims> = token.claims();
                 if let Some(audience) = &claims.custom.aud {
                     if audience != expected_audience {
-                        tracing::error!(
-                            "Invalid audience: got {}, expected {}",
-                            audience,
-                            expected_audience
-                        );
+                        tracing::error!("JWT audience does not match the required token type");
                         return Err(ApiError::InvalidJwt);
                     }
                 } else {
-                    tracing::error!("Missing audience in token, expected {}", expected_audience);
+                    tracing::error!("Missing audience in token");
                     return Err(ApiError::InvalidJwt);
                 }
 
@@ -1098,7 +1120,10 @@ fn validate_token_with_keys_for_auth(
                         true
                     }
                     Err(e) => {
-                        tracing::error!("Token expiration validation failed: {:?}", e);
+                        tracing::error!(
+                            error_kind = token_validation_error_kind(&e),
+                            "Token expiration validation failed"
+                        );
                         return Err(ApiError::InvalidJwt);
                     }
                 };
@@ -1106,7 +1131,10 @@ fn validate_token_with_keys_for_auth(
                 (token, access_token_expired)
             }
             Err(e) => {
-                tracing::debug!("ES256K validation failed: {:?}", e);
+                tracing::debug!(
+                    error_kind = token_validation_error_kind(&e),
+                    "ES256K validation failed"
+                );
                 return Err(ApiError::InvalidJwt);
             }
         };
@@ -1118,6 +1146,39 @@ fn validate_token_with_keys_for_auth(
 mod tests {
     use super::*;
     use jsonwebtoken::{decode as jwt_decode, DecodingKey, Validation};
+
+    #[test]
+    fn jwt_error_categories_omit_untrusted_claims_and_header_values() {
+        const PRIVATE: &str = "PRIVATE_JWT_DESCRIPTION_AND_CLAIMS_SENTINEL";
+        let claims_error = || <serde_json::Error as serde::de::Error>::custom(PRIVATE);
+        let categories = [
+            token_creation_error_kind(&jwt_compact::CreationError::Claims(claims_error())),
+            token_parse_error_kind(&jwt_compact::ParseError::UnsupportedContentType(
+                PRIVATE.to_string(),
+            )),
+            token_parse_error_kind(&jwt_compact::ParseError::MalformedHeader(claims_error())),
+            token_validation_error_kind(&jwt_compact::ValidationError::MalformedClaims(
+                claims_error(),
+            )),
+            token_validation_error_kind(&jwt_compact::ValidationError::AlgorithmMismatch {
+                expected: "ES256K".to_string(),
+                actual: PRIVATE.to_string(),
+            }),
+        ];
+        assert_eq!(
+            categories,
+            [
+                "claims_serialization",
+                "unsupported_content_type",
+                "malformed_header",
+                "malformed_claims",
+                "algorithm_mismatch",
+            ]
+        );
+        assert!(categories
+            .iter()
+            .all(|category| !category.contains(PRIVATE)));
+    }
 
     fn test_keys(byte: u8) -> JwtKeys {
         JwtKeys::new(vec![byte; 32]).unwrap()

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -43,26 +43,43 @@ pub fn get(
     user_secret_key: &SecretKey,
 ) -> StoreResult<Option<String>> {
     debug!("Getting KV pair");
-    let mut conn = pool.get().map_err(|e| {
-        error!("Failed to get database connection: {:?}", e);
+    let mut conn = pool.get().map_err(|_| {
+        error!(
+            stage = "kv_get",
+            error_kind = "database_connection",
+            "Failed to get database connection"
+        );
         StoreError::DatabaseError(UserKVError::DatabaseError(diesel::result::Error::NotFound))
     })?;
 
     let encrypted_key = encrypt_key_deterministic(user_secret_key, key.as_bytes());
 
-    let user_kv = UserKV::get_by_user_and_key(&mut conn, user_id, &encrypted_key).map_err(|e| {
-        error!("Failed to get KV pair: {:?}", e);
-        e
-    })?;
+    let user_kv =
+        UserKV::get_by_user_and_key(&mut conn, user_id, &encrypted_key).inspect_err(|_| {
+            error!(
+                stage = "kv_get",
+                error_kind = "database",
+                "Failed to get KV pair"
+            );
+        })?;
 
     if let Some(user_kv) = user_kv {
         let decrypted_value =
-            decrypt_with_key(user_secret_key, &user_kv.value_enc).map_err(|e| {
-                error!("Failed to decrypt value: {:?}", e);
+            decrypt_with_key(user_secret_key, &user_kv.value_enc).map_err(|_| {
+                error!(
+                    stage = "kv_get",
+                    error_kind = "decryption",
+                    "Failed to decrypt value"
+                );
                 StoreError::DecryptionError
             })?;
-        let value_str = String::from_utf8(decrypted_value).map_err(|e| {
-            error!("Failed to convert decrypted value to string: {:?}", e);
+        let value_str = String::from_utf8(decrypted_value).map_err(|_| {
+            // FromUtf8Error's Debug includes the decrypted byte buffer.
+            error!(
+                stage = "kv_get",
+                error_kind = "invalid_utf8",
+                "Failed to convert decrypted value to string"
+            );
             StoreError::DecryptionError
         })?;
         Ok(Some(value_str))

--- a/src/main.rs
+++ b/src/main.rs
@@ -3099,10 +3099,35 @@ async fn get_secret(key_name: &str) -> Result<String, Error> {
         crate::aws_credentials::MAX_VSOCK_RESPONSE_BYTES,
     )?;
 
-    let parent_response: ParentResponse = serde_json::from_str(&response)?;
+    parse_parent_secret_response(&response)
+}
+
+// Startup's Result error and expect/unwrap failures are printed with Debug by
+// the runtime. Erase payload-bearing parse errors before they reach that sink.
+fn parse_parent_secret_response(response: &str) -> Result<String, Error> {
+    let parent_response: ParentResponse = serde_json::from_str(response).map_err(|error| {
+        error!(
+            stage = "parent_secret_response",
+            error_kind = observability::error_kind(&error),
+            "Failed to parse secret response"
+        );
+        Error::SecretParsingError
+    })?;
     if parent_response.response_type == "secret" {
-        let secret_json: Value =
-            serde_json::from_str(parent_response.response_value.as_str().unwrap())?;
+        let secret_json: Value = serde_json::from_str(
+            parent_response
+                .response_value
+                .as_str()
+                .ok_or(Error::SecretParsingError)?,
+        )
+        .map_err(|error| {
+            error!(
+                stage = "secret_json",
+                error_kind = observability::error_kind(&error),
+                "Failed to parse secret value"
+            );
+            Error::SecretParsingError
+        })?;
 
         // Assuming the secret is always a JSON object with a single key-value pair
         if let Some((_, value)) = secret_json.as_object().and_then(|obj| obj.iter().next()) {
@@ -3112,6 +3137,79 @@ async fn get_secret(key_name: &str) -> Result<String, Error> {
         }
     } else {
         Err(Error::AuthenticationError)
+    }
+}
+
+fn decode_startup_secret(bytes: Vec<u8>) -> Result<String, Error> {
+    String::from_utf8(bytes).map_err(|_| Error::SecretParsingError)
+}
+
+fn decode_local_enclave_key(value: &str) -> Result<[u8; 32], Error> {
+    hex::decode(value)
+        .map_err(|_| Error::SecretParsingError)?
+        .try_into()
+        .map_err(|_| Error::SecretParsingError)
+}
+
+fn required_secret_env(name: &'static str) -> String {
+    // VarError::NotUnicode retains the actual environment value in Debug.
+    env::var(name).unwrap_or_else(|_| panic!("{name} must be set to valid UTF-8"))
+}
+
+#[cfg(test)]
+mod startup_secret_log_tests {
+    use super::*;
+
+    #[test]
+    fn startup_secret_decode_errors_do_not_retain_bytes() {
+        let mut private = b"PRIVATE_STARTUP_SECRET_SENTINEL".to_vec();
+        private.push(0xff);
+        let original = String::from_utf8(private.clone()).unwrap_err();
+        assert!(format!("{original:?}").contains(&format!("{private:?}")));
+        let error = decode_startup_secret(private.clone()).unwrap_err();
+        assert_eq!(format!("{error:?}"), "SecretParsingError");
+        assert!(!format!("{error:?}").contains(&format!("{private:?}")));
+
+        let wrong_length_key = hex::encode(&private[..31]);
+        let error = decode_local_enclave_key(&wrong_length_key).unwrap_err();
+        assert_eq!(format!("{error:?}"), "SecretParsingError");
+        assert!(decode_local_enclave_key("not-hex").is_err());
+    }
+
+    #[test]
+    fn parent_secret_parse_errors_do_not_retain_content() {
+        let payload = serde_json::json!("PRIVATE_PARENT_SECRET_SENTINEL").to_string();
+        let original = serde_json::from_str::<ParentResponse>(&payload).unwrap_err();
+        assert!(format!("{original:?}").contains("PRIVATE_PARENT_SECRET_SENTINEL"));
+        assert_eq!(
+            format!("{:?}", parse_parent_secret_response(&payload).unwrap_err()),
+            "SecretParsingError"
+        );
+        let malformed_inner = serde_json::json!({"response_type":"secret", "response_value":"{PRIVATE_PARENT_SECRET_SENTINEL"});
+        assert_eq!(
+            format!(
+                "{:?}",
+                parse_parent_secret_response(&malformed_inner.to_string()).unwrap_err()
+            ),
+            "SecretParsingError"
+        );
+    }
+
+    #[test]
+    fn startup_secret_success_values_are_preserved() {
+        assert_eq!(
+            decode_startup_secret(b"synthetic-secret".to_vec()).unwrap(),
+            "synthetic-secret"
+        );
+        assert_eq!(
+            decode_local_enclave_key(&hex::encode([7u8; 32])).unwrap(),
+            [7u8; 32]
+        );
+        let response = serde_json::json!({"response_type":"secret", "response_value":serde_json::json!({"database_url":"synthetic-ciphertext"}).to_string()});
+        assert_eq!(
+            parse_parent_secret_response(&response.to_string()).unwrap(),
+            "synthetic-ciphertext"
+        );
     }
 }
 
@@ -3397,9 +3495,7 @@ async fn get_or_create_jwt_secret(
     match app_mode {
         AppMode::Local => {
             // For local mode, use environment variable
-            Ok(std::env::var("JWT_SECRET")
-                .expect("JWT_SECRET must be set in local mode")
-                .into_bytes())
+            Ok(required_secret_env("JWT_SECRET").into_bytes())
         }
         _ => {
             // Check if JWT secret exists in enclave_secrets
@@ -4053,7 +4149,7 @@ async fn main() -> Result<(), Error> {
                     Error::EncryptionError(e.to_string())
                 })?;
 
-                String::from_utf8(url_vec).expect("should parse url")
+                decode_startup_secret(url_vec).expect("database URL must be valid UTF-8")
             }
             Err(e) => {
                 tracing::error!(
@@ -4064,7 +4160,7 @@ async fn main() -> Result<(), Error> {
             }
         }
     } else {
-        std::env::var("DATABASE_URL").expect("DATABASE_URL must be set")
+        required_secret_env("DATABASE_URL")
     };
 
     let db = setup_db(pg_url);
@@ -4076,12 +4172,9 @@ async fn main() -> Result<(), Error> {
                 .await?;
         enclave_key.key
     } else {
-        let enclave_key =
-            std::env::var("ENCLAVE_SECRET_MOCK").expect("needs ENCLAVE_SECRET_MOCK in local mode");
-        let enclave_key: [u8; 32] = hex::decode(enclave_key)
-            .unwrap()
-            .try_into()
-            .expect("ENCLAVE_SECRET_MOCK must be 32 bytes");
+        let enclave_key = required_secret_env("ENCLAVE_SECRET_MOCK");
+        let enclave_key = decode_local_enclave_key(&enclave_key)
+            .expect("ENCLAVE_SECRET_MOCK must encode 32 bytes");
         enclave_key.to_vec()
     };
 
@@ -4096,10 +4189,7 @@ async fn main() -> Result<(), Error> {
                     .expect("OpenAI API key should be retrieved correctly"),
             )
         } else {
-            Some(
-                std::env::var("OPENAI_API_KEY")
-                    .expect("OPENAI_API_KEY must be set for OpenAI domain"),
-            )
+            Some(required_secret_env("OPENAI_API_KEY"))
         }
     } else {
         None // No API key needed if not using OpenAI's domain
@@ -4198,7 +4288,7 @@ async fn main() -> Result<(), Error> {
                 Error::EncryptionError(e.to_string())
             })?;
 
-            Some(String::from_utf8(url_vec).expect("should parse url"))
+            Some(decode_startup_secret(url_vec).expect("SQS URL must be valid UTF-8"))
         } else {
             // URL not found in database - this is optional so we'll return None
             None

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,7 @@ use tokio::spawn;
 use tokio::sync::RwLock;
 use tokio::task::{self};
 use tower_http::cors::{Any, CorsLayer};
+use tracing::Instrument;
 use tracing::{debug, error, info, trace, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use url::Url;
@@ -114,6 +115,7 @@ mod migrations;
 mod model_config;
 mod models;
 mod oauth;
+mod observability;
 mod os_flags;
 mod private_key;
 #[allow(dead_code)] // Used by the dormant Transport V2 core in this stack layer.
@@ -564,7 +566,10 @@ impl From<ProviderRequestError> for ApiError {
 
 impl From<DBError> for ApiError {
     fn from(err: DBError) -> Self {
-        error!("Database error: {:?}", err);
+        error!(
+            error_kind = crate::observability::error_kind(&err),
+            "Database error"
+        );
         match err {
             DBError::PlatformUserNotFound => ApiError::UserNotFound,
             DBError::PlatformUserError(_) => ApiError::InternalServerError,
@@ -796,9 +801,9 @@ fn optional_env(name: &str) -> Option<String> {
 }
 
 /// Default `RUST_LOG` when unset. The binary crate is `opensecret`; the old
-/// `sg_backend` default matched no events, so local `cargo run` was silent.
-const DEFAULT_RUST_LOG_FILTER: &str =
-    "opensecret=debug,axum_login=debug,tower_sessions=debug,sqlx=warn,tower_http=debug";
+/// `sg_backend` default matched no events. Dependencies remain at warn unless
+/// explicitly selected; application diagnostics can be enabled per module.
+const DEFAULT_RUST_LOG_FILTER: &str = "warn,opensecret=info";
 
 fn init_tracing(app_mode: &AppMode) -> Result<(), Error> {
     let filter = EnvFilter::new(
@@ -850,8 +855,8 @@ mod default_log_filter_tests {
         assert!(
             DEFAULT_RUST_LOG_FILTER
                 .split(',')
-                .any(|directive| directive == "opensecret=debug"),
-            "local default must enable opensecret=debug: {DEFAULT_RUST_LOG_FILTER}"
+                .any(|directive| directive == "opensecret=info"),
+            "default must enable opensecret=info: {DEFAULT_RUST_LOG_FILTER}"
         );
         assert!(
             !DEFAULT_RUST_LOG_FILTER.contains("sg_backend"),
@@ -1256,21 +1261,30 @@ impl AppStateBuilder {
 
         // Initialize GitHub provider
         let github_provider = GithubProvider::new(db.clone()).await.map_err(|e| {
-            error!("Failed to initialize GitHub OAuth provider: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to initialize GitHub OAuth provider"
+            );
             Error::BuilderError("Failed to initialize GitHub OAuth provider".to_string())
         })?;
         oauth_manager.add_provider("github".to_string(), Box::new(github_provider));
 
         // Initialize Google provider
         let google_provider = GoogleProvider::new(db.clone()).await.map_err(|e| {
-            error!("Failed to initialize Google OAuth provider: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to initialize Google OAuth provider"
+            );
             Error::BuilderError("Failed to initialize Google OAuth provider".to_string())
         })?;
         oauth_manager.add_provider("google".to_string(), Box::new(google_provider));
 
         // Initialize Apple provider
         let apple_provider = AppleProvider::new(db.clone()).await.map_err(|e| {
-            error!("Failed to initialize Apple OAuth provider: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to initialize Apple OAuth provider"
+            );
             Error::BuilderError("Failed to initialize Apple OAuth provider".to_string())
         })?;
         oauth_manager.add_provider("apple".to_string(), Box::new(apple_provider));
@@ -1338,8 +1352,8 @@ impl AppStateBuilder {
                 }
                 Err(e) => {
                     tracing::error!(
-                        "Failed to initialize Kagi client: {:?}. Web search will be unavailable.",
-                        e
+                        error_kind = observability::error_kind(&e),
+                        "Failed to initialize Kagi client; web search will be unavailable"
                     );
                     None
                 }
@@ -1396,8 +1410,9 @@ impl AppState {
             Ok(enabled) => enabled,
             Err(e) => {
                 warn!(
-                    "os-flags check failed (user_uuid={}, flag_key={}): {}",
-                    user_uuid, flag_key, e
+                    flag_key,
+                    error_kind = observability::error_kind(&e),
+                    "os-flags check failed"
                 );
                 false
             }
@@ -1437,8 +1452,8 @@ impl AppState {
             Ok(Ok(response)) => PaidModelAliasOverrides::from_flag_values(&response.flags),
             Ok(Err(e)) => {
                 warn!(
-                    "os-flags paid model alias check failed (user_uuid={}): {}; using default aliases",
-                    user_uuid, e
+                    error_kind = observability::error_kind(&e),
+                    "os-flags paid model alias check failed; using default aliases"
                 );
                 PaidModelAliasOverrides::default()
             }
@@ -1498,7 +1513,7 @@ impl AppState {
                 warn!(
                     user_uuid = %user_uuid,
                     flag_key,
-                    %error,
+                    error_kind = observability::error_kind(&error),
                     "os-flags inference-router check failed; retaining legacy router"
                 );
                 InferenceRoutingMode::Legacy
@@ -1560,8 +1575,9 @@ impl AppState {
             }
             Ok(Err(e)) => {
                 warn!(
-                    "os-flags provider routing check failed (user_uuid={}, requested_model={}, flag_key={}): {}; using default provider routing",
-                    user_uuid, requested_model, flag_key, e
+                    flag_key,
+                    error_kind = observability::error_kind(&e),
+                    "os-flags provider routing check failed; using default provider routing"
                 );
                 None
             }
@@ -1600,8 +1616,8 @@ impl AppState {
             Ok(Ok(access)) => Some(access),
             Ok(Err(e)) => {
                 warn!(
-                    "billing access check failed (user_uuid={}): {}; using free model access",
-                    user_uuid, e
+                    error_kind = observability::error_kind(&e),
+                    "billing access check failed; using free model access"
                 );
                 None
             }
@@ -1997,8 +2013,8 @@ impl AppState {
             .get_org_project_by_client_id(creds.client_id)
             .map_err(|e| {
                 error!(
-                    "Database error during client_id ({:?}) lookup: {:?}",
-                    creds.client_id, e
+                    error_kind = observability::error_kind(&e),
+                    "Database error during client ID lookup"
                 );
                 DBError::OrgProjectNotFound
             })?;
@@ -2046,7 +2062,7 @@ impl AppState {
             user_seed_words.as_bytes(),
         )?;
 
-        tracing::info!("Registered new user: {}", user.uuid);
+        tracing::debug!("Registered new user");
 
         Ok(user)
     }
@@ -2078,7 +2094,7 @@ impl AppState {
 
         // Check if the user is an OAuth-only user
         if user.password_enc.is_none() {
-            error!("OAuth-only user attempted password login");
+            debug!(reason = "oauth_only", "Password login rejected");
             return Ok(None);
         }
 
@@ -2096,9 +2112,11 @@ impl AppState {
 
         // Verifying the password is blocking and potentially slow, so we'll do so via
         // `spawn_blocking`.
-        let res =
-            task::spawn_blocking(move || verify_password(user_password, &decrypted_password_hash))
-                .await?;
+        let span = tracing::Span::current();
+        let res = task::spawn_blocking(move || {
+            span.in_scope(|| verify_password(user_password, &decrypted_password_hash))
+        })
+        .await?;
 
         match res {
             Ok(_) => {
@@ -2170,7 +2188,7 @@ impl AppState {
         let result = message_signing::sign_message(&user_secret_key, message_bytes, algorithm);
 
         if result.is_err() {
-            error!("Failed to sign message for user: {}", user.uuid);
+            error!("Failed to sign user message");
         }
 
         result
@@ -2321,12 +2339,15 @@ impl AppState {
         session_lease: &SessionLease,
         encrypted_data: &str,
     ) -> Result<Vec<u8>, ApiError> {
-        tracing::trace!("decrypting session data for session_id: {}", session_id);
+        tracing::trace!("Decrypting session data");
 
         let decoded_data = general_purpose::STANDARD
             .decode(encrypted_data)
             .map_err(|e| {
-                tracing::error!("Failed to decode base64 data: {:?}", e);
+                tracing::error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Failed to decode base64 data"
+                );
                 ApiError::BadRequest
             })?;
 
@@ -2339,19 +2360,23 @@ impl AppState {
 
         let (nonce, ciphertext) = decoded_data.split_at(12);
         let nonce_array: [u8; 12] = nonce.try_into().map_err(|e| {
-            tracing::error!("Failed to convert nonce: {:?}", e);
+            tracing::error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to convert nonce"
+            );
             ApiError::BadRequest
         })?;
 
-        tracing::trace!("nonce: {:?}", nonce_array);
         tracing::trace!("ciphertext length: {}", ciphertext.len());
 
         let decrypted = session_lease
             .value()
             .decrypt(ciphertext, &nonce_array)
-            .map_err(|e| {
-                tracing::error!("Decryption failed: {:?}", e);
-                e
+            .inspect_err(|e| {
+                tracing::error!(
+                    error_kind = crate::observability::error_kind(e),
+                    "Decryption failed"
+                );
             })?;
 
         // Invalid ciphertext must not extend an attacker's retained session.
@@ -2428,14 +2453,20 @@ impl AppState {
                     let app_state = self.clone();
                     let user_email = email.clone();
                     let code = alphanumeric_code.clone();
-                    tokio::spawn(async move {
-                        if let Err(e) =
-                            send_password_reset_email(&app_state, project_id, user_email, code)
-                                .await
-                        {
-                            error!("Failed to send password reset email: {:?}", e);
+                    tokio::spawn(
+                        async move {
+                            if let Err(e) =
+                                send_password_reset_email(&app_state, project_id, user_email, code)
+                                    .await
+                            {
+                                error!(
+                                    error_kind = crate::observability::error_kind(&e),
+                                    "Failed to send password reset email"
+                                );
+                            }
                         }
-                    });
+                        .in_current_span(),
+                    );
                 }
             }
             Err(DBError::UserNotFound) => {
@@ -2445,7 +2476,10 @@ impl AppState {
             }
             Err(e) => {
                 // For other errors, we should still log them but not expose them to the user
-                error!("Error during password reset request: {:?}", e);
+                error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Error during password reset request"
+                );
             }
         }
 
@@ -2520,17 +2554,23 @@ impl AppState {
                 // Send confirmation email in the background
                 let app_state = self.clone();
                 let user_email = user.email.clone();
-                tokio::spawn(async move {
-                    if let Err(e) = send_password_reset_confirmation_email(
-                        &app_state,
-                        project_id,
-                        user_email.expect("We checked email had to exist above"),
-                    )
-                    .await
-                    {
-                        error!("Failed to send password reset confirmation email: {:?}", e);
+                tokio::spawn(
+                    async move {
+                        if let Err(e) = send_password_reset_confirmation_email(
+                            &app_state,
+                            project_id,
+                            user_email.expect("We checked email had to exist above"),
+                        )
+                        .await
+                        {
+                            error!(
+                                error_kind = crate::observability::error_kind(&e),
+                                "Failed to send password reset confirmation email"
+                            );
+                        }
                     }
-                });
+                    .in_current_span(),
+                );
 
                 Ok(())
             } else {
@@ -2597,18 +2637,24 @@ impl AppState {
                     let app_state = self.clone();
                     let user_email = email.clone();
                     let code = alphanumeric_code.clone();
-                    spawn(async move {
-                        if let Err(e) = send_platform_password_reset_email(
-                            &app_state,
-                            app_state.resend_api_key.clone(),
-                            user_email,
-                            code,
-                        )
-                        .await
-                        {
-                            error!("Failed to send platform password reset email: {:?}", e);
+                    spawn(
+                        async move {
+                            if let Err(e) = send_platform_password_reset_email(
+                                &app_state,
+                                app_state.resend_api_key.clone(),
+                                user_email,
+                                code,
+                            )
+                            .await
+                            {
+                                error!(
+                                    error_kind = crate::observability::error_kind(&e),
+                                    "Failed to send platform password reset email"
+                                );
+                            }
                         }
-                    });
+                        .in_current_span(),
+                    );
                 }
             }
             Ok(None) => {
@@ -2618,7 +2664,10 @@ impl AppState {
             }
             Err(e) => {
                 // For other errors, we should still log them but not expose them to the user
-                error!("Error during platform password reset request: {:?}", e);
+                error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Error during platform password reset request"
+                );
             }
         }
 
@@ -2633,7 +2682,7 @@ impl AppState {
         plaintext_secret: String,
         new_password: String,
     ) -> Result<(), Error> {
-        trace!("Confirm platform password reset for {email}");
+        trace!("Confirm platform password reset");
 
         let platform_user = match self.db.get_platform_user_by_email(&email) {
             Ok(Some(user)) => user,
@@ -2690,20 +2739,23 @@ impl AppState {
                 // Send confirmation email in the background
                 let user_email = platform_user.email.clone();
                 let app_state = self.clone();
-                spawn(async move {
-                    if let Err(e) = send_platform_password_reset_confirmation_email(
-                        &app_state,
-                        app_state.resend_api_key.clone(),
-                        user_email,
-                    )
-                    .await
-                    {
-                        error!(
-                            "Failed to send platform password reset confirmation email: {:?}",
-                            e
-                        );
+                spawn(
+                    async move {
+                        if let Err(e) = send_platform_password_reset_confirmation_email(
+                            &app_state,
+                            app_state.resend_api_key.clone(),
+                            user_email,
+                        )
+                        .await
+                        {
+                            error!(
+                                error_kind = crate::observability::error_kind(&e),
+                                "Failed to send platform password reset confirmation email"
+                            );
+                        }
                     }
-                });
+                    .in_current_span(),
+                );
 
                 Ok(())
             } else {
@@ -2829,15 +2881,22 @@ impl AppState {
                 let app_state = self.clone();
                 let user_email = user.email.clone();
                 let code = confirmation_code.to_string();
-                tokio::spawn(async move {
-                    if let Some(email) = user_email {
-                        if let Err(e) =
-                            send_account_deletion_email(&app_state, project_id, email, code).await
-                        {
-                            error!("Failed to send account deletion email: {:?}", e);
+                tokio::spawn(
+                    async move {
+                        if let Some(email) = user_email {
+                            if let Err(e) =
+                                send_account_deletion_email(&app_state, project_id, email, code)
+                                    .await
+                            {
+                                error!(
+                                    error_kind = crate::observability::error_kind(&e),
+                                    "Failed to send account deletion email"
+                                );
+                            }
                         }
                     }
-                });
+                    .in_current_span(),
+                );
             }
             Err(DBError::UserNotFound) => {
                 // User doesn't exist, but we don't want to reveal this information
@@ -2849,7 +2908,10 @@ impl AppState {
             }
             Err(e) => {
                 // For other errors, we should still log them but not expose them to the user
-                error!("Error during account deletion request: {:?}", e);
+                error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Error during account deletion request"
+                );
             }
         }
 
@@ -2908,17 +2970,21 @@ impl AppState {
                 if let Some(email) = user.email.clone() {
                     let app_state = self.clone();
                     let project_id = user.project_id;
-                    tokio::spawn(async move {
-                        if let Err(e) =
-                            send_account_deletion_confirmation_email(&app_state, project_id, email)
-                                .await
-                        {
-                            error!(
-                                "Failed to send account deletion confirmation email: {:?}",
-                                e
-                            );
+                    tokio::spawn(
+                        async move {
+                            if let Err(e) = send_account_deletion_confirmation_email(
+                                &app_state, project_id, email,
+                            )
+                            .await
+                            {
+                                error!(
+                                    error_kind = crate::observability::error_kind(&e),
+                                    "Failed to send account deletion confirmation email"
+                                );
+                            }
                         }
-                    });
+                        .in_current_span(),
+                    );
                 }
 
                 Ok(())
@@ -2950,7 +3016,7 @@ impl AppState {
 
         // Check if this is an OAuth-only user (no password)
         if platform_user.password_enc.is_none() {
-            error!("OAuth-only platform user attempted password login");
+            debug!(reason = "oauth_only", "Platform password login rejected");
             return Ok(None);
         }
 
@@ -2966,8 +3032,11 @@ impl AppState {
 
         // Verifying the password is blocking and potentially slow, so we'll do so via
         // `spawn_blocking`.
-        let res = task::spawn_blocking(move || verify_password(password, &decrypted_password_hash))
-            .await?;
+        let span = tracing::Span::current();
+        let res = task::spawn_blocking(move || {
+            span.in_scope(|| verify_password(password, &decrypted_password_hash))
+        })
+        .await?;
 
         match res {
             Ok(_) => Ok(Some(platform_user)),
@@ -3933,7 +4002,10 @@ async fn main() -> Result<(), Error> {
                         tokio::time::sleep(refresh_interval).await;
                     }
                     Err(e) => {
-                        tracing::error!("Failed to refresh AWS credentials: {:?}", e);
+                        tracing::error!(
+                            error_kind = crate::observability::error_kind(&e),
+                            "Failed to refresh AWS credentials"
+                        );
                         tracing::info!("Retrying in 5 seconds...");
                         tokio::time::sleep(retry_interval).await;
                     }
@@ -3974,7 +4046,10 @@ async fn main() -> Result<(), Error> {
                     &encrypted_url,
                 )
                 .map_err(|e| {
-                    tracing::error!("Failed to decrypt database URL: {:?}", e);
+                    tracing::error!(
+                        error_kind = crate::observability::error_kind(&e),
+                        "Failed to decrypt database URL"
+                    );
                     Error::EncryptionError(e.to_string())
                 })?;
 
@@ -3982,8 +4057,8 @@ async fn main() -> Result<(), Error> {
             }
             Err(e) => {
                 tracing::error!(
-                    "Failed to retrieve database URL from Secrets Manager: {:?}",
-                    e
+                    error_kind = crate::observability::error_kind(&e),
+                    "Failed to retrieve database URL from Secrets Manager"
                 );
                 return Err(e);
             }
@@ -4116,7 +4191,10 @@ async fn main() -> Result<(), Error> {
                 &general_purpose::STANDARD.encode(&encrypted_url.value),
             )
             .map_err(|e| {
-                tracing::error!("Failed to decrypt SQS queue URL: {:?}", e);
+                tracing::error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Failed to decrypt SQS queue URL"
+                );
                 Error::EncryptionError(e.to_string())
             })?;
 
@@ -4228,7 +4306,8 @@ async fn main() -> Result<(), Error> {
         .clone()
         .merge(health_routes_with_state(app_state.clone()))
         .merge(native_handoff_routes(app_state.clone()))
-        .layer(from_fn(add_error_contract_header));
+        .layer(from_fn(add_error_contract_header))
+        .layer(from_fn(observability::trace_logical_request));
     let transport_v2_gateway =
         transport_v2::gateway::TransportV2Gateway::new(app_state.clone(), v2_application);
 
@@ -4237,7 +4316,8 @@ async fn main() -> Result<(), Error> {
         .merge(attestation_routes::router(app_state.clone()))
         .merge(transport_v2_gateway.router())
         .layer(cors)
-        .layer(from_fn(add_error_contract_header));
+        .layer(from_fn(add_error_contract_header))
+        .layer(from_fn(observability::trace_request));
 
     let bind_addr =
         std::env::var("OPENSECRET_BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".to_string());

--- a/src/models/platform_invite_codes.rs
+++ b/src/models/platform_invite_codes.rs
@@ -15,7 +15,10 @@ impl From<PlatformInviteCodeError> for ApiError {
     fn from(err: PlatformInviteCodeError) -> Self {
         match err {
             PlatformInviteCodeError::DatabaseError(e) => {
-                tracing::error!("Database error: {:?}", e);
+                tracing::error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Database error"
+                );
                 ApiError::InternalServerError
             }
             PlatformInviteCodeError::InviteCodeNotFound(_) => {

--- a/src/models/platform_users.rs
+++ b/src/models/platform_users.rs
@@ -21,19 +21,22 @@ impl From<PlatformUserError> for ApiError {
     fn from(err: PlatformUserError) -> Self {
         match err {
             PlatformUserError::DatabaseError(e) => {
-                tracing::error!("Database error: {:?}", e);
+                tracing::error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Platform user database error"
+                );
                 ApiError::InternalServerError
             }
-            PlatformUserError::InvalidEmail(msg) => {
-                tracing::error!("Invalid email error: {}", msg);
+            PlatformUserError::InvalidEmail(_) => {
+                tracing::debug!(reason = "invalid_email", "Platform user input rejected");
                 ApiError::BadRequest
             }
-            PlatformUserError::DuplicateEmail(email) => {
-                tracing::error!("Duplicate email error: {}", email);
+            PlatformUserError::DuplicateEmail(_) => {
+                tracing::debug!(reason = "duplicate_email", "Platform user input rejected");
                 ApiError::EmailAlreadyExists
             }
-            PlatformUserError::InvalidPassword(msg) => {
-                tracing::error!("Invalid password error: {}", msg);
+            PlatformUserError::InvalidPassword(_) => {
+                tracing::debug!(reason = "invalid_password", "Platform user input rejected");
                 ApiError::BadRequest
             }
         }

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -357,10 +357,7 @@ impl GithubProvider {
             match db.create_oauth_provider(new_provider) {
                 Ok(_) => info!("GitHub OAuth provider successfully added to database"),
                 Err(e) => {
-                    error!(
-                        "Failed to create GitHub OAuth provider in database: {:?}",
-                        e
-                    );
+                    error!("Failed to create GitHub OAuth provider in database");
                     return Err(e.into());
                 }
             }
@@ -469,10 +466,7 @@ impl GoogleProvider {
             match db.create_oauth_provider(new_provider) {
                 Ok(_) => info!("Google OAuth provider successfully added to database"),
                 Err(e) => {
-                    error!(
-                        "Failed to create Google OAuth provider in database: {:?}",
-                        e
-                    );
+                    error!("Failed to create Google OAuth provider in database");
                     return Err(e.into());
                 }
             }
@@ -589,7 +583,7 @@ impl AppleProvider {
             match db.create_oauth_provider(new_provider) {
                 Ok(_) => info!("Apple OAuth provider successfully added to database"),
                 Err(e) => {
-                    error!("Failed to create Apple OAuth provider in database: {:?}", e);
+                    error!("Failed to create Apple OAuth provider in database");
                     return Err(e.into());
                 }
             }

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -1,0 +1,739 @@
+//! Request correlation without exporting credentials, content, or client trace context.
+//!
+//! The root is server-generated. Logical Transport V2 requests are child spans,
+//! and body polling/drop stays in the originating span after the handler returns.
+use axum::{
+    body::{Body, Bytes, HttpBody},
+    extract::{MatchedPath, Request},
+    http::{Method, StatusCode},
+    middleware::Next,
+    response::Response,
+};
+use http_body::{Frame, SizeHint};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+    time::Instant,
+};
+use tracing::{Instrument, Span};
+use uuid::Uuid;
+
+/// A bounded diagnostic category, never an error's Display/Debug payload.
+/// Walk typed sources so DB model wrappers retain useful SQL failure classes.
+pub(crate) fn error_kind(mut error: &(dyn std::error::Error + 'static)) -> &'static str {
+    for _ in 0..8 {
+        if let Some(error) = error.downcast_ref::<crate::db::DBError>() {
+            use crate::db::DBError;
+            match error {
+                DBError::ConnectionError => return "db_pool_acquire",
+                DBError::UserNotFound
+                | DBError::EmailVerificationNotFound
+                | DBError::PasswordResetRequestNotFound
+                | DBError::AccountDeletionRequestNotFound
+                | DBError::OrgNotFound
+                | DBError::OrgProjectNotFound
+                | DBError::OrgProjectSecretNotFound
+                | DBError::InviteCodeNotFound
+                | DBError::PlatformInviteCodeNotFound
+                | DBError::PlatformUserNotFound
+                | DBError::PlatformEmailVerificationNotFound
+                | DBError::PlatformPasswordResetRequestNotFound
+                | DBError::OrgMembershipNotFound
+                | DBError::ProjectSettingNotFound => return "db_not_found",
+                _ => {}
+            }
+        }
+        if let Some(error) = error.downcast_ref::<crate::provider_client::ProviderRequestError>() {
+            use crate::provider_client::ProviderRequestError;
+            return match error {
+                ProviderRequestError::TinfoilUnavailable => "provider_unavailable",
+                ProviderRequestError::Timeout(_) => "provider_timeout",
+                ProviderRequestError::Build(_) => "provider_build",
+                ProviderRequestError::Connect(_) => "provider_connect",
+                ProviderRequestError::Send(_) => "provider_send",
+                ProviderRequestError::Upstream(_) => "provider_status",
+            };
+        }
+        if let Some(error) = error.downcast_ref::<diesel::result::Error>() {
+            use diesel::result::{DatabaseErrorKind as Kind, Error};
+            return match error {
+                Error::DatabaseError(kind, _) => match kind {
+                    Kind::UniqueViolation => "db_unique_violation",
+                    Kind::ForeignKeyViolation => "db_foreign_key_violation",
+                    Kind::NotNullViolation => "db_not_null_violation",
+                    Kind::CheckViolation => "db_check_violation",
+                    Kind::SerializationFailure => "db_serialization_failure",
+                    Kind::ReadOnlyTransaction => "db_read_only_transaction",
+                    Kind::ClosedConnection => "db_closed_connection",
+                    _ => "db_query",
+                },
+                Error::NotFound => "db_not_found",
+                Error::DeserializationError(_) => "db_deserialization",
+                Error::SerializationError(_) => "db_serialization",
+                _ => "db_query",
+            };
+        }
+        if let Some(error) = error.downcast_ref::<serde_json::Error>() {
+            return match error.classify() {
+                serde_json::error::Category::Io => "json_io",
+                serde_json::error::Category::Syntax => "json_syntax",
+                serde_json::error::Category::Data => "json_data",
+                serde_json::error::Category::Eof => "json_eof",
+            };
+        }
+        if let Some(error) = error.downcast_ref::<reqwest::Error>() {
+            return if error.is_timeout() {
+                "http_timeout"
+            } else if error.is_connect() {
+                "http_connect"
+            } else if error.is_decode() {
+                "http_decode"
+            } else if error.is_status() {
+                "http_status"
+            } else {
+                "http_request"
+            };
+        }
+        if error.is::<std::string::FromUtf8Error>() {
+            return "invalid_utf8";
+        }
+        if error.is::<diesel::r2d2::PoolError>() {
+            return "db_pool_timeout";
+        }
+        match error.source() {
+            Some(source) => error = source,
+            None => break,
+        }
+    }
+    "operation_failed"
+}
+
+pub(crate) async fn trace_request(request: Request, next: Next) -> Response {
+    // Never accept a caller's trace ID or log a raw path/query (including 404s).
+    let span = tracing::info_span!(
+        parent: None,
+        "http_request",
+        trace_id = %Uuid::new_v4().simple(),
+        method = method_label(request.method()),
+        route = route_label(&request),
+    );
+    trace_response(request, next, span).await
+}
+
+pub(crate) async fn trace_logical_request(request: Request, next: Next) -> Response {
+    let span = tracing::info_span!(
+        "logical_request",
+        method = method_label(request.method()),
+        route = route_label(&request),
+    );
+    trace_response(request, next, span).await
+}
+
+fn route_label(request: &Request) -> &str {
+    request
+        .extensions()
+        .get::<MatchedPath>()
+        .map_or("unmatched", MatchedPath::as_str)
+}
+
+fn method_label(method: &Method) -> &'static str {
+    match *method {
+        Method::GET => "GET",
+        Method::POST => "POST",
+        Method::PUT => "PUT",
+        Method::PATCH => "PATCH",
+        Method::DELETE => "DELETE",
+        Method::HEAD => "HEAD",
+        Method::OPTIONS => "OPTIONS",
+        Method::CONNECT => "CONNECT",
+        Method::TRACE => "TRACE",
+        _ => "OTHER",
+    }
+}
+
+async fn trace_response(request: Request, next: Next, span: Span) -> Response {
+    let quiet = matches!(
+        route_label(&request),
+        "/health-check" | "/health-check-extended"
+    );
+    let started = Instant::now();
+    let response = next.run(request).instrument(span.clone()).await;
+    let (parts, body) = response.into_parts();
+    let mut body = TracedBody {
+        inner: Some(body),
+        span,
+        started,
+        status: parts.status,
+        quiet,
+        finished: false,
+    };
+    if body.inner.as_ref().expect("body present").is_end_stream() {
+        body.finish("body_complete");
+    }
+    Response::from_parts(parts, Body::new(body))
+}
+
+struct TracedBody {
+    // An Option lets Drop dispose of the inner stream in its span as well.
+    inner: Option<Body>,
+    span: Span,
+    started: Instant,
+    status: StatusCode,
+    quiet: bool,
+    finished: bool,
+}
+
+impl TracedBody {
+    fn finish(&mut self, outcome: &'static str) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+        let _entered = self.span.enter();
+        let elapsed_ms = self.started.elapsed().as_millis() as u64;
+        let status = self.status.as_u16();
+        // This describes HTTP body production, not client receipt, inference
+        // success, or a durable storage commit. Those have their own events.
+        if outcome == "body_error" || self.status.is_server_error() {
+            tracing::warn!(status, elapsed_ms, outcome, "HTTP response body finished");
+        } else if self.quiet || outcome == "body_dropped" {
+            tracing::debug!(status, elapsed_ms, outcome, "HTTP response body finished");
+        } else {
+            tracing::info!(status, elapsed_ms, outcome, "HTTP response body finished");
+        }
+    }
+}
+
+impl HttpBody for TracedBody {
+    type Data = Bytes;
+    type Error = axum::Error;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Bytes>, Self::Error>>> {
+        let span = self.span.clone();
+        let _entered = span.enter();
+        let inner = self.inner.as_mut().expect("body present until drop");
+        let result = Pin::new(&mut *inner).poll_frame(cx);
+        match &result {
+            Poll::Ready(Some(Err(_))) => self.finish("body_error"),
+            Poll::Ready(None) => self.finish("body_complete"),
+            Poll::Ready(Some(Ok(_))) if inner.is_end_stream() => self.finish("body_complete"),
+            _ => {}
+        }
+        result
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner
+            .as_ref()
+            .expect("body present until drop")
+            .is_end_stream()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.inner
+            .as_ref()
+            .expect("body present until drop")
+            .size_hint()
+    }
+}
+
+impl Drop for TracedBody {
+    fn drop(&mut self) {
+        self.finish("body_dropped");
+        self.span.in_scope(|| drop(self.inner.take()));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        http::{HeaderMap, Request as HttpRequest},
+        middleware::from_fn,
+        routing::get,
+        Router,
+    };
+    use std::{
+        collections::{HashSet, VecDeque},
+        io::{self, Write},
+        sync::{Arc, Mutex},
+    };
+    use tower::ServiceExt;
+
+    #[derive(Clone, Default)]
+    struct Capture(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for Capture {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl Capture {
+        fn subscriber(&self) -> impl tracing::Subscriber + Send + Sync {
+            let output = self.clone();
+            tracing_subscriber::fmt()
+                .with_max_level(tracing::Level::TRACE)
+                .with_ansi(false)
+                .without_time()
+                .with_writer(move || output.clone())
+                .finish()
+        }
+        fn text(&self) -> String {
+            String::from_utf8(self.0.lock().unwrap().clone()).unwrap()
+        }
+    }
+
+    struct FixtureBody(VecDeque<Result<Frame<Bytes>, io::Error>>);
+    impl HttpBody for FixtureBody {
+        type Data = Bytes;
+        type Error = io::Error;
+        fn poll_frame(
+            mut self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+        ) -> Poll<Option<Result<Frame<Bytes>, io::Error>>> {
+            tracing::info!("fixture body poll");
+            Poll::Ready(self.0.pop_front())
+        }
+        fn is_end_stream(&self) -> bool {
+            self.0.is_empty()
+        }
+        fn size_hint(&self) -> SizeHint {
+            let mut hint = SizeHint::new();
+            hint.set_exact(
+                self.0
+                    .iter()
+                    .filter_map(|f| f.as_ref().ok()?.data_ref())
+                    .map(|b| b.len() as u64)
+                    .sum(),
+            );
+            hint
+        }
+    }
+    impl Drop for FixtureBody {
+        fn drop(&mut self) {
+            tracing::info!("fixture body drop");
+        }
+    }
+
+    fn trace_ids(text: &str) -> HashSet<String> {
+        regex::Regex::new(r"trace_id=([0-9a-f]{32})")
+            .unwrap()
+            .captures_iter(text)
+            .map(|capture| capture[1].to_string())
+            .collect()
+    }
+
+    #[test]
+    fn diagnostics_classify_wrapped_errors_without_formatting_sensitive_values() {
+        let capture = Capture::default();
+        let _subscriber = tracing::subscriber::set_default(capture.subscriber());
+        let json = serde_json::from_str::<u64>("\"private-json-content\"").unwrap_err();
+        let invalid_utf8 =
+            String::from_utf8([b"private-kv-content".as_slice(), &[255]].concat()).unwrap_err();
+        let database = crate::db::DBError::QueryError(diesel::result::Error::DatabaseError(
+            diesel::result::DatabaseErrorKind::UniqueViolation,
+            Box::new("private-db-message".to_owned()),
+        ));
+        let provider = crate::provider_client::ProviderRequestError::Connect(
+            "private-provider-url".to_owned(),
+        );
+        for (error, kind) in [
+            (&json as &dyn std::error::Error, "json_data"),
+            (&invalid_utf8, "invalid_utf8"),
+            (&database, "db_unique_violation"),
+            (&provider, "provider_connect"),
+        ] {
+            assert_eq!(error_kind(error), kind);
+            tracing::warn!(error_kind = error_kind(error), "fixture diagnostic");
+        }
+        assert!(!capture.text().contains("private-"));
+        assert_eq!(
+            error_kind(&crate::db::DBError::UserNotFound),
+            "db_not_found"
+        );
+    }
+
+    async fn poll_frame(body: &mut Body) -> Option<Result<Frame<Bytes>, axum::Error>> {
+        std::future::poll_fn(|cx| Pin::new(&mut *body).poll_frame(cx)).await
+    }
+
+    #[tokio::test]
+    async fn trace_covers_handler_background_task_body_and_drop_without_changing_frames() {
+        let capture = Capture::default();
+        let _subscriber = tracing::subscriber::set_default(capture.subscriber());
+        let released = Arc::new(tokio::sync::Notify::new());
+        let completed = Arc::new(tokio::sync::Notify::new());
+        let app = Router::new()
+            .route(
+                "/resource/:id",
+                get({
+                    let released = released.clone();
+                    let completed = completed.clone();
+                    move || async move {
+                        tracing::info!("fixture handler");
+                        tokio::spawn(
+                            async move {
+                                released.notified().await;
+                                tracing::info!("fixture background after body");
+                                completed.notify_one();
+                            }
+                            .in_current_span(),
+                        );
+                        let mut trailers = HeaderMap::new();
+                        trailers.insert("x-fixture", "trailer".parse().unwrap());
+                        let body = Body::new(FixtureBody(VecDeque::from([
+                            Ok(Frame::data(Bytes::from_static(b"a"))),
+                            Ok(Frame::data(Bytes::from_static(b"b"))),
+                            Ok(Frame::trailers(trailers)),
+                        ])));
+                        Response::builder()
+                            .status(StatusCode::CREATED)
+                            .header("x-fixture", "header")
+                            .body(body)
+                            .unwrap()
+                    }
+                }),
+            )
+            .layer(from_fn(trace_request));
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/resource/private-path?token=private-query")
+                    .header("authorization", "Bearer private-token")
+                    .header("traceparent", "private-traceparent")
+                    .header("x-request-id", "private-request-id")
+                    .body(Body::from("private-body"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        assert_eq!(response.headers()["x-fixture"], "header");
+        let mut body = response.into_body();
+        assert_eq!(body.size_hint().exact(), Some(2));
+        assert_eq!(
+            poll_frame(&mut body)
+                .await
+                .unwrap()
+                .unwrap()
+                .into_data()
+                .unwrap(),
+            "a"
+        );
+        assert_eq!(
+            poll_frame(&mut body)
+                .await
+                .unwrap()
+                .unwrap()
+                .into_data()
+                .unwrap(),
+            "b"
+        );
+        assert_eq!(
+            poll_frame(&mut body)
+                .await
+                .unwrap()
+                .unwrap()
+                .into_trailers()
+                .unwrap()["x-fixture"],
+            "trailer"
+        );
+        assert!(body.is_end_stream());
+        drop(body);
+        released.notify_one();
+        completed.notified().await;
+        let logs = capture.text();
+        assert_eq!(trace_ids(&logs).len(), 1, "{logs}");
+        for marker in [
+            "fixture handler",
+            "fixture background after body",
+            "fixture body poll",
+            "fixture body drop",
+            "body_complete",
+        ] {
+            assert!(
+                logs.lines()
+                    .filter(|line| line.contains(marker))
+                    .all(|line| trace_ids(line).len() == 1),
+                "{logs}"
+            );
+            assert!(logs.contains(marker), "{logs}");
+        }
+        assert!(logs.contains("/resource/:id"));
+        assert!(!logs.contains("private-"), "{logs}");
+        assert_eq!(logs.matches("HTTP response body finished").count(), 1);
+        assert!(logs.contains("status=201"));
+    }
+
+    #[tokio::test]
+    async fn unknown_routes_methods_and_client_trace_ids_cannot_pollute_or_merge_traces() {
+        let capture = Capture::default();
+        let _subscriber = tracing::subscriber::set_default(capture.subscriber());
+        let app = Router::new()
+            .fallback(|| async {
+                tokio::task::yield_now().await;
+                tracing::info!("fixture fallback");
+                StatusCode::NOT_FOUND
+            })
+            .layer(from_fn(trace_request));
+        let requests = (0..20).map(|i| {
+            app.clone().oneshot(
+                HttpRequest::builder()
+                    .method("PRIVATE-METHOD")
+                    .uri(format!("/private-{i}?secret=private-value"))
+                    .header("traceparent", "same-private-id")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+        });
+        for response in futures::future::join_all(requests).await {
+            assert_eq!(response.unwrap().status(), StatusCode::NOT_FOUND);
+        }
+        let logs = capture.text();
+        assert_eq!(trace_ids(&logs).len(), 20, "{logs}");
+        assert!(logs.contains("method=\"OTHER\"") || logs.contains("method=OTHER"));
+        assert!(logs.contains("route=\"unmatched\"") || logs.contains("route=unmatched"));
+        assert!(!logs.contains("private"));
+        assert!(!logs.contains("PRIVATE-METHOD"));
+    }
+
+    #[tokio::test]
+    async fn logical_dispatch_shares_outer_trace_after_handler_returns() {
+        let capture = Capture::default();
+        let _subscriber = tracing::subscriber::set_default(capture.subscriber());
+        let inner = Router::new()
+            .route(
+                "/logical/:id",
+                get(|| async {
+                    Body::new(FixtureBody(VecDeque::from([Ok(Frame::data(
+                        Bytes::from_static(b"unchanged"),
+                    ))])))
+                }),
+            )
+            .layer(from_fn(trace_logical_request));
+        let outer = Router::new()
+            .route(
+                "/v2/request",
+                get(move || async move {
+                    inner
+                        .oneshot(
+                            HttpRequest::builder()
+                                .uri("/logical/private-id")
+                                .body(Body::empty())
+                                .unwrap(),
+                        )
+                        .await
+                        .unwrap()
+                }),
+            )
+            .layer(from_fn(trace_request));
+        let response = outer
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/v2/request")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            axum::body::to_bytes(response.into_body(), 100)
+                .await
+                .unwrap(),
+            "unchanged"
+        );
+        let logs = capture.text();
+        assert_eq!(trace_ids(&logs).len(), 1, "{logs}");
+        assert!(
+            logs.lines().any(|line| line.contains("fixture body poll")
+                && line.contains("logical_request")
+                && line.contains("http_request")),
+            "{logs}"
+        );
+        assert!(!logs.contains("private-id"));
+    }
+
+    #[tokio::test]
+    async fn dropping_or_failing_a_body_is_not_reported_as_success_and_errors_stay_private() {
+        for fail in [false, true] {
+            let capture = Capture::default();
+            let _subscriber = tracing::subscriber::set_default(capture.subscriber());
+            let app = Router::new()
+                .route(
+                    "/stream",
+                    get(move || async move {
+                        Body::new(FixtureBody(VecDeque::from([Err(io::Error::other(
+                            "private-provider-body",
+                        ))])))
+                    }),
+                )
+                .layer(from_fn(trace_request));
+            let mut body = app
+                .oneshot(
+                    HttpRequest::builder()
+                        .uri("/stream")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+                .into_body();
+            if fail {
+                assert!(poll_frame(&mut body).await.unwrap().is_err());
+            }
+            drop(body);
+            let logs = capture.text();
+            assert!(
+                logs.contains(if fail { "body_error" } else { "body_dropped" }),
+                "{logs}"
+            );
+            assert!(!logs.contains("body_complete"));
+            assert!(!logs.contains("private-provider-body"));
+            assert_eq!(logs.matches("HTTP response body finished").count(), 1);
+            assert_eq!(trace_ids(&logs).len(), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn default_filter_keeps_each_concurrent_pending_body_and_task_in_its_own_trace() {
+        let capture = Capture::default();
+        let writer = capture.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_env_filter(crate::DEFAULT_RUST_LOG_FILTER)
+            .with_ansi(false)
+            .without_time()
+            .with_writer(move || writer.clone())
+            .finish();
+        let _subscriber = tracing::subscriber::set_default(subscriber);
+        struct BodyDrop(usize);
+        impl Drop for BodyDrop {
+            fn drop(&mut self) {
+                tracing::info!(fixture_request = self.0, "concurrent body drop");
+            }
+        }
+        let app = Router::new()
+            .route(
+                "/stream/:id",
+                get(
+                    |axum::extract::Path(id): axum::extract::Path<usize>| async move {
+                        tracing::info!(fixture_request = id, "concurrent handler");
+                        tokio::spawn(
+                            async move {
+                                tokio::task::yield_now().await;
+                                tracing::info!(fixture_request = id, "concurrent background");
+                            }
+                            .in_current_span(),
+                        )
+                        .await
+                        .unwrap();
+                        let guard = BodyDrop(id);
+                        Body::from_stream(async_stream::stream! {
+                            let _guard = guard;
+                            tracing::info!(fixture_request = id, "concurrent before pending");
+                            tokio::task::yield_now().await;
+                            tracing::info!(fixture_request = id, "concurrent after pending");
+                            yield Ok::<_, io::Error>(Bytes::from_static(b"frame"));
+                        })
+                    },
+                ),
+            )
+            .layer(from_fn(trace_request));
+        futures::future::join_all((0..20).map(|id| {
+            let app = app.clone();
+            async move {
+                let response = app
+                    .oneshot(
+                        HttpRequest::builder()
+                            .uri(format!("/stream/{id}"))
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    axum::body::to_bytes(response.into_body(), 100)
+                        .await
+                        .unwrap(),
+                    "frame"
+                );
+            }
+        }))
+        .await;
+        let logs = capture.text();
+        let id_pattern = regex::Regex::new(r"fixture_request=(\d+)\b").unwrap();
+        let mut observed = std::collections::HashMap::<usize, (HashSet<String>, usize)>::new();
+        for line in logs.lines() {
+            if let Some(id) = id_pattern.captures(line) {
+                let entry = observed.entry(id[1].parse().unwrap()).or_default();
+                let ids = trace_ids(line);
+                assert_eq!(ids.len(), 1, "{line}");
+                entry.0.extend(ids);
+                entry.1 += 1;
+            }
+        }
+        assert_eq!(observed.len(), 20, "{logs}");
+        for (ids, events) in observed.values() {
+            assert_eq!(ids.len(), 1, "a request changed trace: {logs}");
+            assert_eq!(
+                *events, 5,
+                "handler/task/pending/resume/drop each occurs once: {logs}"
+            );
+        }
+        assert_eq!(
+            trace_ids(&logs).len(),
+            20,
+            "requests shared a trace: {logs}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_before_headers_drops_handler_inside_its_trace() {
+        let capture = Capture::default();
+        let _subscriber = tracing::subscriber::set_default(capture.subscriber());
+        struct HandlerDrop;
+        impl Drop for HandlerDrop {
+            fn drop(&mut self) {
+                tracing::info!("cancelled handler drop");
+            }
+        }
+        let app = Router::new()
+            .route(
+                "/pending",
+                get(|| async {
+                    let _guard = HandlerDrop;
+                    tracing::info!("pending handler entered");
+                    std::future::pending::<StatusCode>().await
+                }),
+            )
+            .layer(from_fn(trace_request));
+        let mut future = Box::pin(
+            app.oneshot(
+                HttpRequest::builder()
+                    .uri("/pending")
+                    .body(Body::empty())
+                    .unwrap(),
+            ),
+        );
+        std::future::poll_fn(|cx| {
+            assert!(std::future::Future::poll(future.as_mut(), cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+        drop(future);
+        let logs = capture.text();
+        assert_eq!(trace_ids(&logs).len(), 1, "{logs}");
+        for line in logs.lines().filter(|line| line.contains("handler")) {
+            assert_eq!(trace_ids(line).len(), 1, "{line}");
+        }
+        assert!(logs.contains("cancelled handler drop"));
+        assert!(!logs.contains("body_complete"));
+    }
+}

--- a/src/os_flags.rs
+++ b/src/os_flags.rs
@@ -178,17 +178,11 @@ impl OsFlagsClient {
             self.cache.insert(cache_key, response.clone()).await;
             Ok(response)
         } else {
-            let text = resp.text().await.unwrap_or_default();
-            let message = serde_json::from_str::<serde_json::Value>(&text)
-                .ok()
-                .and_then(|v| {
-                    v.get("error")
-                        .and_then(|e| e.as_str())
-                        .map(ToOwned::to_owned)
-                })
-                .unwrap_or(text);
-
-            Err(OsFlagsError::Service { status, message })
+            // The service body can contain user data or proxy diagnostics.
+            Err(OsFlagsError::Service {
+                status,
+                message: "flag service rejected request".to_owned(),
+            })
         }
     }
 

--- a/src/private_key.rs
+++ b/src/private_key.rs
@@ -132,7 +132,11 @@ pub fn decrypt_and_derive_bip85_mnemonic(
     // 1. Validate BIP-85 path format
     // Convert ApiError to our Error type
     validate_bip85_path(bip85_path).map_err(|_| {
-        error!("BIP-85 path validation failed: {}", bip85_path);
+        error!(
+            stage = "bip85_derivation",
+            error_kind = "invalid_path",
+            "BIP-85 path validation failed"
+        );
         Error::InvalidDerivationPath(format!("Invalid BIP-85 path format: {}", bip85_path))
     })?;
 
@@ -148,7 +152,11 @@ pub fn derive_bip85_mnemonic_from_root(
     // 1. Validate BIP-85 path format
     // Convert ApiError to our Error type
     validate_bip85_path(bip85_path).map_err(|_| {
-        error!("BIP-85 path validation failed: {}", bip85_path);
+        error!(
+            stage = "bip85_derivation",
+            error_kind = "invalid_path",
+            "BIP-85 path validation failed"
+        );
         Error::InvalidDerivationPath(format!("Invalid BIP-85 path format: {}", bip85_path))
     })?;
 
@@ -157,7 +165,11 @@ pub fn derive_bip85_mnemonic_from_root(
     // 2. Convert root_seed to Xpriv
     let secp = Secp256k1::new();
     let xpriv = Xpriv::new_master(Network::Bitcoin, &root_seed).map_err(|e| {
-        error!("Failed to create master key from seed: {}", e);
+        error!(
+            stage = "bip85_derivation",
+            error_kind = "master_key",
+            "Failed to create master key from seed"
+        );
         Error::EncryptionError(e.to_string())
     })?;
 
@@ -168,15 +180,20 @@ pub fn derive_bip85_mnemonic_from_root(
     // Extract word count (segment 4)
     let word_count_segment = segments[4].trim_end_matches(&['\'', 'h'][..]);
     let word_count = word_count_segment.parse::<u32>().map_err(|_| {
-        error!("Failed to parse word count: {}", word_count_segment);
+        error!(
+            stage = "bip85_derivation",
+            error_kind = "invalid_word_count",
+            "Failed to parse word count"
+        );
         Error::InvalidDerivationPath(format!("Invalid word count: {}", word_count_segment))
     })?;
 
     // Validate word count is one of the allowed values
     if !VALID_BIP39_WORD_COUNTS.contains(&word_count) {
         error!(
-            "Invalid word count: {}, must be one of: {:?}",
-            word_count, VALID_BIP39_WORD_COUNTS
+            stage = "bip85_derivation",
+            error_kind = "unsupported_word_count",
+            "Invalid word count"
         );
         return Err(Error::InvalidDerivationPath(format!(
             "Word count must be one of {:?}, got: {}",
@@ -187,7 +204,11 @@ pub fn derive_bip85_mnemonic_from_root(
     // Extract derivation index (segment 5)
     let index_segment = segments[5].trim_end_matches(&['\'', 'h'][..]);
     let index = index_segment.parse::<u32>().map_err(|_| {
-        error!("Failed to parse index: {}", index_segment);
+        error!(
+            stage = "bip85_derivation",
+            error_kind = "invalid_index",
+            "Failed to parse index"
+        );
         Error::InvalidDerivationPath(format!("Invalid index: {}", index_segment))
     })?;
 
@@ -199,7 +220,11 @@ pub fn derive_bip85_mnemonic_from_root(
     match bip85_mnemonic_result {
         Ok(derived_mnemonic) => Ok(derived_mnemonic),
         Err(e) => {
-            error!("BIP-85 derivation failed: {}, path: {}", e, bip85_path);
+            error!(
+                stage = "bip85_derivation",
+                error_kind = "key_derivation",
+                "BIP-85 derivation failed"
+            );
             Err(Error::KeyDerivationError(format!(
                 "BIP-85 derivation error: {}. Path: {}",
                 e, bip85_path

--- a/src/provider_client.rs
+++ b/src/provider_client.rs
@@ -12,6 +12,7 @@ use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
+use tracing::Instrument;
 
 type StandardHttpClient = reqwest::Client;
 type TinfoilRefreshTask = JoinHandle<Result<SecureClientSnapshot, ProviderRequestError>>;
@@ -295,7 +296,7 @@ where
     F: Future<Output = T> + Send + 'static,
     T: Send + 'static,
 {
-    tokio::spawn(recovery)
+    tokio::spawn(recovery.in_current_span())
 }
 
 fn spawn_tinfoil_refresh_after_connect_failure(
@@ -382,10 +383,10 @@ impl SecureTinfoilTransport {
                     tracing::info!("Tinfoil router discovery and attestation succeeded");
                     return;
                 }
-                Ok(Err(error)) => {
+                Ok(Err(_error)) => {
                     tracing::warn!(
                         retry_delay_seconds = retry_delay.as_secs(),
-                        error = %error,
+                        error_kind = "discovery_or_attestation",
                         "Tinfoil router discovery or attestation failed; retrying in background"
                     );
                 }
@@ -459,9 +460,9 @@ impl SecureTinfoilTransport {
                     refresh_attempt: slot.refresh_attempt,
                 })
             }
-            Ok(Err(error)) => {
+            Ok(Err(_error)) => {
                 tracing::warn!(
-                    error = %error,
+                    error_kind = "discovery_or_attestation",
                     "Tinfoil router refresh failed; transitioning unavailable"
                 );
                 slot.client = None;

--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -201,9 +201,8 @@ impl SqsEventPublisher {
 
     pub async fn publish_event(&self, event: UsageEvent) -> Result<(), SqsError> {
         let event_id = event.event_id;
-        let user_id = event.user_id;
 
-        info!("Publishing event {} for user {}", event_id, user_id);
+        debug!(%event_id, "Publishing usage event to SQS");
 
         let backoff = ExponentialBackoff::<SystemClock> {
             initial_interval: Duration::from_millis(INITIAL_INTERVAL_MS),
@@ -222,7 +221,7 @@ impl SqsEventPublisher {
             let message_body = serde_json::to_string(&event)
                 .map_err(|e| BackoffError::permanent(SqsError::Serialization(e)))?;
 
-            debug!("sending message to SQS: {:?}", event);
+            debug!(%event_id, "Sending usage event to SQS");
 
             match client
                 .send_message()
@@ -239,17 +238,16 @@ impl SqsEventPublisher {
 
         match result {
             Ok(_) => {
-                info!(
-                    "Successfully published event {} for user {} to SQS",
-                    event_id, user_id
-                );
+                info!(%event_id, "Successfully published usage event to SQS");
                 Ok(())
             }
-            Err(_) => {
-                error!(
-                    "Failed to publish event after retries. Event data: {:?}",
-                    event
-                );
+            Err(error) => {
+                let error_kind = match error {
+                    SqsError::AwsSdk(_) => "aws_sdk",
+                    SqsError::Serialization(_) => "serialization",
+                    SqsError::NoCredentials => "credentials_unavailable",
+                };
+                error!(%event_id, error_kind, "Failed to publish usage event after retries");
                 Err(SqsError::AwsSdk(
                     "Failed to publish after retries".to_string(),
                 ))

--- a/src/web/attestation_routes.rs
+++ b/src/web/attestation_routes.rs
@@ -37,9 +37,11 @@ impl SessionState {
     }
 
     pub fn decrypt(&self, encrypted_data: &[u8], nonce: &[u8; 12]) -> Result<Vec<u8>, ApiError> {
-        tracing::trace!("decrypting encrypted data");
-        tracing::trace!("nonce: {:?}", nonce);
-        tracing::trace!("encrypted data length: {}", encrypted_data.len());
+        tracing::trace!(
+            stage = "session_decrypt",
+            encrypted_bytes = encrypted_data.len(),
+            "Decrypting encrypted data"
+        );
 
         let key = Key::from_slice(self.session_key.as_ref());
         let cipher = ChaCha20Poly1305::new(key);

--- a/src/web/encryption_middleware.rs
+++ b/src/web/encryption_middleware.rs
@@ -401,7 +401,7 @@ where
         .map_err(|_| ApiError::BadRequest)?;
 
     let decrypted: T = serde_json::from_slice(&decrypted_data).map_err(|e| {
-        tracing::error!("Failed to deserialize decrypted data: {:?}", e);
+        tracing::error!(stage = "request_deserialization", error_kind = ?e.classify(), "Failed to deserialize decrypted data");
         ApiError::BadRequest
     })?;
 

--- a/src/web/login_routes.rs
+++ b/src/web/login_routes.rs
@@ -25,7 +25,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
 use tokio::spawn;
-use tracing::{error, info};
+use tracing::Instrument;
+use tracing::{debug, error};
 use uuid::Uuid;
 
 #[derive(Deserialize, Clone)]
@@ -194,11 +195,14 @@ async fn login_internal(
             match data.db.get_user_by_email(email.clone(), project.id) {
                 Ok(user) => user,
                 Err(DBError::UserNotFound) => {
-                    error!("User not found by provided login identifier");
+                    debug!(reason = "unknown_login", "Authentication request rejected");
                     return Err(ApiError::InvalidUsernameOrPassword);
                 }
                 Err(e) => {
-                    error!("Error fetching user by email: {:?}", e);
+                    error!(
+                        error_kind = crate::observability::error_kind(&e),
+                        "Error fetching user by email"
+                    );
                     return Err(ApiError::InternalServerError);
                 }
             }
@@ -208,35 +212,50 @@ async fn login_internal(
             match data.db.get_user_by_uuid(*id) {
                 Ok(user) => {
                     if !user.is_guest() {
-                        error!("ID-based login not allowed for users with email addresses");
+                        debug!(
+                            reason = "id_login_not_allowed",
+                            "Authentication request rejected"
+                        );
                         return Err(ApiError::InvalidUsernameOrPassword);
                     }
                     // Verify user belongs to the specified project
                     if user.project_id != project.id {
-                        error!("User does not belong to specified project");
+                        debug!(
+                            reason = "project_mismatch",
+                            "Authentication request rejected"
+                        );
                         return Err(ApiError::InvalidUsernameOrPassword);
                     }
                     user
                 }
                 Err(DBError::UserNotFound) => {
-                    error!("User not found by ID: {id}");
+                    debug!(reason = "unknown_login", "Authentication request rejected");
                     return Err(ApiError::InvalidUsernameOrPassword);
                 }
                 Err(e) => {
-                    error!("Error fetching user by ID: {:?}", e);
+                    error!(
+                        error_kind = crate::observability::error_kind(&e),
+                        "Error fetching user by ID"
+                    );
                     return Err(ApiError::InternalServerError);
                 }
             }
         }
         (None, None) => {
-            error!("Neither email nor ID provided for login");
+            debug!(
+                reason = "missing_login_identifier",
+                "Authentication request rejected"
+            );
             return Err(ApiError::InvalidUsernameOrPassword);
         }
     };
 
     // Check if the user is an OAuth-only user
     if user.password_enc.is_none() {
-        error!("Attempted password login for OAuth-only user");
+        debug!(
+            reason = "password_login_not_available",
+            "Authentication request rejected"
+        );
         return Err(ApiError::InvalidUsernameOrPassword);
     }
 
@@ -267,11 +286,17 @@ async fn login_internal(
             Ok(auth_response)
         }
         Ok(None) => {
-            error!("Invalid password attempt");
+            debug!(
+                reason = "invalid_credentials",
+                "Authentication request rejected"
+            );
             Err(ApiError::InvalidUsernameOrPassword)
         }
         Err(e) => {
-            error!("Error authenticating user: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Error authenticating user"
+            );
             Err(ApiError::InternalServerError)
         }
     }
@@ -282,7 +307,7 @@ pub async fn logout(
     Decrypted(logout_request): Decrypted<LogoutRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
-    info!("Logout request received");
+    debug!("Logout request received");
     // TODO actually delete the refresh token
     drop(logout_request.refresh_token);
     let response = json!({ "message": "Logged out successfully" });
@@ -300,11 +325,17 @@ pub async fn register(
     let user = match data.register_user(creds.clone()).await {
         Ok(user) => user,
         Err(Error::UserAlreadyExists) => {
-            tracing::warn!("Cannot register user that already exists");
+            debug!(
+                reason = "already_registered",
+                "Registration request rejected"
+            );
             return Err(ApiError::EmailAlreadyExists);
         }
         Err(e) => {
-            tracing::error!("Error registering user: {:?}", e);
+            tracing::error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Error registering user"
+            );
             return Err(ApiError::InternalServerError);
         }
     };
@@ -341,7 +372,10 @@ pub async fn handle_new_user_registration(
         let verification = match data.db.create_email_verification(new_verification) {
             Ok(v) => v,
             Err(e) => {
-                tracing::error!("Error creating email verification: {:?}", e);
+                tracing::error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Error creating email verification"
+                );
                 return Err(ApiError::InternalServerError);
             }
         };
@@ -352,13 +386,19 @@ pub async fn handle_new_user_registration(
             let verification_code = verification.verification_code;
             let data = data.clone();
             let project_id = user.project_id;
-            spawn(async move {
-                if let Err(e) =
-                    send_verification_email(&data, project_id, email, verification_code).await
-                {
-                    tracing::error!("Could not send verification email: {e}");
+            spawn(
+                async move {
+                    if let Err(e) =
+                        send_verification_email(&data, project_id, email, verification_code).await
+                    {
+                        tracing::error!(
+                            error_kind = crate::observability::error_kind(&e),
+                            "Could not send verification email"
+                        );
+                    }
                 }
-            });
+                .in_current_span(),
+            );
         }
     }
 
@@ -367,11 +407,17 @@ pub async fn handle_new_user_registration(
         let welcome_email = user.get_email().unwrap().to_string(); // Safe to unwrap since we checked is_guest()
         let data = data.clone();
         let project_id = user.project_id;
-        spawn(async move {
-            if let Err(e) = send_hello_email(&data, project_id, welcome_email).await {
-                tracing::error!("Could not schedule welcome email: {e}");
+        spawn(
+            async move {
+                if let Err(e) = send_hello_email(&data, project_id, welcome_email).await {
+                    tracing::error!(
+                        error_kind = crate::observability::error_kind(&e),
+                        "Could not schedule welcome email"
+                    );
+                }
             }
-        });
+            .in_current_span(),
+        );
     }
 
     Ok(())
@@ -382,7 +428,7 @@ pub async fn refresh_token(
     Decrypted(refresh_request): Decrypted<RefreshRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
-    info!("Refresh token request received");
+    debug!("Refresh token request received");
 
     let refresh_audience = if session_id.is_v2() {
         crate::jwt::TRANSPORT_V2_USER_REFRESH
@@ -473,7 +519,10 @@ pub async fn password_reset_request(
     match data.db.get_user_by_email(payload.email.clone(), project.id) {
         Ok(user) => {
             if user.password_enc.is_none() {
-                error!("OAuth-only user attempted to reset password");
+                debug!(
+                    reason = "password_reset_not_available",
+                    "Authentication request rejected"
+                );
                 // Still return success to not leak information about the account
                 let response = json!({
                     "message": "If an account with that email exists, we have sent a password reset link."
@@ -489,7 +538,10 @@ pub async fn password_reset_request(
             return encrypt_response(&data, &session_id, &response).await;
         }
         Err(e) => {
-            error!("Error in password reset request: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Error in password reset request"
+            );
             return Err(ApiError::InternalServerError);
         }
     }
@@ -499,7 +551,10 @@ pub async fn password_reset_request(
         .create_password_reset_request(payload.email.clone(), payload.hashed_secret, project.id)
         .await
         .map_err(|e| {
-            error!("Error in create_password_reset_request: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Error in create_password_reset_request"
+            );
             // We don't expose this error to the user
         });
 
@@ -525,16 +580,22 @@ pub async fn password_reset_confirm(
     match data.db.get_user_by_email(payload.email.clone(), project.id) {
         Ok(user) => {
             if user.password_enc.is_none() {
-                error!("OAuth-only user attempted to reset password");
+                debug!(
+                    reason = "password_reset_not_available",
+                    "Authentication request rejected"
+                );
                 return Err(ApiError::InvalidUsernameOrPassword);
             }
         }
         Err(DBError::UserNotFound) => {
-            error!("User not found in password reset confirm");
+            debug!(reason = "unknown_login", "Authentication request rejected");
             return Err(ApiError::InvalidUsernameOrPassword);
         }
         Err(e) => {
-            error!("Error in password reset confirm: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Error in password reset confirm"
+            );
             return Err(ApiError::InternalServerError);
         }
     }

--- a/src/web/login_routes.rs
+++ b/src/web/login_routes.rs
@@ -229,7 +229,11 @@ async fn login_internal(
                     user
                 }
                 Err(DBError::UserNotFound) => {
-                    debug!(reason = "unknown_login", "Authentication request rejected");
+                    debug!(
+                        reason = "unknown_login",
+                        user_id = %id,
+                        "Authentication request rejected"
+                    );
                     return Err(ApiError::InvalidUsernameOrPassword);
                 }
                 Err(e) => {

--- a/src/web/oauth_routes.rs
+++ b/src/web/oauth_routes.rs
@@ -40,6 +40,26 @@ use std::sync::Arc;
 use tracing::{debug, error, trace};
 use uuid::Uuid;
 
+fn oauth_token_error_kind<E: std::error::Error + 'static>(
+    error: &oauth2::basic::BasicRequestTokenError<E>,
+) -> &'static str {
+    use oauth2::basic::BasicErrorResponseType;
+    match error {
+        oauth2::RequestTokenError::ServerResponse(response) => match response.error() {
+            BasicErrorResponseType::InvalidClient => "invalid_client",
+            BasicErrorResponseType::InvalidGrant => "invalid_grant",
+            BasicErrorResponseType::InvalidRequest => "invalid_request",
+            BasicErrorResponseType::InvalidScope => "invalid_scope",
+            BasicErrorResponseType::UnauthorizedClient => "unauthorized_client",
+            BasicErrorResponseType::UnsupportedGrantType => "unsupported_grant_type",
+            BasicErrorResponseType::Extension(_) => "other_server_response",
+        },
+        oauth2::RequestTokenError::Request(_) => "request",
+        oauth2::RequestTokenError::Parse(_, _) => "response_parse",
+        oauth2::RequestTokenError::Other(_) => "other",
+    }
+}
+
 pub fn router(app_state: Arc<AppState>) -> Router {
     Router::new()
         .route(
@@ -258,10 +278,7 @@ async fn get_project_oauth_client(
             if let Some(ref mut settings) = apple_settings {
                 if !settings.client_id.ends_with(".services") {
                     settings.client_id = format!("{}.services", settings.client_id);
-                    debug!(
-                        "Modified Apple client ID for OAuth client: {}",
-                        settings.client_id
-                    );
+                    debug!("Using Apple Services ID for OAuth client");
                 }
             }
 
@@ -281,7 +298,7 @@ async fn get_project_oauth_client(
             (enabled, standard_settings, secret)
         }
         _ => {
-            error!("Unsupported OAuth provider: {}", provider_name);
+            error!("Unsupported OAuth provider");
             return Err(ApiError::BadRequest);
         }
     };
@@ -386,11 +403,7 @@ async fn get_project_oauth_client(
             ApiError::InternalServerError
         })?;
 
-        // Log the OAuth URL and redirect URL being used
-        debug!(
-            "Building Apple OAuth client with Client ID: {}, Redirect URL: {}",
-            client_id_with_services, apple_settings.redirect_url
-        );
+        debug!("Building Apple OAuth client");
 
         // Use the same client ID for the OAuth client as in the JWT's sub claim
         let client_id_for_client = client_id_with_services.clone();
@@ -404,8 +417,8 @@ async fn get_project_oauth_client(
                 apple_settings.redirect_url.clone(),
             )
             .await
-            .map_err(|e| {
-                error!("Failed to build Apple OAuth client: {:?}", e);
+            .map_err(|_| {
+                error!("Failed to build Apple OAuth client");
                 ApiError::InternalServerError
             })
     } else {
@@ -541,13 +554,13 @@ pub async fn oauth_callback(
     // Decode and parse the state
     let state_json = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .decode(&callback_request.state)
-        .map_err(|e| {
-            error!("Could not parse state: {:?}", e);
+        .map_err(|_| {
+            error!("Could not parse state");
             ApiError::BadRequest
         })?;
     debug!("Parsed state from request");
     let state: OAuthState = serde_json::from_slice(&state_json).map_err(|e| {
-        error!("Could not parse OAuthState: {:?}", e);
+        error!(error_kind = ?e.classify(), "Could not parse OAuthState");
         ApiError::BadRequest
     })?;
     debug!("Converted state to OAuthState");
@@ -587,15 +600,12 @@ pub async fn oauth_callback(
     };
 
     // Get project (we can trust the client_id now since we validated it against our stored state)
-    debug!("Getting project from client_id: {:?}", state.client_id);
+    debug!("Getting project for verified OAuth state");
     let project = app_state
         .db
         .get_org_project_by_client_id(state.client_id)
-        .map_err(|e| {
-            error!(
-                "Could not get project by client {:?} id: {:?}",
-                state.client_id, e
-            );
+        .map_err(|_| {
+            error!("Could not get project for verified OAuth state");
             ApiError::BadRequest
         })?;
 
@@ -749,7 +759,12 @@ pub async fn oauth_callback(
 
         // Send the request
         let response = request.send().await.map_err(|e| {
-            error!("HTTP request failed: {:?}", e);
+            error!(
+                timeout = e.is_timeout(),
+                connect = e.is_connect(),
+                decode = e.is_decode(),
+                "HTTP request failed"
+            );
             ApiError::InternalServerError
         })?;
 
@@ -768,13 +783,18 @@ pub async fn oauth_callback(
 
         // Parse the successful response
         let token_json = response.text().await.map_err(|e| {
-            error!("Failed to read response body: {:?}", e);
+            error!(
+                timeout = e.is_timeout(),
+                connect = e.is_connect(),
+                decode = e.is_decode(),
+                "Failed to read response body"
+            );
             ApiError::InternalServerError
         })?;
 
         // Parse the JSON using our custom AppleTokenResponse struct
         let apple_token: AppleTokenResponse = serde_json::from_str(&token_json).map_err(|e| {
-            error!("Failed to parse Apple token response: {:?}", e);
+            error!(error_kind = ?e.classify(), "Failed to parse Apple token response");
             ApiError::InternalServerError
         })?;
 
@@ -796,7 +816,12 @@ pub async fn oauth_callback(
             .redirect(oauth2::reqwest::redirect::Policy::none())
             .build()
             .map_err(|e| {
-                error!("Failed to build OAuth HTTP client: {:?}", e);
+                error!(
+                    timeout = e.is_timeout(),
+                    connect = e.is_connect(),
+                    decode = e.is_decode(),
+                    "Failed to build OAuth HTTP client"
+                );
                 ApiError::InternalServerError
             })?;
         let exchange =
@@ -807,7 +832,10 @@ pub async fn oauth_callback(
             exchange
         };
         let token = exchange.request_async(&http_client).await.map_err(|e| {
-            error!("Failed to exchange code for access token: {:?}", e);
+            error!(
+                error_kind = oauth_token_error_kind(&e),
+                "Failed to exchange code for access token"
+            );
             ApiError::InternalServerError
         })?;
 
@@ -834,7 +862,7 @@ pub async fn oauth_callback(
                     user
                 }
                 Err(e) => {
-                    error!("Failed to fetch GitHub user: {:?}", e);
+                    error!("Failed to fetch GitHub user");
                     return Err(e);
                 }
             };
@@ -863,7 +891,7 @@ pub async fn oauth_callback(
                     user
                 }
                 Err(e) => {
-                    error!("Failed to fetch Google user: {:?}", e);
+                    error!("Failed to fetch Google user");
                     return Err(e);
                 }
             };
@@ -910,7 +938,7 @@ pub async fn oauth_callback(
             // This is because Apple requires Services ID for web flow, not App ID
             if !client_id.ends_with(".services") {
                 client_id = format!("{}.services", client_id);
-                debug!("Modified Apple client ID for web flow: {}", client_id);
+                debug!("Using Apple Services ID for web flow");
             }
 
             // For Apple, we need to extract the ID token from the token exchange response
@@ -937,7 +965,7 @@ pub async fn oauth_callback(
                     user
                 }
                 Err(e) => {
-                    error!("Failed to verify Apple ID token: {:?}", e);
+                    error!("Failed to verify Apple ID token");
                     return Err(e);
                 }
             };
@@ -961,7 +989,7 @@ pub async fn oauth_callback(
             .await?
         }
         _ => {
-            error!("Unsupported provider: {}", provider_name);
+            error!("Unsupported OAuth provider");
             return Err(ApiError::InternalServerError);
         }
     };
@@ -978,7 +1006,7 @@ async fn fetch_github_user(
     let client = crate::http_client::client();
     let user_url = &github_provider.user_info_url;
 
-    debug!("Sending request to GitHub API: {}", user_url);
+    debug!("Sending request to GitHub user API");
     let response = client
         .get(user_url)
         .header("Authorization", format!("token {}", access_token))
@@ -986,15 +1014,20 @@ async fn fetch_github_user(
         .send()
         .await
         .map_err(|e| {
-            error!("Failed to send request to GitHub API: {:?}", e);
+            error!(
+                timeout = e.is_timeout(),
+                connect = e.is_connect(),
+                decode = e.is_decode(),
+                "Failed to send request to GitHub API"
+            );
             ApiError::InternalServerError
         })?;
 
-    // Get status and headers before consuming the response
     let status = response.status();
-    let headers = response.headers().clone();
-    debug!("GitHub API response status: {}", status);
-    trace!("GitHub API response headers: {:?}", headers);
+    debug!(
+        status = status.as_u16(),
+        "GitHub user API response received"
+    );
 
     if !status.is_success() {
         error!(
@@ -1006,17 +1039,25 @@ async fn fetch_github_user(
     }
 
     let user_body = response.text().await.map_err(|e| {
-        error!("Failed to read GitHub user response body: {:?}", e);
+        error!(
+            timeout = e.is_timeout(),
+            connect = e.is_connect(),
+            decode = e.is_decode(),
+            "Failed to read GitHub user response body"
+        );
         ApiError::InternalServerError
     })?;
 
-    trace!("GitHub user response body: {}", user_body);
+    debug!(
+        response_bytes = user_body.len(),
+        "GitHub user response received"
+    );
 
     let mut github_user: GithubUser = serde_json::from_str(&user_body).map_err(|e| {
         error!(
-            "Failed to parse GitHub user JSON: {} (response_bytes={})",
-            e,
-            user_body.len()
+            error_kind = ?e.classify(),
+            response_bytes = user_body.len(),
+            "Failed to parse GitHub user JSON"
         );
         ApiError::InternalServerError
     })?;
@@ -1024,7 +1065,7 @@ async fn fetch_github_user(
     // If the email is not public, fetch the email separately
     if github_user.email.is_none() {
         let emails_url = "https://api.github.com/user/emails";
-        debug!("Fetching GitHub user emails: {}", emails_url);
+        debug!("Fetching GitHub user emails");
         let emails_response = client
             .get(emails_url)
             .header("Authorization", format!("token {}", access_token))
@@ -1032,14 +1073,20 @@ async fn fetch_github_user(
             .send()
             .await
             .map_err(|e| {
-                error!("Failed to send request for GitHub user emails: {:?}", e);
+                error!(
+                    timeout = e.is_timeout(),
+                    connect = e.is_connect(),
+                    decode = e.is_decode(),
+                    "Failed to send request for GitHub user emails"
+                );
                 ApiError::InternalServerError
             })?;
 
         let emails_status = emails_response.status();
-        let emails_headers = emails_response.headers().clone();
-        trace!("GitHub emails API response status: {}", emails_status);
-        trace!("GitHub emails API response headers: {:?}", emails_headers);
+        trace!(
+            status = emails_status.as_u16(),
+            "GitHub emails API response received"
+        );
 
         if !emails_status.is_success() {
             error!(
@@ -1051,17 +1098,25 @@ async fn fetch_github_user(
         }
 
         let emails_body = emails_response.text().await.map_err(|e| {
-            error!("Failed to read GitHub emails response body: {:?}", e);
+            error!(
+                timeout = e.is_timeout(),
+                connect = e.is_connect(),
+                decode = e.is_decode(),
+                "Failed to read GitHub emails response body"
+            );
             ApiError::InternalServerError
         })?;
 
-        trace!("GitHub emails response body: {}", emails_body);
+        trace!(
+            response_bytes = emails_body.len(),
+            "GitHub emails response received"
+        );
 
         let emails: Vec<GithubEmail> = serde_json::from_str(&emails_body).map_err(|e| {
             error!(
-                "Failed to parse GitHub emails JSON: {} (response_bytes={})",
-                e,
-                emails_body.len()
+                error_kind = ?e.classify(),
+                response_bytes = emails_body.len(),
+                "Failed to parse GitHub emails JSON"
             );
             ApiError::InternalServerError
         })?;
@@ -1088,14 +1143,19 @@ async fn fetch_google_user(
     let client = crate::http_client::client();
     let user_url = &google_provider.user_info_url;
 
-    debug!("Sending request to Google API: {}", user_url);
+    debug!("Sending request to Google user API");
     let response = client
         .get(user_url)
         .header(AUTHORIZATION, format!("Bearer {}", access_token))
         .send()
         .await
         .map_err(|e| {
-            error!("Failed to send request to Google API: {:?}", e);
+            error!(
+                timeout = e.is_timeout(),
+                connect = e.is_connect(),
+                decode = e.is_decode(),
+                "Failed to send request to Google API"
+            );
             ApiError::InternalServerError
         })?;
 
@@ -1106,7 +1166,12 @@ async fn fetch_google_user(
     }
 
     let google_user: GoogleUser = response.json().await.map_err(|e| {
-        error!("Failed to parse Google user JSON: {:?}", e);
+        error!(
+            timeout = e.is_timeout(),
+            connect = e.is_connect(),
+            decode = e.is_decode(),
+            "Failed to parse Google user JSON"
+        );
         ApiError::InternalServerError
     })?;
 
@@ -1165,15 +1230,15 @@ fn authenticated_oauth_user(
 ) -> Result<AuthenticatedOAuthUser, ApiError> {
     let auth_context = app_state
         .oauth_auth_context_for_user(&user, provider_name, provider_user_id)
-        .map_err(|e| {
-            error!("Failed to compute OAuth auth context: {:?}", e);
+        .map_err(|_| {
+            error!("Failed to compute OAuth auth context");
             ApiError::InternalServerError
         })?;
 
     app_state
         .verify_seed_wrap_for_auth_context(&user, &auth_context)
-        .map_err(|e| {
-            error!("OAuth seed wrap verification failed: {:?}", e);
+        .map_err(|_| {
+            error!("OAuth seed wrap verification failed");
             ApiError::Unauthorized
         })?;
 
@@ -1191,8 +1256,8 @@ fn oauth_callback_response(
         app_state,
         &authenticated_user.auth_context,
     )
-    .map_err(|e| {
-        error!("Failed to generate access token: {:?}", e);
+    .map_err(|_| {
+        error!("Failed to generate access token");
         ApiError::InternalServerError
     })?;
     let refresh_token = NewToken::new_with_auth_context(
@@ -1201,8 +1266,8 @@ fn oauth_callback_response(
         app_state,
         &authenticated_user.auth_context,
     )
-    .map_err(|e| {
-        error!("Failed to generate refresh token: {:?}", e);
+    .map_err(|_| {
+        error!("Failed to generate refresh token");
         ApiError::InternalServerError
     })?;
 
@@ -1230,8 +1295,8 @@ async fn find_or_create_user_from_oauth(
     let provider = app_state
         .db
         .get_oauth_provider_by_name(provider_name)
-        .map_err(|e| {
-            error!("Failed to get {} OAuth provider: {:?}", provider_name, e);
+        .map_err(|_| {
+            error!("Failed to get {} OAuth provider", provider_name);
             ApiError::InternalServerError
         })?
         .ok_or_else(|| {
@@ -1246,11 +1311,8 @@ async fn find_or_create_user_from_oauth(
             &provider_user_id,
             project_id,
         )
-        .map_err(|e| {
-            error!(
-                "Failed to get OAuth connection for verified provider subject: {:?}",
-                e
-            );
+        .map_err(|_| {
+            error!("Failed to get OAuth connection for verified provider subject");
             ApiError::InternalServerError
         })?
     {
@@ -1276,8 +1338,8 @@ async fn find_or_create_user_from_oauth(
             let existing_connection = app_state
                 .db
                 .get_user_oauth_connection_by_user_and_provider(existing_user.uuid, provider.id)
-                .map_err(|e| {
-                    error!("Failed to get existing OAuth connection: {:?}", e);
+                .map_err(|_| {
+                    error!("Failed to get existing OAuth connection");
                     ApiError::InternalServerError
                 })?;
 
@@ -1319,8 +1381,8 @@ async fn find_or_create_user_from_oauth(
                     encrypted_access_token,
                     user_seed_words.as_bytes(),
                 )
-                .map_err(|e| {
-                    error!("Failed to create new OAuth user and seed wrap: {:?}", e);
+                .map_err(|_| {
+                    error!("Failed to create new OAuth user and seed wrap");
                     ApiError::InternalServerError
                 })?;
 
@@ -1329,8 +1391,8 @@ async fn find_or_create_user_from_oauth(
 
             authenticated_oauth_user(app_state, user, provider_name, &provider_user_id)
         }
-        Err(e) => {
-            error!("Database error when fetching user: {:?}", e);
+        Err(_) => {
+            error!("Database error when fetching OAuth user");
             Err(ApiError::InternalServerError)
         }
     }
@@ -1399,8 +1461,8 @@ pub async fn handle_apple_native_signin(
     let apple_provider = app_state
         .db
         .get_oauth_provider_by_name("apple")
-        .map_err(|e| {
-            error!("Failed to get Apple OAuth provider: {:?}", e);
+        .map_err(|_| {
+            error!("Failed to get Apple OAuth provider");
             ApiError::InternalServerError
         })?
         .ok_or_else(|| {
@@ -1419,11 +1481,8 @@ pub async fn handle_apple_native_signin(
             &verified_user_id,
             project.id,
         )
-        .map_err(|e| {
-            error!(
-                "Failed to get Apple OAuth connection for verified subject: {:?}",
-                e
-            );
+        .map_err(|_| {
+            error!("Failed to get Apple OAuth connection for verified subject");
             ApiError::InternalServerError
         })?
     {
@@ -1528,8 +1587,8 @@ async fn update_provider_connection(
     app_state
         .db
         .update_user_oauth_connection(&connection)
-        .map_err(|e| {
-            error!("Failed to update OAuth connection: {:?}", e);
+        .map_err(|_| {
+            error!("Failed to update OAuth connection");
             ApiError::InternalServerError
         })?;
 
@@ -1563,8 +1622,8 @@ async fn create_provider_connection(
     app_state
         .db
         .create_user_oauth_connection(new_connection)
-        .map_err(|e| {
-            error!("Failed to create new OAuth connection: {:?}", e);
+        .map_err(|_| {
+            error!("Failed to create new OAuth connection");
             ApiError::InternalServerError
         })?;
 
@@ -1575,8 +1634,8 @@ async fn encrypt_access_token(
     app_state: &AppState,
     access_token: &str,
 ) -> Result<Vec<u8>, ApiError> {
-    let secret_key = SecretKey::from_slice(&app_state.enclave_key).map_err(|e| {
-        error!("Failed to create SecretKey from enclave key: {:?}", e);
+    let secret_key = SecretKey::from_slice(&app_state.enclave_key).map_err(|_| {
+        error!("Failed to create SecretKey from enclave key");
         ApiError::InternalServerError
     })?;
     Ok(encrypt::encrypt_with_key(&secret_key, access_token.as_bytes()).await)
@@ -1593,6 +1652,45 @@ mod tests {
     };
     use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
     use tokio::sync::RwLock;
+
+    #[test]
+    fn oauth_token_error_category_omits_malformed_token_response_and_description() {
+        use oauth2::basic::{BasicClient, BasicErrorResponse, BasicErrorResponseType};
+        use oauth2::{ClientId, HttpRequest, HttpResponse, RequestTokenError, TokenUrl};
+
+        const RESPONSE: &str = r#"{"access_token":"PRIVATE_ACCESS_SENTINEL","refresh_token":"PRIVATE_REFRESH_SENTINEL","token_type":"bearer","expires_in":{"private":"PRIVATE_CLAIMS_SENTINEL"}}"#;
+        let client = BasicClient::new(ClientId::new("test-client".to_string()))
+            .set_token_uri(TokenUrl::new("https://oauth.invalid/token".to_string()).unwrap());
+        let error = client
+            .exchange_code(AuthorizationCode::new("test-code".to_string()))
+            .request(&|_: HttpRequest| {
+                Ok::<HttpResponse, std::io::Error>(
+                    oauth2::http::Response::builder()
+                        .status(200)
+                        .header("content-type", "application/json")
+                        .body(RESPONSE.as_bytes().to_vec())
+                        .unwrap(),
+                )
+            })
+            .unwrap_err();
+        let RequestTokenError::Parse(_, body) = &error else {
+            panic!("malformed token response must produce a parse error");
+        };
+        assert_eq!(body.as_slice(), RESPONSE.as_bytes());
+        let category = oauth_token_error_kind(&error);
+        assert_eq!(category, "response_parse");
+        assert!(!category.contains("PRIVATE_"));
+
+        let error: oauth2::basic::BasicRequestTokenError<std::io::Error> =
+            RequestTokenError::ServerResponse(BasicErrorResponse::new(
+                BasicErrorResponseType::Extension("PRIVATE_ERROR_SENTINEL".to_string()),
+                Some("PRIVATE_DESCRIPTION_SENTINEL".to_string()),
+                Some("https://oauth.invalid/PRIVATE_URI_SENTINEL".to_string()),
+            ));
+        let category = oauth_token_error_kind(&error);
+        assert_eq!(category, "other_server_response");
+        assert!(!category.contains("PRIVATE_"));
+    }
 
     #[tokio::test]
     #[ignore = "requires AEAD_TAMPER_TEST_DATABASE_URL pointing at disposable migrated local Postgres"]

--- a/src/web/oauth_routes.rs
+++ b/src/web/oauth_routes.rs
@@ -600,7 +600,7 @@ pub async fn oauth_callback(
     };
 
     // Get project (we can trust the client_id now since we validated it against our stored state)
-    debug!("Getting project for verified OAuth state");
+    debug!(client_id = %state.client_id, "Getting project for verified OAuth state");
     let project = app_state
         .db
         .get_org_project_by_client_id(state.client_id)

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -1545,12 +1545,12 @@ async fn proxy_openai(
 
     // Check if guest user is allowed (paid guests are allowed, free guests are not)
     if user.is_guest() && !model_plan.is_paid() {
-        debug!(reason = "guest_requires_paid_plan", "Chat request rejected");
+        debug!(user_uuid = %user.uuid, reason = "guest_requires_paid_plan", "Chat request rejected");
         return Err(ApiError::Unauthorized);
     }
 
     if billing_access.is_some_and(|access| !access.can_use()) {
-        debug!(reason = "usage_limit", "Chat request rejected");
+        debug!(user_uuid = %user.uuid, reason = "usage_limit", "Chat request rejected");
         return Err(ApiError::UsageLimitReached);
     }
 
@@ -2965,7 +2965,7 @@ async fn publish_usage_event_internal(
         BigDecimal::from_str("0.0000053").unwrap() * BigDecimal::from(usage.completion_tokens);
     let total_cost = input_cost + output_cost;
 
-    debug!(model = resolve_public_model_id(&billing_context.model_name).unwrap_or("custom"), provider = provider_name, prompt_tokens = usage.prompt_tokens, cached_prompt_tokens = usage.cached_prompt_tokens.unwrap_or(0), completion_tokens = usage.completion_tokens, estimated_cost = %total_cost, "Chat completion usage");
+    debug!(user_uuid = %user.uuid, model = resolve_public_model_id(&billing_context.model_name).unwrap_or("custom"), provider = provider_name, prompt_tokens = usage.prompt_tokens, cached_prompt_tokens = usage.cached_prompt_tokens.unwrap_or(0), completion_tokens = usage.completion_tokens, estimated_cost = %total_cost, "Chat completion usage");
 
     // Spawn background task for DB + SQS
     let state_clone = state.clone();
@@ -2984,7 +2984,7 @@ async fn publish_usage_event_internal(
         );
 
         if let Err(e) = state_clone.db.create_token_usage(new_usage) {
-            error!(error_kind = crate::observability::error_kind(&e), "Failed to save token usage");
+            error!(user_uuid = %user_id, error_kind = crate::observability::error_kind(&e), "Failed to save token usage");
         }
 
         let cached_input_tokens = usage.cached_prompt_tokens;
@@ -3000,7 +3000,7 @@ async fn publish_usage_event_internal(
                 model_name,
             );
 
-            debug!(provider = %event.provider_name, model = resolve_public_model_id(&event.model_name).unwrap_or("custom"), input_tokens = event.input_tokens, output_tokens = event.output_tokens, cached_input_tokens = ?event.cached_input_tokens, "Prepared SQS usage event");
+            debug!(user_uuid = %event.user_id, provider = %event.provider_name, model = resolve_public_model_id(&event.model_name).unwrap_or("custom"), input_tokens = event.input_tokens, output_tokens = event.output_tokens, cached_input_tokens = ?event.cached_input_tokens, "Prepared SQS usage event");
 
             match publisher.publish_event(event).await {
                 Ok(_) => debug!("published usage event successfully"),
@@ -3251,14 +3251,15 @@ async fn proxy_transcription(
         if let Some(billing_client) = &state.billing_client {
             match billing_client.is_user_paid(user.uuid).await {
                 Ok(true) => {
-                    debug!("Paid guest request allowed");
+                    debug!(user_uuid = %user.uuid, "Paid guest request allowed");
                 }
                 Ok(false) => {
-                    debug!(reason = "guest_requires_paid_plan", "Request rejected");
+                    debug!(user_uuid = %user.uuid, reason = "guest_requires_paid_plan", "Request rejected");
                     return Err(ApiError::Unauthorized);
                 }
                 Err(e) => {
                     warn!(
+                        user_uuid = %user.uuid,
                         error_kind = crate::observability::error_kind(&e),
                         "Guest billing check failed"
                     );
@@ -3266,7 +3267,7 @@ async fn proxy_transcription(
                 }
             }
         } else {
-            warn!(reason = "billing_unavailable", "Guest request rejected");
+            warn!(user_uuid = %user.uuid, reason = "billing_unavailable", "Guest request rejected");
             return Err(ApiError::Unauthorized);
         }
     }
@@ -3612,11 +3613,12 @@ async fn ensure_paid_tts_access(state: &AppState, user: &User) -> Result<(), Api
             Ok(Ok(true)) => TTSBillingAccess::Allowed,
             Ok(Ok(false)) => TTSBillingAccess::FreeOrExhausted,
             Ok(Err(_)) => {
-                warn!("TTS billing entitlement check failed");
+                warn!(user_uuid = %user.uuid, "TTS billing entitlement check failed");
                 TTSBillingAccess::Unavailable
             }
             Err(_) => {
                 warn!(
+                    user_uuid = %user.uuid,
                     timeout_seconds = TTS_BILLING_CHECK_TIMEOUT.as_secs(),
                     "TTS billing entitlement check timed out"
                 );
@@ -3624,14 +3626,14 @@ async fn ensure_paid_tts_access(state: &AppState, user: &User) -> Result<(), Api
             }
         }
     } else {
-        warn!("TTS requested while the billing client is unavailable");
+        warn!(user_uuid = %user.uuid, "TTS requested while the billing client is unavailable");
         TTSBillingAccess::Unavailable
     };
 
     let result = tts_billing_access_decision(access);
     if result.is_err() {
         debug!(
-
+            user_uuid = %user.uuid,
             access = ?access,
             "Denied paid TTS access"
         );
@@ -3756,14 +3758,15 @@ async fn proxy_embeddings(
         if let Some(billing_client) = &state.billing_client {
             match billing_client.is_user_paid(user.uuid).await {
                 Ok(true) => {
-                    debug!("Paid guest request allowed");
+                    debug!(user_uuid = %user.uuid, "Paid guest request allowed");
                 }
                 Ok(false) => {
-                    debug!(reason = "guest_requires_paid_plan", "Request rejected");
+                    debug!(user_uuid = %user.uuid, reason = "guest_requires_paid_plan", "Request rejected");
                     return Err(ApiError::Unauthorized);
                 }
                 Err(e) => {
                     warn!(
+                        user_uuid = %user.uuid,
                         error_kind = crate::observability::error_kind(&e),
                         "Guest billing check failed"
                     );
@@ -3771,7 +3774,7 @@ async fn proxy_embeddings(
                 }
             }
         } else {
-            warn!(reason = "billing_unavailable", "Guest request rejected");
+            warn!(user_uuid = %user.uuid, reason = "billing_unavailable", "Guest request rejected");
             return Err(ApiError::Unauthorized);
         }
     }

--- a/src/web/openai.rs
+++ b/src/web/openai.rs
@@ -7,7 +7,7 @@ use crate::inference::{
 use crate::inference_planning::{RoutePlan, RoutePlanningError};
 use crate::model_config::{
     model_alias_requires_flag_lookup, model_catalog_response, openai_models_response,
-    ModelAliasTargets, ModelPlan,
+    resolve_public_model_id, ModelAliasTargets, ModelPlan,
 };
 use crate::models::token_usage::NewTokenUsage;
 use crate::models::users::User;
@@ -54,7 +54,8 @@ use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::{sleep, timeout};
-use tracing::{debug, error, info, trace, warn};
+use tracing::Instrument;
+use tracing::{debug, error, trace, warn};
 use uuid::Uuid;
 
 // Maximum audio file size (100MB) - sanity check, CF already limits to 50MB
@@ -1114,22 +1115,16 @@ fn log_attempt_terminal(
             attempt.route.provider_model_id,
             evidence
         ),
-        AttemptTerminal::Failed { failure, .. } => warn!(
-            "Inference attempt failed: request_id={}, execution_id={}, attempt_id={}, provider={}, public_model={}, provider_model={}, kind={:?}, stage={:?}, replay_safety={:?}, status={:?}, retry_after_ms={:?}, upstream_request_id={:?}, upstream_code={:?}",
-            attempt.request_id,
-            attempt.execution_id,
-            attempt.attempt_id,
-            attempt.route.provider.as_str(),
-            attempt.route.public_model_id,
-            attempt.route.provider_model_id,
-            failure.kind,
-            failure.stage,
-            failure.replay_safety,
-            failure.status,
-            failure.retry_after.map(|duration| duration.as_millis()),
-            failure.upstream_request_id,
-            failure.upstream_code
-        ),
+        AttemptTerminal::Failed { failure, .. }
+            if failure.kind == AttemptFailureKind::ConsumerDropped => debug!(
+                request_id = %attempt.request_id,
+                execution_id = %attempt.execution_id,
+                attempt_id = %attempt.attempt_id,
+                provider = attempt.route.provider.as_str(),
+                stage = ?failure.stage,
+                "Inference consumer disconnected"
+            ),
+        AttemptTerminal::Failed { failure, .. } => warn!(request_id = %attempt.request_id, execution_id = %attempt.execution_id, attempt_id = %attempt.attempt_id, provider = attempt.route.provider.as_str(), public_model = %attempt.route.public_model_id, provider_model = %attempt.route.provider_model_id, kind = ?failure.kind, stage = ?failure.stage, replay_safety = ?failure.replay_safety, status = ?failure.status, retry_after_ms = ?failure.retry_after.map(|duration| duration.as_millis()), "Inference attempt failed"),
     }
 }
 
@@ -1231,10 +1226,7 @@ async fn read_non_streaming_completion_response(
             collect_bounded_provider_response_body(response.bytes_stream(), limit_bytes)
                 .await
                 .map_err(|error| {
-                    error!(
-                        "Failed to read bounded inference response body: request_id={}, execution_id={}, attempt_id={}, error={}",
-                        attempt.request_id, attempt.execution_id, attempt.attempt_id, error
-                    );
+                    error!(request_id = %attempt.request_id, execution_id = %attempt.execution_id, attempt_id = %attempt.attempt_id, error_kind = crate::observability::error_kind(&error), "Failed to read bounded inference response body");
                     let kind = match error {
                         BoundedProviderResponseBodyError::Read => {
                             AttemptFailureKind::ResponseBody
@@ -1250,11 +1242,8 @@ async fn read_non_streaming_completion_response(
                     )
                 })?,
         ),
-        None => response.bytes().await.map_err(|error| {
-            error!(
-                "Failed to read inference response body: request_id={}, execution_id={}, attempt_id={}, error={}",
-                attempt.request_id, attempt.execution_id, attempt.attempt_id, error
-            );
+        None => response.bytes().await.map_err(|_error| {
+            error!(request_id = %attempt.request_id, execution_id = %attempt.execution_id, attempt_id = %attempt.attempt_id, stage = "response_body", "Failed to read inference response body");
             AttemptFailure::new(
                 AttemptFailureKind::ResponseBody,
                 AttemptStage::ResponseBody,
@@ -1264,10 +1253,7 @@ async fn read_non_streaming_completion_response(
     };
 
     let mut response_json: Value = serde_json::from_slice(&body_bytes).map_err(|error| {
-        error!(
-            "Failed to parse inference response JSON: request_id={}, execution_id={}, attempt_id={}, error={}",
-            attempt.request_id, attempt.execution_id, attempt.attempt_id, error
-        );
+        error!(request_id = %attempt.request_id, execution_id = %attempt.execution_id, attempt_id = %attempt.attempt_id, error_kind = crate::observability::error_kind(&error), "Failed to parse inference response JSON");
         AttemptFailure::new(
             AttemptFailureKind::InvalidResponse,
             AttemptStage::ResponseBody,
@@ -1280,13 +1266,7 @@ async fn read_non_streaming_completion_response(
         AttemptFailureKind::UpstreamResponseError,
         AttemptStage::ResponseBody,
     ) {
-        warn!(
-            "Inference provider emitted a non-streaming error payload: request_id={}, execution_id={}, attempt_id={}, upstream_code={:?}",
-            attempt.request_id,
-            attempt.execution_id,
-            attempt.attempt_id,
-            failure.upstream_code
-        );
+        warn!(request_id = %attempt.request_id, execution_id = %attempt.execution_id, attempt_id = %attempt.attempt_id, kind = ?failure.kind, stage = ?failure.stage, "Inference provider emitted a non-streaming error payload");
         return Err(failure);
     }
 
@@ -1360,13 +1340,7 @@ async fn process_completion_stream(
                     let mut json = match serde_json::from_slice::<Value>(&frame) {
                         Ok(json) => json,
                         Err(error) => {
-                            error!(
-                                "Received invalid inference stream data: request_id={}, execution_id={}, attempt_id={}, error={}",
-                                attempt.request_id,
-                                attempt.execution_id,
-                                attempt.attempt_id,
-                                error
-                            );
+                            error!(request_id = %attempt.request_id, execution_id = %attempt.execution_id, attempt_id = %attempt.attempt_id, error_kind = crate::observability::error_kind(&error), "Received invalid inference stream data");
                             return finish_stream_processing(
                                 &mut usage_accumulator,
                                 StreamUsageFinalization::InvalidData,
@@ -1383,13 +1357,7 @@ async fn process_completion_stream(
                     };
 
                     if let Some(failure) = upstream_stream_failure(&json) {
-                        warn!(
-                            "Inference provider emitted an error stream frame: request_id={}, execution_id={}, attempt_id={}, upstream_code={:?}",
-                            attempt.request_id,
-                            attempt.execution_id,
-                            attempt.attempt_id,
-                            failure.upstream_code
-                        );
+                        warn!(request_id = %attempt.request_id, execution_id = %attempt.execution_id, attempt_id = %attempt.attempt_id, kind = ?failure.kind, stage = ?failure.stage, "Inference provider emitted an error stream frame");
                         return finish_stream_processing(
                             &mut usage_accumulator,
                             StreamUsageFinalization::ProviderError,
@@ -1421,11 +1389,8 @@ async fn process_completion_stream(
                     }
                 }
             }
-            Ok(Some(Err(error))) => {
-                error!(
-                    "Inference stream transport error: request_id={}, execution_id={}, attempt_id={}, error={}",
-                    attempt.request_id, attempt.execution_id, attempt.attempt_id, error
-                );
+            Ok(Some(Err(_error))) => {
+                error!(request_id = %attempt.request_id, execution_id = %attempt.execution_id, attempt_id = %attempt.attempt_id, stage = "stream_transport", "Inference stream transport error");
                 return finish_stream_processing(
                     &mut usage_accumulator,
                     StreamUsageFinalization::TransportError,
@@ -1494,7 +1459,7 @@ async fn publish_stream_usage(
     if !finalization.is_provider_done() {
         warn!(
             "Finalizing streaming usage from terminal fallback: trigger={:?}, provider={}, model={}",
-            finalization, provider, billing_context.model_name
+            finalization, provider, resolve_public_model_id(&billing_context.model_name).unwrap_or("custom")
         );
     }
 
@@ -1580,15 +1545,12 @@ async fn proxy_openai(
 
     // Check if guest user is allowed (paid guests are allowed, free guests are not)
     if user.is_guest() && !model_plan.is_paid() {
-        error!(
-            "Guest user without a paid plan attempted to use chat: {}",
-            user.uuid
-        );
+        debug!(reason = "guest_requires_paid_plan", "Chat request rejected");
         return Err(ApiError::Unauthorized);
     }
 
     if billing_access.is_some_and(|access| !access.can_use()) {
-        error!("Usage limit reached for user: {}", user.uuid);
+        debug!(reason = "usage_limit", "Chat request rejected");
         return Err(ApiError::UsageLimitReached);
     }
 
@@ -1597,7 +1559,7 @@ async fn proxy_openai(
         .get("model")
         .and_then(|m| m.as_str())
         .ok_or_else(|| {
-            error!("Model not specified in request");
+            debug!("Model not specified in request");
             ApiError::BadRequest
         })?
         .to_string();
@@ -1623,8 +1585,8 @@ async fn proxy_openai(
     let pinned_completion = prepare_completion_request(&state, &user, intent, routing).await?;
     if requested_model_name != model_name {
         debug!(
-            "Resolved chat model {} to {}",
-            requested_model_name, model_name
+            public_model = resolve_public_model_id(&model_name).unwrap_or("custom"),
+            "Resolved chat model alias"
         );
         body.as_object_mut()
             .expect("model was read from a JSON object")
@@ -1687,7 +1649,7 @@ async fn proxy_openai(
                     match encrypt_sse_event(&state, &session_id, &json).await {
                         Ok(event) => yield Ok::<Event, std::convert::Infallible>(event),
                         Err(e) => {
-                            error!("Failed to encrypt event data: {:?}", e);
+                            error!(error_kind = crate::observability::error_kind(&e), "Failed to encrypt event data");
                             break;
                         }
                     }
@@ -1711,7 +1673,7 @@ async fn proxy_openai(
                             match encrypt_sse_event(&state, &session_id, &error_payload).await {
                                 Ok(event) => yield Ok(event),
                                 Err(error) => {
-                                    error!("Failed to encrypt terminal error event: {error:?}");
+                                    error!(error_kind = crate::observability::error_kind(&error), "Failed to encrypt terminal error event");
                                 }
                             }
                         }
@@ -1726,7 +1688,7 @@ async fn proxy_openai(
                     match encrypt_sse_event(&state, &session_id, &error_payload).await {
                         Ok(event) => yield Ok(event),
                         Err(error) => {
-                            error!("Failed to encrypt invalid-format error event: {error:?}");
+                            error!(error_kind = crate::observability::error_kind(&error), "Failed to encrypt invalid-format error event");
                         }
                     }
                     break;
@@ -1745,7 +1707,7 @@ async fn proxy_openai(
             {
                 Ok(event) => yield Ok(event),
                 Err(error) => {
-                    error!("Failed to encode terminal stream error: {:?}", error);
+                    error!(error_kind = crate::observability::error_kind(&error), "Failed to encode terminal stream error");
                 }
             }
         }
@@ -1816,12 +1778,12 @@ fn retain_active_route_after_shadow_observation(
 
 fn provider_routing_api_error(error: ProviderRoutingError) -> ApiError {
     match error {
-        ProviderRoutingError::UnsupportedModel(model) => {
-            error!("Unsupported completion model requested: {}", model);
+        ProviderRoutingError::UnsupportedModel(_model) => {
+            debug!(reason = "unsupported_model", "Completion request rejected");
             ApiError::BadRequest
         }
-        ProviderRoutingError::NoEligibleRoute(model) => {
-            error!("No eligible provider route for completion model: {}", model);
+        ProviderRoutingError::NoEligibleRoute(_model) => {
+            error!(reason = "no_eligible_route", "Completion routing failed");
             ApiError::InternalServerError
         }
         ProviderRoutingError::CapacityUnavailable { model, retry_after } => {
@@ -1919,14 +1881,13 @@ pub(crate) async fn prepare_completion_request(
     };
 
     debug!(
-        "Pinned inference route: request_id={}, routing_mode={:?}, selection_mode={:?}, auto={}, surface={:?}, workload={:?}, requested_model={}, public_model={}, provider={}, provider_model={}, bucket={:?}, source={:?}",
+        "Pinned inference route: request_id={}, routing_mode={:?}, selection_mode={:?}, auto={}, surface={:?}, workload={:?}, public_model={}, provider={}, provider_model={}, bucket={:?}, source={:?}",
         intent.request_id,
         routing.mode(),
         intent.selection_mode,
         intent.selection_mode.is_auto(),
         intent.surface,
         intent.workload_class,
-        intent.requested_model_id,
         route.public_model_id,
         route.provider.as_str(),
         route.provider_model_id,
@@ -2268,10 +2229,7 @@ pub(crate) async fn get_chat_completion_response_for_expected_route(
     let pinned = prepare_completion_request(state, user, intent, routing)
         .await
         .map_err(|error| {
-            error!(
-                "Failed to prepare server-selected completion route: expected_provider={}, expected_provider_model={}, error={error:?}",
-                route.provider_name, route.provider_model_id
-            );
+            error!(provider = %route.provider_name, provider_model = %route.provider_model_id, error_kind = crate::observability::error_kind(&error), "Failed to prepare server-selected completion route");
             CompletionExecutionError::Request(ApiError::ServiceUnavailable)
         })?;
 
@@ -2348,14 +2306,14 @@ async fn get_chat_completion_response_with_options(
     let cache_policy = cache;
     let require_provider_done = cache_policy.requires_provider_done();
     if body.is_null() || body.as_object().is_none_or(|obj| obj.is_empty()) {
-        error!("Request body is empty or invalid");
+        debug!("Request body is empty or invalid");
         return Err(ApiError::BadRequest.into());
     }
 
     let mut modified_body = body
         .as_object()
         .ok_or_else(|| {
-            error!("Request body is not a JSON object");
+            debug!("Request body is not a JSON object");
             ApiError::BadRequest
         })?
         .clone();
@@ -2370,19 +2328,13 @@ async fn get_chat_completion_response_with_options(
         .get("model")
         .and_then(|m| m.as_str())
         .ok_or_else(|| {
-            error!("Model not specified in request");
+            debug!("Model not specified in request");
             ApiError::BadRequest
         })?
         .to_string();
 
     if body_model_name != pinned.public_model_id() {
-        error!(
-            "Prepared inference model did not match execution body: request_id={}, preferred_model={}, prepared_model={}, body_model={}",
-            pinned.intent.request_id,
-            pinned.intent.public_model_id,
-            pinned.public_model_id(),
-            body_model_name
-        );
+        error!(request_id = %pinned.intent.request_id, prepared_model = pinned.public_model_id(), "Prepared inference model did not match execution body");
         return Err(ApiError::InternalServerError.into());
     }
 
@@ -2504,10 +2456,7 @@ async fn get_chat_completion_response_with_options(
                     AttemptStage::BeforeSend,
                     ReplaySafety::ProvenPreAcceptance,
                 );
-                error!(
-                    "Failed to serialize inference request: request_id={}, execution_id={}, attempt_id={}, error={:?}",
-                    attempt.request_id, attempt.execution_id, attempt.attempt_id, error
-                );
+                error!(request_id = %attempt.request_id, execution_id = %attempt.execution_id, attempt_id = %attempt.attempt_id, error_kind = crate::observability::error_kind(&error), "Failed to serialize inference request");
                 let terminal = AttemptTerminal::Failed { attempt, failure };
                 terminal_guard.record_terminal(&terminal);
                 return Err(CompletionExecutionError::Attempt {
@@ -2564,7 +2513,7 @@ async fn get_chat_completion_response_with_options(
                     },
                     ShadowObservationMode::Update,
                 );
-                info!(
+                debug!(
                     "Inference response started: request_id={}, execution_id={}, attempt_id={}",
                     attempt.request_id, attempt.execution_id, attempt.attempt_id
                 );
@@ -2717,32 +2666,35 @@ pub(crate) async fn finish_started_completion(
     let stream_attempt = attempt.clone();
     terminal_guard.set_stage(AttemptStage::Stream);
 
-    tokio::spawn(async move {
-        let _response_execution_guard = response_execution_guard;
-        let result = process_completion_stream(
-            response,
-            &response_model_id,
-            stream_attempt,
-            &tx_consumer,
-            Duration::from_secs(STREAM_CHUNK_TIMEOUT_SECS),
-            response_execution.as_ref(),
-            require_provider_done,
-        )
-        .await;
-        let terminal = result.terminal.clone();
-        terminal_guard.record_terminal(&terminal);
-        publish_stream_usage(
-            result.usage,
-            result.finalization,
-            &state_clone,
-            &user_clone,
-            &billing_ctx,
-            &provider,
-            &tx_consumer,
-        )
-        .await;
-        let _ = tx_consumer.send(CompletionChunk::Terminal(terminal)).await;
-    });
+    tokio::spawn(
+        async move {
+            let _response_execution_guard = response_execution_guard;
+            let result = process_completion_stream(
+                response,
+                &response_model_id,
+                stream_attempt,
+                &tx_consumer,
+                Duration::from_secs(STREAM_CHUNK_TIMEOUT_SECS),
+                response_execution.as_ref(),
+                require_provider_done,
+            )
+            .await;
+            let terminal = result.terminal.clone();
+            terminal_guard.record_terminal(&terminal);
+            publish_stream_usage(
+                result.usage,
+                result.finalization,
+                &state_clone,
+                &user_clone,
+                &billing_ctx,
+                &provider,
+                &tx_consumer,
+            )
+            .await;
+            let _ = tx_consumer.send(CompletionChunk::Terminal(terminal)).await;
+        }
+        .in_current_span(),
+    );
 
     Ok(CompletionStream {
         stream: rx_consumer,
@@ -2775,9 +2727,9 @@ pub(crate) fn ensure_completion_model_access(
     model_plan: ModelPlan,
 ) -> Result<(), ApiError> {
     if !model_plan.allows_model(model_name) {
-        error!(
-            "Paid completion model requested without entitlement: {}",
-            model_name
+        debug!(
+            reason = "model_requires_paid_plan",
+            "Completion request rejected"
         );
         return Err(ApiError::ModelNotAvailableOnPlan);
     }
@@ -3013,17 +2965,7 @@ async fn publish_usage_event_internal(
         BigDecimal::from_str("0.0000053").unwrap() * BigDecimal::from(usage.completion_tokens);
     let total_cost = input_cost + output_cost;
 
-    info!(
-        "Chat completion usage for user {}: model={}, provider={}, prompt_tokens={}, cached_prompt_tokens={}, completion_tokens={}, total_tokens={}, estimated_cost={}",
-        user.uuid,
-        billing_context.model_name,
-        provider_name,
-        usage.prompt_tokens,
-        usage.cached_prompt_tokens.unwrap_or(0),
-        usage.completion_tokens,
-        usage.prompt_tokens + usage.completion_tokens,
-        total_cost
-    );
+    debug!(model = resolve_public_model_id(&billing_context.model_name).unwrap_or("custom"), provider = provider_name, prompt_tokens = usage.prompt_tokens, cached_prompt_tokens = usage.cached_prompt_tokens.unwrap_or(0), completion_tokens = usage.completion_tokens, estimated_cost = %total_cost, "Chat completion usage");
 
     // Spawn background task for DB + SQS
     let state_clone = state.clone();
@@ -3042,7 +2984,7 @@ async fn publish_usage_event_internal(
         );
 
         if let Err(e) = state_clone.db.create_token_usage(new_usage) {
-            error!("Failed to save token usage: {:?}", e);
+            error!(error_kind = crate::observability::error_kind(&e), "Failed to save token usage");
         }
 
         let cached_input_tokens = usage.cached_prompt_tokens;
@@ -3058,19 +3000,11 @@ async fn publish_usage_event_internal(
                 model_name,
             );
 
-            debug!(
-                "Prepared SQS usage event: user_uuid={}, provider={}, model={}, input_tokens={}, output_tokens={}, cached_input_tokens={:?}",
-                event.user_id,
-                event.provider_name,
-                event.model_name,
-                event.input_tokens,
-                event.output_tokens,
-                event.cached_input_tokens
-            );
+            debug!(provider = %event.provider_name, model = resolve_public_model_id(&event.model_name).unwrap_or("custom"), input_tokens = event.input_tokens, output_tokens = event.output_tokens, cached_input_tokens = ?event.cached_input_tokens, "Prepared SQS usage event");
 
             match publisher.publish_event(event).await {
                 Ok(_) => debug!("published usage event successfully"),
-                Err(e) => error!("error publishing usage event: {e}"),
+                Err(e) => error!(error_kind = crate::observability::error_kind(&e), "error publishing usage event"),
             }
         } else {
             debug!(
@@ -3078,7 +3012,7 @@ async fn publish_usage_event_internal(
                 cached_input_tokens
             );
         }
-    });
+    }.in_current_span());
 }
 
 fn build_usage_event(
@@ -3114,7 +3048,10 @@ async fn encrypt_sse_event(
         .encode_sse_data(state, &json_str)
         .await
         .map_err(|e| {
-            error!("Failed to encode SSE event data: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to encode SSE event data"
+            );
             ApiError::InternalServerError
         })?;
 
@@ -3169,10 +3106,7 @@ async fn fetch_provider_models(
         )
         .await
         .map_err(|e| {
-            error!(
-                "Failed to fetch models from provider {}: {:?}",
-                proxy_config.provider_name, e
-            );
+            error!(provider = %proxy_config.provider_name, error_kind = crate::observability::error_kind(&e), "Failed to fetch provider models");
             ApiError::from(e)
         })?;
 
@@ -3185,13 +3119,16 @@ async fn fetch_provider_models(
         return Err(ApiError::InternalServerError);
     }
 
-    let body_bytes = res.bytes().await.map_err(|e| {
-        error!("Failed to read models response body: {:?}", e);
+    let body_bytes = res.bytes().await.map_err(|_e| {
+        error!("Failed to read models response body");
         ApiError::InternalServerError
     })?;
 
     serde_json::from_slice(&body_bytes).map_err(|e| {
-        error!("Failed to parse models response: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to parse models response"
+        );
         ApiError::InternalServerError
     })
 }
@@ -3255,7 +3192,7 @@ async fn send_transcription_with_retries(
 
         match send_transcription_request(client, primary_provider, &primary_model, params).await {
             Ok(response) => {
-                info!(
+                debug!(
                     "Successfully got transcription from primary provider {} on cycle {}",
                     primary_provider.provider_name,
                     cycle + 1
@@ -3263,12 +3200,7 @@ async fn send_transcription_with_retries(
                 return Ok(response);
             }
             Err(err) => {
-                error!(
-                    "Cycle {}: Primary provider {} failed: {}",
-                    cycle + 1,
-                    primary_provider.provider_name,
-                    err
-                );
+                warn!(cycle = cycle + 1, provider = %primary_provider.provider_name, error_kind = crate::observability::error_kind(&err), "Primary transcription provider failed");
                 last_error = Some(err);
             }
         }
@@ -3287,7 +3219,7 @@ async fn send_transcription_with_retries(
                 .await
             {
                 Ok(response) => {
-                    info!(
+                    debug!(
                         "Successfully got transcription from fallback provider {} on cycle {}",
                         fallback_provider.provider_name,
                         cycle + 1
@@ -3295,22 +3227,14 @@ async fn send_transcription_with_retries(
                     return Ok(response);
                 }
                 Err(err) => {
-                    error!(
-                        "Cycle {}: Fallback provider {} failed: {}",
-                        cycle + 1,
-                        fallback_provider.provider_name,
-                        err
-                    );
+                    warn!(cycle = cycle + 1, provider = %fallback_provider.provider_name, error_kind = crate::observability::error_kind(&err), "Fallback transcription provider failed");
                     last_error = Some(err);
                 }
             }
         }
     }
 
-    error!(
-        "All transcription providers failed after {} cycles. Last error: {:?}",
-        max_cycles, last_error
-    );
+    error!(cycles = max_cycles, "All transcription providers failed");
     Err(last_error.unwrap_or(ApiError::InternalServerError))
 }
 
@@ -3327,25 +3251,22 @@ async fn proxy_transcription(
         if let Some(billing_client) = &state.billing_client {
             match billing_client.is_user_paid(user.uuid).await {
                 Ok(true) => {
-                    debug!("Paid guest user allowed for transcription: {}", user.uuid);
+                    debug!("Paid guest request allowed");
                 }
                 Ok(false) => {
-                    error!(
-                        "Free guest user attempted to use transcription feature: {}",
-                        user.uuid
-                    );
+                    debug!(reason = "guest_requires_paid_plan", "Request rejected");
                     return Err(ApiError::Unauthorized);
                 }
                 Err(e) => {
-                    error!("Billing check failed for guest user {}: {}", user.uuid, e);
+                    warn!(
+                        error_kind = crate::observability::error_kind(&e),
+                        "Guest billing check failed"
+                    );
                     return Err(ApiError::Unauthorized);
                 }
             }
         } else {
-            error!(
-                "Guest user attempted to use transcription without billing client: {}",
-                user.uuid
-            );
+            warn!(reason = "billing_unavailable", "Guest request rejected");
             return Err(ApiError::Unauthorized);
         }
     }
@@ -3354,14 +3275,17 @@ async fn proxy_transcription(
     let file_bytes = general_purpose::STANDARD
         .decode(&transcription_request.file)
         .map_err(|e| {
-            error!("Failed to decode base64 audio file: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to decode base64 audio file"
+            );
             ApiError::BadRequest
         })?;
 
     // Validate file size (100MB limit as sanity check, CF already limits to 50MB)
     let file_size = file_bytes.len();
     if file_size == 0 {
-        error!("Audio file is empty");
+        debug!("Audio file is empty");
         return Err(ApiError::BadRequest);
     }
     if file_size > MAX_AUDIO_SIZE {
@@ -3371,7 +3295,7 @@ async fn proxy_transcription(
         );
         return Err(ApiError::BadRequest);
     }
-    info!("Audio file size: {} bytes", file_size);
+    debug!("Audio file size: {} bytes", file_size);
 
     // Check if we need to split the audio
     let splitter = AudioSplitter::new();
@@ -3384,12 +3308,12 @@ async fn proxy_transcription(
     // Always split the audio (returns single chunk if no splitting needed)
     let chunks = splitter
         .split_audio(&file_bytes, &transcription_request.content_type)
-        .map_err(|e| {
-            error!("Failed to split audio: {}", e);
+        .map_err(|_e| {
+            error!("Failed to split audio");
             ApiError::InternalServerError
         })?;
 
-    info!("Processing {} chunk(s)", chunks.len());
+    debug!("Processing {} chunk(s)", chunks.len());
 
     // Process chunks in parallel (even if it's just one)
     let mut futures = Vec::new();
@@ -3408,7 +3332,7 @@ async fn proxy_transcription(
 
         let future = async move {
             let chunk_size = chunk.data.len();
-            info!(
+            debug!(
                 "Processing chunk {} (size: {} bytes)",
                 chunk.index, chunk_size
             );
@@ -3417,7 +3341,7 @@ async fn proxy_transcription(
             let mut fallback_provider = Some(default_proxy.clone());
 
             if chunk_size > TINFOIL_MAX_SIZE && primary_provider.provider_name == "tinfoil" {
-                info!(
+                debug!(
                     "Chunk {} size {} bytes exceeds Tinfoil's 0.5MB limit, using fallback only",
                     chunk.index, chunk_size
                 );
@@ -3453,11 +3377,15 @@ async fn proxy_transcription(
             .await
             {
                 Ok(response) => {
-                    info!("Chunk {} transcribed successfully", chunk.index);
+                    debug!("Chunk {} transcribed successfully", chunk.index);
                     Ok((chunk.index, response))
                 }
                 Err(err) => {
-                    error!("Chunk {} failed: {}", chunk.index, err);
+                    error!(
+                        chunk_index = chunk.index,
+                        error_kind = crate::observability::error_kind(&err),
+                        "Transcription chunk failed"
+                    );
                     Err(err)
                 }
             }
@@ -3475,7 +3403,10 @@ async fn proxy_transcription(
         match result {
             Ok(r) => successful_results.push(r),
             Err(e) => {
-                error!("Chunk processing failed: {}", e);
+                error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Chunk processing failed"
+                );
                 return Err(e);
             }
         }
@@ -3497,8 +3428,8 @@ async fn proxy_transcription(
             })?
     } else {
         // Multiple chunks - merge the results
-        let merged = merge_transcriptions(successful_results).map_err(|e| {
-            error!("Failed to merge transcriptions: {}", e);
+        let merged = merge_transcriptions(successful_results).map_err(|_e| {
+            error!("Failed to merge transcriptions");
             ApiError::InternalServerError
         })?;
 
@@ -3625,13 +3556,16 @@ async fn send_transcription_request(
     {
         Ok(res) => {
             if res.is_success() {
-                let body_bytes = res.bytes().await.map_err(|e| {
-                    error!("Failed to read transcription response body: {:?}", e);
+                let body_bytes = res.bytes().await.map_err(|_e| {
+                    error!("Failed to read transcription response body");
                     ApiError::InternalServerError
                 })?;
 
                 let response_json: Value = serde_json::from_slice(&body_bytes).map_err(|e| {
-                    error!("Failed to parse transcription response: {:?}", e);
+                    error!(
+                        error_kind = crate::observability::error_kind(&e),
+                        "Failed to parse transcription response"
+                    );
                     ApiError::InternalServerError
                 })?;
 
@@ -3646,10 +3580,7 @@ async fn send_transcription_request(
             }
         }
         Err(e) => {
-            error!(
-                "Failed to send transcription request to {}: {:?}",
-                provider.provider_name, e
-            );
+            error!(provider = %provider.provider_name, error_kind = crate::observability::error_kind(&e), "Failed to send transcription request");
             Err(ApiError::from(e))
         }
     }
@@ -3681,15 +3612,11 @@ async fn ensure_paid_tts_access(state: &AppState, user: &User) -> Result<(), Api
             Ok(Ok(true)) => TTSBillingAccess::Allowed,
             Ok(Ok(false)) => TTSBillingAccess::FreeOrExhausted,
             Ok(Err(_)) => {
-                warn!(
-                    user_uuid = %user.uuid,
-                    "TTS billing entitlement check failed"
-                );
+                warn!("TTS billing entitlement check failed");
                 TTSBillingAccess::Unavailable
             }
             Err(_) => {
                 warn!(
-                    user_uuid = %user.uuid,
                     timeout_seconds = TTS_BILLING_CHECK_TIMEOUT.as_secs(),
                     "TTS billing entitlement check timed out"
                 );
@@ -3697,17 +3624,14 @@ async fn ensure_paid_tts_access(state: &AppState, user: &User) -> Result<(), Api
             }
         }
     } else {
-        warn!(
-            user_uuid = %user.uuid,
-            "TTS requested while the billing client is unavailable"
-        );
+        warn!("TTS requested while the billing client is unavailable");
         TTSBillingAccess::Unavailable
     };
 
     let result = tts_billing_access_decision(access);
     if result.is_err() {
-        warn!(
-            user_uuid = %user.uuid,
+        debug!(
+
             access = ?access,
             "Denied paid TTS access"
         );
@@ -3723,10 +3647,7 @@ async fn proxy_tts(
     Decrypted(tts_request): Decrypted<TTSRequest>,
 ) -> Result<Response, ApiError> {
     let prepared = prepare_tts_request(tts_request).map_err(|validation_error| {
-        warn!(
-            error = %validation_error,
-            "Rejected invalid TTS request"
-        );
+        debug!(reason = ?validation_error, "Rejected invalid TTS request");
         match validation_error {
             TTSRequestValidationError::InputTooLong => ApiError::PayloadTooLarge,
             _ => ApiError::BadRequest,
@@ -3736,7 +3657,10 @@ async fn proxy_tts(
 
     let proxy_config = state.proxy_router.get_tinfoil_proxy();
     let request_body = serde_json::to_vec(&prepared.provider_payload).map_err(|e| {
-        error!("Failed to serialize TTS request: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to serialize TTS request"
+        );
         ApiError::InternalServerError
     })?;
 
@@ -3751,7 +3675,10 @@ async fn proxy_tts(
             )
             .await
             .map_err(|e| {
-                error!("Failed to create TTS request: {:?}", e);
+                error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Failed to create TTS request"
+                );
                 ApiError::from(e)
             })?;
 
@@ -3768,8 +3695,8 @@ async fn proxy_tts(
             .content_type()
             .unwrap_or("application/octet-stream")
             .to_string();
-        let body_bytes = res.bytes().await.map_err(|e| {
-            error!("Failed to read TTS response body: {:?}", e);
+        let body_bytes = res.bytes().await.map_err(|_e| {
+            error!("Failed to read TTS response body");
             ApiError::InternalServerError
         })?;
         Ok((body_bytes, content_type))
@@ -3788,15 +3715,15 @@ async fn proxy_tts(
     if is_json_response {
         warn!(
             model = %prepared.model,
-            voice = %prepared.voice_for_log,
+            voice_is_default = (prepared.voice_for_log == DEFAULT_VOXTRAL_TTS_VOICE),
             response_bytes = body_bytes.len(),
             "TTS provider returned a successful JSON response"
         );
     } else {
-        info!(
+        debug!(
             model = %prepared.model,
-            voice = %prepared.voice_for_log,
-            content_type = %response_content_type,
+            voice_is_default = (prepared.voice_for_log == DEFAULT_VOXTRAL_TTS_VOICE),
+            content_type_is_audio = response_content_type.starts_with("audio/"),
             audio_bytes = body_bytes.len(),
             "TTS synthesis succeeded"
         );
@@ -3829,25 +3756,22 @@ async fn proxy_embeddings(
         if let Some(billing_client) = &state.billing_client {
             match billing_client.is_user_paid(user.uuid).await {
                 Ok(true) => {
-                    debug!("Paid guest user allowed for embeddings: {}", user.uuid);
+                    debug!("Paid guest request allowed");
                 }
                 Ok(false) => {
-                    error!(
-                        "Free guest user attempted to use embeddings feature: {}",
-                        user.uuid
-                    );
+                    debug!(reason = "guest_requires_paid_plan", "Request rejected");
                     return Err(ApiError::Unauthorized);
                 }
                 Err(e) => {
-                    error!("Billing check failed for guest user {}: {}", user.uuid, e);
+                    warn!(
+                        error_kind = crate::observability::error_kind(&e),
+                        "Guest billing check failed"
+                    );
                     return Err(ApiError::Unauthorized);
                 }
             }
         } else {
-            error!(
-                "Guest user attempted to use embeddings without billing client: {}",
-                user.uuid
-            );
+            warn!(reason = "billing_unavailable", "Guest request rejected");
             return Err(ApiError::Unauthorized);
         }
     }
@@ -3859,7 +3783,7 @@ async fn proxy_embeddings(
         _ => true,
     };
     if is_empty {
-        error!("Input is empty or invalid");
+        debug!("Input is empty or invalid");
         return Err(ApiError::BadRequest);
     }
 
@@ -3867,7 +3791,10 @@ async fn proxy_embeddings(
 
     // Build request body
     let request_body = serde_json::to_string(&embedding_request).map_err(|e| {
-        error!("Failed to serialize embedding request: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to serialize embedding request"
+        );
         ApiError::InternalServerError
     })?;
 
@@ -3885,7 +3812,10 @@ async fn proxy_embeddings(
         )
         .await
         .map_err(|e| {
-            error!("Failed to send embeddings request: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to send embeddings request"
+            );
             ApiError::from(e)
         })?;
 
@@ -3899,13 +3829,16 @@ async fn proxy_embeddings(
     }
 
     // Parse response
-    let body_bytes = res.bytes().await.map_err(|e| {
-        error!("Failed to read embeddings response body: {:?}", e);
+    let body_bytes = res.bytes().await.map_err(|_e| {
+        error!("Failed to read embeddings response body");
         ApiError::InternalServerError
     })?;
 
     let response_json: Value = serde_json::from_slice(&body_bytes).map_err(|e| {
-        error!("Failed to parse embeddings response: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to parse embeddings response"
+        );
         ApiError::InternalServerError
     })?;
 
@@ -4018,10 +3951,7 @@ async fn try_provider(
             }
         }
         Err(e) => {
-            error!(
-                "Failed to send request to {}: {:?}",
-                proxy_config.provider_name, e
-            );
+            error!(provider = %proxy_config.provider_name, error_kind = crate::observability::error_kind(&e), "Failed to send provider request");
             Err(e)
         }
     };

--- a/src/web/openai_auth.rs
+++ b/src/web/openai_auth.rs
@@ -79,7 +79,10 @@ pub async fn validate_openai_auth(
                         return ApiError::Unauthorized.into_response();
                     }
                     Err(e) => {
-                        tracing::error!("Database error during API key lookup: {:?}", e);
+                        tracing::error!(
+                            error_kind = crate::observability::error_kind(&e),
+                            "Database error during API key lookup"
+                        );
                         return ApiError::InternalServerError.into_response();
                     }
                 }
@@ -113,7 +116,10 @@ pub async fn validate_openai_auth(
     let user_uuid: Uuid = match Uuid::parse_str(&claims.sub) {
         Ok(uuid) => uuid,
         Err(e) => {
-            tracing::error!("Error parsing user uuid: {:?}", e);
+            tracing::error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Error parsing user uuid"
+            );
             return ApiError::InvalidJwt.into_response();
         }
     };
@@ -121,7 +127,10 @@ pub async fn validate_openai_auth(
     let user = match data.get_user(user_uuid).await {
         Ok(user) => user,
         Err(e) => {
-            tracing::error!("Error getting user: {:?}", e);
+            tracing::error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Error getting user"
+            );
             return ApiError::InternalServerError.into_response();
         }
     };
@@ -133,8 +142,8 @@ pub async fn validate_openai_auth(
 
     if let Err(e) = data.verify_seed_wrap_for_auth_context(&user, &auth_context) {
         tracing::error!(
-            "OpenAI JWT auth context no longer unwraps an active seed wrap: {:?}",
-            e
+            error_kind = crate::observability::error_kind(&e),
+            "OpenAI JWT auth context no longer unwraps an active seed wrap"
         );
         return ApiError::InvalidJwt.into_response();
     }

--- a/src/web/platform/invite_routes.rs
+++ b/src/web/platform/invite_routes.rs
@@ -17,6 +17,7 @@ use axum::{
 };
 use std::sync::Arc;
 use tokio::spawn;
+use tracing::Instrument;
 use tracing::{debug, error};
 use uuid::Uuid;
 
@@ -92,7 +93,10 @@ async fn create_invite(
     );
 
     let invite = data.db.create_invite_code(new_invite).map_err(|e| {
-        error!("Failed to create invite code: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to create invite code"
+        );
         ApiError::InternalServerError
     })?;
 
@@ -102,20 +106,26 @@ async fn create_invite(
     let app_mode = data.app_mode.clone();
     let resend_api_key = data.resend_api_key.clone();
     let org_uuid = org.uuid;
-    spawn(async move {
-        if let Err(e) = send_platform_invite_email(
-            app_mode,
-            resend_api_key,
-            email,
-            org.name,
-            invite_code,
-            org_uuid,
-        )
-        .await
-        {
-            error!("Failed to send invite email: {:?}", e);
+    spawn(
+        async move {
+            if let Err(e) = send_platform_invite_email(
+                app_mode,
+                resend_api_key,
+                email,
+                org.name,
+                invite_code,
+                org_uuid,
+            )
+            .await
+            {
+                error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Failed to send invite email"
+                );
+            }
         }
-    });
+        .in_current_span(),
+    );
 
     let response = InviteResponse {
         code: invite.code,
@@ -157,7 +167,10 @@ async fn list_invites(
 
     // Get all invite codes for the org
     let all_invites = data.db.get_all_invite_codes_for_org(org.id).map_err(|e| {
-        error!("Failed to get invite codes: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to get invite codes"
+        );
         ApiError::InternalServerError
     })?;
 
@@ -200,7 +213,10 @@ async fn get_invite(
 
     // Get invite by code
     let invite = data.db.get_invite_code_by_code(invite_code).map_err(|e| {
-        error!("Failed to get invite code: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to get invite code"
+        );
         match e {
             DBError::InviteCodeNotFound => ApiError::NotFound,
             _ => ApiError::InternalServerError,
@@ -271,7 +287,10 @@ async fn delete_invite(
 
     // Get invite by code
     let invite = data.db.get_invite_code_by_code(invite_code).map_err(|e| {
-        error!("Failed to get invite code: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to get invite code"
+        );
         match e {
             DBError::InviteCodeNotFound => ApiError::NotFound,
             _ => ApiError::InternalServerError,
@@ -285,7 +304,10 @@ async fn delete_invite(
 
     // Delete the invite
     data.db.delete_invite_code(&invite).map_err(|e| {
-        error!("Failed to delete invite code: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to delete invite code"
+        );
         ApiError::InternalServerError
     })?;
 
@@ -331,7 +353,10 @@ async fn accept_invite(
     data.db
         .accept_invite_transaction(&invite, new_membership)
         .map_err(|e| {
-            error!("Failed to accept invite: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to accept invite"
+            );
             match e {
                 DBError::InviteCodeError(InviteCodeError::AlreadyUsed) => ApiError::BadRequest,
                 DBError::InviteCodeError(InviteCodeError::Expired) => ApiError::BadRequest,

--- a/src/web/platform/login_routes.rs
+++ b/src/web/platform/login_routes.rs
@@ -23,7 +23,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::sync::Arc;
 use tokio::spawn;
-use tracing::{error, info};
+use tracing::Instrument;
+use tracing::{debug, error};
 use uuid::Uuid;
 use validator::Validate;
 
@@ -230,7 +231,10 @@ pub async fn login_platform_user(
 ) -> Result<Response, ApiError> {
     // Validate request
     if login_request.validate().is_err() {
-        error!("Platform login request validation failed");
+        debug!(
+            reason = "invalid_login_request",
+            "Authentication request rejected"
+        );
         return Err(ApiError::BadRequest);
     }
 
@@ -273,11 +277,17 @@ async fn login_internal_platform(
             Ok(auth_response)
         }
         Ok(None) => {
-            error!("Invalid login attempt for platform user");
+            debug!(
+                reason = "invalid_credentials",
+                "Authentication request rejected"
+            );
             Err(ApiError::InvalidUsernameOrPassword)
         }
         Err(e) => {
-            error!("Error authenticating platform user: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Error authenticating platform user"
+            );
             Err(ApiError::InternalServerError)
         }
     }
@@ -290,7 +300,10 @@ pub async fn register_platform_user(
 ) -> Result<Response, ApiError> {
     // Validate request
     if register_request.validate().is_err() {
-        error!("Platform registration request validation failed");
+        debug!(
+            reason = "invalid_registration_request",
+            "Authentication request rejected"
+        );
         return Err(ApiError::BadRequest);
     }
 
@@ -307,14 +320,22 @@ pub async fn register_platform_user(
     let invite_code = match Uuid::parse_str(&register_request.invite_code) {
         Ok(code) => code,
         Err(e) => {
-            error!("Invalid invite code format: {:?}", e);
+            debug!(
+                reason = "invalid_invite_format",
+                error_kind = crate::observability::error_kind(&e),
+                "Registration request rejected"
+            );
             return Err(ApiError::BadRequest);
         }
     };
 
     // Check if invite code is valid
     if let Err(e) = data.db.validate_platform_invite_code(invite_code) {
-        error!("Invalid invite code: {:?}", e);
+        debug!(
+            reason = "invalid_invite",
+            error_kind = crate::observability::error_kind(&e),
+            "Registration request rejected"
+        );
         return Err(ApiError::BadRequest);
     }
 
@@ -334,7 +355,10 @@ pub async fn register_platform_user(
         .db
         .create_platform_user(new_platform_user)
         .map_err(|e| {
-            error!("Failed to create platform user: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to create platform user"
+            );
             ApiError::InternalServerError
         })?;
 
@@ -342,14 +366,20 @@ pub async fn register_platform_user(
     let new_verification = match NewPlatformEmailVerification::new(platform_user.uuid, 24, false) {
         Ok(v) => v,
         Err(e) => {
-            error!("Error creating platform email verification: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Error creating platform email verification"
+            );
             return Err(ApiError::InternalServerError);
         }
     };
     let verification = match data.db.create_platform_email_verification(new_verification) {
         Ok(v) => v,
         Err(e) => {
-            error!("Error creating platform email verification: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Error creating platform email verification"
+            );
             return Err(ApiError::InternalServerError);
         }
     };
@@ -359,18 +389,24 @@ pub async fn register_platform_user(
     let verification_code = verification.verification_code;
     let app_state = data.clone();
 
-    spawn(async move {
-        if let Err(e) = send_platform_verification_email(
-            &app_state,
-            app_state.resend_api_key.clone(),
-            email,
-            verification_code,
-        )
-        .await
-        {
-            error!("Could not send verification email: {}", e);
+    spawn(
+        async move {
+            if let Err(e) = send_platform_verification_email(
+                &app_state,
+                app_state.resend_api_key.clone(),
+                email,
+                verification_code,
+            )
+            .await
+            {
+                error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Could not send verification email"
+                );
+            }
         }
-    });
+        .in_current_span(),
+    );
 
     // Generate tokens
     let access_token = NewToken::new_for_platform_user(
@@ -403,7 +439,10 @@ pub async fn refresh_platform_token(
 ) -> Result<Response, ApiError> {
     // Validate request
     if refresh_request.validate().is_err() {
-        error!("Platform token refresh request validation failed");
+        debug!(
+            reason = "invalid_refresh_request",
+            "Authentication request rejected"
+        );
         return Err(ApiError::BadRequest);
     }
 
@@ -449,11 +488,17 @@ pub async fn verify_platform_email(
     let verification = match data.db.get_platform_email_verification_by_code(code) {
         Ok(verification) => verification,
         Err(crate::db::DBError::PlatformEmailVerificationNotFound) => {
-            error!("Platform email verification code not found: {}", code);
+            debug!(
+                reason = "unknown_verification",
+                "Email verification rejected"
+            );
             return Err(ApiError::BadRequest);
         }
         Err(e) => {
-            error!("Error retrieving platform email verification: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Error retrieving platform email verification"
+            );
             return Err(ApiError::InternalServerError);
         }
     };
@@ -468,9 +513,9 @@ pub async fn verify_platform_email(
 
     // Check if verification is expired
     if verification.expires_at < Utc::now() {
-        error!(
-            "verification is expired for user: {}",
-            verification.platform_user_id
+        debug!(
+            reason = "expired_verification",
+            "Email verification rejected"
         );
         return Err(ApiError::BadRequest);
     }
@@ -478,7 +523,10 @@ pub async fn verify_platform_email(
     // Mark the verification as verified
     let mut verification_to_update = verification.clone();
     if let Err(e) = data.db.verify_platform_email(&mut verification_to_update) {
-        error!("Error verifying platform email: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Error verifying platform email"
+        );
         return Err(ApiError::InternalServerError);
     }
 
@@ -495,7 +543,7 @@ pub async fn logout_platform_user(
     Decrypted(logout_request): Decrypted<PlatformLogoutRequest>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
-    info!("Platform logout request received");
+    debug!("Platform logout request received");
 
     // TODO: Implement token invalidation logic here when needed
     drop(logout_request.refresh_token);
@@ -511,7 +559,10 @@ pub async fn platform_password_reset_request(
 ) -> Result<Response, ApiError> {
     // Validate request
     if payload.validate().is_err() {
-        error!("Platform password reset request validation failed");
+        debug!(
+            reason = "invalid_password_reset_request",
+            "Authentication request rejected"
+        );
         return Err(ApiError::BadRequest);
     }
 
@@ -519,7 +570,10 @@ pub async fn platform_password_reset_request(
     match data.db.get_platform_user_by_email(&payload.email) {
         Ok(Some(user)) => {
             if user.password_enc.is_none() {
-                error!("OAuth-only platform user attempted to reset password");
+                debug!(
+                    reason = "password_reset_not_available",
+                    "Authentication request rejected"
+                );
                 // Still return success to not leak information about the account
                 let response = json!({
                     "message": "If an account with that email exists, we have sent a password reset link."
@@ -535,7 +589,10 @@ pub async fn platform_password_reset_request(
             return encrypt_response(&data, &session_id, &response).await;
         }
         Err(e) => {
-            error!("Error in platform password reset request: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Error in platform password reset request"
+            );
             return Err(ApiError::InternalServerError);
         }
     }
@@ -545,7 +602,10 @@ pub async fn platform_password_reset_request(
         .create_platform_password_reset_request(payload.email.clone(), payload.hashed_secret)
         .await
         .map_err(|e| {
-            error!("Error in create_platform_password_reset_request: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Error in create_platform_password_reset_request"
+            );
             // We don't expose this error to the user
         });
 
@@ -563,7 +623,10 @@ pub async fn platform_password_reset_confirm(
 ) -> Result<Response, ApiError> {
     // Validate request
     if payload.validate().is_err() {
-        error!("Platform password reset confirmation validation failed");
+        debug!(
+            reason = "invalid_password_reset_confirmation",
+            "Authentication request rejected"
+        );
         return Err(ApiError::BadRequest);
     }
 
@@ -571,16 +634,22 @@ pub async fn platform_password_reset_confirm(
     match data.db.get_platform_user_by_email(&payload.email) {
         Ok(Some(user)) => {
             if user.password_enc.is_none() {
-                error!("OAuth-only platform user attempted to reset password");
+                debug!(
+                    reason = "password_reset_not_available",
+                    "Authentication request rejected"
+                );
                 return Err(ApiError::InvalidUsernameOrPassword);
             }
         }
         Ok(None) => {
-            error!("Platform user not found in password reset confirm");
+            debug!(reason = "unknown_login", "Authentication request rejected");
             return Err(ApiError::InvalidUsernameOrPassword);
         }
         Err(e) => {
-            error!("Error in platform password reset confirm: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Error in platform password reset confirm"
+            );
             return Err(ApiError::InternalServerError);
         }
     }

--- a/src/web/platform/me_routes.rs
+++ b/src/web/platform/me_routes.rs
@@ -17,6 +17,7 @@ use serde_json::json;
 use std::sync::Arc;
 use tokio::spawn;
 use tracing::error;
+use tracing::Instrument;
 use validator::Validate;
 
 use super::common::{MeResponse, OrgResponse, PlatformUserResponse};
@@ -73,7 +74,10 @@ async fn get_platform_user(
         Ok(verification) => verification.is_verified,
         Err(crate::db::DBError::PlatformEmailVerificationNotFound) => false,
         Err(e) => {
-            error!("Error fetching platform email verification: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Error fetching platform email verification"
+            );
             return Err(ApiError::InternalServerError);
         }
     };
@@ -85,7 +89,10 @@ async fn get_platform_user(
     {
         Ok(memberships) => memberships,
         Err(e) => {
-            error!("Error fetching organization memberships: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Error fetching organization memberships"
+            );
             return Err(ApiError::InternalServerError);
         }
     };
@@ -103,7 +110,11 @@ async fn get_platform_user(
                     name: org.name,
                 }),
                 Err(e) => {
-                    error!("Error fetching organization {}: {:?}", org_id, e);
+                    error!(
+                        org_id,
+                        error_kind = crate::observability::error_kind(&e),
+                        "Error fetching organization"
+                    );
                     None // Skip this organization but continue processing others
                 }
             }
@@ -144,7 +155,10 @@ async fn request_platform_verification(
             }
             // Delete the old verification
             if let Err(e) = data.db.delete_platform_email_verification(&verification) {
-                error!("Error deleting old platform verification: {:?}", e);
+                error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Error deleting old platform verification"
+                );
                 return Err(ApiError::InternalServerError);
             }
         }
@@ -152,7 +166,10 @@ async fn request_platform_verification(
             // This is fine, we'll create a new verification
         }
         Err(e) => {
-            error!("Error checking platform email verification: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Error checking platform email verification"
+            );
             return Err(ApiError::InternalServerError);
         }
     }
@@ -162,14 +179,20 @@ async fn request_platform_verification(
         // 24 hours expiration
         Ok(v) => v,
         Err(e) => {
-            error!("Error creating platform email verification: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Error creating platform email verification"
+            );
             return Err(ApiError::InternalServerError);
         }
     };
     let verification = match data.db.create_platform_email_verification(new_verification) {
         Ok(v) => v,
         Err(e) => {
-            error!("Error creating platform email verification: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Error creating platform email verification"
+            );
             return Err(ApiError::InternalServerError);
         }
     };
@@ -179,18 +202,24 @@ async fn request_platform_verification(
     let verification_code = verification.verification_code;
     let app_state = data.clone();
 
-    spawn(async move {
-        if let Err(e) = send_platform_verification_email(
-            &app_state,
-            app_state.resend_api_key.clone(),
-            email,
-            verification_code,
-        )
-        .await
-        {
-            error!("Could not send platform verification email: {}", e);
+    spawn(
+        async move {
+            if let Err(e) = send_platform_verification_email(
+                &app_state,
+                app_state.resend_api_key.clone(),
+                email,
+                verification_code,
+            )
+            .await
+            {
+                error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Could not send platform verification email"
+                );
+            }
         }
-    });
+        .in_current_span(),
+    );
 
     let response = json!({ "message": "New verification code sent successfully" });
     encrypt_response(&data, &session_id, &response).await
@@ -230,7 +259,10 @@ pub async fn platform_change_password(
                     encrypt_response(&data, &session_id, &response).await
                 }
                 Err(e) => {
-                    error!("Error changing platform user password: {:?}", e);
+                    error!(
+                        error_kind = crate::observability::error_kind(&e),
+                        "Error changing platform user password"
+                    );
                     Err(ApiError::InternalServerError)
                 }
             }

--- a/src/web/platform/membership_routes.rs
+++ b/src/web/platform/membership_routes.rs
@@ -119,8 +119,10 @@ async fn update_membership(
         Ok(m) => m,
         Err(e) => {
             error!(
-                "Current user {} not in org {} - Error: {:?}",
-                platform_user.uuid, org_id, e
+                user_id = %platform_user.uuid,
+                %org_id,
+                error_kind = crate::observability::error_kind(&e),
+                "Current user membership lookup failed"
             );
             return Err(ApiError::Unauthorized);
         }
@@ -143,8 +145,10 @@ async fn update_membership(
         Ok(m) => m,
         Err(e) => {
             error!(
-                "Target user {} not found in org {} - Error: {:?}",
-                user_id, org_id, e
+                %user_id,
+                %org_id,
+                error_kind = crate::observability::error_kind(&e),
+                "Target user membership lookup failed"
             );
             return Err(ApiError::NotFound);
         }
@@ -167,8 +171,12 @@ async fn update_membership(
             }
             _ => {
                 error!(
-                    "Failed to update membership for user {} from '{}' to '{:?}': {:?}",
-                    user_id, target_membership.role, update_request.role, e
+                    %user_id,
+                    %org_id,
+                    previous_role = %target_membership.role,
+                    requested_role = ?update_request.role,
+                    error_kind = crate::observability::error_kind(&e),
+                    "Failed to update membership"
                 );
                 ApiError::InternalServerError
             }

--- a/src/web/platform/membership_routes.rs
+++ b/src/web/platform/membership_routes.rs
@@ -66,7 +66,10 @@ async fn list_memberships(
         .db
         .get_all_org_memberships_with_users_for_org(org.id)
         .map_err(|e| {
-            error!("Failed to get memberships with users: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to get memberships with users"
+            );
             ApiError::InternalServerError
         })?;
 
@@ -99,7 +102,11 @@ async fn update_membership(
     let org = match data.db.get_org_by_uuid(org_id) {
         Ok(org) => org,
         Err(e) => {
-            error!("Organization not found: {} - Error: {:?}", org_id, e);
+            error!(
+                %org_id,
+                error_kind = crate::observability::error_kind(&e),
+                "Organization lookup failed"
+            );
             return Err(ApiError::NotFound);
         }
     };
@@ -172,7 +179,10 @@ async fn update_membership(
         .db
         .get_org_membership_by_platform_user_and_org_with_user(user_id, org.id)
         .map_err(|e| {
-            error!("Failed to get membership with user after update: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to get membership with user after update"
+            );
             ApiError::InternalServerError
         })?;
 
@@ -232,7 +242,10 @@ async fn delete_membership(
                 ApiError::BadRequest
             }
             _ => {
-                error!("Failed to delete membership: {:?}", e);
+                error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Failed to delete membership"
+                );
                 ApiError::InternalServerError
             }
         })?;

--- a/src/web/platform/org_routes.rs
+++ b/src/web/platform/org_routes.rs
@@ -104,8 +104,9 @@ async fn list_orgs(
             }
             Err(e) => {
                 error!(
-                    "Failed to get org details for org_id {}: {:?}",
-                    membership.org_id, e
+                    org_id = membership.org_id,
+                    error_kind = crate::observability::error_kind(&e),
+                    "Failed to get organization details"
                 );
                 // Continue with the next membership
             }

--- a/src/web/platform/org_routes.rs
+++ b/src/web/platform/org_routes.rs
@@ -58,7 +58,10 @@ async fn create_org(
         .db
         .create_org_with_owner(new_org, platform_user.uuid)
         .map_err(|e| {
-            error!("Failed to create organization with owner: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to create organization with owner"
+            );
             ApiError::InternalServerError
         })?;
 
@@ -82,7 +85,10 @@ async fn list_orgs(
         .db
         .get_all_org_memberships_for_platform_user(platform_user.uuid)
         .map_err(|e| {
-            error!("Failed to get org memberships: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to get org memberships"
+            );
             ApiError::InternalServerError
         })?;
 
@@ -136,7 +142,10 @@ async fn delete_org(
 
     // Delete the org
     data.db.delete_org(&org).map_err(|e| {
-        error!("Failed to delete organization: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to delete organization"
+        );
         ApiError::InternalServerError
     })?;
 

--- a/src/web/platform/project_routes.rs
+++ b/src/web/platform/project_routes.rs
@@ -141,7 +141,10 @@ async fn create_project(
         .db
         .get_org_project_by_name_and_org(&create_request.name, org.id)
         .map_err(|e| {
-            error!("Failed to check for existing project: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to check for existing project"
+            );
             ApiError::InternalServerError
         })?
         .is_some()
@@ -162,7 +165,10 @@ async fn create_project(
     );
 
     let project = data.db.create_org_project(new_project).map_err(|e| {
-        error!("Failed to create project: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to create project"
+        );
         ApiError::InternalServerError
     })?;
 
@@ -200,7 +206,10 @@ async fn list_projects(
 
     // Get all projects
     let projects = data.db.get_all_org_projects_for_org(org.id).map_err(|e| {
-        error!("Failed to get projects: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to get projects"
+        );
         ApiError::InternalServerError
     })?;
 
@@ -264,7 +273,10 @@ async fn update_project(
                 .db
                 .get_org_project_by_name_and_org(&name, org.id)
                 .map_err(|e| {
-                    error!("Failed to check for existing project: {:?}", e);
+                    error!(
+                        error_kind = crate::observability::error_kind(&e),
+                        "Failed to check for existing project"
+                    );
                     ApiError::InternalServerError
                 })?
                 .is_some()
@@ -286,7 +298,10 @@ async fn update_project(
     }
 
     data.db.update_org_project(&updated_project).map_err(|e| {
-        error!("Failed to update project: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to update project"
+        );
         ApiError::InternalServerError
     })?;
 
@@ -383,7 +398,10 @@ async fn delete_project(
 
     // Delete the project
     data.db.delete_org_project(&project).map_err(|e| {
-        error!("Failed to delete project: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to delete project"
+        );
         ApiError::InternalServerError
     })?;
 
@@ -441,13 +459,19 @@ async fn create_secret(
     let secret_bytes = general_purpose::STANDARD
         .decode(&create_request.secret)
         .map_err(|e| {
-            error!("Invalid base64 encoding: {}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Invalid base64 encoding"
+            );
             ApiError::BadRequest
         })?;
 
     // Encrypt the secret bytes with the enclave key
     let secret_key = SecretKey::from_slice(&data.enclave_key).map_err(|e| {
-        error!("Failed to create secret key: {}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to create secret key"
+        );
         ApiError::InternalServerError
     })?;
     let encrypted_secret = crate::encrypt::encrypt_with_key(&secret_key, &secret_bytes).await;
@@ -460,7 +484,10 @@ async fn create_secret(
     );
 
     let secret = data.db.create_org_project_secret(new_secret).map_err(|e| {
-        error!("Failed to create project secret: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to create project secret"
+        );
         ApiError::InternalServerError
     })?;
 
@@ -509,7 +536,10 @@ async fn list_secrets(
         .db
         .get_all_org_project_secrets_for_project(project.id)
         .map_err(|e| {
-            error!("Failed to get project secrets: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to get project secrets"
+            );
             ApiError::InternalServerError
         })?;
 
@@ -566,7 +596,10 @@ async fn delete_secret(
         .db
         .get_org_project_secret_by_key_name_and_project(&key_name, project.id)
         .map_err(|e| {
-            error!("Failed to get project secret: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to get project secret"
+            );
             ApiError::InternalServerError
         })?
         .ok_or_else(|| {
@@ -576,7 +609,10 @@ async fn delete_secret(
 
     // Delete the secret
     data.db.delete_org_project_secret(&secret).map_err(|e| {
-        error!("Failed to delete project secret: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to delete project secret"
+        );
         ApiError::InternalServerError
     })?;
 
@@ -687,7 +723,10 @@ async fn update_email_settings(
 
     // Get the updated settings from the database to return
     let updated_settings = settings.get_email_settings().map_err(|e| {
-        error!("Failed to parse updated email settings: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to parse updated email settings"
+        );
         ApiError::InternalServerError
     })?;
 
@@ -810,7 +849,10 @@ async fn update_oauth_settings(
 
     // Get the updated settings from the database to return
     let updated_settings = settings.get_oauth_settings().map_err(|e| {
-        error!("Failed to parse updated oauth settings: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to parse updated oauth settings"
+        );
         ApiError::InternalServerError
     })?;
 

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -165,9 +165,10 @@ pub fn validate_bip85_path(path: &str) -> Result<(), ApiError> {
     // Path must have exactly 6 segments: m/PURPOSE'/APP'/LANGUAGE'/WORDS'/INDEX'
     if segments.len() != 6 {
         error!(
-            "BIP-85 path must have exactly 6 segments, found {}: {}",
-            segments.len(),
-            path
+            stage = "bip85_path_validation",
+            error_kind = "segment_count",
+            segment_count = segments.len(),
+            "BIP-85 path must have exactly 6 segments"
         );
         return Err(ApiError::BadRequest);
     }
@@ -175,35 +176,39 @@ pub fn validate_bip85_path(path: &str) -> Result<(), ApiError> {
     // First segment should be "m" (master key)
     if segments[0] != "m" {
         error!(
-            "BIP-85 path must start with 'm', found '{}': {}",
-            segments[0], path
+            stage = "bip85_path_validation",
+            error_kind = "master_segment",
+            "BIP-85 path must start with 'm'"
         );
         return Err(ApiError::BadRequest);
     }
 
-    let purpose = parse_hardened_bip85_segment(segments[1], "purpose", path)?;
+    let purpose = parse_hardened_bip85_segment(segments[1], "purpose")?;
     if purpose != BIP85_PURPOSE {
         error!(
-            "BIP-85 path purpose must be {}' or {}h, found '{}': {}",
-            BIP85_PURPOSE, BIP85_PURPOSE, segments[1], path
+            stage = "bip85_path_validation",
+            error_kind = "purpose",
+            "BIP-85 path has an unsupported purpose"
         );
         return Err(ApiError::BadRequest);
     }
 
-    let application = parse_hardened_bip85_segment(segments[2], "application", path)?;
+    let application = parse_hardened_bip85_segment(segments[2], "application")?;
     if application != BIP85_APPLICATION_BIP39 {
         error!(
-            "BIP-85 path application must be {}' or {}h for BIP-39 mnemonics, found '{}': {}",
-            BIP85_APPLICATION_BIP39, BIP85_APPLICATION_BIP39, segments[2], path
+            stage = "bip85_path_validation",
+            error_kind = "application",
+            "BIP-85 path has an unsupported application"
         );
         return Err(ApiError::BadRequest);
     }
 
-    let language = parse_hardened_bip85_segment(segments[3], "language", path)?;
+    let language = parse_hardened_bip85_segment(segments[3], "language")?;
     if language != 0 {
         error!(
-            "BIP-85 path language must be 0' or 0h for English, found '{}': {}",
-            segments[3], path
+            stage = "bip85_path_validation",
+            error_kind = "language",
+            "BIP-85 path has an unsupported language"
         );
         return Err(ApiError::BadRequest);
     }
@@ -214,8 +219,9 @@ pub fn validate_bip85_path(path: &str) -> Result<(), ApiError> {
         Ok(value) => value,
         Err(_) => {
             error!(
-                "BIP-85 path word count must be a number, found '{}': {}",
-                word_count, path
+                stage = "bip85_path_validation",
+                error_kind = "word_count_number",
+                "BIP-85 path word count must be a number"
             );
             return Err(ApiError::BadRequest);
         }
@@ -224,8 +230,9 @@ pub fn validate_bip85_path(path: &str) -> Result<(), ApiError> {
     // Validate word count is one of the valid options
     if !VALID_BIP39_WORD_COUNTS.contains(&word_count_value) {
         error!(
-            "BIP-85 path word count must be one of {:?}, found {}: {}",
-            VALID_BIP39_WORD_COUNTS, word_count_value, path
+            stage = "bip85_path_validation",
+            error_kind = "word_count_range",
+            "BIP-85 path word count is unsupported"
         );
         return Err(ApiError::BadRequest);
     }
@@ -233,8 +240,9 @@ pub fn validate_bip85_path(path: &str) -> Result<(), ApiError> {
     // Check word count is hardened
     if !(word_count.ends_with('\'') || word_count.ends_with('h')) {
         error!(
-            "BIP-85 path word count must be hardened, found '{}': {}",
-            word_count, path
+            stage = "bip85_path_validation",
+            error_kind = "word_count_hardening",
+            "BIP-85 path word count must be hardened"
         );
         return Err(ApiError::BadRequest);
     }
@@ -243,8 +251,9 @@ pub fn validate_bip85_path(path: &str) -> Result<(), ApiError> {
     let index = segments[5];
     if !(index.ends_with('\'') || index.ends_with('h')) {
         error!(
-            "BIP-85 path index must be hardened, found '{}': {}",
-            index, path
+            stage = "bip85_path_validation",
+            error_kind = "index_hardening",
+            "BIP-85 path index must be hardened"
         );
         return Err(ApiError::BadRequest);
     }
@@ -254,8 +263,9 @@ pub fn validate_bip85_path(path: &str) -> Result<(), ApiError> {
         Ok(value) => value,
         Err(_) => {
             error!(
-                "BIP-85 path index must be a valid number, found '{}': {}",
-                index, path
+                stage = "bip85_path_validation",
+                error_kind = "index_number",
+                "BIP-85 path index must be a valid number"
             );
             return Err(ApiError::BadRequest);
         }
@@ -264,11 +274,13 @@ pub fn validate_bip85_path(path: &str) -> Result<(), ApiError> {
     Ok(())
 }
 
-fn parse_hardened_bip85_segment(segment: &str, name: &str, path: &str) -> Result<u32, ApiError> {
+fn parse_hardened_bip85_segment(segment: &str, name: &'static str) -> Result<u32, ApiError> {
     if !(segment.ends_with('\'') || segment.ends_with('h')) {
         error!(
-            "BIP-85 path {} must be hardened, found '{}': {}",
-            name, segment, path
+            stage = "bip85_path_validation",
+            error_kind = "segment_hardening",
+            segment = name,
+            "BIP-85 path segment must be hardened"
         );
         return Err(ApiError::BadRequest);
     }
@@ -278,8 +290,10 @@ fn parse_hardened_bip85_segment(segment: &str, name: &str, path: &str) -> Result
         .parse::<u32>()
         .map_err(|_| {
             error!(
-                "BIP-85 path {} must be a valid number, found '{}': {}",
-                name, segment, path
+                stage = "bip85_path_validation",
+                error_kind = "segment_number",
+                segment = name,
+                "BIP-85 path segment must be a valid number"
             );
             ApiError::BadRequest
         })
@@ -309,8 +323,12 @@ fn validate_path(path: &str) -> Result<(), ApiError> {
     }
 
     // For non-empty paths, validate using bitcoin library's DerivationPath
-    DerivationPath::from_str(path).map_err(|e| {
-        error!("Invalid derivation path format: {}", e);
+    DerivationPath::from_str(path).map_err(|_| {
+        error!(
+            stage = "bip32_path_validation",
+            error_kind = "invalid_path",
+            "Invalid derivation path format"
+        );
         ApiError::BadRequest
     })?;
 
@@ -568,7 +586,11 @@ pub async fn user_protected(
             Ok(verification) => verification.is_verified,
             Err(DBError::EmailVerificationNotFound) => false,
             Err(e) => {
-                tracing::error!("Error checking email verification: {:?}", e);
+                tracing::error!(
+                    stage = "user_protected",
+                    error_kind = crate::observability::error_kind(&e),
+                    "Error checking email verification"
+                );
                 return Err(ApiError::InternalServerError);
             }
         }
@@ -590,7 +612,11 @@ pub async fn user_protected(
                                 "apple" => LoginMethod::Apple,
                                 // Add other providers here as they're supported
                                 _ => {
-                                    tracing::error!("Unknown OAuth provider: {}", provider.name);
+                                    tracing::error!(
+                                        stage = "user_protected",
+                                        error_kind = "unknown_oauth_provider",
+                                        "Unknown OAuth provider"
+                                    );
                                     return Err(ApiError::InternalServerError);
                                 }
                             };
@@ -603,14 +629,22 @@ pub async fn user_protected(
                             return Err(ApiError::InternalServerError);
                         }
                         Err(e) => {
-                            tracing::error!("Error fetching OAuth provider: {:?}", e);
+                            tracing::error!(
+                                stage = "user_protected",
+                                error_kind = crate::observability::error_kind(&e),
+                                "Error fetching OAuth provider"
+                            );
                             return Err(ApiError::InternalServerError);
                         }
                     }
                 }
             }
             Err(e) => {
-                tracing::error!("Error fetching OAuth connections: {:?}", e);
+                tracing::error!(
+                    stage = "user_protected",
+                    error_kind = crate::observability::error_kind(&e),
+                    "Error fetching OAuth connections"
+                );
                 return Err(ApiError::InternalServerError);
             }
         }
@@ -630,7 +664,11 @@ pub async fn get_kv(
     let value = match data.get(&user, &auth_context, key).await {
         Ok(kv) => kv,
         Err(e) => {
-            tracing::error!("Error getting key-value pair: {:?}", e);
+            tracing::error!(
+                stage = "get_kv",
+                error_kind = crate::observability::error_kind(&e),
+                "Error getting key-value pair"
+            );
             return Err(ApiError::InternalServerError);
         }
     };
@@ -648,7 +686,11 @@ pub async fn put_kv(
     match data.put(&user, &auth_context, key, value.clone()).await {
         Ok(kv) => kv,
         Err(e) => {
-            tracing::error!("Error putting key-value pair: {:?}", e);
+            tracing::error!(
+                stage = "put_kv",
+                error_kind = crate::observability::error_kind(&e),
+                "Error putting key-value pair"
+            );
             return Err(ApiError::InternalServerError);
         }
     };
@@ -668,7 +710,11 @@ pub async fn delete_kv(
             encrypt_response(&data, &session_id, &response).await
         }
         Err(e) => {
-            tracing::error!("Error deleting key-value pair: {:?}", e);
+            tracing::error!(
+                stage = "delete_kv",
+                error_kind = crate::observability::error_kind(&e),
+                "Error deleting key-value pair"
+            );
             Err(ApiError::InternalServerError)
         }
     }
@@ -687,7 +733,11 @@ pub async fn delete_all_kv(
             encrypt_response(&data, &session_id, &response).await
         }
         Err(e) => {
-            tracing::error!("Error deleting all key-value pairs: {:?}", e);
+            tracing::error!(
+                stage = "delete_all_kv",
+                error_kind = crate::observability::error_kind(&e),
+                "Error deleting all key-value pairs"
+            );
             Err(ApiError::InternalServerError)
         }
     }
@@ -702,7 +752,11 @@ pub async fn list_kv(
     let kvs = match data.list(&user, &auth_context).await {
         Ok(kvs) => kvs,
         Err(e) => {
-            tracing::error!("Error listing key-value pairs: {:?}", e);
+            tracing::error!(
+                stage = "list_kv",
+                error_kind = crate::observability::error_kind(&e),
+                "Error listing key-value pairs"
+            );
             return Err(ApiError::InternalServerError);
         }
     };
@@ -732,7 +786,11 @@ pub async fn request_new_verification_code(
             }
             // Delete the old verification
             if let Err(e) = data.db.delete_email_verification(&verification) {
-                tracing::error!("Error deleting old verification: {:?}", e);
+                tracing::error!(
+                    stage = "request_new_verification_code",
+                    error_kind = crate::observability::error_kind(&e),
+                    "Error deleting old verification"
+                );
                 return Err(ApiError::InternalServerError);
             }
         }
@@ -740,7 +798,11 @@ pub async fn request_new_verification_code(
             // This is fine, we'll create a new verification
         }
         Err(e) => {
-            tracing::error!("Error checking email verification: {:?}", e);
+            tracing::error!(
+                stage = "request_new_verification_code",
+                error_kind = crate::observability::error_kind(&e),
+                "Error checking email verification"
+            );
             return Err(ApiError::InternalServerError);
         }
     }
@@ -750,7 +812,11 @@ pub async fn request_new_verification_code(
     let verification = match data.db.create_email_verification(new_verification) {
         Ok(v) => v,
         Err(e) => {
-            tracing::error!("Error creating email verification: {:?}", e);
+            tracing::error!(
+                stage = "request_new_verification_code",
+                error_kind = crate::observability::error_kind(&e),
+                "Error creating email verification"
+            );
             return Err(ApiError::InternalServerError);
         }
     };
@@ -764,7 +830,11 @@ pub async fn request_new_verification_code(
     )
     .await
     {
-        tracing::error!("Error sending verification email: {:?}", e);
+        tracing::error!(
+            stage = "request_new_verification_code",
+            error_kind = crate::observability::error_kind(&e),
+            "Error sending verification email"
+        );
         return Err(ApiError::InternalServerError);
     }
 
@@ -828,7 +898,11 @@ pub async fn change_password(
                     encrypt_response(&data, &session_id, &response).await
                 }
                 Err(e) => {
-                    error!("Error changing password: {:?}", e);
+                    error!(
+                        stage = "change_password",
+                        error_kind = crate::observability::error_kind(&e),
+                        "Error changing password"
+                    );
                     match e {
                         Error::AuthenticationError => Err(ApiError::InvalidUsernameOrPassword),
                         _ => Err(ApiError::InternalServerError),
@@ -856,11 +930,19 @@ pub async fn get_private_key(
     let plaintext_seed = data
         .decrypt_seed_for_auth_context(&user, &auth_context)
         .map_err(|e| {
-            error!("Failed to decrypt authenticated seed wrap: {:?}", e);
+            error!(
+                stage = "get_private_key",
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to decrypt authenticated seed wrap"
+            );
             ApiError::Unauthorized
         })?;
     let root_mnemonic = plaintext_user_seed_to_mnemonic(&plaintext_seed).map_err(|e| {
-        error!("Failed to parse user seed mnemonic: {:?}", e);
+        error!(
+            stage = "get_private_key",
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to parse user seed mnemonic"
+        );
         ApiError::InternalServerError
     })?;
 
@@ -869,7 +951,11 @@ pub async fn get_private_key(
         // Derive a child mnemonic
         let child_mnemonic =
             derive_bip85_mnemonic_from_root(root_mnemonic, bip85_path).map_err(|e| {
-                error!("BIP-85 derivation error: {:?}", e);
+                error!(
+                    stage = "get_private_key",
+                    error_kind = crate::observability::error_kind(&e),
+                    "BIP-85 derivation error"
+                );
                 ApiError::BadRequest
             })?;
 
@@ -908,16 +994,28 @@ pub async fn get_private_key_bytes(
         )
         .await
         .map_err(|e| match e {
-            Error::InvalidDerivationPath(msg) => {
-                error!("Invalid derivation path: {}", msg);
+            Error::InvalidDerivationPath(_) => {
+                error!(
+                    stage = "user_key_derivation",
+                    error_kind = "invalid_path",
+                    "Invalid derivation path"
+                );
                 ApiError::BadRequest
             }
-            Error::KeyDerivationError(msg) => {
-                error!("Failed to derive key: {}", msg);
+            Error::KeyDerivationError(_) => {
+                error!(
+                    stage = "user_key_derivation",
+                    error_kind = "key_derivation",
+                    "Failed to derive key"
+                );
                 ApiError::BadRequest
             }
             _ => {
-                error!("Failed to get user key: {:?}", e);
+                error!(
+                    stage = "get_private_key_bytes",
+                    error_kind = crate::observability::error_kind(&e),
+                    "Failed to get user key"
+                );
                 ApiError::InternalServerError
             }
         })?;
@@ -956,7 +1054,11 @@ pub async fn sign_message(
     let message_bytes = general_purpose::STANDARD
         .decode(&sign_request.message_base64)
         .map_err(|e| {
-            error!("Failed to decode base64 message: {:?}", e);
+            error!(
+                stage = "sign_message",
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to decode base64 message"
+            );
             ApiError::BadRequest
         })?;
 
@@ -971,7 +1073,11 @@ pub async fn sign_message(
         )
         .await
         .map_err(|e| {
-            error!("Error signing message: {:?}", e);
+            error!(
+                stage = "sign_message",
+                error_kind = crate::observability::error_kind(&e),
+                "Error signing message"
+            );
             ApiError::InternalServerError
         })?;
 
@@ -1009,7 +1115,11 @@ pub async fn get_public_key(
         )
         .await
         .map_err(|e| {
-            error!("Error getting user key: {:?}", e);
+            error!(
+                stage = "get_public_key",
+                error_kind = crate::observability::error_kind(&e),
+                "Error getting user key"
+            );
             ApiError::InternalServerError
         })?;
 
@@ -1044,7 +1154,11 @@ pub async fn generate_third_party_token(
     // Validate the audience
     if let Some(audience) = request.audience.as_ref() {
         if audience.is_empty() || (audience.contains(':') && url::Url::parse(audience).is_err()) {
-            error!("Invalid audience provided: {}", audience);
+            error!(
+                stage = "third_party_token",
+                error_kind = "invalid_audience",
+                "Invalid audience provided"
+            );
             return Err(ApiError::BadRequest);
         }
     }
@@ -1061,7 +1175,11 @@ pub async fn generate_third_party_token(
     ) {
         Ok(token) => token,
         Err(e) => {
-            error!("Failed to generate third party token: {:?}", e);
+            error!(
+                stage = "generate_third_party_token",
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to generate third party token"
+            );
             return Err(e);
         }
     };
@@ -1097,16 +1215,28 @@ pub async fn encrypt_data(
         )
         .await
         .map_err(|e| match e {
-            Error::InvalidDerivationPath(msg) => {
-                error!("Invalid derivation path: {}", msg);
+            Error::InvalidDerivationPath(_) => {
+                error!(
+                    stage = "user_key_derivation",
+                    error_kind = "invalid_path",
+                    "Invalid derivation path"
+                );
                 ApiError::BadRequest
             }
-            Error::KeyDerivationError(msg) => {
-                error!("Failed to derive key: {}", msg);
+            Error::KeyDerivationError(_) => {
+                error!(
+                    stage = "user_key_derivation",
+                    error_kind = "key_derivation",
+                    "Failed to derive key"
+                );
                 ApiError::BadRequest
             }
             _ => {
-                error!("Failed to get user key: {:?}", e);
+                error!(
+                    stage = "encrypt_data",
+                    error_kind = crate::observability::error_kind(&e),
+                    "Failed to get user key"
+                );
                 ApiError::InternalServerError
             }
         })?;
@@ -1151,16 +1281,28 @@ pub async fn decrypt_data(
         )
         .await
         .map_err(|e| match e {
-            Error::InvalidDerivationPath(msg) => {
-                error!("Invalid derivation path: {}", msg);
+            Error::InvalidDerivationPath(_) => {
+                error!(
+                    stage = "user_key_derivation",
+                    error_kind = "invalid_path",
+                    "Invalid derivation path"
+                );
                 ApiError::BadRequest
             }
-            Error::KeyDerivationError(msg) => {
-                error!("Failed to derive key: {}", msg);
+            Error::KeyDerivationError(_) => {
+                error!(
+                    stage = "user_key_derivation",
+                    error_kind = "key_derivation",
+                    "Failed to derive key"
+                );
                 ApiError::BadRequest
             }
             _ => {
-                error!("Failed to get user key: {e}");
+                error!(
+                    stage = "decrypt_data",
+                    error_kind = crate::observability::error_kind(&e),
+                    "Failed to get user key"
+                );
                 ApiError::InternalServerError
             }
         })?;
@@ -1169,7 +1311,11 @@ pub async fn decrypt_data(
     let encrypted_data = match general_purpose::STANDARD.decode(&request.encrypted_data) {
         Ok(data) => data,
         Err(e) => {
-            error!("Failed to decode base64 data: {e}");
+            error!(
+                stage = "decrypt_data",
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to decode base64 data"
+            );
             return Err(ApiError::BadRequest);
         }
     };
@@ -1178,7 +1324,11 @@ pub async fn decrypt_data(
     let decrypted_data = match encrypt::decrypt_with_key(&user_key, &encrypted_data) {
         Ok(data) => data,
         Err(e) => {
-            error!("Decryption failed: {e}");
+            error!(
+                stage = "decrypt_data",
+                error_kind = crate::observability::error_kind(&e),
+                "Decryption failed"
+            );
             return Err(ApiError::BadRequest);
         }
     };
@@ -1187,7 +1337,11 @@ pub async fn decrypt_data(
     let decrypted_string = match String::from_utf8(decrypted_data) {
         Ok(s) => s,
         Err(e) => {
-            error!("Failed to convert decrypted data to string: {e}");
+            error!(
+                stage = "decrypt_data",
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to convert decrypted data to string"
+            );
             return Err(ApiError::BadRequest);
         }
     };
@@ -1222,7 +1376,11 @@ pub async fn initiate_account_deletion(
             result
         }
         Err(e) => {
-            error!("Error in initiating account deletion: {:?}", e);
+            error!(
+                stage = "initiate_account_deletion",
+                error_kind = crate::observability::error_kind(&e),
+                "Error in initiating account deletion"
+            );
             Err(ApiError::InternalServerError)
         }
     }
@@ -1255,19 +1413,35 @@ pub async fn confirm_account_deletion(
         }
         Err(e) => match e {
             Error::AccountDeletionExpired => {
-                warn!("Account deletion confirmation has expired: {:?}", e);
+                warn!(
+                    stage = "confirm_account_deletion",
+                    error_kind = crate::observability::error_kind(&e),
+                    "Account deletion confirmation has expired"
+                );
                 Err(ApiError::BadRequest)
             }
             Error::InvalidAccountDeletionSecret => {
-                warn!("Invalid account deletion secret: {:?}", e);
+                warn!(
+                    stage = "confirm_account_deletion",
+                    error_kind = crate::observability::error_kind(&e),
+                    "Invalid account deletion secret"
+                );
                 Err(ApiError::BadRequest)
             }
             Error::InvalidAccountDeletionRequest => {
-                warn!("Invalid account deletion request: {:?}", e);
+                warn!(
+                    stage = "confirm_account_deletion",
+                    error_kind = crate::observability::error_kind(&e),
+                    "Invalid account deletion request"
+                );
                 Err(ApiError::BadRequest)
             }
             _ => {
-                error!("Error in confirming account deletion: {:?}", e);
+                error!(
+                    stage = "confirm_account_deletion",
+                    error_kind = crate::observability::error_kind(&e),
+                    "Error in confirming account deletion"
+                );
                 Err(ApiError::InternalServerError)
             }
         },
@@ -1313,11 +1487,19 @@ pub async fn create_api_key(
             DBError::UserApiKeyError(
                 crate::models::user_api_keys::UserApiKeyError::DuplicateName,
             ) => {
-                error!("API key with name '{}' already exists for user", name);
+                error!(
+                    stage = "create_api_key",
+                    error_kind = "duplicate_name",
+                    "API key name already exists for user"
+                );
                 ApiError::Conflict // 409 - name already in use
             }
             _ => {
-                error!("Failed to create API key: {:?}", e);
+                error!(
+                    stage = "create_api_key",
+                    error_kind = crate::observability::error_kind(&e),
+                    "Failed to create API key"
+                );
                 ApiError::InternalServerError
             }
         }
@@ -1329,7 +1511,7 @@ pub async fn create_api_key(
         created_at: api_key_record.created_at,
     };
 
-    info!("Created API key '{}' for user {}", response.name, user.uuid);
+    info!(stage = "create_api_key", "Created API key");
     encrypt_response(&data, &session_id, &response).await
 }
 
@@ -1344,7 +1526,11 @@ pub async fn list_api_keys(
         .db
         .get_all_user_api_keys_for_user(user.uuid)
         .map_err(|e| {
-            error!("Failed to list API keys: {:?}", e);
+            error!(
+                stage = "list_api_keys",
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to list API keys"
+            );
             ApiError::InternalServerError
         })?;
 
@@ -1367,12 +1553,16 @@ pub async fn delete_api_key(
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
-    debug!("Deleting API key '{}' for user: {}", name, user.uuid);
+    debug!(stage = "delete_api_key", "Deleting API key");
 
     data.db
         .delete_user_api_key_by_name(&name, user.uuid)
         .map_err(|e| {
-            error!("Failed to delete API key: {:?}", e);
+            error!(
+                stage = "delete_api_key",
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to delete API key"
+            );
             match e {
                 DBError::UserApiKeyError(
                     crate::models::user_api_keys::UserApiKeyError::NotFound,
@@ -1381,7 +1571,7 @@ pub async fn delete_api_key(
             }
         })?;
 
-    info!("Deleted API key '{}' for user {}", name, user.uuid);
+    info!(stage = "delete_api_key", "Deleted API key");
 
     let response = json!({ "success": true });
     encrypt_response(&data, &session_id, &response).await
@@ -1392,6 +1582,53 @@ mod tests {
     use super::*;
     use crate::encrypt::{decrypt_with_key, encrypt_with_key};
     use secp256k1::SecretKey;
+
+    #[test]
+    fn invalid_derivation_paths_are_diagnosed_without_logging_input() {
+        #[derive(Clone)]
+        struct LogCapture(Arc<std::sync::Mutex<Vec<u8>>>);
+
+        impl std::io::Write for LogCapture {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(bytes);
+                Ok(bytes.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let writer = LogCapture(captured.clone());
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::TRACE)
+            .with_ansi(false)
+            .without_time()
+            .with_writer(move || writer.clone())
+            .finish();
+        let _subscriber = tracing::subscriber::set_default(subscriber);
+
+        for path in [
+            "private-path\nforged-log-line",
+            "private-path/83696968'/39'/0'/12'/0'",
+            "m/private-path'/39'/0'/12'/0'",
+            "m/83696968'/private-path'/0'/12'/0'",
+            "m/83696968'/39'/private-path'/12'/0'",
+            "m/83696968'/39'/0'/private-path'/0'",
+            "m/83696968'/39'/0'/12'/private-path'",
+        ] {
+            assert!(validate_bip85_path(path).is_err());
+        }
+        assert!(validate_path("m/private-path\nforged-log-line").is_err());
+
+        let logs = String::from_utf8(captured.lock().unwrap().clone()).unwrap();
+        assert!(logs.contains("bip85_path_validation"), "{logs}");
+        assert!(logs.contains("bip32_path_validation"), "{logs}");
+        assert!(logs.contains("error_kind="), "{logs}");
+        assert!(!logs.contains("private-path"), "{logs}");
+        assert!(!logs.contains("forged-log-line"), "{logs}");
+    }
 
     #[test]
     fn test_derivation_path_validation() {

--- a/src/web/protected_routes.rs
+++ b/src/web/protected_routes.rs
@@ -1511,7 +1511,12 @@ pub async fn create_api_key(
         created_at: api_key_record.created_at,
     };
 
-    info!(stage = "create_api_key", "Created API key");
+    info!(
+        stage = "create_api_key",
+        user_id = %user.uuid,
+        api_key_name = ?response.name,
+        "Created API key"
+    );
     encrypt_response(&data, &session_id, &response).await
 }
 
@@ -1553,7 +1558,12 @@ pub async fn delete_api_key(
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
-    debug!(stage = "delete_api_key", "Deleting API key");
+    debug!(
+        stage = "delete_api_key",
+        user_id = %user.uuid,
+        api_key_name = ?name,
+        "Deleting API key"
+    );
 
     data.db
         .delete_user_api_key_by_name(&name, user.uuid)
@@ -1571,7 +1581,12 @@ pub async fn delete_api_key(
             }
         })?;
 
-    info!(stage = "delete_api_key", "Deleted API key");
+    info!(
+        stage = "delete_api_key",
+        user_id = %user.uuid,
+        api_key_name = ?name,
+        "Deleted API key"
+    );
 
     let response = json!({ "success": true });
     encrypt_response(&data, &session_id, &response).await

--- a/src/web/responses/context_builder.rs
+++ b/src/web/responses/context_builder.rs
@@ -152,16 +152,18 @@ pub fn build_prompt_with_token_reserve<D: DBConnection + ?Sized>(
                 Ok(None) => None,
                 Err(e) => {
                     error!(
-                        "Failed to load default instruction for user {}: {:?}",
-                        user_id, e
+                        stage = "context_default_instruction",
+                        error_kind = crate::observability::error_kind(&e),
+                        "Failed to load default instruction"
                     );
                     return Err(crate::ApiError::InternalServerError);
                 }
             },
             Err(e) => {
                 error!(
-                    "Failed to load project instruction for conversation {}: {:?}",
-                    conversation_id, e
+                    stage = "context_project_instruction",
+                    error_kind = crate::observability::error_kind(&e),
+                    "Failed to load project instruction"
                 );
                 return Err(crate::ApiError::InternalServerError);
             }
@@ -287,7 +289,7 @@ pub fn build_prompt_with_token_reserve<D: DBConnection + ?Sized>(
                 // Parse arguments as JSON - if malformed, use empty object but continue safely
                 let arguments: serde_json::Value =
                     serde_json::from_str(&arguments_str).unwrap_or_else(|e| {
-                        error!("Failed to parse tool call arguments as JSON: {:?}. Using empty object.", e);
+                        error!(stage = "context_tool_arguments", error_kind = ?e.classify(), "Failed to parse tool call arguments as JSON; using empty object");
                         serde_json::json!({})
                     });
 
@@ -298,8 +300,8 @@ pub fn build_prompt_with_token_reserve<D: DBConnection + ?Sized>(
                 // OpenAI expects arguments as a JSON string, not a JSON object
                 let arguments_string = serde_json::to_string(&arguments).unwrap_or_else(|e| {
                     error!(
-                        "Failed to serialize tool arguments: {:?}. Using empty object string.",
-                        e
+                        stage = "context_tool_arguments", error_kind = ?e.classify(),
+                        "Failed to serialize tool arguments; using empty object string"
                     );
                     "{}".to_string()
                 });
@@ -323,8 +325,8 @@ pub fn build_prompt_with_token_reserve<D: DBConnection + ?Sized>(
                     Ok(s) => s,
                     Err(e) => {
                         error!(
-                            "Failed to serialize tool_call message: {:?}. Skipping this tool call.",
-                            e
+                            stage = "context_tool_call", error_kind = ?e.classify(),
+                            "Failed to serialize tool_call message; skipping this tool call"
                         );
                         // If this fails, skip this message entirely rather than corrupting the conversation
                         continue;
@@ -878,7 +880,7 @@ pub fn build_prompt_from_chat_messages_with_token_reserve(
                 // User messages are stored as MessageContent - convert to OpenAI format
                 use crate::web::responses::{MessageContent, MessageContentConverter};
                 let mc: MessageContent = serde_json::from_str(&m.content).map_err(|e| {
-                    error!("Failed to deserialize user message content: {:?}", e);
+                    error!(stage = "context_user_message", error_kind = ?e.classify(), "Failed to deserialize user message content");
                     crate::ApiError::InternalServerError
                 })?;
                 MessageContentConverter::to_model_format(&mc)
@@ -985,8 +987,9 @@ fn normalize_tool_call_ids_for_kimi(messages: &mut [Value]) {
                     }
                 } else {
                     warn!(
-                        "Leaving unmatched tool_call_id {} unchanged during Kimi ID normalization",
-                        original_id
+                        stage = "kimi_tool_id_normalization",
+                        error_kind = "unmatched_tool_call",
+                        "Leaving unmatched tool_call_id unchanged during Kimi ID normalization"
                     );
                 }
             }

--- a/src/web/responses/conversations.rs
+++ b/src/web/responses/conversations.rs
@@ -429,7 +429,10 @@ async fn create_conversation(
 
     // Encrypt the entire metadata object
     let metadata_json = serde_json::to_string(&metadata).map_err(|e| {
-        error!("Failed to serialize metadata: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to serialize metadata"
+        );
         ApiError::InternalServerError
     })?;
     let metadata_enc = Some(encrypt_with_key(&user_key, metadata_json.as_bytes()).await);
@@ -504,7 +507,10 @@ async fn update_conversation(
     let metadata_enc = if let Some(metadata) = body.metadata.as_ref() {
         validate_metadata(metadata)?;
         let metadata_json = serde_json::to_string(metadata).map_err(|e| {
-            error!("Failed to serialize metadata: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to serialize metadata"
+            );
             ApiError::InternalServerError
         })?;
         Some(encrypt_with_key(&ctx.user_key, metadata_json.as_bytes()).await)
@@ -802,7 +808,7 @@ async fn batch_delete_conversations(
                         });
                     }
                     Err(e) => {
-                        error!("Failed to delete conversation {}: {:?}", conversation_id, e);
+                        error!(%conversation_id, error_kind = crate::observability::error_kind(&e), "Failed to delete conversation");
                         results.push(BatchDeleteItemResult {
                             id: conversation_id,
                             object: constants::OBJECT_TYPE_CONVERSATION_DELETED,

--- a/src/web/responses/conversions.rs
+++ b/src/web/responses/conversions.rs
@@ -399,8 +399,12 @@ impl ConversationItemConverter {
             "tool_call" => Self::tool_call_to_item(msg, content),
             "tool_output" => Self::tool_output_to_item(msg, content),
             "reasoning" => Self::reasoning_to_item(msg, content),
-            unknown => {
-                error!("Unknown message type: {}", unknown);
+            _ => {
+                error!(
+                    stage = "message_conversion",
+                    error_kind = "unknown_message_type",
+                    "Unknown message type"
+                );
                 Err(ApiError::InternalServerError)
             }
         }
@@ -413,7 +417,7 @@ impl ConversationItemConverter {
     ) -> Result<ConversationItem, ApiError> {
         // User messages MUST be stored as MessageContent
         let message_content: MessageContent = serde_json::from_str(&content).map_err(|e| {
-            error!("Failed to deserialize message content: {:?}", e);
+            error!(stage = "message_conversion", error_kind = ?e.classify(), "Failed to deserialize message content");
             ApiError::InternalServerError
         })?;
 

--- a/src/web/responses/errors.rs
+++ b/src/web/responses/errors.rs
@@ -26,7 +26,10 @@ pub mod error_mapping {
             }
             DBError::ResponsesError(ResponsesError::ValidationError) => ApiError::BadRequest,
             _ => {
-                error!("Conversation database error: {:?}", e);
+                error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Conversation database error"
+                );
                 ApiError::InternalServerError
             }
         }
@@ -41,7 +44,10 @@ pub mod error_mapping {
             }
             DBError::ResponsesError(ResponsesError::ValidationError) => ApiError::BadRequest,
             _ => {
-                error!("Batch conversation project database error: {:?}", e);
+                error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Batch conversation project database error"
+                );
                 ApiError::InternalServerError
             }
         }
@@ -55,7 +61,10 @@ pub mod error_mapping {
             }
             DBError::ResponsesError(ResponsesError::ValidationError) => ApiError::BadRequest,
             _ => {
-                error!("Conversation project database error: {:?}", e);
+                error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Conversation project database error"
+                );
                 ApiError::InternalServerError
             }
         }
@@ -75,7 +84,10 @@ pub mod error_mapping {
                 ApiError::NotFound
             }
             _ => {
-                error!("Instruction database error: {:?}", e);
+                error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Instruction database error"
+                );
                 ApiError::InternalServerError
             }
         }
@@ -94,7 +106,10 @@ pub mod error_mapping {
             DBError::ResponsesError(ResponsesError::Unauthorized) => ApiError::Unauthorized,
             DBError::ResponsesError(ResponsesError::ValidationError) => ApiError::BadRequest,
             _ => {
-                error!("Response database error: {:?}", e);
+                error!(
+                    error_kind = crate::observability::error_kind(&e),
+                    "Response database error"
+                );
                 ApiError::InternalServerError
             }
         }
@@ -108,7 +123,10 @@ pub mod error_mapping {
     /// # Returns
     /// ApiError with logging
     pub fn map_message_error(e: DBError) -> ApiError {
-        error!("Message database error: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Message database error"
+        );
         ApiError::InternalServerError
     }
 
@@ -122,7 +140,10 @@ pub mod error_mapping {
     /// # Returns
     /// ApiError with logging
     pub fn map_generic_db_error(e: DBError) -> ApiError {
-        error!("Database error: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Database error"
+        );
         ApiError::InternalServerError
     }
 

--- a/src/web/responses/events.rs
+++ b/src/web/responses/events.rs
@@ -77,7 +77,11 @@ impl<'a> SseEventEmitter<'a> {
                         event
                     }
                     Err(e) => {
-                        error!("Failed to encrypt {} event: {:?}", event_type, e);
+                        error!(
+                            event_type,
+                            error_kind = crate::observability::error_kind(&e),
+                            "Failed to encrypt event"
+                        );
                         Event::default()
                             .event("error")
                             .data(ERROR_DATA_ENCRYPTION_FAILED)
@@ -85,7 +89,11 @@ impl<'a> SseEventEmitter<'a> {
                 }
             }
             Err(e) => {
-                error!("Failed to serialize {}: {:?}", event_type, e);
+                error!(
+                    event_type,
+                    error_kind = crate::observability::error_kind(&e),
+                    "Failed to serialize event"
+                );
                 Event::default()
                     .event("error")
                     .data(ERROR_DATA_SERIALIZATION_FAILED)
@@ -103,7 +111,11 @@ impl<'a> SseEventEmitter<'a> {
                 match encrypt_event(self.state, &self.transport_session, event_type, &json).await {
                     Ok(event) => event,
                     Err(e) => {
-                        error!("Failed to encrypt {} event: {:?}", event_type, e);
+                        error!(
+                            event_type,
+                            error_kind = crate::observability::error_kind(&e),
+                            "Failed to encrypt event"
+                        );
                         Event::default()
                             .event("error")
                             .data(ERROR_DATA_ENCRYPTION_FAILED)
@@ -111,7 +123,11 @@ impl<'a> SseEventEmitter<'a> {
                 }
             }
             Err(e) => {
-                error!("Failed to serialize {}: {:?}", event_type, e);
+                error!(
+                    event_type,
+                    error_kind = crate::observability::error_kind(&e),
+                    "Failed to serialize event"
+                );
                 Event::default()
                     .event("error")
                     .data(ERROR_DATA_SERIALIZATION_FAILED)

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -75,7 +75,8 @@ use std::{
 };
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::Instant as TokioInstant;
-use tracing::{debug, error, info, trace, warn};
+use tracing::Instrument;
+use tracing::{debug, error, trace, warn};
 use uuid::Uuid;
 
 const RESPONSES_SSE_KEEPALIVE_INTERVAL_SECS: u64 = 1;
@@ -225,7 +226,7 @@ fn resolve_responses_model(
         Some(model) => Ok(model.to_string()),
         None if completion_provider_name != "tinfoil" => Ok(requested_model.to_string()),
         None => {
-            error!("Unsupported responses model requested: {}", requested_model);
+            debug!(reason = "unsupported_model", "Responses request rejected");
             Err(ApiError::BadRequest)
         }
     }
@@ -399,19 +400,13 @@ fn web_search_is_selected(
     is_tool_choice_allowed(tool_choice) && is_web_search_enabled(tools) && kagi_available
 }
 
-fn select_web_search(state: &AppState, user_uuid: Uuid, body: &ResponsesCreateRequest) -> bool {
+fn select_web_search(state: &AppState, _user_uuid: Uuid, body: &ResponsesCreateRequest) -> bool {
     let kagi_available = state.kagi_client.is_some();
     let selected = web_search_is_selected(&body.tool_choice, &body.tools, kagi_available);
     if selected {
-        info!(
-            user_uuid = %user_uuid,
-            "Selected Kagi as the Responses web-search provider"
-        );
+        debug!("Selected Kagi as the Responses web-search provider");
     } else if is_tool_choice_allowed(&body.tool_choice) && is_web_search_enabled(&body.tools) {
-        debug!(
-            user_uuid = %user_uuid,
-            "Kagi web-search client is unavailable"
-        );
+        debug!("Kagi web-search client is unavailable");
     }
     selected
 }
@@ -549,13 +544,21 @@ fn has_streamed_tool_call_entries(tool_call_delta: &Value) -> bool {
         .is_some_and(|entries| !entries.is_empty())
 }
 
+fn tool_kind_for_log(name: &str) -> &'static str {
+    match name {
+        "web_search" => "web_search",
+        "open_urls" => "open_urls",
+        _ => "unknown",
+    }
+}
+
 fn finalize_first_model_tool_call(tool_calls: &[StreamedToolCall]) -> Option<ModelToolCall> {
     let tool_call = tool_calls.first()?;
     let name = tool_call.name.clone()?;
     let arguments = serde_json::from_str(&tool_call.arguments).unwrap_or_else(|e| {
         warn!(
-            "Failed to parse tool arguments for {} as JSON: {:?}. Using empty object.",
-            name, e
+            error_kind = crate::observability::error_kind(&e),
+            "Invalid tool arguments; using empty object"
         );
         json!({})
     });
@@ -3606,23 +3609,17 @@ async fn describe_images(
     for (image_index, content_index, result) in outcomes {
         let outcome = match result {
             Ok(outcome) => outcome,
-            Err(ImageDescriptionError::InvalidRequest(error)) => {
-                warn!(
+            Err(ImageDescriptionError::InvalidRequest(_error)) => {
+                debug!(
                     image_index,
-                    "Rejected invalid Responses image description input: {}", error
+                    reason = "invalid_image_input",
+                    "Responses image description rejected"
                 );
                 return Err(ApiError::BadRequest);
             }
             Err(error @ ImageDescriptionError::AttemptsFailed { .. }) => {
                 for failure in error.attempts() {
-                    warn!(
-                        image_index,
-                        provider = failure.candidate.provider.as_str(),
-                        model = failure.candidate.public_model_id,
-                        failure_class = ?failure.error.class,
-                        "Responses image description attempt failed: {}",
-                        failure.error.summary
-                    );
+                    warn!(image_index, provider = failure.candidate.provider.as_str(), model = failure.candidate.public_model_id, failure_class = ?failure.error.class, "Responses image description attempt failed");
                 }
                 return Err(ApiError::ImageDescriptionUnavailable);
             }
@@ -3743,10 +3740,7 @@ fn spawn_title_generation_task(
             match prepare_completion_request(&state, &user, title_intent, routing).await {
                 Ok(pinned) => pinned,
                 Err(error) => {
-                    error!(
-                        "Title generation: failed to prepare inference route: {:?}",
-                        error
-                    );
+                    error!(error_kind = crate::observability::error_kind(&error), "Title generation: failed to prepare inference route");
                     return;
                 }
             };
@@ -3814,7 +3808,7 @@ fn spawn_title_generation_task(
                                                         metadata_enc,
                                                     )
                                                 {
-                                                    error!("Failed to update conversation metadata with generated title: {:?}", e);
+                                                    error!(error_kind = crate::observability::error_kind(&e), "Failed to update conversation metadata with generated title");
                                                 } else {
                                                     debug!("Successfully updated conversation {} with generated title", conversation_uuid);
                                                 }
@@ -3823,15 +3817,12 @@ fn spawn_title_generation_task(
                                             }
                                         }
                                         Err(e) => {
-                                            error!(
-                                                "Failed to decrypt conversation metadata: {:?}",
-                                                e
-                                            );
+                                            error!(error_kind = crate::observability::error_kind(&e), "Failed to decrypt conversation metadata");
                                         }
                                     }
                                 }
                                 Err(e) => {
-                                    error!("Failed to get conversation for title update: {:?}", e);
+                                    error!(error_kind = crate::observability::error_kind(&e), "Failed to get conversation for title update");
                                 }
                             }
                         } else {
@@ -3849,10 +3840,10 @@ fn spawn_title_generation_task(
                 }
             }
             Err(e) => {
-                error!("Failed to generate conversation title: {:?}", e);
+                error!(has_terminal = e.terminal().is_some(), "Failed to generate conversation title");
             }
         }
-    });
+    }.in_current_span());
 }
 
 /// Phase 1: Validate and normalize input
@@ -3886,9 +3877,9 @@ async fn validate_and_normalize_input(
         if let MessageContent::Parts(parts) = &msg.content {
             for part in parts {
                 if matches!(part, MessageContentPart::InputFile { .. }) {
-                    error!(
-                        "User {} attempted to use unsupported file upload feature",
-                        user.uuid
+                    debug!(
+                        reason = "unsupported_file_upload",
+                        "Responses request rejected"
                     );
                     return Err(ApiError::BadRequest);
                 }
@@ -3925,16 +3916,21 @@ async fn validate_and_normalize_input(
     let ctx_budget = prompt_token_budget(&body.model);
 
     if user_message_tokens as usize >= ctx_budget {
-        error!(
-            "User message too large for user {}: {} tokens exceeds budget {} for model {}",
-            user.uuid, user_message_tokens, ctx_budget, body.model
+        debug!(
+            input_tokens = user_message_tokens,
+            token_budget = ctx_budget,
+            reason = "input_too_large",
+            "Responses request rejected"
         );
         return Err(ApiError::MessageExceedsContextLimit);
     }
 
     // Serialize the MessageContent for storage
     let content_for_storage = serde_json::to_string(&message_content).map_err(|e| {
-        error!("Failed to serialize message content: {:?}", e);
+        error!(
+            error_kind = crate::observability::error_kind(&e),
+            "Failed to serialize message content"
+        );
         ApiError::InternalServerError
     })?;
 
@@ -4024,12 +4020,11 @@ async fn build_context_and_check_billing(
     normalize_tool_call_ids_for_model(&mut prompt_messages, &body.model);
 
     if total_prompt_tokens >= prompt_token_budget(&body.model) {
-        error!(
-            "Responses prompt too large for user {}: {} tokens exceeds budget {} for model {}",
-            user.uuid,
-            total_prompt_tokens,
-            prompt_token_budget(&body.model),
-            body.model
+        debug!(
+            input_tokens = total_prompt_tokens,
+            token_budget = prompt_token_budget(&body.model),
+            reason = "prompt_too_large",
+            "Responses request rejected"
         );
         return Err(ApiError::MessageExceedsContextLimit);
     }
@@ -4043,31 +4038,35 @@ async fn build_context_and_check_billing(
     // Check billing with token validation (BEFORE any persistence).
     if let Some(billing_access) = billing_access {
         debug!(
-            "Checking billing for user {} with {} input tokens",
-            user.uuid, total_prompt_tokens
+            input_tokens = total_prompt_tokens,
+            "Checking Responses billing"
         );
 
         if let Err(e) = billing_access.check_with_tokens(total_prompt_tokens as i32) {
             match e {
                 BillingError::UsageLimitExceeded => {
-                    error!("Usage limit exceeded for user: {}", user.uuid);
+                    debug!(reason = "usage_limit", "Responses request rejected");
                     return Err(ApiError::UsageLimitReached);
                 }
                 BillingError::FreeTokenLimitExceeded => {
                     // This error is only returned for free users
-                    error!(
-                        "Free tier token limit exceeded for user {} with {} tokens",
-                        user.uuid, total_prompt_tokens
+                    debug!(
+                        input_tokens = total_prompt_tokens,
+                        reason = "free_tier_token_limit",
+                        "Responses request rejected"
                     );
                     return Err(ApiError::FreeTokenLimitExceeded);
                 }
                 _ => {
                     // Log the error but allow the request for other billing service errors
-                    error!("Billing service error, allowing request: {}", e);
+                    error!(
+                        error_kind = crate::observability::error_kind(&e),
+                        "Billing service error, allowing request"
+                    );
                 }
             }
         }
-        debug!("Billing check passed for user {}", user.uuid);
+        debug!("Responses billing check passed");
     }
 
     Ok(BuiltContext {
@@ -4102,7 +4101,10 @@ async fn persist_request_data(
     // Encrypt metadata if provided
     let metadata_enc = if let Some(metadata) = &body.metadata {
         let metadata_json = serde_json::to_string(metadata).map_err(|e| {
-            error!("Failed to serialize metadata: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to serialize metadata"
+            );
             ApiError::InternalServerError
         })?;
         Some(encrypt_with_key(&prepared.user_key, metadata_json.as_bytes()).await)
@@ -4140,8 +4142,8 @@ async fn persist_request_data(
     for pair in image_descriptions {
         let arguments_json = serde_json::to_string(&pair.arguments).map_err(|e| {
             error!(
-                "Failed to serialize automatic read_image arguments: {:?}",
-                e
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to serialize automatic read_image arguments"
             );
             ApiError::InternalServerError
         })?;
@@ -4183,10 +4185,7 @@ async fn persist_request_data(
         .map_err(error_mapping::map_generic_db_error)?;
     let response = persisted.response;
 
-    info!(
-        "Created response {} for user {} in conversation {}",
-        response.uuid, user.uuid, conversation.uuid
-    );
+    debug!(response_uuid = %response.uuid, conversation_uuid = %conversation.uuid, "Created response");
 
     Ok(PersistedData {
         response,
@@ -4296,10 +4295,7 @@ async fn execute_tool_call_and_wait(
     let tool_output_id = Uuid::new_v4();
     let tool_call_enqueue_started = std::time::Instant::now();
 
-    debug!(
-        "Tool loop: enqueueing tool_call {} ({}) for response {}",
-        tool_call_id, tool_call.name, persisted.response.uuid
-    );
+    debug!(tool_call_id = %tool_call_id, tool_kind = tool_kind_for_log(&tool_call.name), response_uuid = %persisted.response.uuid, "Enqueueing tool call");
 
     let tool_call_msg = StorageMessage::ToolCall {
         tool_call_id,
@@ -4316,26 +4312,14 @@ async fn execute_tool_call_and_wait(
                 persisted.response.uuid
             );
         })?;
-    debug!(
-        "Tool loop: enqueued tool_call {} ({}) for response {} in {} ms",
-        tool_call_id,
-        tool_call.name,
-        persisted.response.uuid,
-        tool_call_enqueue_started.elapsed().as_millis()
-    );
+    debug!(tool_call_id = %tool_call_id, tool_kind = tool_kind_for_log(&tool_call.name), response_uuid = %persisted.response.uuid, elapsed_ms = tool_call_enqueue_started.elapsed().as_millis(), "Enqueued tool call");
 
     let tool_execution_started = std::time::Instant::now();
-    debug!(
-        "Tool loop: starting execution for tool_call {} ({}) on response {}",
-        tool_call_id, tool_call.name, persisted.response.uuid
-    );
+    debug!(tool_call_id = %tool_call_id, tool_kind = tool_kind_for_log(&tool_call.name), response_uuid = %persisted.response.uuid, "Starting tool execution");
 
     let tool_result = if web_search_tool_turn_limit_reached(tool_turn_count, model_plan) {
         let max_tool_turns = web_search_tool_turn_limit(model_plan);
-        info!(
-            "Reached max web_search tool turns ({}) for response {}; returning limit error without executing {}",
-            max_tool_turns, persisted.response.uuid, tool_call.name
-        );
+        debug!(max_tool_turns, response_uuid = %persisted.response.uuid, tool_kind = tool_kind_for_log(&tool_call.name), "Tool execution limit reached");
         Err(web_search_tool_turn_limit_error(model_plan))
     } else {
         let result = tools::execute_tool(
@@ -4346,21 +4330,12 @@ async fn execute_tool_call_and_wait(
         )
         .await;
         if result.is_err() {
-            warn!(
-                "Tool execution failed for tool_call {} ({}) on response {}",
-                tool_call_id, tool_call.name, persisted.response.uuid
-            );
+            warn!(tool_call_id = %tool_call_id, tool_kind = tool_kind_for_log(&tool_call.name), response_uuid = %persisted.response.uuid, "Tool execution failed");
         }
         result
     };
     let tool_output = tools::format_tool_result(tool_result);
-    debug!(
-        "Tool loop: finished execution for tool_call {} ({}) on response {} in {} ms",
-        tool_call_id,
-        tool_call.name,
-        persisted.response.uuid,
-        tool_execution_started.elapsed().as_millis()
-    );
+    debug!(tool_call_id = %tool_call_id, tool_kind = tool_kind_for_log(&tool_call.name), response_uuid = %persisted.response.uuid, elapsed_ms = tool_execution_started.elapsed().as_millis(), "Finished tool execution");
 
     let tool_output_enqueue_started = std::time::Instant::now();
     debug!(
@@ -4390,7 +4365,7 @@ async fn execute_tool_call_and_wait(
         tool_output_enqueue_started.elapsed().as_millis()
     );
 
-    info!(
+    debug!(
         "Successfully sent tool_call {} and tool_output {} to streams for conversation {}",
         tool_call_id, tool_output_id, persisted.response.conversation_id
     );
@@ -4407,8 +4382,11 @@ async fn execute_tool_call_and_wait(
             );
             Ok(())
         }
-        Ok(Some(Err(e))) => {
-            error!("Failed to persist tools to database: {}", e);
+        Ok(Some(Err(_e))) => {
+            error!(
+                stage = "tool_persistence",
+                "Failed to persist tools to database"
+            );
             Err(ApiError::InternalServerError)
         }
         Ok(None) => {
@@ -4464,10 +4442,9 @@ fn best_effort_fail_response_after_storage_error(
             "Response {} was already terminal after storage worker error",
             response_uuid
         ),
-        Err(e) => error!(
-            "Failed to mark response {} failed after storage worker error: {:?}",
-            response_uuid, e
-        ),
+        Err(e) => {
+            error!(response_uuid = %response_uuid, error_kind = crate::observability::error_kind(&e), "Failed to mark response failed after storage worker error")
+        }
     }
 }
 
@@ -4567,7 +4544,7 @@ async fn start_responses_assistant_turn(
         pinned_completion.intent().request_id,
         conversation_uuid,
         response_uuid,
-        body.model,
+        resolve_public_model_id(&body.model).unwrap_or("custom"),
         tool_turn_count,
         prompt_token_estimate,
         prompt_messages.len(),
@@ -4803,8 +4780,8 @@ async fn consume_assistant_turn(
                     finish_reason.as_deref(),
                 ) {
                     debug!(
-                        "Assistant turn finalized tool_call after model stream completion (finish_reason={})",
-                        finish_reason.as_deref().unwrap_or("unknown")
+                        finish_reason_present = finish_reason.is_some(),
+                        "Assistant turn finalized tool call"
                     );
                     let tool_call = finalize_first_model_tool_call(&streamed_tool_calls)
                         .ok_or(ApiError::InternalServerError)?;
@@ -4968,10 +4945,7 @@ async fn setup_completion_processor(
 
         match turn {
             AssistantTurnOutcome::ToolCall(tool_call) => {
-                debug!(
-                    "Tool loop: assistant turn requested tool {} for response {}",
-                    tool_call.name, persisted.response.uuid
-                );
+                debug!(tool_kind = tool_kind_for_log(&tool_call.name), response_uuid = %persisted.response.uuid, "Assistant turn requested tool");
                 tool_turn_count += 1;
                 if execute_tool_call_and_wait(
                     state,
@@ -5126,11 +5100,8 @@ async fn forward_authoritative_response_terminal(
             );
             return;
         }
-        Ok(Err(e)) => {
-            error!(
-                "Storage task could not verify terminal persistence: response_uuid={}, error={}",
-                response_uuid, e
-            );
+        Ok(Err(_e)) => {
+            error!(response_uuid = %response_uuid, stage = "terminal_persistence", "Storage task could not verify terminal persistence");
             return;
         }
         Err(_) => {
@@ -5170,9 +5141,9 @@ async fn create_response_stream(
     let model_plan =
         ModelPlan::from_is_paid(billing_access.is_some_and(ChatBillingAccess::is_paid));
     if user.is_guest() && !model_plan.is_paid() {
-        error!(
-            "Guest user without a paid plan attempted to use Responses API: {}",
-            user.uuid
+        debug!(
+            reason = "guest_requires_paid_plan",
+            "Responses request rejected"
         );
         return Err(ApiError::Unauthorized);
     }
@@ -5194,8 +5165,8 @@ async fn create_response_stream(
     )?;
     if requested_model != resolved_model {
         debug!(
-            "Resolved responses model {} to {}",
-            requested_model, resolved_model
+            public_model = resolve_public_model_id(&resolved_model).unwrap_or("custom"),
+            "Resolved Responses model alias"
         );
     }
     body.model = resolved_model;
@@ -5213,7 +5184,7 @@ async fn create_response_stream(
         .unwrap_or_default();
     trace!(
         "Request body metadata: model={}, stream={}, input_kind={}, input_message_count={}, instructions_present={}, tools_count={}, tool_choice_present={}, metadata_present={}, max_output_tokens_present={}, temperature_present={}, top_p_present={}, parallel_tool_calls={}, store={}",
-        body.model,
+        resolve_public_model_id(&body.model).unwrap_or("custom"),
         body.stream,
         input_kind,
         input_message_count,
@@ -5423,44 +5394,50 @@ async fn create_response_stream(
     }
 
     let storage_db = state.db.clone();
-    tokio::spawn(async move {
-        let _storage_execution_guard = storage_execution_guard;
-        storage_task(
-            rx_storage,
-            Some(tx_tool_ack),
-            Some(tx_terminal_ack),
-            storage_db,
-            response_id,
-            response_uuid,
-            first_response_item_created_at,
-            conversation_id,
-            user_id,
-            user_key,
-        )
-        .await;
-    });
+    tokio::spawn(
+        async move {
+            let _storage_execution_guard = storage_execution_guard;
+            storage_task(
+                rx_storage,
+                Some(tx_tool_ack),
+                Some(tx_terminal_ack),
+                storage_db,
+                response_id,
+                response_uuid,
+                first_response_item_created_at,
+                conversation_id,
+                user_id,
+                user_key,
+            )
+            .await;
+        }
+        .in_current_span(),
+    );
 
-    tokio::spawn(supervise_response_execution(
-        state.clone(),
-        user.clone(),
-        model_turn_body,
-        pinned_completion,
-        model_plan,
-        context,
-        user_key,
-        assistant_message_id,
-        persisted,
-        headers,
-        tx_client,
-        tx_storage,
-        rx_tool_ack,
-        rx_terminal_ack,
-        response_execution.clone(),
-        first_started,
-        execution_policy,
-        supervisor_execution_guard,
-        cache_policy.clone(),
-    ));
+    tokio::spawn(
+        supervise_response_execution(
+            state.clone(),
+            user.clone(),
+            model_turn_body,
+            pinned_completion,
+            model_plan,
+            context,
+            user_key,
+            assistant_message_id,
+            persisted,
+            headers,
+            tx_client,
+            tx_storage,
+            rx_tool_ack,
+            rx_terminal_ack,
+            response_execution.clone(),
+            first_started,
+            execution_policy,
+            supervisor_execution_guard,
+            cache_policy.clone(),
+        )
+        .in_current_span(),
+    );
 
     drop(response_execution_registration);
     drop(response_setup_guard);
@@ -5746,10 +5723,7 @@ async fn create_response_stream(
                     name,
                     arguments,
                 } => {
-                    debug!(
-                        "Client stream received tool_call {} ({}) for response {}",
-                        tool_call_id, name, response_uuid
-                    );
+                    debug!(tool_call_id = %tool_call_id, tool_kind = tool_kind_for_log(&name), response_uuid = %response_uuid, "Client stream received tool call");
                     let tool_name = name.clone();
                     let arguments_json =
                         serde_json::to_string(&arguments).unwrap_or_else(|_| "{}".to_string());
@@ -5933,7 +5907,10 @@ pub async fn encrypt_event(
         .encode_sse_data(state, &payload_str)
         .await
         .map_err(|e| {
-            error!("Failed to encode event data: {:?}", e);
+            error!(
+                error_kind = crate::observability::error_kind(&e),
+                "Failed to encode event data"
+            );
             ApiError::InternalServerError
         })?;
     Ok(Event::default().event(event_type).data(event_data))
@@ -5947,7 +5924,7 @@ async fn get_response(
     Extension(auth_context): Extension<AuthContext>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
-    debug!("Getting response {} for user {}", id, user.uuid);
+    debug!("Retrieving response");
 
     // Get the response
     let response = state
@@ -5978,7 +5955,10 @@ async fn get_response(
         match msg.message_type.as_str() {
             "assistant" => {
                 let text = decrypt_string(&user_key, msg.content_enc.as_ref()).map_err(|e| {
-                    error!("Failed to decrypt assistant message content: {:?}", e);
+                    error!(
+                        error_kind = crate::observability::error_kind(&e),
+                        "Failed to decrypt assistant message content"
+                    );
                     error_mapping::map_decryption_error("assistant message content")
                 })?;
 
@@ -5997,7 +5977,10 @@ async fn get_response(
             "tool_call" => {
                 let arguments =
                     decrypt_string(&user_key, msg.content_enc.as_ref()).map_err(|e| {
-                        error!("Failed to decrypt tool call arguments: {:?}", e);
+                        error!(
+                            error_kind = crate::observability::error_kind(&e),
+                            "Failed to decrypt tool call arguments"
+                        );
                         error_mapping::map_decryption_error("tool call arguments")
                     })?;
 
@@ -6019,7 +6002,10 @@ async fn get_response(
             }
             "tool_output" => {
                 let output = decrypt_string(&user_key, msg.content_enc.as_ref()).map_err(|e| {
-                    error!("Failed to decrypt tool output: {:?}", e);
+                    error!(
+                        error_kind = crate::observability::error_kind(&e),
+                        "Failed to decrypt tool output"
+                    );
                     error_mapping::map_decryption_error("tool output")
                 })?;
 
@@ -6109,14 +6095,17 @@ async fn cancel_response(
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
-    debug!("Cancelling response {} for user {}", id, user.uuid);
+    debug!("Cancelling response");
 
     // Verify the response exists and belongs to the user, and is in_progress
     let response = state
         .db
         .get_response_by_uuid_and_user(id, user.uuid)
         .map_err(|e| {
-            debug!("Response {} not found for user {}: {:?}", id, user.uuid, e);
+            debug!(
+                error_kind = crate::observability::error_kind(&e),
+                "Response lookup failed"
+            );
             match e {
                 DBError::ResponsesError(ResponsesError::ResponseNotFound) => ApiError::NotFound,
                 DBError::ResponsesError(ResponsesError::Unauthorized) => ApiError::Unauthorized,
@@ -6167,10 +6156,7 @@ async fn cancel_response(
                 .db
                 .get_response_by_uuid_and_user(id, user.uuid)
                 .map_err(|e| {
-                    error!(
-                        "Failed to observe cancellation acknowledgement for response {}: {:?}",
-                        id, e
-                    );
+                    error!(response_uuid = %id, error_kind = crate::observability::error_kind(&e), "Failed to observe cancellation acknowledgement");
                     ApiError::InternalServerError
                 })?;
 
@@ -6232,15 +6218,15 @@ async fn delete_response(
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
-    debug!("Deleting response {} for user {}", id, user.uuid);
+    debug!("Deleting response");
 
     let existing = state
         .db
         .get_response_by_uuid_and_user(id, user.uuid)
         .map_err(|e| {
             debug!(
-                "Response {} not found for user {} before delete: {:?}",
-                id, user.uuid, e
+                error_kind = crate::observability::error_kind(&e),
+                "Response lookup failed"
             );
             match e {
                 DBError::ResponsesError(ResponsesError::ResponseNotFound) => ApiError::NotFound,
@@ -6269,8 +6255,8 @@ async fn delete_response(
     // Delete the response (cascade will handle related records)
     state.db.delete_response(id, user.uuid).map_err(|e| {
         debug!(
-            "Response {} not found for user {} during delete: {:?}",
-            id, user.uuid, e
+            error_kind = crate::observability::error_kind(&e),
+            "Response lookup failed"
         );
         match e {
             DBError::ResponsesError(ResponsesError::ResponseNotFound) => ApiError::NotFound,

--- a/src/web/responses/handlers.rs
+++ b/src/web/responses/handlers.rs
@@ -3917,6 +3917,7 @@ async fn validate_and_normalize_input(
 
     if user_message_tokens as usize >= ctx_budget {
         debug!(
+            user_uuid = %user.uuid,
             input_tokens = user_message_tokens,
             token_budget = ctx_budget,
             reason = "input_too_large",
@@ -4021,6 +4022,7 @@ async fn build_context_and_check_billing(
 
     if total_prompt_tokens >= prompt_token_budget(&body.model) {
         debug!(
+            user_uuid = %user.uuid,
             input_tokens = total_prompt_tokens,
             token_budget = prompt_token_budget(&body.model),
             reason = "prompt_too_large",
@@ -4038,6 +4040,7 @@ async fn build_context_and_check_billing(
     // Check billing with token validation (BEFORE any persistence).
     if let Some(billing_access) = billing_access {
         debug!(
+            user_uuid = %user.uuid,
             input_tokens = total_prompt_tokens,
             "Checking Responses billing"
         );
@@ -4045,12 +4048,13 @@ async fn build_context_and_check_billing(
         if let Err(e) = billing_access.check_with_tokens(total_prompt_tokens as i32) {
             match e {
                 BillingError::UsageLimitExceeded => {
-                    debug!(reason = "usage_limit", "Responses request rejected");
+                    debug!(user_uuid = %user.uuid, reason = "usage_limit", "Responses request rejected");
                     return Err(ApiError::UsageLimitReached);
                 }
                 BillingError::FreeTokenLimitExceeded => {
                     // This error is only returned for free users
                     debug!(
+                        user_uuid = %user.uuid,
                         input_tokens = total_prompt_tokens,
                         reason = "free_tier_token_limit",
                         "Responses request rejected"
@@ -4060,13 +4064,14 @@ async fn build_context_and_check_billing(
                 _ => {
                     // Log the error but allow the request for other billing service errors
                     error!(
+                        user_uuid = %user.uuid,
                         error_kind = crate::observability::error_kind(&e),
                         "Billing service error, allowing request"
                     );
                 }
             }
         }
-        debug!("Responses billing check passed");
+        debug!(user_uuid = %user.uuid, "Responses billing check passed");
     }
 
     Ok(BuiltContext {
@@ -4185,7 +4190,7 @@ async fn persist_request_data(
         .map_err(error_mapping::map_generic_db_error)?;
     let response = persisted.response;
 
-    debug!(response_uuid = %response.uuid, conversation_uuid = %conversation.uuid, "Created response");
+    debug!(user_uuid = %user.uuid, response_uuid = %response.uuid, conversation_uuid = %conversation.uuid, "Created response");
 
     Ok(PersistedData {
         response,
@@ -4780,7 +4785,15 @@ async fn consume_assistant_turn(
                     finish_reason.as_deref(),
                 ) {
                     debug!(
-                        finish_reason_present = finish_reason.is_some(),
+                        finish_reason = match finish_reason.as_deref() {
+                            Some("stop") => "stop",
+                            Some("length") => "length",
+                            Some("tool_calls") => "tool_calls",
+                            Some("function_call") => "function_call",
+                            Some("content_filter") => "content_filter",
+                            Some(_) => "other",
+                            None => "unspecified",
+                        },
                         "Assistant turn finalized tool call"
                     );
                     let tool_call = finalize_first_model_tool_call(&streamed_tool_calls)
@@ -5142,6 +5155,7 @@ async fn create_response_stream(
         ModelPlan::from_is_paid(billing_access.is_some_and(ChatBillingAccess::is_paid));
     if user.is_guest() && !model_plan.is_paid() {
         debug!(
+            user_uuid = %user.uuid,
             reason = "guest_requires_paid_plan",
             "Responses request rejected"
         );
@@ -5924,7 +5938,7 @@ async fn get_response(
     Extension(auth_context): Extension<AuthContext>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
-    debug!("Retrieving response");
+    debug!(user_uuid = %user.uuid, response_uuid = %id, "Retrieving response");
 
     // Get the response
     let response = state
@@ -6095,7 +6109,7 @@ async fn cancel_response(
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
-    debug!("Cancelling response");
+    debug!(user_uuid = %user.uuid, response_uuid = %id, "Cancelling response");
 
     // Verify the response exists and belongs to the user, and is in_progress
     let response = state
@@ -6103,6 +6117,8 @@ async fn cancel_response(
         .get_response_by_uuid_and_user(id, user.uuid)
         .map_err(|e| {
             debug!(
+                user_uuid = %user.uuid,
+                response_uuid = %id,
                 error_kind = crate::observability::error_kind(&e),
                 "Response lookup failed"
             );
@@ -6156,7 +6172,7 @@ async fn cancel_response(
                 .db
                 .get_response_by_uuid_and_user(id, user.uuid)
                 .map_err(|e| {
-                    error!(response_uuid = %id, error_kind = crate::observability::error_kind(&e), "Failed to observe cancellation acknowledgement");
+                    error!(user_uuid = %user.uuid, response_uuid = %id, error_kind = crate::observability::error_kind(&e), "Failed to observe cancellation acknowledgement");
                     ApiError::InternalServerError
                 })?;
 
@@ -6218,13 +6234,15 @@ async fn delete_response(
     Extension(user): Extension<User>,
     Extension(session_id): Extension<TransportSession>,
 ) -> Result<Response, ApiError> {
-    debug!("Deleting response");
+    debug!(user_uuid = %user.uuid, response_uuid = %id, "Deleting response");
 
     let existing = state
         .db
         .get_response_by_uuid_and_user(id, user.uuid)
         .map_err(|e| {
             debug!(
+                user_uuid = %user.uuid,
+                response_uuid = %id,
                 error_kind = crate::observability::error_kind(&e),
                 "Response lookup failed"
             );
@@ -6255,6 +6273,8 @@ async fn delete_response(
     // Delete the response (cascade will handle related records)
     state.db.delete_response(id, user.uuid).map_err(|e| {
         debug!(
+            user_uuid = %user.uuid,
+            response_uuid = %id,
             error_kind = crate::observability::error_kind(&e),
             "Response lookup failed"
         );

--- a/src/web/responses/instructions.rs
+++ b/src/web/responses/instructions.rs
@@ -298,14 +298,14 @@ async fn create_instruction(
         is_default: body.is_default,
     };
 
-    trace!("Creating instruction with: {:?}", new_instruction);
+    trace!(stage = "instruction_create", "Creating instruction");
 
     let instruction = state
         .db
         .create_user_instruction(new_instruction)
         .map_err(error_mapping::map_generic_db_error)?;
 
-    trace!("Created instruction: {:?}", instruction);
+    trace!(stage = "instruction_create", "Created instruction");
 
     let response = InstructionResponseBuilder::new(instruction)
         .name(body.name.clone())

--- a/src/web/responses/storage.rs
+++ b/src/web/responses/storage.rs
@@ -197,19 +197,13 @@ fn update_terminal_response_status(
                     Ok(None)
                 }
                 Err(e) => {
-                    error!(
-                        "Failed to read authoritative response {} ({}) status after {}: {:?}",
-                        response_id, response_uuid, reason, e
-                    );
+                    error!(response_uuid = %response_uuid, stage = "terminal_read", error_kind = crate::observability::error_kind(&e), "Storage terminal persistence failed");
                     Err("Failed to read authoritative terminal response status".to_string())
                 }
             }
         }
         Err(e) => {
-            error!(
-                "Failed to update response {} ({}) status to {:?} after {}: {:?}",
-                response_id, response_uuid, status, reason, e
-            );
+            error!(response_uuid = %response_uuid, status = ?status, stage = "terminal_update", error_kind = crate::observability::error_kind(&e), "Storage terminal persistence failed");
             Err("Failed to persist terminal response status".to_string())
         }
     }
@@ -476,10 +470,7 @@ async fn finalize_pending_items_for_terminal(
                 pending_messages.remove(&item_id);
             }
             Err(e) => {
-                error!(
-                    "Failed to finalize pending assistant message {}: {}",
-                    item_id, e
-                );
+                error!(item_id = %item_id, stage = "message_cleanup", "Storage operation failed");
                 failures.push(e);
             }
         }
@@ -516,10 +507,7 @@ async fn finalize_pending_items_for_terminal(
                 pending_reasoning.remove(&item_id);
             }
             Err(e) => {
-                error!(
-                    "Failed to finalize pending reasoning item {}: {}",
-                    item_id, e
-                );
+                error!(item_id = %item_id, stage = "reasoning_cleanup", "Storage operation failed");
                 failures.push(e);
             }
         }
@@ -597,10 +585,7 @@ async fn finalize_pending_tool_calls_for_terminal(
                 pending_tool_calls.remove(&tool_call_id);
             }
             Err(e) => {
-                error!(
-                    "Failed to terminalize pending tool_call {}: {}",
-                    tool_call_id, e
-                );
+                error!(tool_call_id = %tool_call_id, stage = "tool_cleanup", "Storage operation failed");
                 failures.push(e);
             }
         }
@@ -685,10 +670,7 @@ async fn persist_terminal_until_authoritative(
                 }
                 Ok(_) => Err(cleanup_error),
                 Err(e) => {
-                    warn!(
-                        "Failed to verify response existence after cleanup error: response_uuid={}, error={:?}",
-                        response_uuid, e
-                    );
+                    warn!(response_uuid = %response_uuid, stage = "cleanup_response_lookup", error_kind = crate::observability::error_kind(&e), "Storage cleanup lookup failed");
                     Err(cleanup_error)
                 }
             },
@@ -696,14 +678,8 @@ async fn persist_terminal_until_authoritative(
 
         match terminal_result {
             Ok(authoritative) => return authoritative,
-            Err(e) => {
-                warn!(
-                    "Storage terminal persistence will retry: response_uuid={}, reason={}, retry_delay_ms={}, error={}",
-                    response_uuid,
-                    reason,
-                    retry_delay.as_millis(),
-                    e
-                );
+            Err(_e) => {
+                warn!(response_uuid = %response_uuid, stage = "terminal_persistence", retry_delay_ms = retry_delay.as_millis(), "Storage terminal persistence will retry");
                 tokio::time::sleep(retry_delay).await;
                 retry_delay = retry_delay.saturating_mul(2).min(TERMINAL_RETRY_MAX_DELAY);
             }
@@ -742,7 +718,7 @@ pub async fn storage_task(
                     .created_at
                     .get_or_insert_with(|| allocate_created_at(&mut next_item_created_at))
                     .to_owned();
-                if let Err(e) = create_assistant_message_if_missing(
+                if let Err(_e) = create_assistant_message_if_missing(
                     &db,
                     conversation_id,
                     response_id,
@@ -750,7 +726,7 @@ pub async fn storage_task(
                     item_id,
                     created_at,
                 ) {
-                    error!("{}", e);
+                    error!(stage = "message_start", "Storage operation failed");
                     storage_failed = true;
                 }
             }
@@ -770,10 +746,7 @@ pub async fn storage_task(
                 item_id,
                 finish_reason,
             } => {
-                debug!(
-                    "Storage: message done {} with finish_reason={}",
-                    item_id, finish_reason
-                );
+                debug!(item_id = %item_id, "Storage: message done");
                 let (created_at, content) = {
                     let pending = pending_messages.entry(item_id).or_default();
                     pending.completed_finish_reason = Some(finish_reason.clone());
@@ -791,8 +764,8 @@ pub async fn storage_task(
                     item_id,
                     created_at,
                 );
-                if let Err(e) = &create_result {
-                    error!("{}", e);
+                if let Err(_e) = &create_result {
+                    error!(stage = "message_create", "Storage operation failed");
                     storage_failed = true;
                 }
                 if create_result.is_ok() {
@@ -809,8 +782,8 @@ pub async fn storage_task(
                         Ok(()) => {
                             pending_messages.remove(&item_id);
                         }
-                        Err(e) => {
-                            error!("{}", e);
+                        Err(_e) => {
+                            error!(stage = "message_finalize", "Storage operation failed");
                             storage_failed = true;
                         }
                     }
@@ -823,7 +796,7 @@ pub async fn storage_task(
                     .created_at
                     .get_or_insert_with(|| allocate_created_at(&mut next_item_created_at))
                     .to_owned();
-                if let Err(e) = create_reasoning_item_if_missing(
+                if let Err(_e) = create_reasoning_item_if_missing(
                     &db,
                     conversation_id,
                     response_id,
@@ -831,7 +804,7 @@ pub async fn storage_task(
                     item_id,
                     created_at,
                 ) {
-                    error!("{}", e);
+                    error!(stage = "reasoning_start", "Storage operation failed");
                     storage_failed = true;
                 }
             }
@@ -858,17 +831,11 @@ pub async fn storage_task(
                     pending.completed = true;
                     pending.content.clone()
                 };
-                if let Err(e) =
+                if let Err(_e) =
                     finalize_reasoning_item(&db, &user_key, item_id, content, STATUS_COMPLETED)
                         .await
                 {
-                    error!(
-                        "Failed to finalize reasoning item {} for response {} after {} ms: {}",
-                        item_id,
-                        response_id,
-                        reasoning_finalize_started.elapsed().as_millis(),
-                        e
-                    );
+                    error!(item_id = %item_id, response_id, stage = "reasoning_finalize", elapsed_ms = reasoning_finalize_started.elapsed().as_millis(), "Storage operation failed");
                     storage_failed = true;
                 } else {
                     pending_reasoning.remove(&item_id);
@@ -932,12 +899,8 @@ pub async fn storage_task(
                 name,
                 arguments,
             } => {
-                let tool_name = name.clone();
                 let tool_call_persist_started = Instant::now();
-                debug!(
-                    "Storage: persisting tool_call {} ({}) for response {}",
-                    tool_call_id, tool_name, response_id
-                );
+                debug!(tool_call_id = %tool_call_id, response_id, "Storage: persisting tool call");
                 let created_at = allocate_created_at(&mut next_item_created_at);
                 pending_tool_calls.insert(
                     tool_call_id,
@@ -963,22 +926,11 @@ pub async fn storage_task(
                 )
                 .await
                 {
-                    Ok(()) => debug!(
-                        "Storage: persisted tool_call {} ({}) for response {} in {} ms",
-                        tool_call_id,
-                        tool_name,
-                        response_id,
-                        tool_call_persist_started.elapsed().as_millis()
-                    ),
+                    Ok(()) => {
+                        debug!(tool_call_id = %tool_call_id, response_id, elapsed_ms = tool_call_persist_started.elapsed().as_millis(), "Storage: persisted tool call")
+                    }
                     Err(e) => {
-                        error!(
-                            "Failed to persist tool_call {} ({}) for response {} after {} ms: {}",
-                            tool_call_id,
-                            tool_name,
-                            response_id,
-                            tool_call_persist_started.elapsed().as_millis(),
-                            e
-                        );
+                        error!(tool_call_id = %tool_call_id, response_id, stage = "tool_call_persist", elapsed_ms = tool_call_persist_started.elapsed().as_millis(), "Storage operation failed");
                         storage_failed = true;
                         if let Some(ack) = &tool_ack {
                             let _ = ack.send(Err(e)).await;
@@ -1029,14 +981,7 @@ pub async fn storage_task(
                         }
                     }
                     Err(e) => {
-                        error!(
-                            "Failed to persist tool_output {} for tool_call {} on response {} after {} ms: {}",
-                            tool_output_id,
-                            tool_call_id,
-                            response_id,
-                            tool_output_persist_started.elapsed().as_millis(),
-                            e
-                        );
+                        error!(tool_call_id = %tool_call_id, tool_output_id = %tool_output_id, response_id, stage = "tool_output_persist", elapsed_ms = tool_output_persist_started.elapsed().as_millis(), "Storage operation failed");
                         storage_failed = true;
                         if let Some(ack) = &tool_ack {
                             let _ = ack.send(Err(e)).await;

--- a/src/web/responses/tools.rs
+++ b/src/web/responses/tools.rs
@@ -99,7 +99,7 @@ async fn execute_kagi_search(
 
     debug!(
         elapsed_ms = started.elapsed().as_millis(),
-        trace_id = response.meta.trace.as_deref().unwrap_or("unavailable"),
+        upstream_trace_id = %sanitize_trace_id(response.meta.trace.as_deref().unwrap_or("unavailable")),
         "Finished Kagi search request"
     );
 
@@ -263,7 +263,7 @@ async fn execute_kagi_open_urls(
     debug!(
         elapsed_ms = started.elapsed().as_millis(),
         url_count = urls.len(),
-        trace_id = response.meta.trace.as_deref().unwrap_or("unavailable"),
+        upstream_trace_id = %sanitize_trace_id(response.meta.trace.as_deref().unwrap_or("unavailable")),
         "Finished Kagi extract request"
     );
 
@@ -675,7 +675,12 @@ pub async fn execute_tool(
     kagi_client: Option<&Arc<KagiClient>>,
     kagi_allowed_urls: &mut HashSet<String>,
 ) -> Result<String, String> {
-    debug!(tool_name, "Executing tool");
+    let tool_kind = match tool_name {
+        "web_search" => "web_search",
+        "open_urls" => "open_urls",
+        _ => "unknown",
+    };
+    debug!(tool_kind, "Executing tool");
 
     match tool_name {
         "web_search" => {
@@ -693,7 +698,7 @@ pub async fn execute_tool(
             execute_kagi_open_urls(arguments, client, kagi_allowed_urls).await
         }
         _ => {
-            error!(tool_name, "Unknown tool requested");
+            error!(tool_kind, "Unknown tool requested");
             Err(format!("Tool '{tool_name}' is unavailable"))
         }
     }


### PR DESCRIPTION
OpenSecret request logs interleave across handlers, streaming bodies, and detached work, while several diagnostics can print credentials or user/provider content. Add server-generated request trace IDs that follow body polling and request-owned tasks, and replace payload-bearing diagnostics with bounded metadata.

- Trace outer HTTP requests and Transport V2 logical dispatch; preserve response status, headers, frames, trailers, and cancellation behavior. Caller trace IDs are not trusted or forwarded.
- Default to `warn,opensecret=info`, quiet routine auth/disconnect/progress noise, and retain IDs, API-key display names, permitted PII/request metadata, and real failure signals. Protect keys/credentials and plaintext that belongs encrypted at rest. HTTP body completion is explicitly distinct from client receipt or durable storage completion.
- Sanitize auth, OAuth, email, provider, storage, KMS, and startup diagnostics, including r2d2's default worker error handler. Erase retained secret bytes and malformed-secret parse text before startup error/panic formatting. Add database initialization timing and actual pool counts; leave pool settings, retries, and proxy behavior unchanged.
- Document logging conventions and the existing parent logger's socket-chunk/event-framing limitation.

Validation in a fresh `opensecret-workspaces` managed local workspace, with pinned Nix toolchains and generated environment/service lifecycle:

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTFLAGS='-D warnings' cargo test --locked --all-features`: 656 passed, 0 failed, 23 ignored. Includes concurrent trace isolation at the default filter, body Pending/resume/drop and cancellation, frame/trailer preservation, V2 logical routing, and synthetic privacy regressions including startup secret decoding/error formatting.
- `bash -n entrypoint.sh` and `bash tests/entrypoint_entropy_preflight.sh` passed.
- Pinned Maple TypeScript SDK 3.5.2 (`183c1d4fe8aeeb3b3c83c5d53f1e78071e4f77e2`) against the migrated local backend: V1 encrypted model listing, malformed login, absent-project login, and invalid-JWT rejection. No Maple source/dependency changes.
- Live local log assertions passed for all six HTTP exchanges: distinct server trace IDs, matched route templates, expected 200/400/401 statuses, and no synthetic private marker in the backend log. The launcher explicitly used `RUST_LOG=warn,opensecret=info` because the host inherited `RUST_LOG=warn`.

Local evidence does not cover authenticated account workflows, live inference, native SDK/UI behavior, or Linux/Nitro runtime. Ignored database/provider suites were not blanket-run. No remote migrations, enclave deployment, PCR references, pool tuning, or collector infrastructure changes are included. Live deployment/log verification remains a separate gate.
