### PR TITLE
Prepare legacy PCR compatibility publication for the Maple import

### DIFF
--- a/.agents/skills/validate-opensecret/SKILL.md
+++ b/.agents/skills/validate-opensecret/SKILL.md
@@ -167,9 +167,13 @@ nix build --no-link --no-write-lock-file .#default
 
 EIF construction, PCR comparison, and reference/history updates are
 release-only work. The Nix Reproducible Builds workflow builds the
-development EIF on pull requests but skips PCR comparison there. Master
-pushes and `workflow_dispatch` still compare against checked-in
-references. Ordinary pull-request completion does not update PCR
+development EIF on source pull requests but skips PCR comparison there.
+Automatic runs skip changes confined to the four PCR files and documentation
+paths explicitly listed in `.github/workflows/build.yml`. Source master pushes
+and `workflow_dispatch` still compare against checked-in references. Use
+`docs/pcr-compatibility.md` for manual publication validation; rebuilding
+retained legacy source does not verify a PCR file copied from Maple.
+Ordinary pull-request completion does not update PCR
 references. If a master or release build succeeds and then fails only
 PCR comparison, treat that as deferred release work and do not copy or
 sign CI values just to make the job green. Treat an EIF build failure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,15 +6,35 @@ on:
   push:
     branches:
       - master
+    # Compatibility publication copies already signed PCR files; it does not
+    # rebuild this repository's retained backend source.
+    paths-ignore:
+      - 'pcrDev.json'
+      - 'pcrDevHistory.json'
+      - 'pcrProd.json'
+      - 'pcrProdHistory.json'
+      - 'README.md'
+      - 'AGENTS.md'
+      - 'docs/**'
+      - '.agents/skills/**/SKILL.md'
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - 'pcrDev.json'
+      - 'pcrDevHistory.json'
+      - 'pcrProd.json'
+      - 'pcrProdHistory.json'
+      - 'README.md'
+      - 'AGENTS.md'
+      - 'docs/**'
+      - '.agents/skills/**/SKILL.md'
   workflow_dispatch:
 
 jobs:
   dev:
     name: "Development Reproducible Build"
-    # Run on all PRs and master pushes
+    # Run on source PRs/master pushes and explicit manual builds.
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'push'
     # Custom runner required: ARM64 architecture needed for AWS Nitro Enclaves
     # 4 cores needed for efficient builds and PCR verification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,11 +137,14 @@ or skipped tests, configured external services, and every unverified layer.
 ## Operator authority
 
 EIF/PCR parity is a release and deployment gate, not an ordinary development
-or pull-request gate. GitHub Actions still builds the development EIF on
-pull requests, but skips PCR comparison there. Master pushes and
-`workflow_dispatch` still verify PCR values against the checked-in
-references. Do not update PCR references as part of ordinary pull-request
-work. Treat an EIF build failure separately from PCR mismatch.
+or pull-request gate. GitHub Actions builds the development EIF on source
+pull requests, but skips PCR comparison there. The build workflow excludes
+automatic PCR-only and documentation-only changes using its explicit
+`paths-ignore` list; Rust CI and supply-chain checks remain enabled. Source
+master pushes and `workflow_dispatch` still verify PCR values against the
+checked-in references. Follow `docs/pcr-compatibility.md` for manual
+compatibility publication. Do not update PCR references as part of ordinary
+pull-request work. Treat an EIF build failure separately from PCR mismatch.
 
 Before publishing or deploying an authorized dev or prod EIF, build it on the
 supported Linux/ARM64 release builder, intentionally review its measurements,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OpenSecret
 
 OpenSecret is the open-source Rust backend for confidential AI applications
