### PR TITLE
docs: close out the backend source cutover

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # OpenSecret agent guide
 
+> **Compatibility repository:** active backend work belongs in
+> [MaplePrivacyLabs/Maple's `services/opensecret/`](https://github.com/MaplePrivacyLabs/Maple/tree/master/services/opensecret)
+> and follows its current agent guide. This repository stays public, writable,
+> and unarchived for manual, exact-byte signed-PCR publication. Follow
+> [the compatibility contract](docs/pcr-compatibility.md); do not sign a second
+> history here. The remaining guide describes the retained legacy source.
+
 This file applies to the whole repository. It contains durable project rules;
 task procedures live in `.agents/skills/`. Load the matching skill before doing
 specialized work.

--- a/README.md
+++ b/README.md
@@ -11,20 +11,32 @@ can validate implementation and build invariants, but does not by itself prove
 the artifact, PCR, IAM/KMS policy, logging, or network configuration of a
 deployed environment.
 
-## Maple monorepo transition
+## Development moved; signed PCR compatibility remains here
 
-The backend is being imported, with its history and existing PCR file layout,
-into `services/opensecret/` in
-[MaplePrivacyLabs/Maple](https://github.com/MaplePrivacyLabs/Maple). Until that
-import is merged and its public files are verified, this repository remains
-the source for the existing backend and SDK PCR URLs.
+**Active backend development now lives in
+[MaplePrivacyLabs/Maple at `services/opensecret/`](https://github.com/MaplePrivacyLabs/Maple/tree/master/services/opensecret).**
+The history-preserving import is complete. Use the
+[current backend guide](https://github.com/MaplePrivacyLabs/Maple/blob/master/services/opensecret/README.md)
+and direct new backend issues and pull requests to the monorepo. OpenSecret
+remains the backend's name.
 
-This repository will remain public, writable, and unarchived for manual
-publication of the same signed PCR files used by older clients. The transition
-does not remove its backend source, change SDK URLs, or introduce GitHub EIF
-publishing or deployment. See
-[`docs/pcr-compatibility.md`](docs/pcr-compatibility.md) for the publication
-contract and cutover prerequisites.
+This repository stays public, writable, and **unarchived** to serve the
+root-level `pcrDev.json`, `pcrProd.json`, `pcrDevHistory.json`, and
+`pcrProdHistory.json` URLs required by older clients. New Maple SDKs use the
+canonical files under `services/opensecret/`; older packages and installed
+clients do not change URLs automatically.
+
+For each authorized PCR update, manually copy all four files byte-for-byte
+from one reviewed monorepo commit and verify both public locations. Do not
+regenerate or sign a second copy here. Follow
+[`docs/pcr-compatibility.md`](docs/pcr-compatibility.md). The existing signing
+scheme and operator authority remain unchanged, and there is no automatic
+sunset date. GitHub does not publish or deploy the active backend's EIFs.
+
+The retained source and instructions below describe this legacy checkout.
+They are historical reference, not the current development or deployment
+entrypoint. Existing issues and pull requests are not closed or ported by this
+notice.
 
 ## Local quick start
 

--- a/docs/pcr-compatibility.md
+++ b/docs/pcr-compatibility.md
@@ -1,10 +1,11 @@
-# Signed PCR compatibility during the Maple import
+# Signed PCR compatibility after the Maple import
 
-The backend import into `MaplePrivacyLabs/Maple` at `services/opensecret/` is
-being prepared. Do not switch clients or publishing ownership until the import
-is merged, its exact source revision is reviewed, and the new public files on
-Maple's `master` branch are verified. This document prepares the legacy side;
-it does not declare the cutover complete.
+The backend import into
+[MaplePrivacyLabs/Maple at `services/opensecret/`](https://github.com/MaplePrivacyLabs/Maple/tree/master/services/opensecret)
+is complete. Backend source and new signed-PCR changes are maintained there.
+This repository remains the writable compatibility mirror for older clients;
+new Maple SDKs use the canonical monorepo histories. Keep both locations
+available and publish identical reviewed files to each.
 
 ## Keep the installed-client URLs working
 
@@ -23,17 +24,18 @@ repository as part of the import. Retaining its current source is intentional;
 source retirement is a separate decision. Existing clients must continue to
 receive JSON directly at these URLs rather than depending on redirects.
 
-## Manual publication after cutover
+## Manual publication
 
-After Maple's import is merged and verified, make new backend and signed-PCR
-changes in `services/opensecret/`. Preserve the existing signing key, JSON
+Make new backend and signed-PCR changes in the monorepo under
+`services/opensecret/`. Preserve the existing signing key, JSON
 format, filenames, and previously published history entries. Copy the four
 files from one reviewed Maple commit into this repository; do not independently
 sign or regenerate a second set here.
 
-The Maple import includes `services/opensecret/docs/pcr-compatibility.md` and
-`services/opensecret/scripts/pcr_compatibility.py`. Once available on the
-verified Maple revision, use that runbook and helper for the precise commands:
+Use the current monorepo
+[runbook](https://github.com/MaplePrivacyLabs/Maple/blob/master/services/opensecret/docs/pcr-compatibility.md)
+and [helper](https://github.com/MaplePrivacyLabs/Maple/blob/master/services/opensecret/scripts/pcr_compatibility.py)
+from the reviewed Maple revision for the precise commands:
 
 1. Fetch both repositories and identify the full reviewed Maple source commit
    and the current legacy `origin/master` commit. Use a clean legacy checkout
@@ -66,9 +68,10 @@ deploy an EIF, modify KMS/IAM, or prove which measurements a live enclave uses.
 
 Coordinate signed history publication with the backend deployment so old
 clients can recognize the authorized measurement when it starts serving.
-Switch new SDK defaults only after the canonical Maple raw URLs exist and are
-verified. There is no automatic sunset date for this legacy publication path;
-ending it needs a separate client-compatibility decision.
+The new SDK defaults already use the canonical Maple raw URLs. This does not
+upgrade existing clients or end their need for these legacy URLs. There is no
+automatic sunset date for this publication path; ending it needs a separate
+client-compatibility decision.
 
 ## CI behavior while source remains here
 


### PR DESCRIPTION
The README and PCR guide still describe the backend import as pending. Update them to the completed cutover: active development is in `MaplePrivacyLabs/Maple/services/opensecret`, and this repository remains public, writable, and unarchived as the signed-PCR compatibility mirror.

Keep all four existing root-level PCR URLs. The operator manually copies the exact bytes from one reviewed monorepo commit, preserves the current signing scheme and history, and verifies both public locations. Retained source/development instructions are marked legacy; there is no source removal, PCR mutation, new publisher, deployment change, or sunset date.

Validation: independent retirement review; canonical source/runbook/helper destinations verified; all four legacy/canonical raw-file pairs returned HTTP 200 without redirects and matched byte-for-byte; `git diff --check` passed. No backend services, builds, signing, or deployment were run.