-such as [Maple](https://github.com/OpenSecretCloud/Maple). It owns
+such as [Maple](https://github.com/MaplePrivacyLabs/Maple). It owns
 authentication, encrypted client sessions and persistence, provider routing,
 usage accounting, and OpenAI-shaped/Responses APIs carried inside the
 OpenSecret encrypted transport.
@@ -10,6 +10,21 @@ Production is designed for AWS Nitro Enclaves. A source checkout or local build
 can validate implementation and build invariants, but does not by itself prove
 the artifact, PCR, IAM/KMS policy, logging, or network configuration of a
 deployed environment.
+
+## Maple monorepo transition
+
+The backend is being imported, with its history and existing PCR file layout,
+into `services/opensecret/` in
+[MaplePrivacyLabs/Maple](https://github.com/MaplePrivacyLabs/Maple). Until that
+import is merged and its public files are verified, this repository remains
+the source for the existing backend and SDK PCR URLs.
+
+This repository will remain public, writable, and unarchived for manual
+publication of the same signed PCR files used by older clients. The transition
+does not remove its backend source, change SDK URLs, or introduce GitHub EIF
+publishing or deployment. See
+[`docs/pcr-compatibility.md`](docs/pcr-compatibility.md) for the publication
+contract and cutover prerequisites.
 
 ## Local quick start
 
@@ -86,9 +101,12 @@ with the repository's Nix flake on the appropriate Linux/ARM environment. Build,
 PCR comparison, deployment, and live trust verification are distinct evidence.
 
 Routine pull requests do not require EIF/PCR parity. The Nix Reproducible
-Builds workflow still builds the development EIF on pull requests, but skips
-PCR comparison there. Master pushes and manual `workflow_dispatch` still
-verify PCR values against the checked-in references. Before an authorized
+Builds workflow builds the development EIF on source pull requests, but skips
+PCR comparison there. It skips automatic runs when every changed path is one
+of the four PCR JSON files or the documentation paths listed in
+[`build.yml`](.github/workflows/build.yml). Source master pushes and manual
+`workflow_dispatch` still verify PCR values against the checked-in references.
+Rust CI and supply-chain checks remain enabled. Before an authorized
 dev or prod publish/deployment, use the supported Linux/ARM64 release
 builder to review and deliberately update/verify the target measurements;
 never update checked-in PCRs solely to clear ordinary pull-request CI.

--- a/docs/pcr-compatibility.md
+++ b/docs/pcr-compatibility.md
@@ -1,0 +1,85 @@
+# Signed PCR compatibility during the Maple import
+
+The backend import into `MaplePrivacyLabs/Maple` at `services/opensecret/` is
+being prepared. Do not switch clients or publishing ownership until the import
+is merged, its exact source revision is reviewed, and the new public files on
+Maple's `master` branch are verified. This document prepares the legacy side;
+it does not declare the cutover complete.
+
+## Keep the installed-client URLs working
+
+Retain this repository at `OpenSecretCloud/opensecret`, public, writable, and
+unarchived, with the `master` branch and these root-level files:
+
+| File | Existing raw URL |
+| --- | --- |
+| `pcrDev.json` | <https://raw.githubusercontent.com/OpenSecretCloud/opensecret/master/pcrDev.json> |
+| `pcrDevHistory.json` | <https://raw.githubusercontent.com/OpenSecretCloud/opensecret/master/pcrDevHistory.json> |
+| `pcrProd.json` | <https://raw.githubusercontent.com/OpenSecretCloud/opensecret/master/pcrProd.json> |
+| `pcrProdHistory.json` | <https://raw.githubusercontent.com/OpenSecretCloud/opensecret/master/pcrProdHistory.json> |
+
+Do not rename, transfer, archive, delete, or rewrite the history of this
+repository as part of the import. Retaining its current source is intentional;
+source retirement is a separate decision. Existing clients must continue to
+receive JSON directly at these URLs rather than depending on redirects.
+
+## Manual publication after cutover
+
+After Maple's import is merged and verified, make new backend and signed-PCR
+changes in `services/opensecret/`. Preserve the existing signing key, JSON
+format, filenames, and previously published history entries. Copy the four
+files from one reviewed Maple commit into this repository; do not independently
+sign or regenerate a second set here.
+
+The Maple import includes `services/opensecret/docs/pcr-compatibility.md` and
+`services/opensecret/scripts/pcr_compatibility.py`. Once available on the
+verified Maple revision, use that runbook and helper for the precise commands:
+
+1. Fetch both repositories and identify the full reviewed Maple source commit
+   and the current legacy `origin/master` commit. Use a clean legacy checkout
+   whose branch starts at that exact legacy commit.
+2. Run the helper's dry-run preparation and review its result. It checks the
+   current references, complete histories, signatures against the SDK's pinned
+   public key, and preservation of every existing history entry.
+3. Apply the same preparation to copy only `pcrDev.json`, `pcrDevHistory.json`,
+   `pcrProd.json`, and `pcrProdHistory.json`, preserving the exact source bytes.
+   The helper performs no network access, signing, commit, push, or deployment.
+4. Review the diff, then publish those files in a normal commit or pull request.
+   Record the immutable Maple source commit in the commit message or PR body.
+   Recheck the legacy tip before publishing; if it advanced, rerun validation
+   against the new baseline. Never force-push through an intervening update.
+5. Fetch the four public raw URLs above after merge/publication. Require a
+   successful response without redirects and compare their bytes with the
+   reviewed Maple source files. Do not report publication complete from a
+   successful Git push alone.
+
+The existing signature scheme authenticates **PCR0 only**. Structural checks
+and matching a current reference to a history entry do not make PCR1 or PCR2
+cryptographically authenticated. Do not change the scheme or claim stronger
+verification as part of this copy step.
+
+The existing `just update-pcr-dev` and `just update-pcr-prod` recipes build/copy
+and append locally signed entries; they are not legacy copy or comprehensive
+history-validation commands. Run them only as part of separately authorized
+measurement/signing work in the owning backend checkout. Publication does not
+deploy an EIF, modify KMS/IAM, or prove which measurements a live enclave uses.
+
+Coordinate signed history publication with the backend deployment so old
+clients can recognize the authorized measurement when it starts serving.
+Switch new SDK defaults only after the canonical Maple raw URLs exist and are
+verified. There is no automatic sunset date for this legacy publication path;
+ending it needs a separate client-compatibility decision.
+
+## CI behavior while source remains here
+
+The Nix Reproducible Builds workflow skips automatic runs whose changes are
+entirely PCR files or the documentation paths listed in
+[`build.yml`](../.github/workflows/build.yml). This avoids rebuilding retained
+legacy code just to publish measurements from the monorepo. A mixed change
+that also edits source, dependencies, Nix, or the workflow itself still runs the
+existing build workflow. Manual `workflow_dispatch` also remains available and
+builds this checkout's EIFs; it is not a substitute for validating copied files.
+
+Rust CI and scheduled supply-chain checks are unchanged. No GitHub publishing
+credential, cross-organization automation, or deployment workflow is needed for
+this manual compatibility path.


### PR DESCRIPTION
After OpenSecret moves into Maple, older clients still need the exact `OpenSecretCloud/opensecret/master/pcr*History.json` URLs. Prepare this repository for manual publication of the same four reviewed PCR files while retaining its source, history, name and writable public status.

The existing EIF workflow skips automatic changes confined to the four PCR JSON files and listed documentation paths. Source changes and explicit manual dispatch retain the existing build behavior; Rust and supply-chain checks remain enabled. Documentation requires the Maple import and public-file verification before ownership/SDK cutover, then exact-byte publication with the existing signing key and history-prefix checks. No automatic backpublisher, source deletion, PCR edits or deployment is included.

Validation: pinned actionlint passed with the existing custom-runner-label exception; 12 representative path-filter cases passed; build jobs/manual-dispatch definitions and PCR files are unchanged. Documentation links and `git diff --check` passed. No currently required legacy build check is left pending by this filter (master protection/rules inspected before preparation).

[Maple#888](https://github.com/MaplePrivacyLabs/Maple/pull/888) supplies the offline validation/copy helper; it performs no commit or push. This PR only prepares the legacy repository and does not declare the migration complete.
